### PR TITLE
fix(swarmkit): merge-stack uses top-down order with ref accumulation

### DIFF
--- a/plugins/swarmkit/skills/merge-stack/SKILL.md
+++ b/plugins/swarmkit/skills/merge-stack/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: merge-stack
-description: Merge all open swarm PRs bottom-up in dependency order. Used after swarmkit:swarm completes to cascade-merge the stacked PR chain.
+description: Merge all open swarm PRs top-down, accumulating issue refs as the stack collapses into the base branch.
 ---
 
 # merge-stack
 
-Merges all open swarm PRs in dependency order — bottom-up, so the most foundational PRs merge first and GitHub automatically retargets dependent PRs to `$BASE` as each merge completes.
+Merges all open swarm PRs top-down — leaf PRs first, cascading down to the base branch. Each merge injects the absorbed PR's `Closes` refs into the next PR's body so refs accumulate on the way down. The PR that finally merges into `$BASE` carries the complete ref set for the entire stack.
+
+This avoids the auto-close cascade caused by bottom-up merging: merging bottom-up deletes the base branch of the PR above it, which GitHub interprets as abandonment and auto-closes the dependent PR.
 
 ## When to use
 
@@ -24,65 +26,102 @@ gh pr list --state open --json number,title,headRefName,baseRefName,body \
 
 If no open swarm PRs are found, report "No open swarm PRs found" and stop.
 
-### 2. Reconstruct dependency order
+### 2. Build the stack graph
 
-For each PR, extract the issue number it closes from the body (`Closes #N`):
+Model the PRs as a directed graph where an edge A → B means "A's head branch is B's base branch" (A sits on top of B). Build this from the `headRefName` / `baseRefName` fields — no issue-body parsing needed for ordering.
 
-```bash
-echo "$PR_BODY" | grep -oiE '(closes|fixes|resolves) #[0-9]+' | grep -oE '[0-9]+'
-```
+Identify:
+- **Leaves**: PRs whose `headRefName` is not the `baseRefName` of any other open PR — these are the tops of chains and merge first.
+- **Root PRs**: PRs whose `baseRefName` is `$BASE` (e.g. `develop`) — these merge last.
+- **Independent PRs**: PRs whose `baseRefName` is already `$BASE` and that no other PR sits on top of — these have no stack relationship and can merge in any order after stacked chains resolve.
 
-Fetch each referenced issue body to extract dependency edges:
-
-```bash
-gh issue view <N> --json body --jq '.body' | grep -oiE '(depends on|blocked by) #[0-9]+' | grep -oE '[0-9]+'
-```
-
-Build a DAG from these edges. Produce a topological sort: PRs with no dependencies (or whose dependencies are already merged) come first.
+For each chain, the merge order is: leaf → … → root (top-down).
 
 ### 3. Present merge plan
 
-Show the merge order before proceeding:
+Show the plan before proceeding:
 
 ```
-Merge order (bottom-up):
-  1. PR #103 → closes #90 (no deps)
-  2. PR #105 → closes #91 (deps: #90)
-  3. PR #106 → closes #94 (deps: #90, #91, #93)
+Merge order (top-down per chain):
+  Chain 1:  PR #105 → PR #104 → PR #103 → develop
+  Chain 2:  PR #108 → develop  (independent)
+
+  Step 1. Merge PR #105 into worktree-agent-104 (head of chain 1)
+  Step 2. Accumulate refs from #105 into PR #104 body
+  Step 3. Merge PR #104 into worktree-agent-103
+  Step 4. Accumulate refs from #104 into PR #103 body
+  Step 5. Merge PR #103 into develop
+  Step 6. Merge PR #108 into develop
 ```
 
 Proceed immediately.
 
-### 4. Merge in order
+### 4. Merge top-down with ref accumulation
 
-For each PR in the sorted order:
+For each chain, work from the leaf down. For each PR in order:
 
-1. Check mergeability:
-   ```bash
-   gh pr view <N> --json mergeable,mergeStateStatus,baseRefName
-   ```
+#### 4a. Check mergeability
 
-2. If `mergeStateStatus` is `BEHIND` (base has moved): update the branch:
-   ```bash
-   gh pr update-branch <N>
-   ```
-   Wait a moment and re-check before merging.
+```bash
+gh pr view <N> --json mergeable,mergeStateStatus,baseRefName
+```
 
-3. Merge:
-   ```bash
-   gh pr merge <N> --squash --delete-branch
-   ```
+If `mergeStateStatus` is `BEHIND`: update the branch and re-check:
 
-4. After each merge, pause briefly for GitHub to retarget dependent PRs:
-   ```bash
-   sleep 3
-   ```
+```bash
+gh pr update-branch <N>
+sleep 3
+```
 
-5. If a merge fails with `CONFLICTING`:
-   - Report the conflict clearly
-   - Skip this PR and all PRs that depend on it
-   - Continue merging independent PRs
-   - At the end, list all skipped PRs and their dependents
+#### 4b. Collect this PR's issue refs
+
+Extract all `Closes/Fixes/Resolves #N` references from the PR body:
+
+```bash
+REFS=$(echo "$PR_BODY" | grep -oiE '(closes|fixes|resolves) #[0-9]+' | sort -u)
+```
+
+#### 4c. Merge — without deleting the base branch
+
+For PRs that are **not** merging into `$BASE` (i.e. their base is another `worktree-agent-*` branch), omit `--delete-branch` so the base branch survives for the next merge step:
+
+```bash
+# Intermediate merge (base is a worktree-agent-* branch)
+gh pr merge <N> --squash
+
+# Final merge into $BASE (root PR or independent PR)
+gh pr merge <N> --squash --delete-branch
+```
+
+#### 4d. Inject refs into the next PR down
+
+After a non-root merge, append this PR's refs into the body of the PR immediately below it in the chain (the PR whose `headRefName` equals the just-merged PR's `baseRefName`):
+
+```bash
+NEXT_PR=<number of the PR below in the chain>
+CURRENT_BODY=$(gh pr view $NEXT_PR --json body --jq '.body')
+NEW_BODY="$CURRENT_BODY
+
+$REFS"
+gh pr edit $NEXT_PR --body "$NEW_BODY"
+```
+
+This ensures that if the merge halts mid-stack (conflict, failure), the surviving lowest unmerged PR already contains all refs from everything above it that successfully merged.
+
+#### 4e. Conflict handling
+
+If a merge fails with `CONFLICTING`:
+- Stop the chain at this PR
+- Report the conflict with the PR number and branch names
+- Mark all PRs below it in the same chain as blocked
+- Continue with any independent PRs or unrelated chains
+- At the end, list all stopped and blocked PRs so the user can resolve and re-run
+
+#### 4f. Pause between merges
+
+```bash
+sleep 3
+```
 
 ### 5. Sync base branch
 
@@ -93,21 +132,25 @@ git checkout $BASE
 git pull origin $BASE
 ```
 
-Where `$BASE` is the base branch of the first merged PR (typically `develop`).
+Where `$BASE` is the base branch of the root PRs (typically `develop`).
 
 ### 6. Report
 
 ```
-── merge-stack complete ──────────────────
-✓ Merged: PR #103 (#90), PR #104 (#91), PR #105 (#94)
-✗ Conflicted: PR #106 (#97) — skipped
-⊘ Blocked: PR #107 (#98) — depends on #97
-─────────────────────────────────────────
+── merge-stack complete ──────────────────────────────
+✓ Merged (chain 1): PR #105 → #104 → #103 → develop
+    Refs accumulated into PR #103: Closes #90, #91, #92, #93, #94
+✓ Merged (independent): PR #108 → develop
+✗ Conflicted: PR #107 — stopped mid-chain
+⊘ Blocked: PR #106 — depends on #107
+──────────────────────────────────────────────────────
 ```
 
 ## Constraints
 
-- Always merge bottom-up (most depended-upon first)
-- Never skip a conflict's dependents — always block them and report
+- Always merge top-down (leaf PRs first, root last)
+- Never use `--delete-branch` on intermediate merges — only on the final merge into `$BASE`
+- Always accumulate refs downward after each intermediate merge
 - Never merge into `main` directly — only into `$BASE` (e.g., `develop`)
-- If the merge order cannot be determined (no issue references), merge PRs targeting `$BASE` first, then stacked PRs in any order
+- Never skip a conflicted chain's dependents — block and report them
+- Independent PRs (targeting `$BASE` with nothing stacked on them) may merge in any order


### PR DESCRIPTION
Redesigns merge-stack to merge top-down (leaf PRs first, root last) instead of bottom-up.

**Problem with bottom-up:** merging PR N deletes its head branch, which is the base branch of PR N+1. GitHub auto-closes N+1 as abandoned, requiring manual rebase and PR recreation.

**Top-down fix:** always merge into a branch that still exists. Each merge collapses one layer of the stack without disturbing anything below.

**Ref accumulation:** after each intermediate merge, the absorbed PR's `Closes #N` refs are injected into the next PR's body. By the time the root PR merges into develop, it carries the complete ref set for the entire stack. Partial failures leave a clean resumable state — the lowest surviving unmerged PR already has all refs from everything above it.

**`--delete-branch` scoping:** omitted on intermediate merges; only applied on the final merge into `$BASE`.