### PR TITLE
feat(repo): add bump-versions skill and bump all plugins to semver

### DIFF
--- a/.claude/HANDOFF.md
+++ b/.claude/HANDOFF.md
@@ -1,0 +1,42 @@
+# Handoff
+
+**Project**: /Users/roman/src/smallorbit-plugins
+**Date**: 2026-04-16
+**Branch**: develop
+
+## Goal
+Ongoing maintenance of the smallorbit-plugins repo — fixing bugs found in live
+usage of swarmkit and flowkit, and shipping them through a full release cycle.
+
+## Progress
+- Added flowkit, sessionkit, and speckit to marketplace.json (PR #24, released)
+- Fixed release skill to aggregate `Closes #N` refs into release PR body (PR #26, released)
+- Fixed swarm plan auto-proceed delay 60s → 30s (PR #30, released)
+- Fixed release skill to filter merged PRs by tag date (PR #31, released — but still has bugs, see Remaining Work)
+- Hardened clean-worktrees: double-force removal, prune-first, cd-to-root (PR #32, released)
+- Released all of the above as `v2026.4.16`
+- Filed issues #34, #35, #36 for known remaining bugs
+
+## Git State
+- Branch: develop (in sync with main at v2026.4.16)
+- Staged: none
+- Unstaged: none
+- Recent commits:
+  - `70b5e78` fix(swarmkit): harden clean-worktrees (#32)
+  - `25ce224` fix(flowkit): filter merged PRs by tag date (#31)
+  - `0172df7` fix(swarmkit): reduce swarm plan auto-proceed delay (#30)
+  - `1d03c5b` fix(flowkit): aggregate Closes references into release PR body (#26)
+  - `f4e03d7` feat(marketplace): add flowkit, sessionkit, and speckit plugins (#24)
+
+## Remaining Work
+1. **#35 (high/bug)** — Release step 4 still broken: `--base "$SOURCE"` should always be `--base develop`; jq `--arg` syntax doesn't work in `gh pr list` — needs shell string interpolation
+2. **#36 (medium/enhancement)** — Auto-close epics by appending `Closes #epic` to release PR body; remove `gh-close-referenced-issues` sub-skill once done
+3. **#34 (medium/bug)** — Audit all skill files for `for N in $VAR` and replace with `while read N` piped pattern
+
+## Context
+- Staging branch exists on this repo (`develop → staging → main` flow)
+- Release works by force-pushing an RC branch to staging, then opening a PR staging → main
+- `gh-close-referenced-issues` sub-skill is now partially redundant: GitHub auto-closes issues referenced in the release PR body. The sub-skill's only remaining value is epic auto-close (step 6) — which #36 proposes to replace with native GitHub behavior
+- The `gh pr list --jq --arg` syntax silently fails; always use shell string interpolation for variable injection into jq expressions
+- `--base staging` returns empty because staging is force-pushed, not PR-merged; always use `--base develop` for issue ref aggregation
+- All agent worktrees use double-force removal (`-f -f`) now — needed for claude-agent-locked worktrees

--- a/.claude/skills/bump-versions/SKILL.md
+++ b/.claude/skills/bump-versions/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: bump-versions
+description: Bump plugin.json versions for changed plugins and create per-plugin semver git tags. Run before every release.
+triggers:
+  - "bump versions"
+  - "bump plugin versions"
+  - "version bump"
+---
+
+# Bump Plugin Versions
+
+Bumps `plugin.json` version fields for plugins that have changed since their last release, then creates per-plugin git tags so clients detect the update.
+
+## Plugin locations
+
+| Plugin | plugin.json |
+|--------|-------------|
+| swarmkit | `plugins/swarmkit/.claude-plugin/plugin.json` |
+| flowkit | `plugins/flowkit/.claude-plugin/plugin.json` |
+| sessionkit | `plugins/sessionkit/.claude-plugin/plugin.json` |
+| speckit | `plugins/speckit/.claude-plugin/plugin.json` |
+
+## Git tag format
+
+Per-plugin tags use the format `{plugin-name}--v{version}` (e.g. `swarmkit--v1.2.0`).  
+Repo-level calver tags (`v2026.4.16`) are separate and not used for plugin version detection.
+
+## Process
+
+### Step 1 — Detect changed plugins
+
+For each plugin, find the most recent `{plugin-name}--v*` tag:
+
+```bash
+git tag --list 'swarmkit--v*' | sort -V | tail -1
+```
+
+If no per-plugin tag exists, use the current version in `plugin.json` as the baseline and treat all files as changed.
+
+Count commits touching the plugin's directory since that tag:
+
+```bash
+git log {tag}..HEAD --oneline -- plugins/{name}/ | wc -l
+```
+
+### Step 2 — Present summary and ask for bump types
+
+Display a table of plugins with changes:
+
+```
+Plugin      Current   Commits since last tag
+----------  --------  ----------------------
+swarmkit    1.0.0     4
+flowkit     1.0.0     2
+```
+
+For each changed plugin, ask the user whether to bump **patch**, **minor**, or **major**:
+
+- **patch** — bug fixes, no new behavior (`1.0.0 → 1.0.1`)
+- **minor** — new skills or backward-compatible features (`1.0.0 → 1.1.0`)
+- **major** — breaking changes (`1.0.0 → 2.0.0`)
+
+If `$ARGUMENTS` is provided (e.g. `patch` or `minor`), apply that bump type to all changed plugins without asking.
+
+Skip plugins with 0 commits since their last tag unless explicitly included via `$ARGUMENTS`.
+
+### Step 3 — Update plugin.json files
+
+For each plugin being bumped, read the current `plugin.json`, increment the version field, and write it back.
+
+### Step 4 — Create git tags
+
+After updating all `plugin.json` files, create a tag for each bumped plugin:
+
+```bash
+git tag {plugin-name}--v{new-version}
+```
+
+Do NOT push tags — leave that to the release flow.
+
+### Step 5 — Report
+
+Print a summary of what changed:
+
+```
+Bumped:
+  swarmkit  1.0.0 → 1.0.1  (tag: swarmkit--v1.0.1)
+  flowkit   1.0.0 → 1.1.0  (tag: flowkit--v1.1.0)
+
+Next: commit the plugin.json changes, then push tags with:
+  git push origin --tags
+```
+
+## Notes
+
+- Always read `plugin.json` before editing it (required by Edit tool).
+- Increment only the relevant semver component; reset lower components to 0 (e.g. minor bump `1.2.3 → 1.3.0`).
+- If a plugin has no per-plugin tag yet, its first tag will be created from the current `plugin.json` version (no bump required unless changes exist).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# smallorbit-plugins
+
+Monorepo hosting Claude Code plugins: swarmkit, flowkit, sessionkit, and speckit.
+
+## Release Process
+
+Before every release, run `/bump-versions` to increment `plugin.json` versions for any plugins that have changed. This is required — without a version bump, existing users' clients won't pick up the updated code.
+
+The bump-versions skill handles:
+1. Detecting which plugins have changed since their last per-plugin tag
+2. Asking for semver bump type (patch / minor / major) per plugin
+3. Updating each `plugin.json`
+4. Creating per-plugin git tags (`{plugin-name}--v{version}`)
+
+Run it before staging and committing the release.

--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship — with runtime staging detection and a one-command hotfix flow.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Román M. Pacheco"
   }

--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sessionkit",
   "description": "Session continuity and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, plan through structured interviews, discover reusable skills, and reduce permission noise.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Román M. Pacheco"
   }

--- a/plugins/speckit/.claude-plugin/plugin.json
+++ b/plugins/speckit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "speckit",
   "description": "Define and capture work as GitHub issues. Interview a feature into existence with /spec, bulk-convert findings with /catalog, or quickly file a single issue with /issue.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Román M. Pacheco"
   }

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "author": {
     "name": "Román M. Pacheco"
   }


### PR DESCRIPTION
## Summary

- Adds `.claude/skills/bump-versions/SKILL.md` — a repo-local skill that detects changed plugins since their last per-plugin tag, asks for semver bump type (patch/minor/major), updates `plugin.json` files, and creates `{plugin-name}--v{version}` git tags
- Adds `CLAUDE.md` with repo-level instructions to run `/bump-versions` before every release
- Bumps all four plugin versions to their first semver release:
  - `swarmkit`: `1.0.0 → 1.1.0` (minor)
  - `flowkit`: `1.0.0 → 1.1.0` (minor)
  - `sessionkit`: `1.0.0 → 1.0.1` (patch)
  - `speckit`: `1.0.0 → 1.0.1` (patch)

## Test plan

- [ ] Verify `/bump-versions` skill is available in this repo after install
- [ ] Confirm per-plugin tags (`swarmkit--v1.1.0`, etc.) are visible via `git tag`
- [ ] Confirm updated versions appear in each `plugin.json`