### PR TITLE
fix(docs): sync flowkit badge to v1.2.2

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -84,7 +84,7 @@
           <div class="card plugin-card">
             <div class="plugin-card-header">
               <span class="plugin-name">flowkit</span>
-              <span class="badge">v1.2.1</span>
+              <span class="badge">v1.2.2</span>
               <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/flowkit" target="_blank" rel="noopener">README →</a>
             </div>
             <p class="plugin-desc">Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship — with runtime staging detection.</p>


### PR DESCRIPTION
Fix pre-existing badge drift on the one-pager. Main has flowkit 1.2.2; the badge showed 1.2.1.