### PR TITLE
fix(docs): correct flow order to speckit → swarmkit → flowkit, reposition sessionkit

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,7 @@
     <div class="container hero">
       <div class="hero-prompt">~/smallorbit-plugins<span class="cursor">▋</span></div>
       <h1 class="hero-title">The complete Claude Code<br>workflow toolkit.</h1>
-      <p class="hero-sub">Four plugins. One end-to-end flow. From idea to production — spec it, ship it, scale it, continue it.</p>
+      <p class="hero-sub">Four plugins. One end-to-end flow. Spec your work, execute it in parallel, ship it — with sessionkit keeping context across every phase.</p>
       <a href="#install" class="hero-cta">Get started →</a>
     </div>
   </header>
@@ -31,17 +31,8 @@
           </div>
           <div class="flow-arrow">→</div>
           <div class="flow-node">
-            <div class="flow-node-name">flowkit</div>
-            <div class="flow-node-label">ship it</div>
-            <div class="flow-node-cmds">
-              <span>/pr</span>
-              <span>/release</span>
-            </div>
-          </div>
-          <div class="flow-arrow">→</div>
-          <div class="flow-node">
             <div class="flow-node-name">swarmkit</div>
-            <div class="flow-node-label">scale it</div>
+            <div class="flow-node-label">execute it</div>
             <div class="flow-node-cmds">
               <span>/swarm</span>
               <span>/merge-stack</span>
@@ -49,8 +40,19 @@
           </div>
           <div class="flow-arrow">→</div>
           <div class="flow-node">
+            <div class="flow-node-name">flowkit</div>
+            <div class="flow-node-label">ship it</div>
+            <div class="flow-node-cmds">
+              <span>/cut</span>
+              <span>/release</span>
+            </div>
+          </div>
+        </div>
+        <div class="flow-throughout">
+          <div class="flow-throughout-label">throughout all phases</div>
+          <div class="flow-node flow-node--throughout">
             <div class="flow-node-name">sessionkit</div>
-            <div class="flow-node-label">continue it</div>
+            <div class="flow-node-label">stay in flow</div>
             <div class="flow-node-cmds">
               <span>/handoff</span>
               <span>/pickup</span>

--- a/docs/style.css
+++ b/docs/style.css
@@ -296,3 +296,28 @@ footer {
 }
 .copy-btn:hover { background: var(--border); color: var(--text); }
 .copy-btn:focus-visible { outline: 2px solid var(--accent-blue); outline-offset: 2px; }
+
+/* sessionkit "throughout" */
+.flow-throughout {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  margin-top: 28px;
+}
+.flow-throughout-label {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+.flow-node--throughout {
+  border-style: dashed;
+  border-color: var(--accent-purple);
+  min-width: 220px;
+}
+.flow-node--throughout .flow-node-name { color: var(--accent-purple); }
+.flow-node--throughout:hover {
+  border-color: var(--accent-purple);
+  box-shadow: 0 0 20px rgba(188, 140, 255, 0.15);
+}


### PR DESCRIPTION
fix one-pager flow order and sessionkit positioning

Corrects the end-to-end flow diagram: speckit → swarmkit → flowkit (not flowkit before swarmkit). Repositions sessionkit as an always-on 'throughout all phases' element rather than a sequential step.