### PR TITLE
fix(skills): audit and fix for-in bash loops, add authoring convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,7 @@ A collection of plugins for Claude Code.
 | **swarmkit** | `/plugin install swarmkit@smallorbit-plugins` | Spec, swarm, and ship GitHub issues with parallel agents |
 
 See each plugin's README for detailed usage.
+
+## Skill Authoring Conventions
+
+**Bash loop convention**: Never use `for N in $VAR` to iterate over newline-delimited output — word splitting is unreliable across shell contexts. Always pipe directly: `some-command | while read N; do ... done`.


### PR DESCRIPTION
## Summary

- Audited all `*.md` skill files under `plugins/` for `for N in $VAR` bash loop patterns — none found
- Added **Bash loop convention** note to `README.md` under a new "Skill Authoring Conventions" section to prevent future use of word-splitting `for N in $VAR` patterns

Closes #34