### PR TITLE
feat(docs): add README links to plugin cards

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -70,6 +70,7 @@
             <div class="plugin-card-header">
               <span class="plugin-name">speckit</span>
               <span class="badge">v1.2.0</span>
+              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/speckit" target="_blank" rel="noopener">README →</a>
             </div>
             <p class="plugin-desc">Define and capture work as GitHub issues. Interview a feature into existence, bulk-convert findings, or quickly file a single issue.</p>
             <ul class="skill-list">
@@ -84,6 +85,7 @@
             <div class="plugin-card-header">
               <span class="plugin-name">flowkit</span>
               <span class="badge">v1.2.1</span>
+              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/flowkit" target="_blank" rel="noopener">README →</a>
             </div>
             <p class="plugin-desc">Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship — with runtime staging detection.</p>
             <ul class="skill-list">
@@ -99,6 +101,7 @@
             <div class="plugin-card-header">
               <span class="plugin-name">swarmkit</span>
               <span class="badge">v2.0.0</span>
+              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/swarmkit" target="_blank" rel="noopener">README →</a>
             </div>
             <p class="plugin-desc">Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order.</p>
             <ul class="skill-list">
@@ -113,6 +116,7 @@
             <div class="plugin-card-header">
               <span class="plugin-name">sessionkit</span>
               <span class="badge">v1.1.0</span>
+              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/sessionkit" target="_blank" rel="noopener">README →</a>
             </div>
             <p class="plugin-desc">Session continuity and meta-learning for Claude Code. Hand off context, resume seamlessly, discover reusable skills, reduce permission noise.</p>
             <ul class="skill-list">

--- a/docs/style.css
+++ b/docs/style.css
@@ -231,6 +231,14 @@ footer {
   font-weight: 600;
   color: var(--accent-green);
 }
+.plugin-card-header { justify-content: flex-start; }
+.plugin-readme {
+  margin-left: auto;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+.plugin-readme:hover { color: var(--accent-blue); text-decoration: none; }
 .plugin-desc {
   font-size: 0.875rem;
   color: var(--text-muted);


### PR DESCRIPTION
add README links to plugin cards

Adds a right-aligned 'README →' link to each plugin card header, opening the plugin's GitHub README in a new tab.