### PR TITLE
feat(docs): add GitHub Pages skeleton with dark terminal design system

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>smallorbit plugins — The complete Claude Code workflow toolkit</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header><!-- hero section placeholder --></header>
+  <main>
+    <section id="flow"><!-- step-flow diagram placeholder --></section>
+    <section id="plugins"><!-- plugin cards placeholder --></section>
+    <section id="install"><!-- install CTA placeholder --></section>
+  </main>
+  <footer>
+    <p>Built for <a href="https://claude.ai/code">Claude Code</a> · <a href="https://github.com/smallorbit/smallorbit-plugins">GitHub</a></p>
+  </footer>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,0 +1,88 @@
+:root {
+  --bg: #0d1117;
+  --surface: #161b22;
+  --surface-raised: #21262d;
+  --border: #30363d;
+  --text: #e6edf3;
+  --text-muted: #8b949e;
+  --accent-green: #3fb950;
+  --accent-blue: #58a6ff;
+  --accent-purple: #bc8cff;
+  --radius: 8px;
+  --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: var(--font-mono);
+  line-height: 1.6;
+  font-size: 15px;
+}
+
+a { color: var(--accent-blue); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+/* Layout */
+.container { max-width: 1100px; margin: 0 auto; padding: 0 24px; }
+
+/* Section spacing */
+section { padding: 80px 0; }
+section + section { border-top: 1px solid var(--border); }
+
+/* Section title */
+.section-title {
+  font-size: 1.4rem;
+  color: var(--accent-green);
+  margin-bottom: 40px;
+  letter-spacing: 0.05em;
+}
+.section-title::before { content: '> '; opacity: 0.5; }
+
+/* Cards */
+.card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 24px;
+  transition: border-color 0.2s;
+}
+.card:hover { border-color: var(--accent-blue); }
+
+/* Badge */
+.badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  padding: 2px 8px;
+  border-radius: 20px;
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  letter-spacing: 0.03em;
+}
+
+/* Code block */
+pre {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  overflow-x: auto;
+  font-size: 0.9rem;
+}
+
+code { font-family: var(--font-mono); }
+
+/* Glow utilities */
+.glow-green { box-shadow: 0 0 20px rgba(63, 185, 80, 0.15); }
+.glow-blue  { box-shadow: 0 0 20px rgba(88, 166, 255, 0.15); }
+
+/* Footer */
+footer {
+  padding: 40px 0;
+  border-top: 1px solid var(--border);
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
Sets up the `docs/` directory for GitHub Pages and establishes the HTML5 skeleton and CSS design system for the one-pager.

Closes #110
Closes #111