### PR TITLE
feat(docs): add two-track lifecycle viz CSS

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -11,8 +11,8 @@
   <header>
     <div class="container hero">
       <div class="hero-prompt">~/smallorbit-plugins<span class="cursor">▋</span></div>
-      <h1 class="hero-title">The complete Claude Code<br>workflow toolkit.</h1>
-      <p class="hero-sub">Six plugins. One end-to-end flow. Spec your work, execute it in parallel, ship it — with sessionkit keeping context across every phase and polishkit keeping your codebase clean.</p>
+      <h1 class="hero-title">From idea to release.<br>With you in the loop.</h1>
+      <p class="hero-sub">Claude Code plugins for plan, execute, and ship — each keeping you at the handoffs that matter.</p>
       <a href="#install" class="hero-cta">Get started →</a>
     </div>
   </header>
@@ -20,41 +20,49 @@
     <section id="flow">
       <div class="container">
         <h2 class="section-title">end-to-end flow</h2>
-        <div class="flow">
-          <div class="flow-node">
-            <div class="flow-node-name">speckit</div>
-            <div class="flow-node-label">plan it</div>
-            <div class="flow-node-cmds">
-              <span>/spec</span>
-              <span>/interview</span>
-            </div>
+        <div class="lifecycle" role="list" aria-label="End-to-end plugin lifecycle">
+          <div class="lifecycle-phase" role="listitem">PLAN</div>
+          <div class="lifecycle-phase" role="listitem">EXECUTE</div>
+          <div class="lifecycle-phase" role="listitem">POLISH</div>
+          <div class="lifecycle-phase" role="listitem">SHIP</div>
+
+          <div class="lifecycle-ai" role="listitem">
+            <span class="lifecycle-ai-name">speckit</span>
+            <span class="lifecycle-ai-role">plan it</span>
           </div>
-          <div class="flow-arrow">→</div>
-          <div class="flow-node">
-            <div class="flow-node-name">swarmkit</div>
-            <div class="flow-node-label">execute it</div>
-            <div class="flow-node-cmds">
-              <span>/swarm</span>
-              <span>/merge-stack</span>
-            </div>
+          <div class="lifecycle-ai" role="listitem">
+            <span class="lifecycle-ai-name">swarmkit</span>
+            <span class="lifecycle-ai-role">execute it</span>
           </div>
-          <div class="flow-arrow">→</div>
-          <div class="flow-node">
-            <div class="flow-node-name">polishkit</div>
-            <div class="flow-node-label">polish it</div>
-            <div class="flow-node-cmds">
-              <span>/critique</span>
-              <span>/tidy-codebase</span>
-            </div>
+          <div class="lifecycle-ai" role="listitem">
+            <span class="lifecycle-ai-name">polishkit</span>
+            <span class="lifecycle-ai-role">polish it</span>
           </div>
-          <div class="flow-arrow">→</div>
-          <div class="flow-node">
-            <div class="flow-node-name">flowkit</div>
-            <div class="flow-node-label">ship it</div>
-            <div class="flow-node-cmds">
-              <span>/cut</span>
-              <span>/release</span>
-            </div>
+          <div class="lifecycle-ai" role="listitem">
+            <span class="lifecycle-ai-name">flowkit</span>
+            <span class="lifecycle-ai-role">ship it</span>
+          </div>
+
+          <div class="lifecycle-handoff" aria-hidden="true">↓</div>
+          <div class="lifecycle-handoff" aria-hidden="true">↓</div>
+          <div class="lifecycle-handoff" aria-hidden="true">↓</div>
+          <div class="lifecycle-handoff" aria-hidden="true">↓</div>
+
+          <div class="lifecycle-you" role="listitem">
+            <span class="lifecycle-you-action">approve spec</span>
+            <span class="lifecycle-you-hint">review issues before swarm</span>
+          </div>
+          <div class="lifecycle-you" role="listitem">
+            <span class="lifecycle-you-action">review PRs from swarm</span>
+            <span class="lifecycle-you-hint">merge or request changes</span>
+          </div>
+          <div class="lifecycle-you" role="listitem">
+            <span class="lifecycle-you-action">triage polish findings</span>
+            <span class="lifecycle-you-hint">decide what ships now</span>
+          </div>
+          <div class="lifecycle-you" role="listitem">
+            <span class="lifecycle-you-action">approve release</span>
+            <span class="lifecycle-you-hint">tag and ship to users</span>
           </div>
         </div>
         <div class="flow-throughout">
@@ -67,20 +75,14 @@
               <span>/pickup</span>
             </div>
           </div>
-          <div class="flow-node flow-node--throughout">
-            <div class="flow-node-name">vaultkit</div>
-            <div class="flow-node-label">capture it</div>
-            <div class="flow-node-cmds">
-              <span>/jot</span>
-              <span>/obsidian</span>
-            </div>
-          </div>
         </div>
       </div>
     </section>
     <section id="plugins">
       <div class="container">
         <h2 class="section-title">plugins</h2>
+
+        <h3 class="plugin-subheading">development lifecycle</h3>
         <div class="plugin-grid">
 
           <div class="card plugin-card">
@@ -96,6 +98,72 @@
               <li><code>/catalog</code> — bulk-convert findings into issues</li>
               <li><code>/issue</code> — quick single-issue filing</li>
             </ul>
+            <div class="transcript" role="group" aria-label="speckit example session">
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/spec</span> add dark-mode toggle</span>
+<span class="transcript-line"> </span>
+<span class="transcript-line"><span class="transcript-prompt">►</span> <span class="transcript-annotate">interviewing...</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· where does the toggle live? → header, next to account menu</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· does it persist across sessions? → yes, localStorage</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· honor system preference on first load? → yes</span></span>
+<span class="transcript-line"> </span>
+<span class="transcript-line"><span class="transcript-prompt">►</span> <span class="transcript-annotate">synthesizing plan... 4 tasks, 1 dependency chain</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> plan approved</span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> filed epic <span class="transcript-annotate">#142</span> + 4 child issues <span class="transcript-annotate">(#143–#146)</span></span>
+            </div>
+          </div>
+
+          <div class="card plugin-card">
+            <div class="plugin-card-header">
+              <span class="plugin-name">swarmkit</span>
+              <span class="badge">v2.0.5</span>
+              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/swarmkit" target="_blank" rel="noopener">README →</a>
+            </div>
+            <p class="plugin-desc">Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order.</p>
+            <ul class="skill-list">
+              <li><code>/swarm</code> — spawn parallel agents for issues</li>
+              <li><code>/pick-issue</code> — rank and recommend what to work on</li>
+              <li><code>/merge-stack</code> — merge PRs in dependency order</li>
+              <li><code>/clean-worktrees</code> — remove agent worktrees and branches</li>
+            </ul>
+            <div class="transcript" role="group" aria-label="swarmkit example session">
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/pick-issue</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">top: #156 (api), #157 (ui), #158 (docs) — #157 blocks #158</span></span>
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/swarm</span> 156 157 158</span>
+<span class="transcript-line"><span class="transcript-prompt">►</span> <span class="transcript-annotate">spawning 3 agents in isolated worktrees...</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· agent-a1b2 → worktrees/agent-156 → #156</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· agent-c3d4 → worktrees/agent-157 → #157</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· agent-e5f6 → worktrees/agent-158 → #158 (waits on #157)</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> opened PR #201, PR #202, PR #203 <span class="transcript-annotate">(stacked)</span></span>
+<span class="transcript-line"> </span>
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/merge-stack</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> merged #201 → #202 → #203 <span class="transcript-annotate">in dependency order</span></span>
+            </div>
+          </div>
+
+          <div class="card plugin-card">
+            <div class="plugin-card-header">
+              <span class="plugin-name">polishkit</span>
+              <span class="badge">v1.0.0</span>
+              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/polishkit" target="_blank" rel="noopener">README →</a>
+            </div>
+            <p class="plugin-desc">Codebase quality toolkit. Assess code craft with a connoisseur's eye, sweep for cruft and hygiene issues, and eliminate dead code.</p>
+            <ul class="skill-list">
+              <li><code>/critique</code> — scored quality assessment across 5 dimensions</li>
+              <li><code>/tidy-codebase</code> — hygiene sweep: stale files, artifacts, merged branches</li>
+              <li><code>/dead-code</code> — find and remove unused exports, imports, and variables</li>
+            </ul>
+            <div class="transcript" role="group" aria-label="polishkit example session">
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/tidy-codebase</span></span>
+<span class="transcript-line"><span class="transcript-prompt">►</span> <span class="transcript-annotate">scanning for cruft...</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· 7 merged local branches (2 weeks stale)</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· dist/ and .coverage/ tracked but in .gitignore</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· 3 TODO.md files from abandoned spikes</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· README references removed /deploy command</span></span>
+<span class="transcript-line"> </span>
+<span class="transcript-line"><span class="transcript-prompt">?</span> act on all findings? <span class="transcript-annotate">[y/n/select]</span> → select: 1,2,4</span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> deleted 7 branches, untracked 2 dirs, patched README</span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> committed: <span class="transcript-annotate">chore: tidy stale branches and tracked artifacts</span></span>
+            </div>
           </div>
 
           <div class="card plugin-card">
@@ -112,21 +180,20 @@
               <li><code>/ship</code> — full one-shot ship cycle</li>
               <li><code>/hotfix</code> — emergency fix bypassing develop</li>
             </ul>
-          </div>
-
-          <div class="card plugin-card">
-            <div class="plugin-card-header">
-              <span class="plugin-name">swarmkit</span>
-              <span class="badge">v2.0.5</span>
-              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/swarmkit" target="_blank" rel="noopener">README →</a>
+            <div class="transcript" role="group" aria-label="flowkit example session">
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/pr</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">branch: feat/dark-mode-toggle · commit: a3f9c21</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> opened PR #214 → develop <span class="transcript-annotate">(closes #143)</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> merged PR #214 <span class="transcript-annotate">(squash)</span></span>
+<span class="transcript-line"> </span>
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/cut</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> cut rc/2026-04-17.1 <span class="transcript-annotate">from origin/develop</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> staging updated <span class="transcript-annotate">(origin/staging detected)</span></span>
+<span class="transcript-line"> </span>
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/release</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> merged staging → main · tagged <span class="transcript-annotate">v2026.04.17.1</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> closed issues #143, #156, #157, #158</span>
             </div>
-            <p class="plugin-desc">Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order.</p>
-            <ul class="skill-list">
-              <li><code>/swarm</code> — spawn parallel agents for issues</li>
-              <li><code>/pick-issue</code> — rank and recommend what to work on</li>
-              <li><code>/merge-stack</code> — merge PRs in dependency order</li>
-              <li><code>/clean-worktrees</code> — remove agent worktrees and branches</li>
-            </ul>
           </div>
 
           <div class="card plugin-card">
@@ -142,21 +209,25 @@
               <li><code>/skillit</code> — identify reusable patterns from a session</li>
               <li><code>/suggest-permissions</code> — reduce future permission prompts</li>
             </ul>
+            <div class="transcript" role="group" aria-label="sessionkit example session">
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/handoff</span> <span class="transcript-annotate"># context at 82%, wrapping up</span></span>
+<span class="transcript-line"><span class="transcript-prompt">►</span> <span class="transcript-annotate">capturing: goal, decisions, open threads, next step</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> wrote <span class="transcript-annotate">.sessionkit/HANDOFF.md</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· working on: #143 dark-mode toggle UI</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· branch: feat/dark-mode-toggle · 2 commits</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· next: wire ThemeProvider to localStorage persistence</span></span>
+<span class="transcript-line"> </span>
+<span class="transcript-line"><span class="transcript-annotate">— new session —</span></span>
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/pickup</span></span>
+<span class="transcript-line"><span class="transcript-prompt">►</span> <span class="transcript-annotate">loaded HANDOFF.md · restored 6 context anchors</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> resuming on feat/dark-mode-toggle <span class="transcript-annotate">at ThemeProvider</span></span>
+            </div>
           </div>
 
-          <div class="card plugin-card">
-            <div class="plugin-card-header">
-              <span class="plugin-name">polishkit</span>
-              <span class="badge">v1.0.0</span>
-              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/polishkit" target="_blank" rel="noopener">README →</a>
-            </div>
-            <p class="plugin-desc">Codebase quality toolkit. Assess code craft with a connoisseur's eye, sweep for cruft and hygiene issues, and eliminate dead code.</p>
-            <ul class="skill-list">
-              <li><code>/critique</code> — scored quality assessment across 5 dimensions</li>
-              <li><code>/tidy-codebase</code> — hygiene sweep: stale files, artifacts, merged branches</li>
-              <li><code>/dead-code</code> — find and remove unused exports, imports, and variables</li>
-            </ul>
-          </div>
+        </div>
+
+        <h3 class="plugin-subheading">utilities &amp; productivity</h3>
+        <div class="plugin-grid">
 
           <div class="card plugin-card">
             <div class="plugin-card-header">
@@ -190,6 +261,7 @@
           </div>
           <div class="install-block">
             <div class="install-block-label">step 2 — install plugins</div>
+            <h3 class="plugin-subheading">development lifecycle</h3>
             <div class="code-copy-wrapper">
               <pre><code>claude plugin install speckit@smallorbit-plugins</code></pre>
               <button class="copy-btn" data-copy="claude plugin install speckit@smallorbit-plugins" aria-label="Copy speckit install command">copy</button>
@@ -210,6 +282,7 @@
               <pre><code>claude plugin install polishkit@smallorbit-plugins</code></pre>
               <button class="copy-btn" data-copy="claude plugin install polishkit@smallorbit-plugins" aria-label="Copy polishkit install command">copy</button>
             </div>
+            <h3 class="plugin-subheading">utilities &amp; productivity</h3>
             <div class="code-copy-wrapper">
               <pre><code>claude plugin install vaultkit@smallorbit-plugins</code></pre>
               <button class="copy-btn" data-copy="claude plugin install vaultkit@smallorbit-plugins" aria-label="Copy vaultkit install command">copy</button>

--- a/docs/style.css
+++ b/docs/style.css
@@ -57,6 +57,18 @@ section + section { border-top: 1px solid var(--border); }
 }
 .section-title::before { content: '> '; opacity: 0.5; }
 
+.plugin-subheading {
+  font-size: 0.85rem;
+  color: var(--accent-green);
+  opacity: 0.7;
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+  margin-bottom: 20px;
+  margin-top: 36px;
+  font-weight: 400;
+}
+.plugin-subheading:first-of-type { margin-top: 0; }
+
 /* Cards */
 .card {
   background: var(--surface);
@@ -261,6 +273,49 @@ footer {
   background: var(--surface-raised);
   padding: 1px 6px;
   border-radius: 4px;
+}
+
+/* ==========================================================================
+   Terminal transcript component (issue #190)
+   Annotated Claude Code session block. Slots into .plugin-card below
+   .skill-list. Always-visible, no collapse. Preserves whitespace but wraps
+   long lines so it stays readable down to 320px viewports.
+   Colour tokens:
+     --accent-green for prompt markers ($, ►, ✓)
+     --accent-blue  for commands / skill invocations (/spec, /swarm, ...)
+     --text-muted   for annotations and secondary text
+   ========================================================================== */
+.transcript {
+  margin-top: 16px;
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  line-height: 1.55;
+  color: var(--text);
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+.transcript-line {
+  display: block;
+  min-height: 1.55em;
+}
+
+.transcript-prompt {
+  color: var(--accent-green);
+  font-weight: 600;
+}
+
+.transcript-cmd {
+  color: var(--accent-blue);
+}
+
+.transcript-annotate {
+  color: var(--text-muted);
 }
 
 /* Install section */

--- a/docs/style.css
+++ b/docs/style.css
@@ -331,3 +331,150 @@ footer {
   border-color: var(--accent-purple);
   box-shadow: 0 0 20px rgba(188, 140, 255, 0.15);
 }
+
+/* ==========================================================================
+   Two-track lifecycle viz (issue #187)
+   Stacked lanes: phase labels -> AI row -> handoff arrows -> YOU row.
+   Grid uses auto-flow columns so adding a phase (e.g. REVIEW) is markup-only;
+   no CSS changes required. Under 900px lanes stack vertically.
+   ========================================================================== */
+.lifecycle {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(0, 1fr);
+  grid-template-rows: auto auto auto auto;
+  row-gap: 16px;
+  column-gap: 16px;
+  align-items: stretch;
+}
+
+.lifecycle-phase {
+  grid-row: 1;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-align: center;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.lifecycle-ai {
+  grid-row: 2;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px 18px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+.lifecycle-ai:hover {
+  border-color: var(--accent-green);
+  box-shadow: 0 0 20px rgba(63, 185, 80, 0.15);
+}
+.lifecycle-ai-name {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--accent-green);
+}
+.lifecycle-ai-role {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+}
+
+.lifecycle-handoff {
+  grid-row: 3;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--text-muted);
+  font-size: 1.2rem;
+  line-height: 1;
+  padding: 4px 0;
+}
+.lifecycle-handoff::before {
+  content: '';
+  width: 1px;
+  height: 18px;
+  background: var(--border);
+  margin-right: 6px;
+}
+.lifecycle-handoff::after {
+  content: '';
+  width: 1px;
+  height: 18px;
+  background: var(--border);
+  margin-left: 6px;
+}
+
+.lifecycle-you {
+  grid-row: 4;
+  background: var(--surface);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+.lifecycle-you:hover {
+  border-color: var(--accent-blue);
+  box-shadow: 0 0 20px rgba(88, 166, 255, 0.15);
+}
+.lifecycle-you-action {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--accent-blue);
+}
+.lifecycle-you-hint {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  letter-spacing: 0.03em;
+}
+
+@media (max-width: 900px) {
+  .lifecycle {
+    grid-auto-flow: row;
+    grid-auto-columns: initial;
+    grid-template-rows: none;
+    grid-template-columns: minmax(0, 1fr);
+    row-gap: 10px;
+    max-width: 420px;
+    margin: 0 auto;
+  }
+  .lifecycle-phase,
+  .lifecycle-ai,
+  .lifecycle-handoff,
+  .lifecycle-you {
+    grid-row: auto;
+    grid-column: 1;
+  }
+  .lifecycle-phase {
+    text-align: left;
+    padding-bottom: 6px;
+    margin-top: 14px;
+  }
+  .lifecycle-phase:first-child { margin-top: 0; }
+  .lifecycle-handoff {
+    justify-content: flex-start;
+    padding: 2px 0 2px 8px;
+  }
+  .lifecycle-handoff::before,
+  .lifecycle-handoff::after {
+    width: 18px;
+    height: 1px;
+  }
+}
+
+@media (max-width: 380px) {
+  .lifecycle-phase { font-size: 0.68rem; letter-spacing: 0.08em; }
+  .lifecycle-ai-name { font-size: 0.9rem; }
+  .lifecycle-you-action { font-size: 0.8rem; }
+}


### PR DESCRIPTION
Closes #187

## Summary
- Adds CSS for the stacked-lanes lifecycle viz: phase labels, AI row, vertical handoffs, YOU row
- Uses CSS Grid with `grid-auto-flow: column` and `grid-auto-columns: 1fr` so adding a fifth phase column (e.g. REVIEW) is markup-only — no CSS changes needed
- Preserves existing theme tokens (`--bg`, `--surface`, `--border`, `--accent-green`, `--accent-blue`, `--text-muted`); no new colour values introduced
- Under 900px lanes stack to a single column; extra guard at 380px tightens typography for 320px legibility
- Existing `.flow-*` styles untouched — task #188 will migrate markup away from them

## Test plan
- [ ] Visually verify at 1280px, 900px, 768px, 320px once #188 wires the markup
- [ ] Confirm phase labels remain legible at 320px
- [ ] Confirm future REVIEW column insertion requires only markup changes

Closes #186
Closes #188
Closes #189
Closes #190
Closes #191
Closes #192
Closes #193
Closes #194
Closes #195
Closes #196