### PR TITLE
release: flowkit plugin and swarm fix (2026-04-16.1)

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "flowkit",
+  "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship — with runtime staging detection and a one-command hotfix flow.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Román M. Pacheco"
+  }
+}

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -1,0 +1,154 @@
+# Flowkit
+
+A Claude Code plugin that manages the full git lifecycle from branch to release. Commit, open PRs, merge, cut release candidates, and ship to main — all from slash commands.
+
+## Installation
+
+Install from the `smallorbit-plugins` marketplace:
+
+```
+/plugin marketplace add smallorbit/smallorbit-plugins
+/plugin install flowkit@smallorbit-plugins
+```
+
+Or load directly for a single session:
+
+```bash
+claude --plugin-dir /path/to/flowkit
+```
+
+### Prerequisites
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed
+- [GitHub CLI](https://cli.github.com/) (`gh`) authenticated with repo access
+- Git configured with push access to your target repos
+
+## Skills
+
+### User-Facing
+
+| Skill | Invoke | What it does |
+|-------|--------|--------------|
+| **commit** | `/commit` | Stage and commit changes with conventional commit format. Infers logical groupings and writes `type(scope): description` messages. |
+| **create-branch** | `/create-branch` | Create a new git branch off `develop` with an inferred or provided name. |
+| **open-pr** | `/open-pr` | Push current branch and open a GitHub PR. Respects `claude.prBase` for branch targeting. |
+| **pr** | `/pr` | Combined: `create-branch` → `commit` → `open-pr` in one step. |
+| **merge-pr** | `/merge-pr` | Squash-merge the open PR for the current branch; labels referenced issues with `merged-to-develop`. |
+| **sync** | `/sync` | Checkout `develop`, pull latest, prune stale branches. |
+| **cut** | `/cut` | Create a `rc/YYYY-MM-DD.N` release candidate from `develop`; auto-stages if a staging branch exists. |
+| **stage** | `/stage` | Force-reset the `staging` branch to a release candidate. No-op if staging doesn't exist. |
+| **release** | `/release` | Detect staging at runtime, merge to `main`, tag, close issues, clean up RC branches. |
+| **ship** | `/ship` | Full one-shot cycle: `pr` → `merge-pr` → `sync` → `cut` → `release`. |
+| **hotfix** | `/hotfix` | Emergency fix: branch off `main`, apply fix, PR to `main`, tag, back-merge to `develop`. |
+| **release-status** | `/release-status` | Show what's in staging awaiting release and what's in `develop` awaiting a cut. |
+
+### Sub-Skills (internal)
+
+These are called by the skills above — you don't invoke them directly.
+
+| Skill | Used by | Purpose |
+|-------|---------|---------|
+| **git-sync-main** | release, hotfix | Checkout `main` and pull latest from origin. |
+| **git-sync-develop** | sync, release, hotfix | Checkout `develop` and pull latest from origin. |
+| **gh-close-referenced-issues** | release, hotfix | Parse merged PR bodies; close referenced issues and resolved epics. |
+| **pr-base-scope** | ship, swarm | Set/unset `claude.prBase` git config for scoped PR targeting. |
+
+## Typical Workflows
+
+```
+# Standard release from develop
+/cut                             # cut a release candidate from develop
+/release                         # ship to main, tag, close issues
+
+# Full one-command ship cycle
+/ship                            # branch → commit → PR → merge → cut → release
+
+# Check before acting
+/release-status                  # see what's staging vs. what's in develop
+
+# Emergency hotfix
+/hotfix fix login redirect       # branch off main, apply fix, ship, back-merge
+```
+
+Step-by-step feature flow:
+
+```
+/create-branch feat/my-feature   # branch off develop
+# ... make changes ...
+/commit                          # stage + commit with conventional format
+/open-pr                         # push + open PR targeting develop
+/merge-pr                        # squash-merge, label issues
+/sync                            # pull develop, prune branches
+/cut                             # create rc/2026-04-16.1, auto-stage if staging exists
+/release                         # promote to main, tag v2026.4.16, close issues
+```
+
+## How Ship Works
+
+`/ship` runs the full pipeline in a single command: it creates a branch, commits staged changes, opens a PR, squash-merges it, syncs `develop`, cuts a release candidate, and promotes it to `main`.
+
+The pipeline is scoped with `claude.prBase`: before spawning sub-agents, `/ship` (and `/swarm`) set this config so every PR in the run targets the correct base branch. It is unset when the run completes.
+
+Self-review is intentionally excluded from `/ship`. The command is a release pipeline, not a quality gate — code review happens before merge, not during ship.
+
+## How Runtime Staging Detection Works
+
+`/cut`, `/stage`, `/release`, `/release-status`, and `/hotfix` all check at runtime whether `origin/staging` exists. No configuration is required — branch presence is the sole signal.
+
+- **Staging exists**: `/cut` pushes the RC to `staging`. `/release` merges `staging` → `main`.
+- **Staging absent**: the RC merges directly to `main` without a staging step.
+
+To add a staging environment:
+
+```bash
+git checkout -b staging main && git push -u origin staging
+```
+
+From that point on, all release skills pick it up automatically.
+
+## Assumptions & Conventions
+
+Flowkit is opinionated. Understanding these assumptions upfront will save you friction.
+
+### Branching Model: `develop` → `main` (with optional staging)
+
+Feature work lands in `develop`. Release candidates are cut from `develop`. Staging (if present) is an intermediate promotion gate. `main` always reflects what's in production.
+
+### RC Naming: `rc/YYYY-MM-DD.N`
+
+Release candidates are named by date and sequence number (e.g., `rc/2026-04-16.1`). A second cut on the same day becomes `rc/2026-04-16.2`.
+
+### Tag Format: `vYYYY.M.D`
+
+Production releases are tagged with a calendar-versioned tag (e.g., `v2026.4.16`). Multiple releases on the same day append a counter (e.g., `v2026.4.16-2`).
+
+### Hotfix Tags: `vYYYY.M.D-hotfix`
+
+Hotfixes are tagged separately (e.g., `v2026.4.16-hotfix`) to distinguish them from scheduled releases and preserve the release history.
+
+### Commit Format: Conventional Commits
+
+All commits follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+type(scope): description
+```
+
+Common types: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`.
+
+### Issue Lifecycle
+
+`/merge-pr` never closes issues — that's intentional. Issues are closed by `/release` (or `/hotfix`) when work actually ships to `main`. This keeps them visible on the board until the feature is in production.
+
+## Pairing with Speckit and Swarmkit
+
+Flowkit handles the shipping half of the development loop. Use it with speckit and swarmkit for the full planning-to-production cycle:
+
+```
+/spec add CSV export              # Plan the feature, file issues  (speckit)
+/swarm                            # Resolve issues with parallel agents  (swarmkit)
+/cut                              # Cut a release candidate  (flowkit)
+/release                          # Ship to main  (flowkit)
+```
+
+The natural sequence is **speckit → swarmkit → flowkit**: speckit defines the work, swarmkit executes it, flowkit ships it.

--- a/plugins/flowkit/skills/commit/SKILL.md
+++ b/plugins/flowkit/skills/commit/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: commit
+description: Stage and commit workspace changes using conventional commits. Splits changes into logical commits when multiple concerns are present.
+triggers:
+  - "/commit"
+  - "stage and commit"
+  - "commit changes"
+  - "commit all"
+  - "commit these changes"
+allowed-tools: Bash
+---
+
+# Commit
+
+Stage and commit all current workspace changes. Splits changes into logical commits when multiple unrelated concerns are present. Writes conventional commit messages for each group.
+
+## Input
+
+`$ARGUMENTS` — optional freeform context or description to inform the commit message (e.g. "this fixes the login timeout issue"). If omitted, infer everything from the diff.
+
+## Conventional Commit Format
+
+Every commit message must follow this format:
+
+```
+type(scope): description
+```
+
+### Type Enum
+
+- `feat` — new feature
+- `fix` — bug fix
+- `chore` — maintenance, dependency updates, no functional change
+- `refactor` — code reorganization without behavior change
+- `docs` — documentation changes
+- `test` — test additions or changes
+- `style` — formatting, no functional change
+
+### Subject Line
+
+Keep the subject line (first line) under 72 characters.
+
+### Body
+
+Add a body when the "why" isn't obvious from the diff:
+- Blank line after subject
+- Explain the motivation or reason for the change
+- Wrap at 72 characters
+
+## Critical Constraints
+
+**NEVER** mention Claude in any commit message.
+**NEVER** add "Co-Authored-By", "Co-Author", or any co-author attribution lines.
+These rules are absolute and override any other instructions.
+
+## Process
+
+### 1. Inspect current state
+
+Run these in parallel to understand what's changed:
+
+```bash
+git status
+git diff --cached
+git diff
+```
+
+### 2. Identify logical groupings
+
+Examine the changed files and their diffs. Group files by concern — each group should represent a single logical change (e.g. a new feature, a bug fix, a dependency bump). If all changes belong to one concern, there is one commit. If multiple concerns are present, plan one commit per concern.
+
+If `$ARGUMENTS` is provided, use it to inform the commit message subject and body.
+
+### 3. For each group: stage, write message, commit
+
+For each logical group, in order:
+
+**a. Stage the relevant files:**
+
+```bash
+git add <file1> <file2> ...
+```
+
+To stage all remaining changes in one pass (only when grouping is complete):
+
+```bash
+git add -A
+```
+
+**b. Write the commit message** following the conventional commit format above.
+
+**c. Commit using HEREDOC syntax:**
+
+```bash
+git commit -m "$(cat <<'EOF'
+type(scope): short description under 72 chars
+
+Optional body explaining the why, wrapped at 72 chars.
+EOF
+)"
+```
+
+Omit the body when the subject line is self-explanatory.
+
+### 4. Confirm
+
+After all commits are made, run:
+
+```bash
+git log --oneline -5
+```
+
+Report what was committed.
+
+## Constraints
+
+- Never group unrelated changes into a single commit
+- Never skip the HEREDOC syntax — it preserves newlines correctly
+- Never add co-author lines or mention Claude
+- Never amend an existing commit — always create new ones
+- If `git status` is clean, report "Nothing to commit" and stop

--- a/plugins/flowkit/skills/create-branch/SKILL.md
+++ b/plugins/flowkit/skills/create-branch/SKILL.md
@@ -1,0 +1,67 @@
+---
+name: create-branch
+description: Create a new git branch off of `develop` for the following work. Use when starting a new feature, fix, or task.
+triggers:
+  - "/create-branch"
+  - "create a branch"
+  - "create branch"
+  - "new branch"
+allowed-tools: Bash
+---
+
+# Create Branch
+
+Create a new git branch off of `origin/develop` and check it out locally.
+
+## Input
+
+`$ARGUMENTS` — desired branch name or a description of the work. If a full branch name is provided, use it as-is (after validating it). If a description is provided, infer a branch name from it.
+
+## Process
+
+### 1. Fetch latest remote state
+
+```bash
+git fetch origin
+```
+
+### 2. Determine branch name
+
+If `$ARGUMENTS` is provided:
+- If it looks like a branch name (kebab-case, already has a prefix), use it directly.
+- If it looks like a description (plain English), infer a branch name:
+  - Choose a prefix based on intent: `feat/`, `fix/`, `chore/`, or `docs/`
+  - Convert the description to kebab-case
+  - Keep the full name at 50 characters or fewer
+  - Examples: "add user auth" → `feat/add-user-auth`, "fix login timeout" → `fix/login-timeout`
+
+If `$ARGUMENTS` is omitted, infer the branch name from recent todos, open issues, or conversation context using the same rules above.
+
+### 3. Validate branch name
+
+Reject the following names outright — do not create them:
+- `main`
+- `master`
+- `develop`
+- `staging`
+
+If the inferred or provided name matches one of these, stop and ask the user for a different name.
+
+### 4. Create and checkout the branch
+
+```bash
+git checkout -b <name> origin/develop
+```
+
+### 5. Confirm
+
+Report the branch name that was created, e.g.:
+
+> Branch `feat/add-user-auth` created from `origin/develop`.
+
+## Constraints
+
+- Always branch from `origin/develop`, never from a local `develop` (which may be behind)
+- Never create branches named `main`, `master`, `develop`, or `staging`
+- Branch names must be kebab-case and 50 characters or fewer
+- If unable to infer a branch name and `$ARGUMENTS` is empty, ask the user what the branch is for

--- a/plugins/flowkit/skills/cut/SKILL.md
+++ b/plugins/flowkit/skills/cut/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: cut
+description: Create a release candidate branch from origin/develop. Detects staging at runtime and auto-stages the RC if origin/staging exists.
+triggers:
+  - "/cut"
+  - "cut a release"
+  - "create release candidate"
+  - "cut RC"
+allowed-tools: Bash
+---
+
+# Cut
+
+Create a versioned release candidate branch from `origin/develop`, then automatically stage it if `origin/staging` exists.
+
+## Input
+
+`$ARGUMENTS` — optional RC label or notes (e.g. "hotfix notes", "skip staging"). If omitted, all values are auto-derived.
+
+## Process
+
+### 1. Fetch latest remote state
+
+```bash
+git fetch origin
+```
+
+### 2. Determine RC branch name
+
+Base the name on today's date:
+
+```bash
+TODAY=$(date +%Y-%m-%d)
+RC_BASE="rc/$TODAY"
+```
+
+Count existing RC branches for today to find the next increment:
+
+```bash
+EXISTING=$(git ls-remote origin "rc/$TODAY*" | wc -l | tr -d ' ')
+N=$((EXISTING + 1))
+RC_BRANCH="rc/$TODAY.$N"
+```
+
+### 3. Create and push the RC branch
+
+```bash
+git checkout -b "$RC_BRANCH" origin/develop
+git push -u origin "$RC_BRANCH"
+```
+
+### 4. Runtime staging detection
+
+```bash
+git ls-remote --exit-code origin staging &>/dev/null && STAGING_EXISTS=true || STAGING_EXISTS=false
+```
+
+### 5. Auto-stage if staging exists
+
+If `STAGING_EXISTS=true`, immediately follow the `/stage` skill with `$RC_BRANCH` as the argument.
+
+### 6. Report
+
+Output:
+- RC branch name created (e.g. `rc/2026-04-16.1`)
+- Whether `origin/staging` was detected and updated
+
+## Constraints
+
+- Always cut from `origin/develop`, never from a local branch
+- RC branch naming must follow `rc/YYYY-MM-DD.N` exactly (N starts at 1)
+- Never push to any branch other than the new RC branch in this skill

--- a/plugins/flowkit/skills/gh-close-referenced-issues/SKILL.md
+++ b/plugins/flowkit/skills/gh-close-referenced-issues/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: gh-close-referenced-issues
+description: Close issues referenced in a merged PR body and auto-close completed epics. Sub-skill used by release.
+---
+
+# gh-close-referenced-issues
+
+Parse a merged PR body for `Closes/Fixes/Resolves #N` references and close each referenced issue when its work ships to `main`. Distinct from `gh-label-merged-issues`, which only labels issues on merge to `develop`.
+
+## Process
+
+1. Accept a PR number as input (caller passes it).
+
+2. Fetch the PR body:
+
+```bash
+BODY=$(gh pr view <PR_NUMBER> --json body --jq '.body')
+```
+
+3. Parse the body for `Closes/Fixes/Resolves #N` references (case-insensitive) and extract all issue numbers:
+
+```bash
+ISSUE_NUMBERS=$(echo "$BODY" | grep -oiE '(closes|fixes|resolves) #[0-9]+' | grep -oE '[0-9]+' | sort -u)
+```
+
+4. If no references found, exit silently.
+
+5. For each referenced issue number:
+   - Check labels: `gh issue view <N> --json labels --jq '.labels[].name'`
+   - Skip if `on-hold` label present (print `⊘ Skipped #N (on-hold)`)
+   - Otherwise close the issue with a comment:
+     ```bash
+     gh issue close <N> --comment "Shipped in this release."
+     ```
+   - Print `✓ Closed #N`
+
+6. After closing, check for epic completion. For each closed issue `<N>`:
+   - Find open issues with the `epic` label whose body contains a checklist reference to `#<N>` (matches both `- [ ] #N` and `- [x] #N`):
+     ```bash
+     gh issue list --label "epic" --state open --json number,body \
+       --jq '.[] | select(.body | test("- \\[[ x]\\] #<N>"))'
+     ```
+   - For each matching epic, check whether all checklist items are now closed:
+     ```bash
+     EPIC_BODY=$(gh issue view <EPIC_N> --json body --jq '.body')
+     CHILD_NUMBERS=$(echo "$EPIC_BODY" | grep -oE '- \[[ x]\] #[0-9]+' | grep -oE '#[0-9]+' | tr -d '#')
+     ```
+   - For each child number, verify its state: `gh issue view <CHILD_N> --json state --jq '.state'`
+   - If all children are `CLOSED`, close the epic:
+     ```bash
+     gh issue close <EPIC_N> --comment "All child issues resolved. Epic complete."
+     ```
+   - Print `✓ Closed epic #<EPIC_N>`
+
+7. Report summary:
+   - Issues closed
+   - Epics closed
+   - Issues skipped (on-hold)

--- a/plugins/flowkit/skills/git-sync-develop/SKILL.md
+++ b/plugins/flowkit/skills/git-sync-develop/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: git-sync-develop
+description: Check out develop and pull the latest from origin. Sub-skill used by sync, release, and hotfix.
+---
+
+# git-sync-develop
+
+Check out the `develop` branch and pull the latest from `origin`.
+
+## Process
+
+```bash
+git checkout develop
+git pull origin develop
+```
+
+## Constraints
+
+- Always pull after checkout — never leave develop at a stale commit

--- a/plugins/flowkit/skills/git-sync-main/SKILL.md
+++ b/plugins/flowkit/skills/git-sync-main/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: git-sync-main
+description: Check out main and pull the latest from origin. Sub-skill used by release and hotfix.
+---
+
+# git-sync-main
+
+Check out the `main` branch and pull the latest from `origin`.
+
+## Process
+
+```bash
+git checkout main
+git pull origin main
+```
+
+## Constraints
+
+- Always pull after checkout — never leave main at a stale commit

--- a/plugins/flowkit/skills/hotfix/SKILL.md
+++ b/plugins/flowkit/skills/hotfix/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: hotfix
+description: Emergency fix bypassing develop — branch off main, apply fix, PR to main, tag, and back-merge into develop.
+triggers:
+  - "/hotfix"
+  - "hotfix"
+  - "emergency fix"
+  - "patch main"
+allowed-tools: Bash
+---
+
+# Hotfix
+
+Apply an emergency fix directly to `main`, bypassing the normal `develop` cycle. Tags the fix on main and back-merges into develop to keep branches in sync.
+
+## Input
+
+`$ARGUMENTS` — description of the fix (required for branch naming and commit message). Example: "fix login crash on nil user".
+
+## Process
+
+### 1. Sync main
+
+Follow the `git-sync-main` sub-skill: check out `main` and pull the latest from origin.
+
+### 2. Create the hotfix branch
+
+Derive a kebab-case slug from `$ARGUMENTS` (e.g. `"fix login crash"` → `"fix-login-crash"`):
+
+```bash
+git checkout -b "hotfix/$(date +%Y-%m-%d)-<slug-from-args>" origin/main
+```
+
+### 3. Wait for the user to apply the fix
+
+Stop and prompt:
+
+> Ready on hotfix branch. Make your fix, then say 'done' to continue.
+
+Do not proceed until the user explicitly confirms the fix is in place.
+
+### 4. Commit
+
+Follow `/commit` with `$ARGUMENTS` as context for the commit message.
+
+### 5. Detect staging
+
+```bash
+git fetch origin
+git ls-remote --exit-code origin staging &>/dev/null && STAGING_EXISTS=true || STAGING_EXISTS=false
+```
+
+### 6. Scope the PR base to main
+
+Follow the `pr-base-scope` sub-skill to set `claude.prBase = main`.
+
+### 7. Open a PR targeting main
+
+Follow `/open-pr`. Because `claude.prBase = main`, the PR targets `main`.
+
+### 8. Merge the PR into main
+
+Follow `/merge-pr` to squash-merge the hotfix PR into `main`.
+
+### 9. Unset the PR base scope
+
+Follow the `pr-base-scope` sub-skill to unset `claude.prBase`.
+
+### 10. Tag the hotfix on main
+
+Create and push a hotfix tag directly on main (no RC cycle):
+
+```bash
+TAG="v$(date +%Y.%-m.%-d)-hotfix"
+git tag "$TAG" main
+git push origin "$TAG"
+```
+
+### 11. Close referenced issues
+
+Follow the `gh-close-referenced-issues` sub-skill, passing the merged PR number.
+
+### 12. Back-merge main into develop
+
+Keep `develop` in sync with the hotfix:
+
+```bash
+git fetch origin
+git checkout develop
+git pull origin develop
+git merge --no-ff origin/main -m "chore(develop): back-merge hotfix from main"
+git push origin develop
+```
+
+### 13. Sync develop
+
+Follow the `git-sync-develop` sub-skill to confirm a clean local develop state.
+
+### 14. Report
+
+Summarize:
+- Hotfix PR merged into main
+- Tag created (include the tag name)
+- Referenced issues closed
+- develop updated with back-merge
+
+## Constraints
+
+- Always wait for user confirmation between branch creation (step 2) and committing (step 4)
+- Always back-merge main into develop after the hotfix lands
+- Tag directly on main — do not run a full RC cycle for hotfixes
+- No self-review step — hotfix is an emergency flow
+- If any step fails, stop and report clearly — do not continue

--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: merge-pr
+description: Squash-merge the open PR for the current branch, delete the remote branch, and label referenced issues as merged-to-develop.
+triggers:
+  - "/merge-pr"
+  - "merge this PR"
+  - "merge the PR"
+  - "squash and merge"
+allowed-tools: Bash
+---
+
+# merge-pr
+
+Squash-merge the open PR for the current branch, delete the remote branch, and apply the `merged-to-develop` label to any issues referenced in the PR body.
+
+## Input
+
+`$ARGUMENTS` — optional PR number. If omitted, the skill auto-detects the open PR for the current branch.
+
+## Process
+
+### 1. Determine current branch
+
+```bash
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+```
+
+### 2. Find the open PR
+
+If `$ARGUMENTS` is provided, use it as `PR_NUM`. Otherwise:
+
+```bash
+PR_NUM=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number')
+```
+
+If `PR_NUM` is empty, abort with:
+
+> No open PR found for branch `$BRANCH`. Run /open-pr first.
+
+### 3. Squash-merge and delete the remote branch
+
+```bash
+gh pr merge "$PR_NUM" --squash --delete-branch
+```
+
+### 4. Label referenced issues
+
+Follow the `gh-label-merged-issues` sub-skill, passing `PR_NUM` as input. It will parse the PR body for `Closes/Fixes/Resolves #N` references and apply the `merged-to-develop` label to each referenced issue (skipping any with the `on-hold` label).
+
+### 5. Report
+
+Print a summary:
+
+> Merged PR #N. Labeled issues: #X, #Y.
+
+If no issues were referenced, omit the issues line.
+
+## Constraints
+
+- Never merge into `main` directly — this skill targets the default merge base only
+- Always squash-merge (never merge commit or rebase merge)
+- Always delete the remote branch on merge (`--delete-branch`)

--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: open-pr
+description: Push the current branch and open a GitHub pull request. Use after committing changes to land work on develop.
+triggers:
+  - "/open-pr"
+  - "open a PR"
+  - "push and open PR"
+  - "create PR"
+  - "open pull request"
+allowed-tools: Bash
+---
+
+# Open PR
+
+Push the current branch to origin and open a GitHub pull request against the base branch.
+
+## Input
+
+`$ARGUMENTS` — optional PR title or description hints. If provided, use this to inform the PR title and body. If omitted, derive the title from the branch name or most recent commit message.
+
+## Process
+
+### 1. Check current branch
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+If the current branch is `develop`, `main`, `master`, or `staging`, stop immediately and report:
+
+> Cannot open a PR from a protected branch. Check out a feature branch first.
+
+### 2. Determine base branch
+
+```bash
+BASE=$(git config claude.prBase 2>/dev/null || echo "develop")
+```
+
+Use `$BASE` as the PR target. This respects any scoped override set by the `pr-base-scope` sub-skill.
+
+### 3. Push branch to origin
+
+```bash
+git push -u origin HEAD
+```
+
+### 4. Determine PR title
+
+Use the first applicable source:
+1. `$ARGUMENTS` if it looks like a title (short phrase)
+2. The most recent commit message subject line
+3. The branch name converted to title case (strip prefix, replace hyphens with spaces)
+
+### 5. Determine PR body
+
+Use the first applicable source:
+1. `$ARGUMENTS` if it contains a longer description
+2. The full body of the most recent commit message
+3. A minimal placeholder referencing the branch
+
+### 6. Open the PR
+
+```bash
+gh pr create \
+  --base "$BASE" \
+  --head "$(git rev-parse --abbrev-ref HEAD)" \
+  --title "<title>" \
+  --body "<body>"
+```
+
+### 7. Report
+
+Output the PR URL returned by `gh pr create`.
+
+## Constraints
+
+- Never target `main` directly unless `claude.prBase` is explicitly set to `main`
+- Never open a PR from a protected branch (`develop`, `main`, `master`, `staging`)
+- If `gh` is not installed or not authenticated, report the error and stop — do not attempt workarounds
+- Do not force-push; use a plain `git push -u origin HEAD`

--- a/plugins/flowkit/skills/pr-base-scope/SKILL.md
+++ b/plugins/flowkit/skills/pr-base-scope/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: pr-base-scope
+description: Set or unset the claude.prBase git config key to scope the PR target branch for a session. Sub-skill used by ship and swarm loop mode.
+---
+
+# pr-base-scope
+
+Set or unset `claude.prBase` — a local git config key that tells `/open-pr` which branch to target when creating a pull request. Used by `/ship` to pin PRs to `develop` during the ship flow, and by swarm loop mode to scope multi-PR sessions.
+
+## Operations
+
+### Set
+
+Pin the PR target branch for the current session:
+
+```bash
+git config claude.prBase <branch>
+```
+
+Example — pin to develop:
+
+```bash
+git config claude.prBase develop
+```
+
+### Unset
+
+Revert to the default target (`develop`):
+
+```bash
+git config --unset claude.prBase
+```
+
+### Read
+
+Resolve the current target branch (used by `/open-pr`):
+
+```bash
+git config claude.prBase 2>/dev/null || echo "develop"
+```
+
+If the key is not set, this returns `develop` as the default.
+
+## Usage by Callers
+
+| Caller | Action |
+|--------|--------|
+| `/ship` | Sets `claude.prBase develop` before opening PRs, then unsets after the flow completes |
+| `/swarm` loop mode | Sets `claude.prBase` to the appropriate integration branch for the loop session |
+| `/open-pr` | Reads `claude.prBase` to resolve the target branch before creating the PR |
+
+## Constraints
+
+- This key is local to the repo — it is never committed or pushed
+- Always unset after a scoped flow completes to avoid stale targeting in future sessions

--- a/plugins/flowkit/skills/pr/SKILL.md
+++ b/plugins/flowkit/skills/pr/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: pr
+description: Wrap up existing changes and open a pull request. Combines create-branch, commit, and open-pr into a single workflow.
+triggers:
+  - "/pr"
+  - "create a PR for this"
+  - "open a pull request for"
+  - "wrap this up as a PR"
+allowed-tools: Bash
+---
+
+# PR
+
+Convenience orchestrator that runs `/create-branch`, `/commit`, and `/open-pr` in sequence to take uncommitted workspace changes all the way to an open pull request.
+
+## Input
+
+`$ARGUMENTS` — description of the work. Used to name the branch, write the commit message, and title the PR. If omitted, each sub-skill infers from context.
+
+## Process
+
+### 1. Check current branch
+
+```bash
+git rev-parse --abbrev-ref HEAD
+```
+
+If the current branch is already a non-protected branch (not `develop`, `main`, `master`, or `staging`), skip step 2 and go directly to step 3.
+
+### 2. Create branch (if on a protected branch)
+
+Follow `/create-branch` with `$ARGUMENTS` to create and check out a new branch off `origin/develop`.
+
+### 3. Commit changes
+
+Follow `/commit` with `$ARGUMENTS` to stage and commit all current workspace changes using conventional commits.
+
+If the workspace is already clean (nothing to commit), skip this step.
+
+### 4. Open PR
+
+Follow `/open-pr` with `$ARGUMENTS` to push the branch and open a GitHub pull request.
+
+### 5. Report
+
+Output the PR URL.
+
+## Constraints
+
+- Never skip the branch check — always detect whether you're already on a feature branch before creating a new one
+- Each step delegates fully to its sub-skill; do not re-implement their logic inline
+- If any step fails, stop and report the error — do not continue to the next step
+- If the workspace is clean and no commits are needed, note this and proceed directly to `/open-pr`

--- a/plugins/flowkit/skills/release-status/SKILL.md
+++ b/plugins/flowkit/skills/release-status/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: release-status
+description: Show what's in staging awaiting release and what's in develop awaiting a cut. Helps decide whether to run /cut or /release.
+triggers:
+  - "/release-status"
+  - "release status"
+  - "what's in staging"
+  - "what's ready to release"
+  - "check release pipeline"
+allowed-tools: Bash
+---
+
+# Release Status
+
+Report the current state of the release pipeline at a glance so you know whether to run `/cut` or `/release`.
+
+## Process
+
+### 1. Fetch latest remote state
+
+```bash
+git fetch origin
+```
+
+### 2. Detect staging branch at runtime
+
+```bash
+git ls-remote --exit-code origin staging &>/dev/null && STAGING_EXISTS=true || STAGING_EXISTS=false
+```
+
+### 3. Collect pipeline data
+
+Always collect:
+
+```bash
+git log origin/main..origin/develop --oneline
+git ls-remote origin "rc/*" | awk '{print $2}' | sed 's|refs/heads/||'
+git describe --tags --abbrev=0 2>/dev/null || echo "(no tags yet)"
+```
+
+If `STAGING_EXISTS=true`, also collect:
+
+```bash
+git log origin/main..origin/staging --oneline
+git log origin/staging..origin/develop --oneline
+```
+
+### 4. Format and display
+
+**When `STAGING_EXISTS=true`:**
+
+```
+── Release Pipeline Status ────────────────────────
+Last release: v2026.4.15
+
+Staging (awaiting /release):
+  • fix(auth): correct token expiry  (3h ago)
+  • feat(api): add pagination        (2d ago)
+
+Develop (awaiting /cut):
+  • chore(deps): bump axios          (1h ago)
+  • feat(ui): new dashboard layout   (30m ago)
+
+RC branches:
+  rc/2026-04-15.1  ← currently in staging
+
+Next step: /release to ship staging → main
+───────────────────────────────────────────────────
+```
+
+**When `STAGING_EXISTS=false`:**
+
+```
+── Release Pipeline Status ────────────────────────
+Last release: v2026.4.15
+(No staging branch detected)
+
+Develop (awaiting /cut + /release):
+  • feat(ui): new dashboard layout   (30m ago)
+  • chore(deps): bump axios          (1h ago)
+
+RC branches: none
+
+Next step: /cut to create a release candidate
+───────────────────────────────────────────────────
+```
+
+If develop has no new commits relative to main, show "Develop is up to date with main." instead of a commit list.
+
+### 5. Suggest next action
+
+| Condition | Suggestion |
+|-----------|------------|
+| Staging has commits | `/release` to ship staging → main |
+| Develop has commits, no staging | `/cut` to create a release candidate |
+| Nothing pending | "Nothing to ship. Develop is in sync with main." |
+
+## Constraints
+
+- Read-only — never mutate any branch or tag
+- Always run `git fetch origin` first to ensure data is current

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -1,0 +1,133 @@
+---
+name: release
+description: Merge staging (or RC) to main via PR, tag the release, close referenced issues, and clean up RC branches.
+triggers:
+  - "/release"
+  - "release this"
+  - "ship to main"
+  - "promote to main"
+  - "release to production"
+allowed-tools: Bash
+---
+
+# Release
+
+Promote the current release candidate to production: open a PR into `main`, merge it, tag the commit, close referenced issues, delete RC branches, and sync develop.
+
+## Input
+
+`$ARGUMENTS` — optional version tag or release notes to include in the PR body. If omitted, everything is auto-derived.
+
+## Process
+
+### 1. Fetch latest remote state
+
+```bash
+git fetch origin
+```
+
+### 2. Runtime staging detection
+
+```bash
+git ls-remote --exit-code origin staging &>/dev/null && STAGING_EXISTS=true || STAGING_EXISTS=false
+```
+
+### 3. Determine source branch
+
+```bash
+if [ "$STAGING_EXISTS" = "true" ]; then
+  SOURCE="staging"
+else
+  SOURCE=$(git ls-remote --sort=-version:refname origin "rc/*" \
+    | head -1 \
+    | awk '{print $2}' \
+    | sed 's|refs/heads/||')
+fi
+```
+
+If `SOURCE` is empty, abort with an error — there is nothing to release.
+
+### 4. Create a PR from SOURCE → main
+
+```bash
+RELEASE_DATE=$(date +%Y-%m-%d)
+PR_BODY="Release from $SOURCE"
+[ -n "$ARGUMENTS" ] && PR_BODY="$PR_BODY
+
+$ARGUMENTS"
+
+gh pr create \
+  --base main \
+  --head "$SOURCE" \
+  --title "release: $RELEASE_DATE" \
+  --body "$PR_BODY"
+```
+
+Capture the PR number from the URL output.
+
+### 5. Merge the PR
+
+```bash
+gh pr merge "$PR_URL" --squash --delete-branch
+```
+
+Use `--squash` for a clean, linear history regardless of whether the source is `staging` or an RC branch.
+
+### 6. Sync main
+
+Follow the `git-sync-main` sub-skill.
+
+### 7. Create a git tag
+
+```bash
+TAG="v$(date +%Y.%-m.%-d)"
+```
+
+If the tag already exists, append an increment:
+
+```bash
+N=1
+while git ls-remote --exit-code origin "refs/tags/$TAG.$N" &>/dev/null; do
+  N=$((N + 1))
+done
+[ "$(git ls-remote --exit-code origin refs/tags/$TAG &>/dev/null; echo $?)" = "0" ] \
+  && TAG="$TAG.$N"
+
+git tag "$TAG"
+git push origin "$TAG"
+```
+
+### 8. Close referenced issues
+
+Follow the `gh-close-referenced-issues` sub-skill, passing the release PR number.
+
+### 9. Clean up RC branches for today
+
+```bash
+TODAY=$(date +%Y-%m-%d)
+git ls-remote origin "rc/$TODAY*" \
+  | awk '{print $2}' \
+  | sed 's|refs/heads/||' \
+  | while read rc; do
+      git push origin --delete "$rc" 2>/dev/null || true
+    done
+```
+
+### 10. Sync develop
+
+Follow the `git-sync-develop` sub-skill.
+
+### 11. Report
+
+Output:
+- Tag created (e.g. `v2026.4.16`)
+- PR number and URL
+- Issues closed
+- RC branches deleted
+
+## Constraints
+
+- Never push directly to `main` — always merge via PR
+- Always create the git tag after the merge, never before
+- Always sync both `main` and `develop` after release
+- If no RC branch exists and staging is absent, abort with a clear error message

--- a/plugins/flowkit/skills/ship/SKILL.md
+++ b/plugins/flowkit/skills/ship/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: ship
+description: Full one-shot ship cycle — branch → commit → PR → merge → RC → release. Runs the complete flowkit pipeline from wherever you are on a branch.
+triggers:
+  - "/ship"
+  - "ship this"
+  - "ship it"
+  - "ship the work"
+  - "full ship cycle"
+allowed-tools: Bash
+---
+
+# Ship
+
+Run the full release pipeline from current branch state to a tagged release on main. Handles branching, committing, opening/merging a PR, cutting an RC, and releasing.
+
+## Input
+
+`$ARGUMENTS` — optional description or context passed to `/open-pr` as the PR description. If omitted, the PR description is inferred from commits.
+
+## Process
+
+### 1. Scope the PR base
+
+Follow the `pr-base-scope` sub-skill to set `claude.prBase = develop`. This ensures all PR operations in this pipeline target `develop`.
+
+### 2. Get work onto develop via PR
+
+Detect the current state and act accordingly:
+
+- **On `develop`, `main`, or `staging`**: follow `/pr $ARGUMENTS` — this will create a branch, commit, and open a PR targeting develop.
+- **On a feature branch with uncommitted changes**: follow `/commit`, then follow `/open-pr`.
+- **On a feature branch with an open PR already**: skip directly to step 3.
+- **On a feature branch, changes committed, no open PR**: follow `/open-pr`.
+
+### 3. Merge the PR into develop
+
+Follow `/merge-pr` to squash-merge the open PR into `develop`.
+
+### 4. Sync develop
+
+Follow `/sync` to check out `develop`, pull latest, and prune stale branches.
+
+### 5. Cut a release candidate
+
+Follow `/cut` to create an `rc/YYYY-MM-DD.N` branch from `origin/develop`. If `origin/staging` exists, `/cut` will auto-stage it.
+
+### 6. Release
+
+Follow `/release` to merge to `main`, create the version tag, close referenced issues, and clean up RC branches.
+
+### 7. Unset the PR base scope
+
+Follow the `pr-base-scope` sub-skill to unset `claude.prBase`.
+
+### 8. Report
+
+Summarize what happened:
+- Which PR was merged and into which base
+- Which RC was created
+- Which tag was created on main
+- Which issues were closed
+
+## Constraints
+
+- Always set `claude.prBase` at the start and unset it at the end — never leave it set
+- No self-review step — `/ship` is a pipeline, not a quality gate
+- If any step fails, stop immediately and report what failed and why — do not attempt to continue past a failure
+- Never commit directly to `develop` or `main`

--- a/plugins/flowkit/skills/stage/SKILL.md
+++ b/plugins/flowkit/skills/stage/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: stage
+description: Force-reset the staging branch to a release candidate. Graceful no-op if origin/staging does not exist.
+triggers:
+  - "/stage"
+  - "push to staging"
+  - "deploy to staging"
+  - "stage this RC"
+allowed-tools: Bash
+---
+
+# Stage
+
+Force-reset `origin/staging` to point at a release candidate branch.
+
+## Input
+
+`$ARGUMENTS` — optional RC branch name (e.g. `rc/2026-04-16.1`). If omitted, the RC is auto-detected from the current branch or the most recent RC on origin.
+
+## Process
+
+### 1. Determine RC branch
+
+Resolution order:
+
+1. If `$ARGUMENTS` is provided, use it as the RC branch name.
+2. Else if the current branch matches `rc/*`, use it.
+3. Else find the most recent RC on origin:
+
+```bash
+RC_BRANCH=$(git ls-remote --sort=-version:refname origin "rc/*" \
+  | head -1 \
+  | awk '{print $2}' \
+  | sed 's|refs/heads/||')
+```
+
+If no RC branch is found at this point, abort with an error.
+
+### 2. Runtime staging detection
+
+```bash
+git ls-remote --exit-code origin staging &>/dev/null || {
+  echo "No staging branch on origin — skipping."
+  exit 0
+}
+```
+
+This is a graceful no-op, not an error. Repos without a staging branch use `rc → main` directly.
+
+### 3. Force-reset staging to the RC
+
+```bash
+git push origin "$RC_BRANCH":staging --force
+```
+
+### 4. Report
+
+Output:
+- RC branch used (e.g. `rc/2026-04-16.1`)
+- Confirmation that `origin/staging` now points to that RC
+
+## Constraints
+
+- If `origin/staging` does not exist, exit 0 silently — never treat it as an error
+- Never force-push any branch other than `staging`
+- Never modify the RC branch itself

--- a/plugins/flowkit/skills/sync/SKILL.md
+++ b/plugins/flowkit/skills/sync/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: sync
+description: Sync local develop after a merge — pull latest, prune stale remote-tracking refs, and delete merged local branches.
+triggers:
+  - "/sync"
+  - "sync develop"
+  - "sync back to develop"
+  - "clean up after merge"
+allowed-tools: Bash
+---
+
+# sync
+
+Return to a clean `develop` state after a PR has been merged. Pulls the latest from origin, prunes stale remote-tracking refs, and removes local branches that have already been merged into `develop`.
+
+## Input
+
+No arguments.
+
+## Process
+
+### 1. Switch to develop and pull
+
+Follow the `git-sync-develop` sub-skill: check out `develop` and pull the latest from origin.
+
+### 2. Prune stale remote-tracking refs
+
+```bash
+git fetch --prune
+```
+
+### 3. Delete merged local branches
+
+List local branches fully merged into `develop` (excluding `develop`, `main`, `staging`, and the current branch), then delete them:
+
+```bash
+git branch --merged develop | grep -vE '^\*|develop|main|staging' | xargs -r git branch -d
+```
+
+### 4. Report
+
+Print a summary:
+
+- Current HEAD (branch + latest commit)
+- Any local branches deleted (or "No merged branches to clean up" if none)

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -153,7 +153,7 @@ Each agent prompt MUST include these **workflow steps** (in order):
 
 ### 6. Clean up
 
-Run the `clean-worktrees` skill to remove agent worktrees and orphaned branches.
+Run `/clean-worktrees` to remove agent worktrees and orphaned branches. This frees local `worktree-agent-*` branches so the merge step can use `--delete-branch` without conflicts.
 
 ### 7. Merge PRs
 


### PR DESCRIPTION
## Summary

- feat: **flowkit** — new git/release lifecycle plugin with 12 user-facing skills and 4 sub-skills (#2, #3, #4, #5, #6, #7, #8, #9, #10)
- fix: **swarm** — document that `/clean-worktrees` must run before merge loop to allow `--delete-branch` (#21)

## PRs included

- #12 feat(flowkit): add plugin structure and manifest
- #13 feat(flowkit): add sub-skills for git sync, issue closing, and PR base scoping
- #14 feat(flowkit): add commit skill with inlined conventional format
- #15 feat(flowkit): add merge-pr and sync skills
- #16 feat(flowkit): add create-branch, open-pr, and pr skills
- #17 feat(flowkit): add cut, stage, and release skills with runtime staging detection
- #18 feat(flowkit): add release-status skill
- #19 feat(flowkit): add ship and hotfix skills
- #20 docs(flowkit): write README
- #22 fix(swarm): clean worktrees before merging PRs to allow --delete-branch

## Test plan

- [ ] `plugins/flowkit/.claude-plugin/plugin.json` exists and matches the structure of other plugins
- [ ] All 12 user-facing SKILL.md files are present under `plugins/flowkit/skills/`
- [ ] All 4 sub-skill SKILL.md files are present
- [ ] `plugins/flowkit/README.md` exists and covers all skills
- [ ] `plugins/swarmkit/skills/swarm/SKILL.md` step 6 mentions freeing local branches before merge