### PR TITLE
feat(polishkit): add polishKit plugin

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -12,7 +12,7 @@
     <div class="container hero">
       <div class="hero-prompt">~/smallorbit-plugins<span class="cursor">▋</span></div>
       <h1 class="hero-title">The complete Claude Code<br>workflow toolkit.</h1>
-      <p class="hero-sub">Four plugins. One end-to-end flow. Spec your work, execute it in parallel, ship it — with sessionkit keeping context across every phase.</p>
+      <p class="hero-sub">Five plugins. One end-to-end flow. Spec your work, execute it in parallel, ship it — with sessionkit keeping context across every phase and polishkit keeping your codebase clean.</p>
       <a href="#install" class="hero-cta">Get started →</a>
     </div>
   </header>
@@ -124,6 +124,20 @@
               <li><code>/pickup</code> — resume from a handoff document</li>
               <li><code>/skillit</code> — identify reusable patterns from a session</li>
               <li><code>/suggest-permissions</code> — reduce future permission prompts</li>
+            </ul>
+          </div>
+
+          <div class="card plugin-card">
+            <div class="plugin-card-header">
+              <span class="plugin-name">polishkit</span>
+              <span class="badge">v1.0.0</span>
+              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/polishkit" target="_blank" rel="noopener">README →</a>
+            </div>
+            <p class="plugin-desc">Codebase quality toolkit. Assess code craft with a connoisseur's eye, sweep for cruft and hygiene issues, and eliminate dead code.</p>
+            <ul class="skill-list">
+              <li><code>/critique</code> — scored quality assessment across 5 dimensions</li>
+              <li><code>/tidy-codebase</code> — hygiene sweep: stale files, artifacts, merged branches</li>
+              <li><code>/dead-code</code> — find and remove unused exports, imports, and variables</li>
             </ul>
           </div>
 

--- a/plugins/polishkit/.claude-plugin/plugin.json
+++ b/plugins/polishkit/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "polishkit",
+  "description": "Codebase quality toolkit. Assess code craft with a connoisseur's eye, sweep for cruft and hygiene issues, and eliminate dead code — three focused skills for improving what you've already built.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Román M. Pacheco"
+  }
+}

--- a/plugins/polishkit/README.md
+++ b/plugins/polishkit/README.md
@@ -1,0 +1,80 @@
+# polishKit
+
+A Claude Code plugin for improving what you've already built. Assess code craft with a connoisseur's eye, sweep for accumulated cruft, and eliminate dead code — three focused skills for codebase quality.
+
+## Installation
+
+Install from the `smallorbit-plugins` marketplace:
+
+```
+/plugin marketplace add smallorbit/smallorbit-plugins
+/plugin install polishkit@smallorbit-plugins
+```
+
+Or load directly for a single session:
+
+```bash
+claude --plugin-dir /path/to/polishkit
+```
+
+### Prerequisites
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed
+
+## Skills
+
+| Skill | Invoke | What it does |
+|-------|--------|--------------|
+| **critique** | `/critique` | Assesses code for elegance, architecture, and craft across 5 weighted dimensions. Produces a scored report with beauty highlights and violation flags. Works on single files, modules, or full repos. |
+| **tidy-codebase** | `/tidy-codebase` | Codebase hygiene sweep — finds and cleans up stale files, outdated documentation, build artifacts, and accumulated cruft. Confirms each action before executing. |
+| **dead-code** | `/dead-code` | Scans for unused exports, unreachable branches, dead variables, and obsolete imports. Runs language-appropriate static analysis, presents findings with file:line references, and removes after confirmation. |
+
+## Typical Workflows
+
+### Assess code quality before a refactor
+
+```
+/critique src/services          # Score the service layer across 5 dimensions
+```
+
+### Clean up after a long sprint
+
+```
+/tidy-codebase                  # Full hygiene sweep — stale docs, artifacts, merged branches
+/dead-code                      # Find and remove unused exports and imports
+```
+
+### Deep-clean a specific module
+
+```
+/dead-code src/components       # Scope dead-code scan to one directory
+/critique src/components        # Then assess what remains
+```
+
+### Prepare for a code review
+
+```
+/critique                       # Get an honest assessment before submitting
+```
+
+## How critique Works
+
+`/critique` surveys the codebase structure, identifies the language(s) in use, and scores across five weighted dimensions: Architecture & Separation of Concerns (30%), Naming & Readability (25%), Algorithmic Elegance (20%), Testability & Test Design (15%), and Idiomatic Consistency (10%). It always leads with beauty highlights before discussing flaws, and flags critical violations (god classes, magic numbers, functions over 30 lines) in a dedicated section.
+
+## How tidy-codebase Works
+
+`/tidy-codebase` runs parallel checks for stale docs, build artifacts, documentation gaps, duplicate content, and git hygiene issues (merged branches, stale worktrees, orphaned remotes). Findings are organized into Remove / Update / Keep categories and confirmed via `AskUserQuestion` before any changes are made.
+
+## How dead-code Works
+
+`/dead-code` detects the project language and available static analysis tools, then runs all applicable checks in parallel: unused exports, unused imports, dead variables, and commented-out code blocks. Findings are grouped by severity, shown with file:line references, and confirmed in batches before removal. After cleanup, it verifies the codebase still compiles.
+
+## Pairing with Other Plugins
+
+polishKit improves quality; [speckit](../speckit) defines the next work; [swarmkit](../swarmkit) executes it:
+
+```
+/critique                       # Assess current quality
+/spec address architecture gaps # Plan improvements as issues
+/swarm                          # Execute with parallel agents
+```

--- a/plugins/polishkit/skills/critique/SKILL.md
+++ b/plugins/polishkit/skills/critique/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: critique
+description: Assess code for elegance, architecture, and craft using a connoisseur's eye. Use when the user asks to critique, assess, evaluate, review, or judge code quality, beauty, or elegance. Also trigger when the user asks "how clean is this code", "is this well-architected", "rate this code", or pastes code and asks for a quality assessment. Produces a scored report across 5 weighted dimensions with beauty highlights and violation flags. Works on single files, modules, or full repos.
+---
+
+# /critique — Code Connoisseur Assessment
+
+You are a **code connoisseur** — an expert with refined taste who appreciates beauty in software and articulates assessments with the authority and warmth of a seasoned craftsperson. You are not a linter. You are not a scold. You notice what is *genuinely beautiful* and say so with conviction, and you identify what falls short with precision and grace.
+
+## Persona & Tone
+
+- **Appreciative first.** Always lead with what is done well. Genuine beauty deserves recognition before any flaw is discussed.
+- **Precise, not pedantic.** Name the principle at stake. Don't nitpick semicolons or trailing whitespace — that's what formatters are for.
+- **Refined, not harsh.** Think wine critic, not drill sergeant. "This service layer has a lovely single-responsibility discipline" rather than "LGTM." And "This god class is shouldering burdens it shouldn't bear" rather than "BAD: too many responsibilities."
+- **Concise.** The entire report must stay under **500 lines**. Brevity is itself a form of elegance.
+
+## Supported Languages
+
+Assess codebases in any of these languages and frameworks, applying both universal principles and language-specific idiomatic standards:
+
+- **C#** — favor idiomatic patterns (LINQ, pattern matching, nullable reference types, async/await conventions)
+- **Go** — favor simplicity, explicit error handling, small interfaces, stdlib style
+- **Python** — favor Pythonic idioms (comprehensions, context managers, dataclasses, type hints)
+- **TypeScript** — favor strict typing, discriminated unions, proper use of generics, avoiding `any`
+- **React** — favor composition, custom hooks, proper state management, separation of concerns between UI and logic
+- **Next.js** — favor proper use of server/client components, data fetching patterns, routing conventions
+
+When reviewing, identify the language and apply the relevant idiomatic lens alongside the universal principles.
+
+## The Five Dimensions
+
+Each dimension is scored **1–10** with the following weighted contribution to the overall score:
+
+### 1. Architecture & Separation of Concerns — 30%
+
+The most important dimension. Beautiful code has a clear, intentional structure.
+
+**What to look for:**
+- Clear boundaries between layers/modules with well-defined interfaces
+- Dependencies flow inward (toward domain logic, away from infrastructure)
+- Alignment with Clean Architecture (Onion) or Hexagonal (Ports & Adapters) principles where appropriate
+- Domain logic is free from framework and infrastructure concerns
+- Appropriate use of abstractions — neither too many nor too few
+- Each module/class/file has a single, well-understood reason to change
+
+**Score anchors:**
+- **9–10**: Architectural intent is immediately legible. Boundaries are crisp. You could swap infrastructure without touching domain logic.
+- **7–8**: Strong structure with minor bleed-through between layers or a few misplaced responsibilities.
+- **5–6**: Some structure exists but boundaries are fuzzy. Several classes straddle layers.
+- **3–4**: Architecture is ad hoc. Business logic is tangled with I/O, frameworks, or UI.
+- **1–2**: No discernible architectural intent. Everything depends on everything.
+
+### 2. Naming & Readability — 25%
+
+Beautiful code reads like well-written prose. You understand intent without deciphering.
+
+**What to look for:**
+- Names reveal intent — you rarely need to read the body to understand what a function does
+- Consistent naming conventions within the codebase
+- Appropriate abstraction level in names (not too generic, not too implementation-specific)
+- Code is self-documenting; comments explain *why*, never *what*
+- Logical ordering of declarations and methods tells a story
+- Functions are short (< ~30 lines) and do one thing
+
+**Score anchors:**
+- **9–10**: Reading the code feels like reading a well-organized essay. Names are precise and consistent. You could onboard a new developer by reading the code alone.
+- **7–8**: Generally clear with occasional ambiguous names or functions that do slightly too much.
+- **5–6**: Readable with effort. Some names are cryptic or generic. A few long functions obscure intent.
+- **3–4**: Frequent head-scratching. Names mislead or are abbreviated beyond recognition.
+- **1–2**: Actively confusing. Variables named `x`, `temp2`, `doStuff`.
+
+### 3. Algorithmic Elegance — 20%
+
+Beautiful code solves problems with the minimum necessary complexity.
+
+**What to look for:**
+- Algorithms and data structures are well-chosen for the problem at hand
+- No unnecessary complexity — the solution is as simple as it can be, but no simpler
+- Clever code is avoided in favor of clear code (unless cleverness genuinely reduces complexity)
+- DRY is applied judiciously, not dogmatically
+- Control flow is linear and predictable where possible
+- Edge cases are handled gracefully, not as afterthoughts bolted on
+
+**Score anchors:**
+- **9–10**: Solutions feel inevitable — "of course it should be done this way." Complexity is precisely proportional to problem complexity.
+- **7–8**: Sound approaches with minor over-engineering or a few places where simpler solutions exist.
+- **5–6**: Works but shows signs of accidental complexity. Some Rube Goldberg paths.
+- **3–4**: Significant over-engineering or under-thinking. Brute force where elegance was available.
+- **1–2**: Needlessly complex, convoluted, or fundamentally misguided approaches.
+
+### 4. Testability & Test Design — 15%
+
+Beautiful code is confident code — and confidence comes from tests.
+
+**What to look for:**
+- Code is structured for testability (injectable dependencies, pure functions, clear boundaries)
+- Tests exist and cover meaningful behaviors, not implementation details
+- Test names describe scenarios and expected outcomes
+- Test code is itself clean and readable — tests are first-class citizens
+- Appropriate test granularity (unit, integration, e2e) for the context
+- Mocking is surgical, not excessive
+
+**Score anchors:**
+- **9–10**: Tests serve as living documentation. Test structure mirrors the domain. You could understand the system's behavior by reading the tests alone.
+- **7–8**: Good test coverage with clear intent. Minor gaps or occasional tight coupling to implementation.
+- **5–6**: Tests exist but are fragile, test implementation details, or have significant coverage gaps.
+- **3–4**: Sparse or poorly structured tests. Hard to tell what's actually being verified.
+- **1–2**: No tests, or tests that are themselves buggy / always pass.
+
+### 5. Idiomatic Consistency — 10%
+
+Beautiful code speaks the language it's written in fluently.
+
+**What to look for:**
+- Follows the conventions and idioms of the specific language/framework
+- Consistent style throughout (not a patchwork of different authors' habits)
+- Uses language features appropriately (not fighting the language)
+- Error handling follows the language's established patterns
+- File and project structure follows community conventions
+
+**Score anchors:**
+- **9–10**: A native speaker of this language would nod in approval at every file. Consistent from top to bottom.
+- **7–8**: Mostly idiomatic with occasional non-native constructs or inconsistencies.
+- **5–6**: Functional but reads like it was translated from another language. Inconsistent conventions.
+- **3–4**: Fights the language. Uses patterns that belong to a different ecosystem.
+- **1–2**: Completely ignores language conventions. Unrecognizable as idiomatic code.
+
+## Always-Flag Violations
+
+Regardless of scores, **always flag** these when found. Present them in a dedicated "Violations" section of the report.
+
+| Violation | Why It Matters |
+|---|---|
+| **God classes / god objects** | A class doing too much is the antithesis of clean architecture. |
+| **Magic numbers / magic strings** | Unnamed literals obscure intent and invite bugs. |
+| **Comments that restate the code** | These add noise, not signal, and rot faster than the code they describe. |
+| **Functions exceeding ~30 lines** | Long functions almost always do more than one thing. |
+| **Files exceeding ~300 lines** | Large files suggest missing abstractions or blurred responsibilities. |
+
+## Scoring Formula
+
+```
+Overall Score = (Architecture × 0.30)
+             + (Naming × 0.25)
+             + (Algorithmic Elegance × 0.20)
+             + (Testability × 0.15)
+             + (Idiomatic Consistency × 0.10)
+```
+
+Round to one decimal place.
+
+**Overall Verdict Tiers:**
+
+| Score Range | Verdict |
+|---|---|
+| 9.0–10.0 | **Masterwork** — Exceptional craft. A reference implementation. |
+| 7.5–8.9 | **Polished** — Professional quality with minor refinements possible. |
+| 6.0–7.4 | **Competent** — Solid foundation with clear room for elevation. |
+| 4.0–5.9 | **Rough** — Functional but needs significant attention to craft. |
+| 1.0–3.9 | **Needs Rethinking** — Fundamental structural issues to address. |
+
+## Report Structure
+
+Produce the report in this exact order:
+
+### Executive Summary (always first)
+- Overall score and verdict tier
+- One-sentence characterization of the codebase's personality
+- The single most beautiful thing in the codebase
+- The single most impactful improvement opportunity
+
+### Beauty Highlights
+- Specifically call out 2–5 instances of genuinely elegant code
+- Explain *why* each is beautiful — name the principle at work
+- Reference specific files/functions
+
+### Dimension Breakdown
+For each of the 5 dimensions:
+- Score (1–10)
+- 2–3 sentence justification
+- Best example (if not already highlighted)
+- Key improvement opportunity (if score < 8)
+
+### Violations
+- List any always-flag violations found
+- Reference specific files/lines
+- Brief note on suggested resolution
+
+### Closing Note
+- One encouraging, forward-looking sentence
+- The single highest-leverage action to elevate the codebase
+
+## Workflow
+
+When invoked:
+
+1. **Determine scope** from what the user provides:
+   - If it's a single file or pasted code → assess that directly
+   - If it's a directory or module → survey its structure, then read key files
+   - If it's a full repo → survey the project structure, identify architectural boundaries, then sample representative files across layers
+
+2. **For repo-wide or module assessments**, start with a structural survey:
+   - Understand the directory tree
+   - Identify entry points, domain logic, infrastructure/adapter code, and tests
+   - Read a representative sample — don't try to read every file
+   - Prioritize: architecture-revealing files > routine implementation files
+
+3. **Detect the language(s)** in use and activate the appropriate idiomatic lens.
+
+4. **Score each of the 5 dimensions** using the anchors above.
+
+5. **Scan for always-flag violations.**
+
+6. **Identify beauty highlights**: find 2–5 genuinely elegant pieces of code worth celebrating.
+
+7. **Produce the report** in the format specified above.
+
+8. **Stay under 500 lines total.** Be precise. Brevity is elegance.

--- a/plugins/polishkit/skills/dead-code/SKILL.md
+++ b/plugins/polishkit/skills/dead-code/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: dead-code
+description: Scan the codebase for dead code — unused exports, unreachable branches, dead variables, and obsolete imports — and remove it after confirmation. Use when the user asks to find dead code, remove unused code, or clean up unused exports/imports/variables.
+triggers:
+  - "find dead code"
+  - "remove dead code"
+  - "unused exports"
+  - "unused imports"
+  - "dead variables"
+  - "unreachable code"
+  - "clean up unused"
+---
+
+# Dead Code Eliminator
+
+Scan for dead code — unused exports, unreachable branches, dead variables, and obsolete imports — and remove it after confirmation.
+
+## Scope
+
+Focus area (if provided): $ARGUMENTS
+If no focus area is provided, scan the entire codebase.
+
+## Process
+
+### 1. Detect language and available tools
+
+Identify the primary language(s) in the repo and check for available static analysis tools:
+
+**TypeScript / JavaScript**
+```bash
+# Check for TypeScript
+ls tsconfig.json 2>/dev/null && echo "TypeScript project"
+# Check for ESLint with unused-vars rule
+ls .eslintrc* eslint.config* 2>/dev/null
+```
+
+**Python**
+```bash
+# Check for pyflakes, vulture, or ruff
+which pyflakes vulture ruff 2>/dev/null
+```
+
+**Go**
+```bash
+# Check for staticcheck
+which staticcheck 2>/dev/null
+```
+
+### 2. Scan for dead code
+
+Run all applicable checks in parallel:
+
+**Unused exports (TypeScript)**
+```bash
+# ts-prune or grep-based analysis
+npx ts-prune 2>/dev/null || \
+  grep -rn "^export " --include="*.ts" --include="*.tsx" | \
+  grep -v "node_modules" | head -100
+```
+
+**Unused imports**
+- TypeScript: `tsc --noEmit` often surfaces these; or ESLint `no-unused-vars`
+- Python: `pyflakes .` or `ruff check --select F401 .`
+- Go: compiler enforces this — no unused imports compile
+
+**Dead variables / unreachable branches**
+- TypeScript: `tsc --noEmit` for `noUnusedLocals`, `noUnusedParameters`
+- Python: `vulture .` for dead code detection
+- Go: `staticcheck ./...`
+
+**Unreachable code patterns (language-agnostic grep)**
+```bash
+# Code after return/throw at same indentation level
+grep -rn "return\b" --include="*.ts" --include="*.tsx" --include="*.js" .
+```
+
+**Commented-out code blocks**
+```bash
+# Large commented blocks (3+ consecutive comment lines)
+grep -rn "^[[:space:]]*//" --include="*.ts" --include="*.tsx" | \
+  awk -F: '{print $1 ":" $2}' | uniq -c | awk '$1 >= 3 {print}'
+```
+
+### 3. Compile and present findings
+
+Group findings by category:
+
+| Category | Count | Severity |
+|----------|-------|----------|
+| Unused exports | N | Medium |
+| Unused imports | N | Low |
+| Dead variables | N | Low |
+| Unreachable branches | N | High |
+| Commented-out code | N | Low |
+
+For each finding, show:
+- File path and line number
+- The dead code snippet (1–3 lines)
+- Why it's considered dead
+
+Skip findings in:
+- `node_modules/`, `dist/`, `build/`, `.next/`
+- Generated files (`*.generated.ts`, `*.d.ts`)
+- Test files (dead code in tests can be intentional fixtures)
+
+### 4. Confirm before acting
+
+Use `AskUserQuestion` to group findings into batches of at most 4 questions. For each batch:
+- Describe what will be removed
+- Show the file:line reference
+- Default to the safe action (remove)
+- Allow keeping if user prefers
+
+Wait for all confirmations before proceeding.
+
+### 5. Execute removals
+
+For each confirmed removal:
+1. Remove the dead code (delete lines, remove import, delete function/variable)
+2. Verify the file still parses (run `tsc --noEmit` or language equivalent if available)
+3. Report what was removed
+
+After all removals:
+```bash
+# Verify nothing broke
+tsc --noEmit 2>/dev/null || echo "No TypeScript to check"
+```
+
+Commit with: `chore: remove dead code` and open a PR targeting develop.

--- a/plugins/polishkit/skills/tidy-codebase/SKILL.md
+++ b/plugins/polishkit/skills/tidy-codebase/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: tidy-codebase
+description: Codebase hygiene sweep — find and clean up stale files, outdated documentation, build artifacts, and accumulated cruft. Use when the user asks to tidy, clean up, sweep, or find cruft in a codebase.
+triggers:
+  - "tidy up"
+  - "tidy the codebase"
+  - "clean up the codebase"
+  - "find cruft"
+  - "codebase hygiene"
+---
+
+Codebase hygiene sweep: find and clean up stale files, outdated documentation, build artifacts, and accumulated cruft.
+
+## Scope
+
+Focus area (if provided): $ARGUMENTS
+If no focus area is provided, perform a full sweep across all categories below.
+
+## Process
+
+### 1. Scan for cruft
+
+Run these checks in parallel and compile findings:
+
+**Stale documentation**
+- WIP/tracking files that reference completed work (check git log for last-modified dates)
+- PRDs and task files for features that shipped months ago
+- Handoff or planning docs for work that's long finished
+- Docs with broken internal links or references to deleted files
+
+**Build artifacts & dead directories**
+- Empty directories, leftover build output not in .gitignore
+- Generated files committed by accident (.DS_Store, logs, temp files)
+- Unused config files (e.g., for tools no longer in use)
+
+**Documentation gaps**
+- README or user-facing docs that don't reflect current features
+- Keyboard shortcuts, env vars, or CLI commands that were added but not documented
+- Stale screenshots or media that no longer match the app
+
+**Duplicate content**
+- Root-level files that duplicate content already in docs/ (e.g., CONTRIBUTING.md vs docs/contributing.md)
+- Repeated information across CLAUDE.md, AGENTS.md, README.md, etc.
+
+**Git hygiene**
+- Local branches whose upstream has been merged (`git branch --merged main` and cross-reference with remote)
+- Stale worktrees (`git worktree list` — flag any where the branch no longer exists or has been merged)
+- Orphaned remote-tracking branches (`git remote prune origin --dry-run`)
+
+### 2. Present findings and confirm each action
+
+Organize findings into a clear summary grouped by category:
+- **Remove** — files/directories to delete (with reason)
+- **Update** — docs that need content changes (with what's wrong)
+- **Keep** — anything you considered but decided to keep (with why)
+
+After presenting the summary, use `AskUserQuestion` to confirm each proposed action individually. Group into at most 4 questions per call (the tool limit); batch closely related items (e.g. two merged remote branches) into a single question. Each question should:
+- State the specific action (delete X, update Y, remove reference to Z)
+- Provide a short reason in the description of each option
+- Default the first option to the recommended action (label it `(Recommended)`)
+
+Wait for all answers before proceeding to step 3.
+
+### 3. Execute cleanup
+
+After approval:
+1. If stale worktrees were identified in the scan, run `polishkit:tidy-codebase` cleanup, then proceed
+2. Make all deletions and edits
+3. Commit with message `chore: tidy codebase` and open a PR targeting develop


### PR DESCRIPTION
## Summary

- Adds `polishkit` plugin with `plugin.json` (v1.0.0), `README.md`, and three skills
- Migrates `critique` and `tidy-codebase` skills with updated namespace references
- Introduces new `dead-code` skill for scanning and removing unused exports, imports, variables, and unreachable branches across TypeScript, JavaScript, Python, and Go
- Adds polishKit card to `docs/index.html` and updates hero subtitle to reflect five plugins

## Test plan

- [ ] Install `polishkit@smallorbit-plugins` in a Claude Code session and verify all three skills load
- [ ] Run `/critique` on a sample codebase and verify the scored 5-dimension report is produced
- [ ] Run `/tidy-codebase` and verify it presents findings with confirmation prompts before acting
- [ ] Run `/dead-code` and verify it detects language, runs appropriate static analysis, and confirms before removing
- [ ] Verify `docs/index.html` renders the polishKit card correctly on the GitHub Pages site

Closes #160