### PR TITLE
release: 2026-04-17 one-pager redesign

### DIFF
--- a/docs/app.js
+++ b/docs/app.js
@@ -1,11 +1,33 @@
+// Copy-to-clipboard for install commands
 document.querySelectorAll('.copy-btn').forEach(btn => {
   btn.addEventListener('click', () => {
+    const text = btn.dataset.copy || '';
     try {
-      navigator.clipboard.writeText(btn.dataset.copy).then(() => {
+      navigator.clipboard.writeText(text).then(() => {
         const orig = btn.textContent;
-        btn.textContent = 'copied!';
-        setTimeout(() => { btn.textContent = orig; }, 1500);
+        btn.textContent = 'copied';
+        btn.classList.add('copied');
+        setTimeout(() => {
+          btn.textContent = orig;
+          btn.classList.remove('copied');
+        }, 1600);
       }).catch(() => {});
     } catch (_) {}
   });
 });
+
+// Scroll-triggered reveals
+if ('IntersectionObserver' in window) {
+  const io = new IntersectionObserver((entries) => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        entry.target.classList.add('in');
+        io.unobserve(entry.target);
+      }
+    });
+  }, { rootMargin: '0px 0px -10% 0px', threshold: 0.08 });
+
+  document.querySelectorAll('.reveal').forEach(el => io.observe(el));
+} else {
+  document.querySelectorAll('.reveal').forEach(el => el.classList.add('in'));
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,93 +3,219 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>smallorbit plugins — The complete Claude Code workflow toolkit</title>
+  <meta name="description" content="smallorbit-plugins — Claude Code plugins for the end-to-end AI development lifecycle, keeping you in the loop at every handoff.">
+  <title>smallorbit-plugins · From idea to release. With you in the loop.</title>
+  <script>document.documentElement.classList.add('js');</script>
   <link rel="stylesheet" href="style.css">
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Ccircle cx='32' cy='32' r='8' fill='%233fb950'/%3E%3Ccircle cx='32' cy='32' r='20' fill='none' stroke='%23bc8cff' stroke-width='1'/%3E%3Ccircle cx='32' cy='32' r='28' fill='none' stroke='%2358a6ff' stroke-width='0.75' stroke-dasharray='2 4'/%3E%3C/svg%3E">
 </head>
 <body>
   <a href="#main-content" class="skip-link">Skip to main content</a>
-  <header>
-    <div class="container hero">
-      <div class="hero-prompt">~/smallorbit-plugins<span class="cursor">▋</span></div>
-      <h1 class="hero-title">From idea to release.<br>With you in the loop.</h1>
-      <p class="hero-sub">Claude Code plugins for plan, execute, and ship — each keeping you at the handoffs that matter.</p>
-      <a href="#install" class="hero-cta">Get started →</a>
+
+  <header class="hero-wrap">
+    <div class="hero-orbit" aria-hidden="true"></div>
+    <div class="container">
+      <div class="hero">
+        <span class="hero-prompt" role="text">
+          ~/smallorbit-plugins<span class="cursor" aria-hidden="true">▋</span>
+        </span>
+        <h1 class="hero-title">
+          From idea to release.<br>
+          <span class="line-two">With you in the loop.</span>
+        </h1>
+        <p class="hero-sub">
+          Claude Code plugins for plan, execute, and ship —
+          each keeping you at the handoffs that matter.
+        </p>
+        <div class="hero-actions">
+          <a href="#install" class="hero-cta">
+            Get started
+            <span class="hero-cta-glyph">→</span>
+          </a>
+          <span class="hero-secondary">or <a href="#lifecycle">see the flow</a></span>
+        </div>
+        <dl class="hero-metrics">
+          <div>
+            <dt class="hero-metric-n">6</dt>
+            <dd class="hero-metric-l">plugins</dd>
+          </div>
+          <div>
+            <dt class="hero-metric-n">4</dt>
+            <dd class="hero-metric-l">lifecycle phases</dd>
+          </div>
+          <div>
+            <dt class="hero-metric-n">∞</dt>
+            <dd class="hero-metric-l">human checkpoints</dd>
+          </div>
+        </dl>
+      </div>
     </div>
   </header>
+
   <main id="main-content">
-    <section id="flow">
+
+    <!-- =================================================================
+         LIFECYCLE — centerpiece subway-map diagram
+    ================================================================= -->
+    <section id="lifecycle" aria-labelledby="lifecycle-title">
       <div class="container">
-        <h2 class="section-title">end-to-end flow</h2>
-        <div class="lifecycle" role="list" aria-label="End-to-end plugin lifecycle">
-          <div class="lifecycle-phase" role="listitem">PLAN</div>
-          <div class="lifecycle-phase" role="listitem">EXECUTE</div>
-          <div class="lifecycle-phase" role="listitem">POLISH</div>
-          <div class="lifecycle-phase" role="listitem">SHIP</div>
+        <span class="eyebrow reveal">end-to-end flow</span>
+        <h2 id="lifecycle-title" class="section-title reveal" data-delay="1">A complete loop, with you at every turn.</h2>
+        <p class="section-lede reveal" data-delay="2">Four phases. Four kits. Four human decision points. Plus one plugin that keeps context flowing between sessions.</p>
 
-          <div class="lifecycle-ai" role="listitem">
-            <span class="lifecycle-ai-name">speckit</span>
-            <span class="lifecycle-ai-role">plan it</span>
-          </div>
-          <div class="lifecycle-ai" role="listitem">
-            <span class="lifecycle-ai-name">swarmkit</span>
-            <span class="lifecycle-ai-role">execute it</span>
-          </div>
-          <div class="lifecycle-ai" role="listitem">
-            <span class="lifecycle-ai-name">polishkit</span>
-            <span class="lifecycle-ai-role">polish it</span>
-          </div>
-          <div class="lifecycle-ai" role="listitem">
-            <span class="lifecycle-ai-name">flowkit</span>
-            <span class="lifecycle-ai-role">ship it</span>
-          </div>
+        <div class="lifecycle-wrap reveal" data-delay="3">
+          <div class="lifecycle-panel">
+            <!-- Desktop: SVG diagram -->
+            <div class="lifecycle-svg-wrap" role="img" aria-label="Development lifecycle subway map: speckit, swarmkit, polishkit, and flowkit arranged left to right across the PLAN, EXECUTE, POLISH, and SHIP phases. Below each is a human-in-the-loop decision point. Sessionkit runs underneath all phases.">
+              <svg class="lifecycle-svg" viewBox="0 0 1040 430" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false">
 
-          <div class="lifecycle-handoff" aria-hidden="true">↓</div>
-          <div class="lifecycle-handoff" aria-hidden="true">↓</div>
-          <div class="lifecycle-handoff" aria-hidden="true">↓</div>
-          <div class="lifecycle-handoff" aria-hidden="true">↓</div>
+                <!-- Phase accent bars -->
+                <rect class="ls-phase-bar" x="130"  y="34" width="60" height="2" fill="var(--speckit)"/>
+                <rect class="ls-phase-bar" x="370"  y="34" width="60" height="2" fill="var(--swarmkit)"/>
+                <rect class="ls-phase-bar" x="610"  y="34" width="60" height="2" fill="var(--polishkit)"/>
+                <rect class="ls-phase-bar" x="850"  y="34" width="60" height="2" fill="var(--flowkit)"/>
 
-          <div class="lifecycle-you" role="listitem">
-            <span class="lifecycle-you-action">approve spec</span>
-            <span class="lifecycle-you-hint">review issues before swarm</span>
-          </div>
-          <div class="lifecycle-you" role="listitem">
-            <span class="lifecycle-you-action">review PRs from swarm</span>
-            <span class="lifecycle-you-hint">merge or request changes</span>
-          </div>
-          <div class="lifecycle-you" role="listitem">
-            <span class="lifecycle-you-action">triage polish findings</span>
-            <span class="lifecycle-you-hint">decide what ships now</span>
-          </div>
-          <div class="lifecycle-you" role="listitem">
-            <span class="lifecycle-you-action">approve release</span>
-            <span class="lifecycle-you-hint">tag and ship to users</span>
-          </div>
-        </div>
-        <div class="flow-throughout">
-          <div class="flow-throughout-label">throughout all phases</div>
-          <div class="flow-node flow-node--throughout">
-            <div class="flow-node-name">sessionkit</div>
-            <div class="flow-node-label">stay in flow</div>
-            <div class="flow-node-cmds">
-              <span>/handoff</span>
-              <span>/pickup</span>
+                <!-- Phase labels -->
+                <text class="ls-phase-text" x="160" y="22" text-anchor="middle">PLAN</text>
+                <text class="ls-phase-text" x="400" y="22" text-anchor="middle">EXECUTE</text>
+                <text class="ls-phase-text" x="640" y="22" text-anchor="middle">POLISH</text>
+                <text class="ls-phase-text" x="880" y="22" text-anchor="middle">SHIP</text>
+
+                <!-- AI spine -->
+                <line class="ls-spine" x1="50" y1="113" x2="990" y2="113"/>
+
+                <!-- AI lane marker -->
+                <text class="ls-lane-label" x="20" y="116">AI</text>
+
+                <!-- Transfer lines (curved) -->
+                <path class="ls-transfer" data-kit="speckit"   d="M 160,150 C 150,190 170,220 160,252"/>
+                <path class="ls-transfer" data-kit="swarmkit"  d="M 400,150 C 390,190 410,220 400,252"/>
+                <path class="ls-transfer" data-kit="polishkit" d="M 640,150 C 630,190 650,220 640,252"/>
+                <path class="ls-transfer" data-kit="flowkit"   d="M 880,150 C 870,190 890,220 880,252"/>
+
+                <!-- AI stations -->
+                <g class="ls-station">
+                  <rect class="ls-node-rect" data-kit="speckit" x="50"  y="76" width="220" height="74" rx="12"/>
+                  <text class="ls-node-name" data-kit="speckit" x="160" y="110">speckit</text>
+                  <text class="ls-node-role"                    x="160" y="132">plan it</text>
+                  <circle class="ls-star" cx="252" cy="84" r="2"/>
+                </g>
+                <g class="ls-station">
+                  <rect class="ls-node-rect" data-kit="swarmkit" x="290" y="76" width="220" height="74" rx="12"/>
+                  <text class="ls-node-name" data-kit="swarmkit" x="400" y="110">swarmkit</text>
+                  <text class="ls-node-role"                     x="400" y="132">execute it</text>
+                  <circle class="ls-star" cx="492" cy="84" r="2"/>
+                </g>
+                <g class="ls-station">
+                  <rect class="ls-node-rect" data-kit="polishkit" x="530" y="76" width="220" height="74" rx="12"/>
+                  <text class="ls-node-name" data-kit="polishkit" x="640" y="110">polishkit</text>
+                  <text class="ls-node-role"                      x="640" y="132">polish it</text>
+                  <circle class="ls-star" cx="732" cy="84" r="2"/>
+                </g>
+                <g class="ls-station">
+                  <rect class="ls-node-rect" data-kit="flowkit" x="770" y="76" width="220" height="74" rx="12"/>
+                  <text class="ls-node-name" data-kit="flowkit" x="880" y="110">flowkit</text>
+                  <text class="ls-node-role"                    x="880" y="132">ship it</text>
+                  <circle class="ls-star" cx="972" cy="84" r="2"/>
+                </g>
+
+                <!-- YOU lane marker -->
+                <text class="ls-lane-label" x="20" y="285">YOU</text>
+
+                <!-- YOU spine (dashed) -->
+                <line x1="50" y1="282" x2="990" y2="282" stroke="var(--border-strong)" stroke-width="1" stroke-dasharray="2 4"/>
+
+                <!-- YOU stations -->
+                <g class="ls-station">
+                  <rect class="ls-you-rect" x="50" y="252" width="220" height="60" rx="10"/>
+                  <text class="ls-you-action" x="160" y="275">approve spec</text>
+                  <text class="ls-you-hint"   x="160" y="294">review issues before swarm</text>
+                </g>
+                <g class="ls-station">
+                  <rect class="ls-you-rect" x="290" y="252" width="220" height="60" rx="10"/>
+                  <text class="ls-you-action" x="400" y="275">review PRs from swarm</text>
+                  <text class="ls-you-hint"   x="400" y="294">merge or request changes</text>
+                </g>
+                <g class="ls-station">
+                  <rect class="ls-you-rect" x="530" y="252" width="220" height="60" rx="10"/>
+                  <text class="ls-you-action" x="640" y="275">triage polish findings</text>
+                  <text class="ls-you-hint"   x="640" y="294">decide what ships now</text>
+                </g>
+                <g class="ls-station">
+                  <rect class="ls-you-rect" x="770" y="252" width="220" height="60" rx="10"/>
+                  <text class="ls-you-action" x="880" y="275">approve release</text>
+                  <text class="ls-you-hint"   x="880" y="294">tag and ship to users</text>
+                </g>
+
+                <!-- sessionkit throughout -->
+                <line class="ls-session-bar" x1="50" y1="370" x2="340" y2="370"/>
+                <line class="ls-session-bar" x1="700" y1="370" x2="990" y2="370"/>
+                <text class="ls-session-label" x="520" y="374" text-anchor="middle">sessionkit · throughout all phases</text>
+                <text class="ls-session-handoff" x="520" y="395" text-anchor="middle">/handoff    /pickup</text>
+              </svg>
+            </div>
+
+            <!-- Mobile fallback: vertical flow -->
+            <ol class="lifecycle-mobile lifecycle-mobile-list" aria-label="Development lifecycle, vertical view">
+              <li class="lcm-phase-label">PLAN</li>
+              <li class="lcm-row">
+                <div class="lcm-ai"><span class="lcm-ai-name" data-kit="speckit">speckit</span><span class="lcm-ai-role">plan it</span></div>
+                <div class="lcm-you"><span class="lcm-you-action">approve spec</span><span class="lcm-you-hint">review issues before swarm</span></div>
+              </li>
+              <li class="lcm-phase-label">EXECUTE</li>
+              <li class="lcm-row">
+                <div class="lcm-ai"><span class="lcm-ai-name" data-kit="swarmkit">swarmkit</span><span class="lcm-ai-role">execute it</span></div>
+                <div class="lcm-you"><span class="lcm-you-action">review PRs</span><span class="lcm-you-hint">merge or request changes</span></div>
+              </li>
+              <li class="lcm-phase-label">POLISH</li>
+              <li class="lcm-row">
+                <div class="lcm-ai"><span class="lcm-ai-name" data-kit="polishkit">polishkit</span><span class="lcm-ai-role">polish it</span></div>
+                <div class="lcm-you"><span class="lcm-you-action">triage findings</span><span class="lcm-you-hint">decide what ships now</span></div>
+              </li>
+              <li class="lcm-phase-label">SHIP</li>
+              <li class="lcm-row">
+                <div class="lcm-ai"><span class="lcm-ai-name" data-kit="flowkit">flowkit</span><span class="lcm-ai-role">ship it</span></div>
+                <div class="lcm-you"><span class="lcm-you-action">approve release</span><span class="lcm-you-hint">tag and ship to users</span></div>
+              </li>
+              <li class="lcm-session">sessionkit · throughout all phases · /handoff · /pickup</li>
+            </ol>
+
+            <div class="lifecycle-legend reveal" data-delay="4">
+              <span class="lifecycle-legend-item"><span class="lifecycle-legend-dot ai"></span>AI agent (plugin-driven)</span>
+              <span class="lifecycle-legend-item"><span class="lifecycle-legend-dot you"></span>Human checkpoint</span>
+              <span class="lifecycle-legend-item"><span class="lifecycle-legend-dot session"></span>sessionkit — throughout</span>
             </div>
           </div>
         </div>
       </div>
     </section>
-    <section id="plugins">
-      <div class="container">
-        <h2 class="section-title">plugins</h2>
 
-        <h3 class="plugin-subheading">development lifecycle</h3>
+    <!-- =================================================================
+         PLUGINS
+    ================================================================= -->
+    <section id="plugins" aria-labelledby="plugins-title">
+      <div class="container">
+        <span class="eyebrow reveal">the kits</span>
+        <h2 id="plugins-title" class="section-title reveal" data-delay="1">Six plugins. One coherent workflow.</h2>
+        <p class="section-lede reveal" data-delay="2">Five cover the dev lifecycle end-to-end. One is a utility for capturing decisions into an Obsidian vault.</p>
+
+        <header class="plugin-category reveal">
+          <h3 class="plugin-category-title">Development lifecycle</h3>
+          <span class="plugin-category-count">05 plugins</span>
+        </header>
+
         <div class="plugin-grid">
 
-          <div class="card plugin-card">
-            <div class="plugin-card-header">
-              <span class="plugin-name">speckit</span>
-              <span class="badge">v1.2.1</span>
-              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/speckit" target="_blank" rel="noopener">README →</a>
+          <article class="plugin-card reveal" data-delay="1" data-kit="speckit">
+            <div class="plugin-card-head">
+              <div class="plugin-card-id">
+                <span class="plugin-name">speckit</span>
+                <span class="plugin-role">plan it</span>
+              </div>
+              <div class="plugin-meta">
+                <span class="badge">v1.2.1</span>
+                <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/speckit" target="_blank" rel="noopener">README ↗</a>
+              </div>
             </div>
             <p class="plugin-desc">Define and capture work as GitHub issues. Interview a feature into existence, bulk-convert findings, or quickly file a single issue.</p>
             <ul class="skill-list">
@@ -110,13 +236,18 @@
 <span class="transcript-line"><span class="transcript-prompt">✓</span> plan approved</span>
 <span class="transcript-line"><span class="transcript-prompt">✓</span> filed epic <span class="transcript-annotate">#142</span> + 4 child issues <span class="transcript-annotate">(#143–#146)</span></span>
             </div>
-          </div>
+          </article>
 
-          <div class="card plugin-card">
-            <div class="plugin-card-header">
-              <span class="plugin-name">swarmkit</span>
-              <span class="badge">v2.0.5</span>
-              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/swarmkit" target="_blank" rel="noopener">README →</a>
+          <article class="plugin-card reveal" data-delay="2" data-kit="swarmkit">
+            <div class="plugin-card-head">
+              <div class="plugin-card-id">
+                <span class="plugin-name">swarmkit</span>
+                <span class="plugin-role">execute it</span>
+              </div>
+              <div class="plugin-meta">
+                <span class="badge">v2.0.5</span>
+                <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/swarmkit" target="_blank" rel="noopener">README ↗</a>
+              </div>
             </div>
             <p class="plugin-desc">Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order.</p>
             <ul class="skill-list">
@@ -138,13 +269,18 @@
 <span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/merge-stack</span></span>
 <span class="transcript-line"><span class="transcript-prompt">✓</span> merged #201 → #202 → #203 <span class="transcript-annotate">in dependency order</span></span>
             </div>
-          </div>
+          </article>
 
-          <div class="card plugin-card">
-            <div class="plugin-card-header">
-              <span class="plugin-name">polishkit</span>
-              <span class="badge">v1.0.0</span>
-              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/polishkit" target="_blank" rel="noopener">README →</a>
+          <article class="plugin-card reveal" data-delay="3" data-kit="polishkit">
+            <div class="plugin-card-head">
+              <div class="plugin-card-id">
+                <span class="plugin-name">polishkit</span>
+                <span class="plugin-role">polish it</span>
+              </div>
+              <div class="plugin-meta">
+                <span class="badge">v1.0.0</span>
+                <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/polishkit" target="_blank" rel="noopener">README ↗</a>
+              </div>
             </div>
             <p class="plugin-desc">Codebase quality toolkit. Assess code craft with a connoisseur's eye, sweep for cruft and hygiene issues, and eliminate dead code.</p>
             <ul class="skill-list">
@@ -164,13 +300,18 @@
 <span class="transcript-line"><span class="transcript-prompt">✓</span> deleted 7 branches, untracked 2 dirs, patched README</span>
 <span class="transcript-line"><span class="transcript-prompt">✓</span> committed: <span class="transcript-annotate">chore: tidy stale branches and tracked artifacts</span></span>
             </div>
-          </div>
+          </article>
 
-          <div class="card plugin-card">
-            <div class="plugin-card-header">
-              <span class="plugin-name">flowkit</span>
-              <span class="badge">v1.2.3</span>
-              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/flowkit" target="_blank" rel="noopener">README →</a>
+          <article class="plugin-card reveal" data-delay="4" data-kit="flowkit">
+            <div class="plugin-card-head">
+              <div class="plugin-card-id">
+                <span class="plugin-name">flowkit</span>
+                <span class="plugin-role">ship it</span>
+              </div>
+              <div class="plugin-meta">
+                <span class="badge">v1.2.3</span>
+                <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/flowkit" target="_blank" rel="noopener">README ↗</a>
+              </div>
             </div>
             <p class="plugin-desc">Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship — with runtime staging detection.</p>
             <ul class="skill-list">
@@ -194,13 +335,18 @@
 <span class="transcript-line"><span class="transcript-prompt">✓</span> merged staging → main · tagged <span class="transcript-annotate">v2026.04.17.1</span></span>
 <span class="transcript-line"><span class="transcript-prompt">✓</span> closed issues #143, #156, #157, #158</span>
             </div>
-          </div>
+          </article>
 
-          <div class="card plugin-card">
-            <div class="plugin-card-header">
-              <span class="plugin-name">sessionkit</span>
-              <span class="badge">v1.1.0</span>
-              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/sessionkit" target="_blank" rel="noopener">README →</a>
+          <article class="plugin-card reveal" data-delay="5" data-kit="sessionkit">
+            <div class="plugin-card-head">
+              <div class="plugin-card-id">
+                <span class="plugin-name">sessionkit</span>
+                <span class="plugin-role">throughout</span>
+              </div>
+              <div class="plugin-meta">
+                <span class="badge">v1.1.0</span>
+                <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/sessionkit" target="_blank" rel="noopener">README ↗</a>
+              </div>
             </div>
             <p class="plugin-desc">Session continuity and meta-learning for Claude Code. Hand off context, resume seamlessly, discover reusable skills, reduce permission noise.</p>
             <ul class="skill-list">
@@ -222,18 +368,27 @@
 <span class="transcript-line"><span class="transcript-prompt">►</span> <span class="transcript-annotate">loaded HANDOFF.md · restored 6 context anchors</span></span>
 <span class="transcript-line"><span class="transcript-prompt">✓</span> resuming on feat/dark-mode-toggle <span class="transcript-annotate">at ThemeProvider</span></span>
             </div>
-          </div>
+          </article>
 
         </div>
 
-        <h3 class="plugin-subheading">utilities &amp; productivity</h3>
-        <div class="plugin-grid">
+        <header class="plugin-category reveal">
+          <h3 class="plugin-category-title">Utilities &amp; productivity</h3>
+          <span class="plugin-category-count">01 plugin</span>
+        </header>
 
-          <div class="card plugin-card">
-            <div class="plugin-card-header">
-              <span class="plugin-name">vaultkit</span>
-              <span class="badge">v1.0.0</span>
-              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/vaultkit" target="_blank" rel="noopener">README →</a>
+        <div class="plugin-grid single">
+
+          <article class="plugin-card reveal" data-kit="vaultkit">
+            <div class="plugin-card-head">
+              <div class="plugin-card-id">
+                <span class="plugin-name">vaultkit</span>
+                <span class="plugin-role">capture it</span>
+              </div>
+              <div class="plugin-meta">
+                <span class="badge">v1.0.0</span>
+                <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/vaultkit" target="_blank" rel="noopener">README ↗</a>
+              </div>
             </div>
             <p class="plugin-desc">Obsidian vault skills for Claude Code. Read, search, edit notes, manage projects, capture decisions, and archive conversations — all via the Obsidian CLI.</p>
             <ul class="skill-list">
@@ -242,59 +397,92 @@
               <li><code>/archive-export</code> — archive a conversation export into the active project</li>
               <li><code>/project</code> — manage projects — create, load, and update</li>
             </ul>
-          </div>
+          </article>
 
         </div>
       </div>
     </section>
-    <section id="install">
-      <div class="container install-section">
-        <h2 class="section-title">install</h2>
-        <p class="install-intro">Two steps to get the full suite running in Claude Code:</p>
-        <div class="install-blocks">
-          <div class="install-block">
-            <div class="install-block-label">step 1 — add the marketplace</div>
-            <div class="code-copy-wrapper">
-              <pre><code>claude marketplace install smallorbit/smallorbit-plugins</code></pre>
-              <button class="copy-btn" data-copy="claude marketplace install smallorbit/smallorbit-plugins" aria-label="Copy marketplace install command">copy</button>
+
+    <!-- =================================================================
+         INSTALL
+    ================================================================= -->
+    <section id="install" aria-labelledby="install-title">
+      <div class="container">
+        <span class="eyebrow reveal">getting started</span>
+        <h2 id="install-title" class="section-title reveal" data-delay="1">Two steps and you're running.</h2>
+        <p class="install-intro reveal" data-delay="2">Add the marketplace once, then install the plugins you want. Everything below runs in a Claude Code session.</p>
+
+        <div class="install-steps">
+          <div class="install-step reveal" data-delay="3">
+            <div class="install-step-n">01</div>
+            <div>
+              <div class="install-step-head">
+                <h3 class="install-step-title">Add the marketplace</h3>
+                <span class="install-step-sub">one-time setup · syncs plugin index</span>
+              </div>
+              <div class="install-commands">
+                <div class="code-copy-wrapper">
+                  <pre><code>claude marketplace install smallorbit/smallorbit-plugins</code></pre>
+                  <button class="copy-btn" data-copy="claude marketplace install smallorbit/smallorbit-plugins" aria-label="Copy marketplace install command">copy</button>
+                </div>
+              </div>
             </div>
           </div>
-          <div class="install-block">
-            <div class="install-block-label">step 2 — install plugins</div>
-            <h3 class="plugin-subheading">development lifecycle</h3>
-            <div class="code-copy-wrapper">
-              <pre><code>claude plugin install speckit@smallorbit-plugins</code></pre>
-              <button class="copy-btn" data-copy="claude plugin install speckit@smallorbit-plugins" aria-label="Copy speckit install command">copy</button>
-            </div>
-            <div class="code-copy-wrapper">
-              <pre><code>claude plugin install flowkit@smallorbit-plugins</code></pre>
-              <button class="copy-btn" data-copy="claude plugin install flowkit@smallorbit-plugins" aria-label="Copy flowkit install command">copy</button>
-            </div>
-            <div class="code-copy-wrapper">
-              <pre><code>claude plugin install swarmkit@smallorbit-plugins</code></pre>
-              <button class="copy-btn" data-copy="claude plugin install swarmkit@smallorbit-plugins" aria-label="Copy swarmkit install command">copy</button>
-            </div>
-            <div class="code-copy-wrapper">
-              <pre><code>claude plugin install sessionkit@smallorbit-plugins</code></pre>
-              <button class="copy-btn" data-copy="claude plugin install sessionkit@smallorbit-plugins" aria-label="Copy sessionkit install command">copy</button>
-            </div>
-            <div class="code-copy-wrapper">
-              <pre><code>claude plugin install polishkit@smallorbit-plugins</code></pre>
-              <button class="copy-btn" data-copy="claude plugin install polishkit@smallorbit-plugins" aria-label="Copy polishkit install command">copy</button>
-            </div>
-            <h3 class="plugin-subheading">utilities &amp; productivity</h3>
-            <div class="code-copy-wrapper">
-              <pre><code>claude plugin install vaultkit@smallorbit-plugins</code></pre>
-              <button class="copy-btn" data-copy="claude plugin install vaultkit@smallorbit-plugins" aria-label="Copy vaultkit install command">copy</button>
+
+          <div class="install-step reveal" data-delay="4">
+            <div class="install-step-n">02</div>
+            <div>
+              <div class="install-step-head">
+                <h3 class="install-step-title">Install the plugins</h3>
+                <span class="install-step-sub">pick the suite or just what you need</span>
+              </div>
+              <div class="install-commands">
+                <div class="install-sublabel">Development lifecycle</div>
+                <div class="code-copy-wrapper">
+                  <pre><code>claude plugin install speckit@smallorbit-plugins</code></pre>
+                  <button class="copy-btn" data-copy="claude plugin install speckit@smallorbit-plugins" aria-label="Copy speckit install command">copy</button>
+                </div>
+                <div class="code-copy-wrapper">
+                  <pre><code>claude plugin install swarmkit@smallorbit-plugins</code></pre>
+                  <button class="copy-btn" data-copy="claude plugin install swarmkit@smallorbit-plugins" aria-label="Copy swarmkit install command">copy</button>
+                </div>
+                <div class="code-copy-wrapper">
+                  <pre><code>claude plugin install polishkit@smallorbit-plugins</code></pre>
+                  <button class="copy-btn" data-copy="claude plugin install polishkit@smallorbit-plugins" aria-label="Copy polishkit install command">copy</button>
+                </div>
+                <div class="code-copy-wrapper">
+                  <pre><code>claude plugin install flowkit@smallorbit-plugins</code></pre>
+                  <button class="copy-btn" data-copy="claude plugin install flowkit@smallorbit-plugins" aria-label="Copy flowkit install command">copy</button>
+                </div>
+                <div class="code-copy-wrapper">
+                  <pre><code>claude plugin install sessionkit@smallorbit-plugins</code></pre>
+                  <button class="copy-btn" data-copy="claude plugin install sessionkit@smallorbit-plugins" aria-label="Copy sessionkit install command">copy</button>
+                </div>
+                <div class="install-sublabel">Utilities &amp; productivity</div>
+                <div class="code-copy-wrapper">
+                  <pre><code>claude plugin install vaultkit@smallorbit-plugins</code></pre>
+                  <button class="copy-btn" data-copy="claude plugin install vaultkit@smallorbit-plugins" aria-label="Copy vaultkit install command">copy</button>
+                </div>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </section>
+
   </main>
+
   <footer>
-    <p>Built for <a href="https://claude.ai/code">Claude Code</a> · <a href="https://github.com/smallorbit/smallorbit-plugins">GitHub</a></p>
+    <div class="container footer-inner">
+      <span class="footer-wordmark">smallorbit&nbsp;<em>plugins</em></span>
+      <nav class="footer-links" aria-label="Footer">
+        <a href="https://github.com/smallorbit/smallorbit-plugins">GitHub</a>
+        <a href="https://claude.ai/code">Claude Code</a>
+        <a href="#main-content">Back to top</a>
+      </nav>
+    </div>
   </footer>
+
   <script src="app.js"></script>
 </body>
 </html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -34,20 +34,6 @@
           </a>
           <span class="hero-secondary">or <a href="#lifecycle">see the flow</a></span>
         </div>
-        <dl class="hero-metrics">
-          <div>
-            <dt class="hero-metric-n">6</dt>
-            <dd class="hero-metric-l">plugins</dd>
-          </div>
-          <div>
-            <dt class="hero-metric-n">4</dt>
-            <dd class="hero-metric-l">lifecycle phases</dd>
-          </div>
-          <div>
-            <dt class="hero-metric-n">∞</dt>
-            <dd class="hero-metric-l">human checkpoints</dd>
-          </div>
-        </dl>
       </div>
     </div>
   </header>
@@ -61,7 +47,7 @@
       <div class="container">
         <span class="eyebrow reveal">end-to-end flow</span>
         <h2 id="lifecycle-title" class="section-title reveal" data-delay="1">A complete loop, with you at every turn.</h2>
-        <p class="section-lede reveal" data-delay="2">Four phases. Four kits. Four human decision points. Plus one plugin that keeps context flowing between sessions.</p>
+        <p class="section-lede reveal" data-delay="2">Claude drives each phase; you approve at every handoff. sessionkit keeps context flowing as you go.</p>
 
         <div class="lifecycle-wrap reveal" data-delay="3">
           <div class="lifecycle-panel">
@@ -196,12 +182,11 @@
     <section id="plugins" aria-labelledby="plugins-title">
       <div class="container">
         <span class="eyebrow reveal">the kits</span>
-        <h2 id="plugins-title" class="section-title reveal" data-delay="1">Six plugins. One coherent workflow.</h2>
-        <p class="section-lede reveal" data-delay="2">Five cover the dev lifecycle end-to-end. One is a utility for capturing decisions into an Obsidian vault.</p>
+        <h2 id="plugins-title" class="section-title reveal" data-delay="1">Tools for the whole lifecycle.</h2>
+        <p class="section-lede reveal" data-delay="2">Each kit is built for a specific phase. A separate utility kit handles personal capture into an Obsidian vault.</p>
 
         <header class="plugin-category reveal">
           <h3 class="plugin-category-title">Development lifecycle</h3>
-          <span class="plugin-category-count">05 plugins</span>
         </header>
 
         <div class="plugin-grid">
@@ -374,7 +359,6 @@
 
         <header class="plugin-category reveal">
           <h3 class="plugin-category-title">Utilities &amp; productivity</h3>
-          <span class="plugin-category-count">01 plugin</span>
         </header>
 
         <div class="plugin-grid single">
@@ -409,8 +393,8 @@
     <section id="install" aria-labelledby="install-title">
       <div class="container">
         <span class="eyebrow reveal">getting started</span>
-        <h2 id="install-title" class="section-title reveal" data-delay="1">Two steps and you're running.</h2>
-        <p class="install-intro reveal" data-delay="2">Add the marketplace once, then install the plugins you want. Everything below runs in a Claude Code session.</p>
+        <h2 id="install-title" class="section-title reveal" data-delay="1">Install and run.</h2>
+        <p class="install-intro reveal" data-delay="2">Add the marketplace, then install the plugins you want. Everything below runs in a Claude Code session.</p>
 
         <div class="install-steps">
           <div class="install-step reveal" data-delay="3">

--- a/docs/index.html
+++ b/docs/index.html
@@ -11,8 +11,8 @@
   <header>
     <div class="container hero">
       <div class="hero-prompt">~/smallorbit-plugins<span class="cursor">▋</span></div>
-      <h1 class="hero-title">The complete Claude Code<br>workflow toolkit.</h1>
-      <p class="hero-sub">Six plugins. One end-to-end flow. Spec your work, execute it in parallel, ship it — with sessionkit keeping context across every phase and polishkit keeping your codebase clean.</p>
+      <h1 class="hero-title">From idea to release.<br>With you in the loop.</h1>
+      <p class="hero-sub">Claude Code plugins for plan, execute, and ship — each keeping you at the handoffs that matter.</p>
       <a href="#install" class="hero-cta">Get started →</a>
     </div>
   </header>
@@ -20,41 +20,49 @@
     <section id="flow">
       <div class="container">
         <h2 class="section-title">end-to-end flow</h2>
-        <div class="flow">
-          <div class="flow-node">
-            <div class="flow-node-name">speckit</div>
-            <div class="flow-node-label">plan it</div>
-            <div class="flow-node-cmds">
-              <span>/spec</span>
-              <span>/interview</span>
-            </div>
+        <div class="lifecycle" role="list" aria-label="End-to-end plugin lifecycle">
+          <div class="lifecycle-phase" role="listitem">PLAN</div>
+          <div class="lifecycle-phase" role="listitem">EXECUTE</div>
+          <div class="lifecycle-phase" role="listitem">POLISH</div>
+          <div class="lifecycle-phase" role="listitem">SHIP</div>
+
+          <div class="lifecycle-ai" role="listitem">
+            <span class="lifecycle-ai-name">speckit</span>
+            <span class="lifecycle-ai-role">plan it</span>
           </div>
-          <div class="flow-arrow">→</div>
-          <div class="flow-node">
-            <div class="flow-node-name">swarmkit</div>
-            <div class="flow-node-label">execute it</div>
-            <div class="flow-node-cmds">
-              <span>/swarm</span>
-              <span>/merge-stack</span>
-            </div>
+          <div class="lifecycle-ai" role="listitem">
+            <span class="lifecycle-ai-name">swarmkit</span>
+            <span class="lifecycle-ai-role">execute it</span>
           </div>
-          <div class="flow-arrow">→</div>
-          <div class="flow-node">
-            <div class="flow-node-name">polishkit</div>
-            <div class="flow-node-label">polish it</div>
-            <div class="flow-node-cmds">
-              <span>/critique</span>
-              <span>/tidy-codebase</span>
-            </div>
+          <div class="lifecycle-ai" role="listitem">
+            <span class="lifecycle-ai-name">polishkit</span>
+            <span class="lifecycle-ai-role">polish it</span>
           </div>
-          <div class="flow-arrow">→</div>
-          <div class="flow-node">
-            <div class="flow-node-name">flowkit</div>
-            <div class="flow-node-label">ship it</div>
-            <div class="flow-node-cmds">
-              <span>/cut</span>
-              <span>/release</span>
-            </div>
+          <div class="lifecycle-ai" role="listitem">
+            <span class="lifecycle-ai-name">flowkit</span>
+            <span class="lifecycle-ai-role">ship it</span>
+          </div>
+
+          <div class="lifecycle-handoff" aria-hidden="true">↓</div>
+          <div class="lifecycle-handoff" aria-hidden="true">↓</div>
+          <div class="lifecycle-handoff" aria-hidden="true">↓</div>
+          <div class="lifecycle-handoff" aria-hidden="true">↓</div>
+
+          <div class="lifecycle-you" role="listitem">
+            <span class="lifecycle-you-action">approve spec</span>
+            <span class="lifecycle-you-hint">review issues before swarm</span>
+          </div>
+          <div class="lifecycle-you" role="listitem">
+            <span class="lifecycle-you-action">review PRs from swarm</span>
+            <span class="lifecycle-you-hint">merge or request changes</span>
+          </div>
+          <div class="lifecycle-you" role="listitem">
+            <span class="lifecycle-you-action">triage polish findings</span>
+            <span class="lifecycle-you-hint">decide what ships now</span>
+          </div>
+          <div class="lifecycle-you" role="listitem">
+            <span class="lifecycle-you-action">approve release</span>
+            <span class="lifecycle-you-hint">tag and ship to users</span>
           </div>
         </div>
         <div class="flow-throughout">
@@ -67,20 +75,14 @@
               <span>/pickup</span>
             </div>
           </div>
-          <div class="flow-node flow-node--throughout">
-            <div class="flow-node-name">vaultkit</div>
-            <div class="flow-node-label">capture it</div>
-            <div class="flow-node-cmds">
-              <span>/jot</span>
-              <span>/obsidian</span>
-            </div>
-          </div>
         </div>
       </div>
     </section>
     <section id="plugins">
       <div class="container">
         <h2 class="section-title">plugins</h2>
+
+        <h3 class="plugin-subheading">development lifecycle</h3>
         <div class="plugin-grid">
 
           <div class="card plugin-card">
@@ -96,6 +98,72 @@
               <li><code>/catalog</code> — bulk-convert findings into issues</li>
               <li><code>/issue</code> — quick single-issue filing</li>
             </ul>
+            <div class="transcript" role="group" aria-label="speckit example session">
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/spec</span> add dark-mode toggle</span>
+<span class="transcript-line"> </span>
+<span class="transcript-line"><span class="transcript-prompt">►</span> <span class="transcript-annotate">interviewing...</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· where does the toggle live? → header, next to account menu</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· does it persist across sessions? → yes, localStorage</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· honor system preference on first load? → yes</span></span>
+<span class="transcript-line"> </span>
+<span class="transcript-line"><span class="transcript-prompt">►</span> <span class="transcript-annotate">synthesizing plan... 4 tasks, 1 dependency chain</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> plan approved</span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> filed epic <span class="transcript-annotate">#142</span> + 4 child issues <span class="transcript-annotate">(#143–#146)</span></span>
+            </div>
+          </div>
+
+          <div class="card plugin-card">
+            <div class="plugin-card-header">
+              <span class="plugin-name">swarmkit</span>
+              <span class="badge">v2.0.5</span>
+              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/swarmkit" target="_blank" rel="noopener">README →</a>
+            </div>
+            <p class="plugin-desc">Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order.</p>
+            <ul class="skill-list">
+              <li><code>/swarm</code> — spawn parallel agents for issues</li>
+              <li><code>/pick-issue</code> — rank and recommend what to work on</li>
+              <li><code>/merge-stack</code> — merge PRs in dependency order</li>
+              <li><code>/clean-worktrees</code> — remove agent worktrees and branches</li>
+            </ul>
+            <div class="transcript" role="group" aria-label="swarmkit example session">
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/pick-issue</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">top: #156 (api), #157 (ui), #158 (docs) — #157 blocks #158</span></span>
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/swarm</span> 156 157 158</span>
+<span class="transcript-line"><span class="transcript-prompt">►</span> <span class="transcript-annotate">spawning 3 agents in isolated worktrees...</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· agent-a1b2 → worktrees/agent-156 → #156</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· agent-c3d4 → worktrees/agent-157 → #157</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· agent-e5f6 → worktrees/agent-158 → #158 (waits on #157)</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> opened PR #201, PR #202, PR #203 <span class="transcript-annotate">(stacked)</span></span>
+<span class="transcript-line"> </span>
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/merge-stack</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> merged #201 → #202 → #203 <span class="transcript-annotate">in dependency order</span></span>
+            </div>
+          </div>
+
+          <div class="card plugin-card">
+            <div class="plugin-card-header">
+              <span class="plugin-name">polishkit</span>
+              <span class="badge">v1.0.0</span>
+              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/polishkit" target="_blank" rel="noopener">README →</a>
+            </div>
+            <p class="plugin-desc">Codebase quality toolkit. Assess code craft with a connoisseur's eye, sweep for cruft and hygiene issues, and eliminate dead code.</p>
+            <ul class="skill-list">
+              <li><code>/critique</code> — scored quality assessment across 5 dimensions</li>
+              <li><code>/tidy-codebase</code> — hygiene sweep: stale files, artifacts, merged branches</li>
+              <li><code>/dead-code</code> — find and remove unused exports, imports, and variables</li>
+            </ul>
+            <div class="transcript" role="group" aria-label="polishkit example session">
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/tidy-codebase</span></span>
+<span class="transcript-line"><span class="transcript-prompt">►</span> <span class="transcript-annotate">scanning for cruft...</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· 7 merged local branches (2 weeks stale)</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· dist/ and .coverage/ tracked but in .gitignore</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· 3 TODO.md files from abandoned spikes</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· README references removed /deploy command</span></span>
+<span class="transcript-line"> </span>
+<span class="transcript-line"><span class="transcript-prompt">?</span> act on all findings? <span class="transcript-annotate">[y/n/select]</span> → select: 1,2,4</span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> deleted 7 branches, untracked 2 dirs, patched README</span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> committed: <span class="transcript-annotate">chore: tidy stale branches and tracked artifacts</span></span>
+            </div>
           </div>
 
           <div class="card plugin-card">
@@ -112,21 +180,20 @@
               <li><code>/ship</code> — full one-shot ship cycle</li>
               <li><code>/hotfix</code> — emergency fix bypassing develop</li>
             </ul>
-          </div>
-
-          <div class="card plugin-card">
-            <div class="plugin-card-header">
-              <span class="plugin-name">swarmkit</span>
-              <span class="badge">v2.0.5</span>
-              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/swarmkit" target="_blank" rel="noopener">README →</a>
+            <div class="transcript" role="group" aria-label="flowkit example session">
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/pr</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">branch: feat/dark-mode-toggle · commit: a3f9c21</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> opened PR #214 → develop <span class="transcript-annotate">(closes #143)</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> merged PR #214 <span class="transcript-annotate">(squash)</span></span>
+<span class="transcript-line"> </span>
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/cut</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> cut rc/2026-04-17.1 <span class="transcript-annotate">from origin/develop</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> staging updated <span class="transcript-annotate">(origin/staging detected)</span></span>
+<span class="transcript-line"> </span>
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/release</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> merged staging → main · tagged <span class="transcript-annotate">v2026.04.17.1</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> closed issues #143, #156, #157, #158</span>
             </div>
-            <p class="plugin-desc">Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order.</p>
-            <ul class="skill-list">
-              <li><code>/swarm</code> — spawn parallel agents for issues</li>
-              <li><code>/pick-issue</code> — rank and recommend what to work on</li>
-              <li><code>/merge-stack</code> — merge PRs in dependency order</li>
-              <li><code>/clean-worktrees</code> — remove agent worktrees and branches</li>
-            </ul>
           </div>
 
           <div class="card plugin-card">
@@ -142,21 +209,25 @@
               <li><code>/skillit</code> — identify reusable patterns from a session</li>
               <li><code>/suggest-permissions</code> — reduce future permission prompts</li>
             </ul>
+            <div class="transcript" role="group" aria-label="sessionkit example session">
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/handoff</span> <span class="transcript-annotate"># context at 82%, wrapping up</span></span>
+<span class="transcript-line"><span class="transcript-prompt">►</span> <span class="transcript-annotate">capturing: goal, decisions, open threads, next step</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> wrote <span class="transcript-annotate">.sessionkit/HANDOFF.md</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· working on: #143 dark-mode toggle UI</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· branch: feat/dark-mode-toggle · 2 commits</span></span>
+<span class="transcript-line">  <span class="transcript-annotate">· next: wire ThemeProvider to localStorage persistence</span></span>
+<span class="transcript-line"> </span>
+<span class="transcript-line"><span class="transcript-annotate">— new session —</span></span>
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/pickup</span></span>
+<span class="transcript-line"><span class="transcript-prompt">►</span> <span class="transcript-annotate">loaded HANDOFF.md · restored 6 context anchors</span></span>
+<span class="transcript-line"><span class="transcript-prompt">✓</span> resuming on feat/dark-mode-toggle <span class="transcript-annotate">at ThemeProvider</span></span>
+            </div>
           </div>
 
-          <div class="card plugin-card">
-            <div class="plugin-card-header">
-              <span class="plugin-name">polishkit</span>
-              <span class="badge">v1.0.0</span>
-              <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/polishkit" target="_blank" rel="noopener">README →</a>
-            </div>
-            <p class="plugin-desc">Codebase quality toolkit. Assess code craft with a connoisseur's eye, sweep for cruft and hygiene issues, and eliminate dead code.</p>
-            <ul class="skill-list">
-              <li><code>/critique</code> — scored quality assessment across 5 dimensions</li>
-              <li><code>/tidy-codebase</code> — hygiene sweep: stale files, artifacts, merged branches</li>
-              <li><code>/dead-code</code> — find and remove unused exports, imports, and variables</li>
-            </ul>
-          </div>
+        </div>
+
+        <h3 class="plugin-subheading">utilities &amp; productivity</h3>
+        <div class="plugin-grid">
 
           <div class="card plugin-card">
             <div class="plugin-card-header">
@@ -190,6 +261,7 @@
           </div>
           <div class="install-block">
             <div class="install-block-label">step 2 — install plugins</div>
+            <h3 class="plugin-subheading">development lifecycle</h3>
             <div class="code-copy-wrapper">
               <pre><code>claude plugin install speckit@smallorbit-plugins</code></pre>
               <button class="copy-btn" data-copy="claude plugin install speckit@smallorbit-plugins" aria-label="Copy speckit install command">copy</button>
@@ -210,6 +282,7 @@
               <pre><code>claude plugin install polishkit@smallorbit-plugins</code></pre>
               <button class="copy-btn" data-copy="claude plugin install polishkit@smallorbit-plugins" aria-label="Copy polishkit install command">copy</button>
             </div>
+            <h3 class="plugin-subheading">utilities &amp; productivity</h3>
             <div class="code-copy-wrapper">
               <pre><code>claude plugin install vaultkit@smallorbit-plugins</code></pre>
               <button class="copy-btn" data-copy="claude plugin install vaultkit@smallorbit-plugins" aria-label="Copy vaultkit install command">copy</button>

--- a/docs/style.css
+++ b/docs/style.css
@@ -164,13 +164,12 @@ section + section { border-top: 1px solid var(--border); }
 }
 
 .section-title {
-  font-family: var(--serif);
-  font-weight: 400;
-  font-style: italic;
-  font-size: clamp(1.8rem, 3.2vw, 2.6rem);
-  letter-spacing: -0.01em;
-  line-height: 1.05;
-  color: var(--text);
+  font-family: var(--sans);
+  font-weight: 700;
+  font-size: clamp(1.9rem, 3.4vw, 2.7rem);
+  letter-spacing: -0.025em;
+  line-height: 1.1;
+  color: var(--text-strong);
   margin-bottom: 14px;
 }
 .section-lede {
@@ -437,7 +436,7 @@ section + section { border-top: 1px solid var(--border); }
 /* SVG element styling */
 .ls-phase-text {
   font-family: var(--mono);
-  font-size: 10px;
+  font-size: 12.5px;
   letter-spacing: 0.22em;
   fill: var(--text-muted);
   text-transform: uppercase;
@@ -497,7 +496,7 @@ section + section { border-top: 1px solid var(--border); }
 .ls-node-name {
   font-family: var(--serif);
   font-weight: 400;
-  font-size: 19px;
+  font-size: 22px;
   letter-spacing: -0.015em;
   dominant-baseline: middle;
   text-anchor: middle;
@@ -509,7 +508,7 @@ section + section { border-top: 1px solid var(--border); }
 
 .ls-node-role {
   font-family: var(--mono);
-  font-size: 10.5px;
+  font-size: 12px;
   fill: var(--text-muted);
   letter-spacing: 0.08em;
   text-transform: uppercase;
@@ -526,7 +525,7 @@ section + section { border-top: 1px solid var(--border); }
 .ls-you-action {
   font-family: var(--sans);
   font-weight: 600;
-  font-size: 12.5px;
+  font-size: 15px;
   fill: var(--text);
   dominant-baseline: middle;
   text-anchor: middle;
@@ -534,7 +533,7 @@ section + section { border-top: 1px solid var(--border); }
 .ls-you-hint {
   font-family: var(--sans);
   font-weight: 400;
-  font-size: 10.5px;
+  font-size: 12px;
   fill: var(--text-muted);
   dominant-baseline: middle;
   text-anchor: middle;
@@ -550,21 +549,22 @@ section + section { border-top: 1px solid var(--border); }
 }
 .ls-session-label {
   font-family: var(--mono);
-  font-size: 10.5px;
+  font-size: 13.5px;
   fill: var(--sessionkit);
   letter-spacing: 0.06em;
+  font-weight: 500;
 }
 .ls-session-handoff {
   font-family: var(--mono);
-  font-size: 10px;
+  font-size: 12px;
   fill: var(--text-muted);
-  letter-spacing: 0.04em;
+  letter-spacing: 0.08em;
 }
 
 /* YOU lane label */
 .ls-lane-label {
   font-family: var(--mono);
-  font-size: 10px;
+  font-size: 12px;
   letter-spacing: 0.22em;
   fill: var(--text-dim);
   text-transform: uppercase;
@@ -698,12 +698,11 @@ section + section { border-top: 1px solid var(--border); }
 }
 .plugin-category:first-of-type { margin-top: 0; }
 .plugin-category-title {
-  font-family: var(--serif);
-  font-style: italic;
-  font-weight: 400;
-  font-size: 1.7rem;
-  color: var(--text);
-  letter-spacing: -0.01em;
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 1.4rem;
+  color: var(--text-strong);
+  letter-spacing: -0.02em;
 }
 .plugin-category-count {
   font-family: var(--mono);
@@ -935,13 +934,12 @@ section + section { border-top: 1px solid var(--border); }
   margin-bottom: 18px;
 }
 .install-step-title {
-  font-family: var(--serif);
-  font-style: italic;
-  font-weight: 400;
-  font-size: 1.35rem;
-  color: var(--text);
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 1.3rem;
+  color: var(--text-strong);
   margin-bottom: 4px;
-  letter-spacing: -0.01em;
+  letter-spacing: -0.02em;
 }
 .install-step-sub {
   font-family: var(--mono);

--- a/docs/style.css
+++ b/docs/style.css
@@ -359,38 +359,6 @@ section + section { border-top: 1px solid var(--border); }
 }
 .hero-secondary a:hover { color: var(--flowkit); border-color: var(--flowkit); text-decoration: none; }
 
-/* Hero metrics */
-.hero-metrics {
-  display: grid;
-  grid-template-columns: repeat(3, auto);
-  gap: 44px;
-  margin-top: 72px;
-  padding-top: 36px;
-  border-top: 1px solid var(--border);
-  max-width: 640px;
-}
-.hero-metric-n {
-  font-family: var(--serif);
-  font-weight: 300;
-  font-size: 2.2rem;
-  line-height: 1;
-  color: var(--text-strong);
-  letter-spacing: -0.02em;
-}
-.hero-metric-l {
-  display: block;
-  font-family: var(--mono);
-  font-size: 0.72rem;
-  letter-spacing: 0.14em;
-  text-transform: uppercase;
-  color: var(--text-muted);
-  margin-top: 8px;
-}
-@media (max-width: 600px) {
-  .hero-metrics { gap: 28px; }
-  .hero-metric-n { font-size: 1.8rem; }
-}
-
 /* ---------- Lifecycle (centerpiece) --------------------------------------- */
 #lifecycle { padding-top: 120px; padding-bottom: 140px; }
 .lifecycle-wrap {
@@ -687,10 +655,6 @@ section + section { border-top: 1px solid var(--border); }
 #plugins { padding-top: 110px; padding-bottom: 110px; }
 
 .plugin-category {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 24px;
   margin-top: 56px;
   margin-bottom: 26px;
   padding-bottom: 14px;
@@ -703,13 +667,6 @@ section + section { border-top: 1px solid var(--border); }
   font-size: 1.4rem;
   color: var(--text-strong);
   letter-spacing: -0.02em;
-}
-.plugin-category-count {
-  font-family: var(--mono);
-  font-size: 0.78rem;
-  color: var(--text-muted);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
 }
 
 .plugin-grid {

--- a/docs/style.css
+++ b/docs/style.css
@@ -1034,10 +1034,16 @@ footer {
   align-items: center;
   gap: 10px;
   color: var(--text);
-  font-family: var(--serif);
-  font-style: italic;
-  font-size: 1.1rem;
-  letter-spacing: -0.01em;
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 1rem;
+  letter-spacing: -0.02em;
+}
+.footer-wordmark em {
+  font-style: normal;
+  font-weight: 400;
+  color: var(--text-muted);
+  margin-left: 2px;
 }
 .footer-wordmark::before {
   content: '';

--- a/docs/style.css
+++ b/docs/style.css
@@ -1,535 +1,1091 @@
+/* ============================================================================
+   smallorbit-plugins · one-pager stylesheet
+   Aesthetic direction: Astronomical Terminal
+   - Fraunces (display serif) + Mona Sans (UI) + JetBrains Mono (code)
+   - GitHub-dark base enriched with per-kit accent identity
+   - Custom SVG lifecycle diagram, atmospheric backgrounds
+   ========================================================================== */
+
+@import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300..900;1,9..144,300..900&family=Mona+Sans:wght@300..900&family=JetBrains+Mono:ital,wght@0,400..700;1,400..700&display=swap');
+
+/* ---------- Design tokens ------------------------------------------------- */
 :root {
-  --bg: #0d1117;
-  --surface: #161b22;
-  --surface-raised: #21262d;
-  --border: #30363d;
-  --text: #e6edf3;          /* 16.02:1 on --bg — WCAG AA pass */
-  --text-muted: #8b949e;    /* 6.15:1 on --bg, 5.62:1 on --surface, 4.95:1 on --surface-raised — WCAG AA pass */
-  --accent-green: #3fb950;  /* 7.45:1 on --bg, 6.81:1 on --surface — WCAG AA pass */
-  --accent-blue: #58a6ff;   /* 7.49:1 on --bg, 6.85:1 on --surface — WCAG AA pass */
-  --accent-purple: #bc8cff;
-  --radius: 8px;
-  --font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+  /* Space & surface */
+  --bg: #0a0d13;
+  --bg-raised: #0d1117;
+  --surface: #141922;
+  --surface-raised: #1b2230;
+  --surface-veil: rgba(27, 34, 48, 0.6);
+  --border: #242c3d;
+  --border-strong: #30394c;
+
+  /* Text */
+  --text: #e6edf3;           /* 14.3:1 on --bg · AAA */
+  --text-strong: #ffffff;
+  --text-muted: #8c95a8;     /* 5.9:1 on --bg · AA */
+  --text-dim: #5e6677;       /* 3.1:1 on --bg · AA large-only */
+
+  /* Accent palette — one identity per kit */
+  --speckit: #bc8cff;        /* 6.3:1 on --bg · AA */
+  --swarmkit: #3fb950;       /* 7.4:1 on --bg · AA */
+  --polishkit: #ffa657;      /* 8.7:1 on --bg · AA */
+  --flowkit: #58a6ff;        /* 7.5:1 on --bg · AA */
+  --sessionkit: #e879f9;     /* 6.0:1 on --bg · AA */
+  --vaultkit: #39c5bb;       /* 7.4:1 on --bg · AA */
+
+  /* Accent helpers */
+  --glow-spec: rgba(188, 140, 255, 0.35);
+  --glow-swarm: rgba(63, 185, 80, 0.35);
+  --glow-polish: rgba(255, 166, 87, 0.35);
+  --glow-flow: rgba(88, 166, 255, 0.35);
+  --glow-session: rgba(232, 121, 249, 0.32);
+  --glow-vault: rgba(57, 197, 187, 0.32);
+
+  /* Type */
+  --serif: 'Fraunces', 'Iowan Old Style', 'Times New Roman', serif;
+  --sans: 'Mona Sans', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, monospace;
+
+  /* Radius & motion */
+  --r-xs: 4px;
+  --r-sm: 6px;
+  --r-md: 10px;
+  --r-lg: 14px;
+  --r-xl: 22px;
+  --ease: cubic-bezier(0.22, 0.61, 0.36, 1);
+  --ease-bounce: cubic-bezier(0.34, 1.26, 0.64, 1);
+}
+
+/* ---------- Reset --------------------------------------------------------- */
+*, *::before, *::after { box-sizing: border-box; }
+* { margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
+body {
+  font-family: var(--sans);
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.6;
+  color: var(--text);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  min-height: 100vh;
+  overflow-x: hidden;
+  position: relative;
+}
+
+/* Atmospheric backdrop — starfield noise + twin nebulae */
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: -2;
+  background:
+    radial-gradient(1200px 700px at 18% -10%, rgba(188, 140, 255, 0.08), transparent 60%),
+    radial-gradient(1000px 600px at 88% 12%, rgba(88, 166, 255, 0.07), transparent 62%),
+    radial-gradient(900px 900px at 50% 110%, rgba(63, 185, 80, 0.05), transparent 60%);
+}
+body::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: -1;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='400' height='400'><filter id='n'><feTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='2' stitchTiles='stitch'/><feColorMatrix values='0 0 0 0 1  0 0 0 0 1  0 0 0 0 1  0 0 0 0.08 0'/></filter><rect width='100%25' height='100%25' filter='url(%23n)'/></svg>");
+  opacity: 0.55;
+  mix-blend-mode: overlay;
+}
+
+img, svg { display: block; max-width: 100%; }
+a { color: var(--flowkit); text-decoration: none; transition: color 0.2s var(--ease); }
+a:hover { color: var(--text-strong); }
+
+:focus-visible {
+  outline: 2px solid var(--flowkit);
+  outline-offset: 3px;
+  border-radius: var(--r-xs);
 }
 
 /* Skip link */
 .skip-link {
   position: absolute;
-  top: -100%;
   left: 16px;
-  background: var(--accent-green);
-  color: #0d1117;
-  padding: 8px 16px;
-  border-radius: 0 0 var(--radius) var(--radius);
-  font-weight: 600;
+  top: -100%;
+  padding: 10px 18px;
+  background: var(--swarmkit);
+  color: #0a0d13;
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  border-radius: 0 0 var(--r-md) var(--r-md);
+  transition: top 0.2s var(--ease);
   z-index: 100;
-  transition: top 0.2s;
 }
 .skip-link:focus { top: 0; }
 
-* { box-sizing: border-box; margin: 0; padding: 0; }
-
-body {
-  background: var(--bg);
-  color: var(--text);
-  font-family: var(--font-mono);
-  line-height: 1.6;
-  font-size: 15px;
-  overflow-wrap: break-word;
+/* ---------- Layout -------------------------------------------------------- */
+.container {
+  width: 100%;
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 0 28px;
+}
+@media (max-width: 600px) {
+  .container { padding: 0 20px; }
 }
 
-a { color: var(--accent-blue); text-decoration: none; }
-a:hover { text-decoration: underline; }
-
-/* Layout */
-.container { max-width: 1100px; margin: 0 auto; padding: 0 24px; }
-
-/* Section spacing */
-section { padding: 80px 0; }
+/* Section framing with hairline dividers and eyebrow prompts */
+section {
+  padding: 96px 0;
+  position: relative;
+}
 section + section { border-top: 1px solid var(--border); }
 
-/* Section title */
-.section-title {
-  font-size: 1.4rem;
-  color: var(--accent-green);
-  margin-bottom: 40px;
-  letter-spacing: 0.05em;
-}
-.section-title::before { content: '> '; opacity: 0.5; }
-
-.plugin-subheading {
-  font-size: 0.85rem;
-  color: var(--accent-green);
-  opacity: 0.7;
-  letter-spacing: 0.08em;
-  text-transform: lowercase;
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--mono);
+  font-size: 0.76rem;
+  font-weight: 500;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
   margin-bottom: 20px;
-  margin-top: 36px;
+}
+.eyebrow::before {
+  content: '';
+  width: 22px;
+  height: 1px;
+  background: var(--text-muted);
+  opacity: 0.6;
+}
+
+.section-title {
+  font-family: var(--serif);
   font-weight: 400;
+  font-style: italic;
+  font-size: clamp(1.8rem, 3.2vw, 2.6rem);
+  letter-spacing: -0.01em;
+  line-height: 1.05;
+  color: var(--text);
+  margin-bottom: 14px;
 }
-.plugin-subheading:first-of-type { margin-top: 0; }
-
-/* Cards */
-.card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 24px;
-  transition: border-color 0.2s;
-}
-.card:hover { border-color: var(--accent-blue); }
-
-/* Badge */
-.badge {
-  display: inline-block;
-  font-size: 0.7rem;
-  padding: 2px 8px;
-  border-radius: 20px;
-  border: 1px solid var(--border);
+.section-lede {
+  font-family: var(--sans);
+  font-weight: 400;
+  font-size: 1.05rem;
+  line-height: 1.55;
   color: var(--text-muted);
-  letter-spacing: 0.03em;
+  max-width: 60ch;
+  margin-bottom: 52px;
 }
 
-/* Code block */
-pre {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 20px;
-  overflow-x: auto;
-  font-size: 0.9rem;
-  max-width: 100%;
+/* ---------- Hero ---------------------------------------------------------- */
+.hero-wrap {
+  position: relative;
+  padding: 140px 0 100px;
+  overflow: hidden;
+  isolation: isolate;
+}
+.hero-wrap::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(900px 520px at 30% 30%, rgba(188, 140, 255, 0.14), transparent 60%),
+    radial-gradient(700px 520px at 80% 10%, rgba(88, 166, 255, 0.11), transparent 65%);
+  pointer-events: none;
+  z-index: -1;
+}
+/* Orbital halo decoration */
+.hero-orbit {
+  position: absolute;
+  top: 10%;
+  right: -220px;
+  width: 620px;
+  height: 620px;
+  border: 1px solid rgba(188, 140, 255, 0.18);
+  border-radius: 50%;
+  pointer-events: none;
+  z-index: -1;
+  mask: radial-gradient(closest-side, transparent 62%, #000 72%);
+  -webkit-mask: radial-gradient(closest-side, transparent 62%, #000 72%);
+}
+.hero-orbit::before,
+.hero-orbit::after {
+  content: '';
+  position: absolute;
+  inset: -40px;
+  border-radius: 50%;
+  border: 1px dashed rgba(88, 166, 255, 0.14);
+  animation: orbit 60s linear infinite;
+}
+.hero-orbit::after {
+  inset: -90px;
+  border-color: rgba(232, 121, 249, 0.1);
+  animation-duration: 110s;
+  animation-direction: reverse;
+}
+@keyframes orbit { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) {
+  .hero-orbit::before,
+  .hero-orbit::after { animation: none; }
 }
 
-code { font-family: var(--font-mono); }
-
-/* Glow utilities */
-.glow-green { box-shadow: 0 0 20px rgba(63, 185, 80, 0.15); }
-.glow-blue  { box-shadow: 0 0 20px rgba(88, 166, 255, 0.15); }
-
-/* Footer */
-footer {
-  padding: 40px 0;
-  border-top: 1px solid var(--border);
-  text-align: center;
-  color: var(--text-muted);
-  font-size: 0.85rem;
-}
-
-/* Hero */
 .hero {
-  padding: 100px 24px 80px;
-  text-align: center;
+  max-width: 880px;
+  position: relative;
 }
+
 .hero-prompt {
-  font-size: 0.85rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  font-family: var(--mono);
+  font-size: 0.8rem;
   color: var(--text-muted);
-  margin-bottom: 24px;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.02em;
+  padding: 7px 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  margin-bottom: 36px;
+}
+.hero-prompt::before {
+  content: '';
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--swarmkit);
+  box-shadow: 0 0 12px var(--glow-swarm);
 }
 .cursor {
-  color: var(--accent-green);
-  animation: blink 1s step-end infinite;
+  color: var(--swarmkit);
+  animation: blink 1.1s steps(1) infinite;
+  margin-left: 2px;
 }
 @keyframes blink { 50% { opacity: 0; } }
+@media (prefers-reduced-motion: reduce) {
+  .cursor { animation: none; }
+}
+
 .hero-title {
-  font-size: 2.5rem;
-  font-size: clamp(2rem, 5vw, 3.2rem);
-  font-weight: 700;
-  line-height: 1.2;
-  margin-bottom: 20px;
-  color: var(--text);
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: clamp(2.6rem, 6.2vw, 5.3rem);
+  line-height: 0.98;
+  letter-spacing: -0.025em;
+  color: var(--text-strong);
+  margin-bottom: 22px;
+  text-wrap: balance;
+}
+.hero-title .line-two {
+  display: block;
+  font-style: italic;
+  font-weight: 300;
+  background: linear-gradient(120deg, var(--speckit) 0%, var(--flowkit) 60%, var(--vaultkit) 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
 }
 .hero-sub {
-  font-size: 1.05rem;
+  font-family: var(--sans);
+  font-weight: 400;
+  font-size: clamp(1.05rem, 1.8vw, 1.24rem);
+  line-height: 1.55;
   color: var(--text-muted);
-  max-width: 560px;
-  margin: 0 auto 36px;
+  max-width: 56ch;
+  margin-bottom: 40px;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 18px;
 }
 .hero-cta {
-  display: inline-block;
-  padding: 12px 28px;
-  background: var(--accent-green);
-  color: #0d1117;
-  border-radius: var(--radius);
-  font-weight: 600;
-  font-size: 0.95rem;
-  transition: opacity 0.2s;
-}
-.hero-cta:hover { opacity: 0.85; text-decoration: none; }
-.hero-cta:focus-visible { outline: 2px solid var(--text); outline-offset: 3px; }
-
-/* Flow diagram */
-.flow {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  gap: 12px;
-  flex-wrap: nowrap;
+  gap: 10px;
+  padding: 14px 24px;
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 0.98rem;
+  letter-spacing: -0.005em;
+  color: #0a0d13;
+  background: var(--text);
+  border: 1px solid var(--text);
+  border-radius: 999px;
+  transition: transform 0.2s var(--ease), box-shadow 0.25s var(--ease);
+  position: relative;
+  overflow: hidden;
 }
-.flow-node {
-  background: var(--surface);
+.hero-cta::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, var(--speckit), var(--flowkit), var(--swarmkit));
+  opacity: 0;
+  transition: opacity 0.3s var(--ease);
+  z-index: -1;
+}
+.hero-cta:hover {
+  transform: translateY(-1px);
+  color: #0a0d13;
+  text-decoration: none;
+  box-shadow: 0 10px 30px -10px var(--glow-flow);
+}
+.hero-cta:hover::before { opacity: 1; }
+.hero-cta-glyph {
+  display: inline-block;
+  transition: transform 0.25s var(--ease);
+}
+.hero-cta:hover .hero-cta-glyph { transform: translateX(3px); }
+
+.hero-secondary {
+  font-family: var(--mono);
+  font-size: 0.86rem;
+  color: var(--text-muted);
+  letter-spacing: 0.01em;
+}
+.hero-secondary a {
+  color: var(--text);
+  border-bottom: 1px dashed var(--border-strong);
+  padding-bottom: 2px;
+  transition: color 0.2s var(--ease), border-color 0.2s var(--ease);
+}
+.hero-secondary a:hover { color: var(--flowkit); border-color: var(--flowkit); text-decoration: none; }
+
+/* Hero metrics */
+.hero-metrics {
+  display: grid;
+  grid-template-columns: repeat(3, auto);
+  gap: 44px;
+  margin-top: 72px;
+  padding-top: 36px;
+  border-top: 1px solid var(--border);
+  max-width: 640px;
+}
+.hero-metric-n {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 2.2rem;
+  line-height: 1;
+  color: var(--text-strong);
+  letter-spacing: -0.02em;
+}
+.hero-metric-l {
+  display: block;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-top: 8px;
+}
+@media (max-width: 600px) {
+  .hero-metrics { gap: 28px; }
+  .hero-metric-n { font-size: 1.8rem; }
+}
+
+/* ---------- Lifecycle (centerpiece) --------------------------------------- */
+#lifecycle { padding-top: 120px; padding-bottom: 140px; }
+.lifecycle-wrap {
+  position: relative;
+  margin-top: 8px;
+}
+
+/* The diagram sits in a glass panel so it feels intentional */
+.lifecycle-panel {
+  position: relative;
+  padding: 64px 48px 56px;
+  background:
+    radial-gradient(600px 400px at 15% 0%, rgba(188, 140, 255, 0.09), transparent 60%),
+    radial-gradient(600px 400px at 85% 100%, rgba(88, 166, 255, 0.09), transparent 60%),
+    linear-gradient(180deg, rgba(20, 25, 34, 0.85), rgba(10, 13, 19, 0.6));
   border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 20px 24px;
-  text-align: center;
-  min-width: 140px;
-  transition: border-color 0.2s, box-shadow 0.2s;
+  border-radius: var(--r-xl);
+  overflow: hidden;
+}
+.lifecycle-panel::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background-image:
+    linear-gradient(rgba(36, 44, 61, 0.35) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(36, 44, 61, 0.35) 1px, transparent 1px);
+  background-size: 48px 48px;
+  mask: radial-gradient(ellipse at center, #000 0%, transparent 75%);
+  -webkit-mask: radial-gradient(ellipse at center, #000 0%, transparent 75%);
+  opacity: 0.4;
+  pointer-events: none;
+}
+
+.lifecycle-svg-wrap {
+  position: relative;
+  display: block;
+  width: 100%;
+  max-width: 1040px;
+  margin: 0 auto;
+}
+.lifecycle-svg { width: 100%; height: auto; display: block; overflow: visible; }
+
+/* SVG element styling */
+.ls-phase-text {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  fill: var(--text-muted);
+  text-transform: uppercase;
+  font-weight: 600;
+}
+.ls-phase-bar {
+  opacity: 0.8;
+}
+
+.ls-spine {
+  stroke: var(--border-strong);
+  stroke-width: 1.5;
+  fill: none;
+  stroke-dasharray: 2000;
+  stroke-dashoffset: 2000;
+  animation: spine-draw 2s var(--ease) 0.2s forwards;
+}
+@keyframes spine-draw { to { stroke-dashoffset: 0; } }
+@media (prefers-reduced-motion: reduce) {
+  .ls-spine { animation: none; stroke-dashoffset: 0; }
+}
+
+.ls-transfer {
+  stroke-width: 1.25;
+  fill: none;
+  stroke-linecap: round;
+  stroke-dasharray: 200;
+  stroke-dashoffset: 200;
+  animation: transfer-draw 0.9s var(--ease) forwards;
+}
+.ls-transfer[data-kit="speckit"] { stroke: var(--speckit); animation-delay: 0.6s; }
+.ls-transfer[data-kit="swarmkit"] { stroke: var(--swarmkit); animation-delay: 0.75s; }
+.ls-transfer[data-kit="polishkit"] { stroke: var(--polishkit); animation-delay: 0.9s; }
+.ls-transfer[data-kit="flowkit"] { stroke: var(--flowkit); animation-delay: 1.05s; }
+@keyframes transfer-draw { to { stroke-dashoffset: 0; } }
+@media (prefers-reduced-motion: reduce) {
+  .ls-transfer { animation: none; stroke-dashoffset: 0; }
+}
+
+.ls-station {
+  transition: transform 0.25s var(--ease), filter 0.3s var(--ease);
+  transform-origin: center;
+  transform-box: fill-box;
   cursor: default;
 }
-.flow-node:hover {
-  border-color: var(--accent-green);
-  box-shadow: 0 0 20px rgba(63, 185, 80, 0.15);
+.ls-station:hover { transform: scale(1.03); filter: brightness(1.12); }
+
+.ls-node-rect {
+  fill: var(--surface);
+  stroke-width: 1;
 }
-.flow-node-name {
-  font-size: 1rem;
+.ls-node-rect[data-kit="speckit"] { stroke: var(--speckit); filter: drop-shadow(0 0 18px var(--glow-spec)); }
+.ls-node-rect[data-kit="swarmkit"] { stroke: var(--swarmkit); filter: drop-shadow(0 0 18px var(--glow-swarm)); }
+.ls-node-rect[data-kit="polishkit"] { stroke: var(--polishkit); filter: drop-shadow(0 0 18px var(--glow-polish)); }
+.ls-node-rect[data-kit="flowkit"] { stroke: var(--flowkit); filter: drop-shadow(0 0 18px var(--glow-flow)); }
+
+.ls-node-name {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 19px;
+  letter-spacing: -0.015em;
+  dominant-baseline: middle;
+  text-anchor: middle;
+}
+.ls-node-name[data-kit="speckit"] { fill: var(--speckit); }
+.ls-node-name[data-kit="swarmkit"] { fill: var(--swarmkit); }
+.ls-node-name[data-kit="polishkit"] { fill: var(--polishkit); }
+.ls-node-name[data-kit="flowkit"] { fill: var(--flowkit); }
+
+.ls-node-role {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  fill: var(--text-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  dominant-baseline: middle;
+  text-anchor: middle;
+}
+
+.ls-you-rect {
+  fill: var(--surface-raised);
+  stroke: var(--border-strong);
+  stroke-width: 1;
+  stroke-dasharray: 3 3;
+}
+.ls-you-action {
+  font-family: var(--sans);
   font-weight: 600;
-  color: var(--accent-green);
-  margin-bottom: 4px;
+  font-size: 12.5px;
+  fill: var(--text);
+  dominant-baseline: middle;
+  text-anchor: middle;
 }
-.flow-node-label {
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  margin-bottom: 12px;
+.ls-you-hint {
+  font-family: var(--sans);
+  font-weight: 400;
+  font-size: 10.5px;
+  fill: var(--text-muted);
+  dominant-baseline: middle;
+  text-anchor: middle;
+}
+
+/* sessionkit throughout */
+.ls-session-bar {
+  stroke: var(--sessionkit);
+  stroke-width: 1.5;
+  stroke-dasharray: 4 5;
+  fill: none;
+  opacity: 0.7;
+}
+.ls-session-label {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  fill: var(--sessionkit);
+  letter-spacing: 0.06em;
+}
+.ls-session-handoff {
+  font-family: var(--mono);
+  font-size: 10px;
+  fill: var(--text-muted);
   letter-spacing: 0.04em;
 }
-.flow-node-cmds {
+
+/* YOU lane label */
+.ls-lane-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.22em;
+  fill: var(--text-dim);
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+/* AI lane icon (little star / node glyph) */
+.ls-star {
+  fill: var(--text-strong);
+  opacity: 0.5;
+}
+
+/* Legend below diagram */
+.lifecycle-legend {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 28px;
+  margin-top: 32px;
+  padding-top: 24px;
+  border-top: 1px dashed var(--border);
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+.lifecycle-legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.lifecycle-legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: var(--border-strong);
+}
+.lifecycle-legend-dot.ai { background: var(--swarmkit); box-shadow: 0 0 8px var(--glow-swarm); }
+.lifecycle-legend-dot.you { background: transparent; border: 1px dashed var(--text-muted); }
+.lifecycle-legend-dot.session { background: var(--sessionkit); box-shadow: 0 0 8px var(--glow-session); }
+
+/* Mobile fallback: hide SVG, show vertical list */
+.lifecycle-mobile { display: none; }
+
+@media (max-width: 760px) {
+  .lifecycle-svg-wrap { display: none; }
+  .lifecycle-panel { padding: 32px 20px 28px; }
+  .lifecycle-mobile { display: block; }
+}
+
+.lifecycle-mobile-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  list-style: none;
+}
+.lcm-phase-label {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.22em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  padding: 18px 0 4px;
+}
+.lcm-phase-label:first-child { padding-top: 0; }
+.lcm-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  align-items: stretch;
+}
+.lcm-ai, .lcm-you {
+  padding: 14px 16px;
+  border-radius: var(--r-md);
+  background: var(--surface);
+}
+.lcm-ai { border: 1px solid var(--border); }
+.lcm-you { border: 1px dashed var(--border-strong); background: var(--surface-raised); }
+.lcm-ai-name {
+  font-family: var(--serif);
+  font-size: 1.1rem;
+  font-weight: 400;
+  display: block;
+  margin-bottom: 4px;
+}
+.lcm-ai-name[data-kit="speckit"] { color: var(--speckit); }
+.lcm-ai-name[data-kit="swarmkit"] { color: var(--swarmkit); }
+.lcm-ai-name[data-kit="polishkit"] { color: var(--polishkit); }
+.lcm-ai-name[data-kit="flowkit"] { color: var(--flowkit); }
+.lcm-ai-role {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  color: var(--text-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.lcm-you-action {
+  font-family: var(--sans);
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--text);
+  display: block;
+  margin-bottom: 3px;
+}
+.lcm-you-hint {
+  font-family: var(--sans);
+  font-size: 0.76rem;
+  color: var(--text-muted);
+}
+.lcm-session {
+  margin-top: 24px;
+  padding: 18px 20px;
+  border: 1px dashed var(--sessionkit);
+  border-radius: var(--r-md);
+  color: var(--sessionkit);
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  text-align: center;
+  letter-spacing: 0.04em;
+}
+
+/* ---------- Plugin cards -------------------------------------------------- */
+#plugins { padding-top: 110px; padding-bottom: 110px; }
+
+.plugin-category {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 24px;
+  margin-top: 56px;
+  margin-bottom: 26px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--border);
+}
+.plugin-category:first-of-type { margin-top: 0; }
+.plugin-category-title {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 1.7rem;
+  color: var(--text);
+  letter-spacing: -0.01em;
+}
+.plugin-category-count {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.plugin-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 22px;
+}
+@media (max-width: 880px) {
+  .plugin-grid { grid-template-columns: 1fr; }
+}
+
+.plugin-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  background:
+    radial-gradient(700px 320px at 0% 0%, rgba(255, 255, 255, 0.022), transparent 60%),
+    linear-gradient(180deg, var(--surface), var(--bg-raised));
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  padding: 28px 26px 22px;
+  transition: border-color 0.25s var(--ease), transform 0.25s var(--ease), box-shadow 0.3s var(--ease);
+  overflow: hidden;
+}
+.plugin-card::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0;
+  width: 52%;
+  height: 2px;
+  background: var(--accent, var(--border));
+  opacity: 0.9;
+  transition: width 0.4s var(--ease);
+}
+.plugin-card:hover {
+  transform: translateY(-2px);
+  border-color: color-mix(in oklab, var(--accent, var(--border-strong)) 60%, var(--border) 40%);
+  box-shadow: 0 22px 48px -24px color-mix(in oklab, var(--accent, var(--border)) 70%, transparent);
+}
+.plugin-card:hover::before { width: 100%; }
+
+/* Per-kit accents via CSS variable */
+.plugin-card[data-kit="speckit"]   { --accent: var(--speckit); }
+.plugin-card[data-kit="swarmkit"]  { --accent: var(--swarmkit); }
+.plugin-card[data-kit="polishkit"] { --accent: var(--polishkit); }
+.plugin-card[data-kit="flowkit"]   { --accent: var(--flowkit); }
+.plugin-card[data-kit="sessionkit"]{ --accent: var(--sessionkit); }
+.plugin-card[data-kit="vaultkit"]  { --accent: var(--vaultkit); }
+
+.plugin-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+.plugin-card-id {
   display: flex;
   flex-direction: column;
   gap: 4px;
 }
-.flow-node-cmds span {
-  font-size: 0.8rem;
-  color: var(--accent-blue);
-  background: var(--surface-raised);
-  border-radius: 4px;
-  padding: 2px 8px;
+.plugin-name {
+  font-family: var(--serif);
+  font-weight: 400;
+  font-size: 1.7rem;
+  line-height: 1;
+  letter-spacing: -0.015em;
+  color: var(--accent, var(--text));
 }
-.flow-arrow {
-  font-size: 1.4rem;
+.plugin-role {
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
   color: var(--text-muted);
-  flex-shrink: 0;
 }
-@media (max-width: 900px) {
-  .flow {
-    flex-direction: column;
-    align-items: stretch;
-    max-width: 320px;
-    margin: 0 auto;
-  }
-  .flow-arrow {
-    text-align: center;
-    transform: rotate(90deg);
-  }
-}
-
-/* Plugin grid */
-.plugin-grid {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 20px;
-}
-@media (max-width: 700px) {
-  .plugin-grid { grid-template-columns: 1fr; }
-}
-.plugin-card-header {
+.plugin-meta {
   display: flex;
   align-items: center;
   gap: 10px;
-  margin-bottom: 12px;
 }
-.plugin-name {
-  font-size: 1.05rem;
-  font-weight: 600;
-  color: var(--accent-green);
+.badge {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  padding: 3px 8px;
+  color: var(--text-muted);
+  border: 1px solid var(--border-strong);
+  border-radius: 999px;
 }
-.plugin-card-header { justify-content: flex-start; }
 .plugin-readme {
-  margin-left: auto;
-  font-size: 0.75rem;
+  font-family: var(--mono);
+  font-size: 0.74rem;
   color: var(--text-muted);
-  white-space: nowrap;
+  letter-spacing: 0.02em;
+  transition: color 0.2s var(--ease);
 }
-.plugin-readme:hover { color: var(--accent-blue); text-decoration: none; }
+.plugin-readme:hover { color: var(--accent, var(--text)); text-decoration: none; }
+
 .plugin-desc {
-  font-size: 0.875rem;
+  font-family: var(--sans);
+  font-size: 0.95rem;
+  line-height: 1.55;
   color: var(--text-muted);
-  margin-bottom: 16px;
-  line-height: 1.6;
-  word-break: break-word;
+  margin-bottom: 20px;
 }
+
 .skill-list {
   list-style: none;
   display: flex;
   flex-direction: column;
   gap: 6px;
+  margin: 0 0 22px;
+  padding: 0;
 }
 .skill-list li {
-  font-size: 0.8rem;
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  line-height: 1.55;
   color: var(--text-muted);
 }
 .skill-list code {
-  color: var(--accent-blue);
-  background: var(--surface-raised);
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  color: var(--accent, var(--flowkit));
+  background: rgba(255, 255, 255, 0.02);
   padding: 1px 6px;
-  border-radius: 4px;
+  border-radius: var(--r-xs);
+  margin-right: 4px;
 }
 
-/* ==========================================================================
-   Terminal transcript component (issue #190)
-   Annotated Claude Code session block. Slots into .plugin-card below
-   .skill-list. Always-visible, no collapse. Preserves whitespace but wraps
-   long lines so it stays readable down to 320px viewports.
-   Colour tokens:
-     --accent-green for prompt markers ($, ►, ✓)
-     --accent-blue  for commands / skill invocations (/spec, /swarm, ...)
-     --text-muted   for annotations and secondary text
-   ========================================================================== */
+/* Transcript — stylized terminal frame */
 .transcript {
-  margin-top: 16px;
-  background: var(--surface-raised);
+  position: relative;
+  margin-top: auto;
+  padding: 36px 18px 16px;
+  background:
+    linear-gradient(180deg, #0a0d13, #070a10);
   border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 14px 16px;
-  font-family: var(--font-mono);
+  border-radius: var(--r-md);
+  font-family: var(--mono);
   font-size: 0.78rem;
-  line-height: 1.55;
+  line-height: 1.75;
   color: var(--text);
+  overflow-x: auto;
   white-space: pre-wrap;
-  overflow-wrap: break-word;
   word-break: break-word;
 }
+.transcript::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0; right: 0;
+  height: 26px;
+  background: linear-gradient(180deg, #131822, #0e1219);
+  border-bottom: 1px solid var(--border);
+  border-radius: var(--r-md) var(--r-md) 0 0;
+}
+.transcript::after {
+  /* Dots + label in the frame chrome */
+  content: '● ● ●   example session';
+  position: absolute;
+  top: 0;
+  left: 14px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  color: var(--text-dim);
+  pointer-events: none;
+}
+.transcript-line { display: block; }
+.transcript-prompt { color: var(--accent, var(--swarmkit)); font-weight: 700; margin-right: 3px; }
+.transcript-cmd { color: var(--flowkit); font-weight: 600; }
+.transcript-annotate { color: var(--text-muted); }
 
-.transcript-line {
-  display: block;
-  min-height: 1.55em;
+/* Utilities card (single card, no transcript) */
+.plugin-grid.single {
+  grid-template-columns: minmax(0, 560px);
 }
 
-.transcript-prompt {
-  color: var(--accent-green);
-  font-weight: 600;
+/* ---------- Install ------------------------------------------------------- */
+#install {
+  padding-top: 110px;
+  padding-bottom: 130px;
 }
-
-.transcript-cmd {
-  color: var(--accent-blue);
-}
-
-.transcript-annotate {
-  color: var(--text-muted);
-}
-
-/* Install section */
-.install-section { max-width: 800px; margin: 0 auto; }
 .install-intro {
-  font-size: 0.9rem;
+  font-family: var(--sans);
+  font-size: 1.02rem;
   color: var(--text-muted);
-  margin-bottom: 24px;
+  max-width: 56ch;
+  margin-bottom: 44px;
 }
-.install-blocks { display: flex; flex-direction: column; gap: 16px; }
-.install-block + .install-block { margin-top: 32px; }
-.install-block .code-copy-wrapper + .code-copy-wrapper { margin-top: 10px; }
-.install-block-label {
-  font-size: 0.8rem;
-  color: var(--accent-green);
-  margin-bottom: 6px;
-  letter-spacing: 0.04em;
+
+.install-steps {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  gap: 22px;
 }
+.install-step {
+  position: relative;
+  display: grid;
+  grid-template-columns: 62px 1fr;
+  gap: 22px;
+  padding: 30px 30px 26px;
+  background: linear-gradient(180deg, var(--surface), var(--bg-raised));
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  overflow: hidden;
+}
+.install-step-n {
+  font-family: var(--serif);
+  font-weight: 300;
+  font-size: 3.2rem;
+  line-height: 1;
+  color: transparent;
+  -webkit-text-stroke: 1px var(--text-muted);
+  letter-spacing: -0.02em;
+  padding-top: 2px;
+}
+.install-step-head {
+  margin-bottom: 18px;
+}
+.install-step-title {
+  font-family: var(--serif);
+  font-style: italic;
+  font-weight: 400;
+  font-size: 1.35rem;
+  color: var(--text);
+  margin-bottom: 4px;
+  letter-spacing: -0.01em;
+}
+.install-step-sub {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  text-transform: lowercase;
+}
+
+.install-commands {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.install-sublabel {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-top: 18px;
+  margin-bottom: 4px;
+}
+.install-sublabel:first-child { margin-top: 4px; }
+
 .code-copy-wrapper {
   position: relative;
   display: flex;
   align-items: stretch;
-  gap: 0;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  overflow: hidden;
+  transition: border-color 0.2s var(--ease);
 }
+.code-copy-wrapper:hover { border-color: var(--border-strong); }
 .code-copy-wrapper pre {
   flex: 1;
-  border-radius: var(--radius) 0 0 var(--radius);
+  margin: 0;
+  padding: 12px 14px;
   overflow-x: auto;
+  background: transparent;
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  color: var(--text);
+  line-height: 1.4;
   white-space: nowrap;
+}
+.code-copy-wrapper pre code {
+  font-family: var(--mono);
+  color: var(--text);
 }
 .copy-btn {
-  background: var(--surface-raised);
-  border: 1px solid var(--border);
-  border-left: none;
-  border-radius: 0 var(--radius) var(--radius) 0;
+  flex-shrink: 0;
+  padding: 0 18px;
+  background: transparent;
+  border: none;
+  border-left: 1px solid var(--border);
+  font-family: var(--mono);
+  font-size: 0.76rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
   color: var(--text-muted);
-  font-family: var(--font-mono);
-  font-size: 0.8rem;
-  padding: 0 16px;
   cursor: pointer;
-  transition: background 0.2s, color 0.2s;
-  white-space: nowrap;
+  transition: background 0.2s var(--ease), color 0.2s var(--ease);
 }
-.copy-btn:hover { background: var(--border); color: var(--text); }
-.copy-btn:focus-visible { outline: 2px solid var(--accent-blue); outline-offset: 2px; }
+.copy-btn:hover { background: var(--surface); color: var(--text); }
+.copy-btn.copied { color: var(--swarmkit); }
 
-/* sessionkit "throughout" */
-.flow-throughout {
+@media (min-width: 700px) {
+  .install-step { grid-template-columns: 120px 1fr; gap: 28px; padding: 34px 34px 30px; }
+  .install-step-n { font-size: 4.6rem; }
+}
+
+/* ---------- Footer -------------------------------------------------------- */
+footer {
+  border-top: 1px solid var(--border);
+  padding: 40px 0 56px;
+}
+.footer-inner {
   display: flex;
-  flex-direction: column;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  font-family: var(--mono);
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+.footer-wordmark {
+  display: inline-flex;
   align-items: center;
   gap: 10px;
-  margin-top: 28px;
+  color: var(--text);
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 1.1rem;
+  letter-spacing: -0.01em;
 }
-.flow-throughout-label {
-  font-size: 0.72rem;
-  color: var(--text-muted);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-}
-.flow-node--throughout {
-  border-style: dashed;
-  border-color: var(--accent-purple);
-  min-width: 220px;
-}
-.flow-node--throughout .flow-node-name { color: var(--accent-purple); }
-.flow-node--throughout:hover {
-  border-color: var(--accent-purple);
-  box-shadow: 0 0 20px rgba(188, 140, 255, 0.15);
-}
-
-/* ==========================================================================
-   Two-track lifecycle viz (issue #187)
-   Stacked lanes: phase labels -> AI row -> handoff arrows -> YOU row.
-   Grid uses auto-flow columns so adding a phase (e.g. REVIEW) is markup-only;
-   no CSS changes required. Under 900px lanes stack vertically.
-   ========================================================================== */
-.lifecycle {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  grid-template-rows: auto auto auto auto;
-  row-gap: 16px;
-  column-gap: 16px;
-  align-items: stretch;
-}
-
-.lifecycle-phase {
-  grid-row: 1;
-  font-size: 0.72rem;
-  font-weight: 600;
-  color: var(--text-muted);
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  text-align: center;
-  padding-bottom: 8px;
-  border-bottom: 1px solid var(--border);
-}
-
-.lifecycle-ai {
-  grid-row: 2;
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 16px 18px;
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  transition: border-color 0.2s, box-shadow 0.2s;
-}
-.lifecycle-ai:hover {
-  border-color: var(--accent-green);
-  box-shadow: 0 0 20px rgba(63, 185, 80, 0.15);
-}
-.lifecycle-ai-name {
-  font-size: 0.95rem;
-  font-weight: 600;
-  color: var(--accent-green);
-  white-space: nowrap;
-}
-.lifecycle-ai-role {
-  font-size: 0.72rem;
-  color: var(--text-muted);
-  letter-spacing: 0.04em;
-}
-
-.lifecycle-handoff {
-  grid-row: 3;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  color: var(--text-muted);
-  font-size: 1.2rem;
-  line-height: 1;
-  padding: 4px 0;
-}
-.lifecycle-handoff::before {
+.footer-wordmark::before {
   content: '';
-  width: 1px;
-  height: 18px;
-  background: var(--border);
-  margin-right: 6px;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, #fff 0%, var(--swarmkit) 40%, transparent 90%);
 }
-.lifecycle-handoff::after {
-  content: '';
-  width: 1px;
-  height: 18px;
-  background: var(--border);
-  margin-left: 6px;
+.footer-links {
+  display: inline-flex;
+  gap: 18px;
+  flex-wrap: wrap;
 }
 
-.lifecycle-you {
-  grid-row: 4;
-  background: var(--surface);
-  border: 1px dashed var(--border);
-  border-radius: var(--radius);
-  padding: 14px 16px;
-  text-align: center;
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  transition: border-color 0.2s, box-shadow 0.2s;
+/* ---------- Scroll-reveal base ------------------------------------------- */
+/* Only hide reveal items when JS is confirmed available; no-JS users see all content */
+.js .reveal {
+  opacity: 0;
+  transform: translateY(14px);
+  transition: opacity 0.7s var(--ease), transform 0.7s var(--ease);
 }
-.lifecycle-you:hover {
-  border-color: var(--accent-blue);
-  box-shadow: 0 0 20px rgba(88, 166, 255, 0.15);
-}
-.lifecycle-you-action {
-  font-size: 0.85rem;
-  font-weight: 600;
-  color: var(--accent-blue);
-}
-.lifecycle-ai,
-.lifecycle-you { word-break: normal; overflow-wrap: normal; }
-.lifecycle-you-hint {
-  font-size: 0.72rem;
-  color: var(--text-muted);
-  letter-spacing: 0.03em;
+.js .reveal.in { opacity: 1; transform: none; }
+.reveal[data-delay="1"] { transition-delay: 0.05s; }
+.reveal[data-delay="2"] { transition-delay: 0.1s; }
+.reveal[data-delay="3"] { transition-delay: 0.2s; }
+.reveal[data-delay="4"] { transition-delay: 0.3s; }
+.reveal[data-delay="5"] { transition-delay: 0.4s; }
+@media (prefers-reduced-motion: reduce) {
+  .reveal { opacity: 1; transform: none; transition: none; }
 }
 
-@media (max-width: 900px) {
-  .lifecycle {
-    grid-template-rows: none;
-    grid-template-columns: minmax(0, 1fr);
-    row-gap: 10px;
-    max-width: 420px;
-    margin: 0 auto;
-  }
-  .lifecycle-phase,
-  .lifecycle-ai,
-  .lifecycle-handoff,
-  .lifecycle-you {
-    grid-row: auto;
-    grid-column: 1;
-  }
-  .lifecycle-phase {
-    text-align: left;
-    padding-bottom: 6px;
-    margin-top: 14px;
-  }
-  .lifecycle-phase:first-child { margin-top: 0; }
-  .lifecycle-handoff {
-    justify-content: flex-start;
-    padding: 2px 0 2px 8px;
-  }
-  .lifecycle-handoff::before,
-  .lifecycle-handoff::after {
-    width: 18px;
-    height: 1px;
-  }
+/* Initial hero load stagger */
+.hero > * {
+  opacity: 0;
+  transform: translateY(14px);
+  animation: hero-fade 0.9s var(--ease) forwards;
 }
-
-@media (max-width: 380px) {
-  .lifecycle-phase { font-size: 0.68rem; letter-spacing: 0.08em; }
-  .lifecycle-ai-name { font-size: 0.9rem; }
-  .lifecycle-you-action { font-size: 0.8rem; }
+.hero > *:nth-child(1) { animation-delay: 0.1s; }
+.hero > *:nth-child(2) { animation-delay: 0.22s; }
+.hero > *:nth-child(3) { animation-delay: 0.34s; }
+.hero > *:nth-child(4) { animation-delay: 0.46s; }
+.hero > *:nth-child(5) { animation-delay: 0.58s; }
+.hero > *:nth-child(6) { animation-delay: 0.7s; }
+@keyframes hero-fade { to { opacity: 1; transform: none; } }
+@media (prefers-reduced-motion: reduce) {
+  .hero > * { opacity: 1; transform: none; animation: none; }
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -57,6 +57,18 @@ section + section { border-top: 1px solid var(--border); }
 }
 .section-title::before { content: '> '; opacity: 0.5; }
 
+.plugin-subheading {
+  font-size: 0.85rem;
+  color: var(--accent-green);
+  opacity: 0.7;
+  letter-spacing: 0.08em;
+  text-transform: lowercase;
+  margin-bottom: 20px;
+  margin-top: 36px;
+  font-weight: 400;
+}
+.plugin-subheading:first-of-type { margin-top: 0; }
+
 /* Cards */
 .card {
   background: var(--surface);
@@ -263,6 +275,49 @@ footer {
   border-radius: 4px;
 }
 
+/* ==========================================================================
+   Terminal transcript component (issue #190)
+   Annotated Claude Code session block. Slots into .plugin-card below
+   .skill-list. Always-visible, no collapse. Preserves whitespace but wraps
+   long lines so it stays readable down to 320px viewports.
+   Colour tokens:
+     --accent-green for prompt markers ($, ►, ✓)
+     --accent-blue  for commands / skill invocations (/spec, /swarm, ...)
+     --text-muted   for annotations and secondary text
+   ========================================================================== */
+.transcript {
+  margin-top: 16px;
+  background: var(--surface-raised);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  line-height: 1.55;
+  color: var(--text);
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  word-break: break-word;
+}
+
+.transcript-line {
+  display: block;
+  min-height: 1.55em;
+}
+
+.transcript-prompt {
+  color: var(--accent-green);
+  font-weight: 600;
+}
+
+.transcript-cmd {
+  color: var(--accent-blue);
+}
+
+.transcript-annotate {
+  color: var(--text-muted);
+}
+
 /* Install section */
 .install-section { max-width: 800px; margin: 0 auto; }
 .install-intro {
@@ -330,4 +385,151 @@ footer {
 .flow-node--throughout:hover {
   border-color: var(--accent-purple);
   box-shadow: 0 0 20px rgba(188, 140, 255, 0.15);
+}
+
+/* ==========================================================================
+   Two-track lifecycle viz (issue #187)
+   Stacked lanes: phase labels -> AI row -> handoff arrows -> YOU row.
+   Grid uses auto-flow columns so adding a phase (e.g. REVIEW) is markup-only;
+   no CSS changes required. Under 900px lanes stack vertically.
+   ========================================================================== */
+.lifecycle {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(0, 1fr);
+  grid-template-rows: auto auto auto auto;
+  row-gap: 16px;
+  column-gap: 16px;
+  align-items: stretch;
+}
+
+.lifecycle-phase {
+  grid-row: 1;
+  font-size: 0.72rem;
+  font-weight: 600;
+  color: var(--text-muted);
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-align: center;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border);
+}
+
+.lifecycle-ai {
+  grid-row: 2;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px 18px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+.lifecycle-ai:hover {
+  border-color: var(--accent-green);
+  box-shadow: 0 0 20px rgba(63, 185, 80, 0.15);
+}
+.lifecycle-ai-name {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--accent-green);
+}
+.lifecycle-ai-role {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  letter-spacing: 0.04em;
+}
+
+.lifecycle-handoff {
+  grid-row: 3;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  color: var(--text-muted);
+  font-size: 1.2rem;
+  line-height: 1;
+  padding: 4px 0;
+}
+.lifecycle-handoff::before {
+  content: '';
+  width: 1px;
+  height: 18px;
+  background: var(--border);
+  margin-right: 6px;
+}
+.lifecycle-handoff::after {
+  content: '';
+  width: 1px;
+  height: 18px;
+  background: var(--border);
+  margin-left: 6px;
+}
+
+.lifecycle-you {
+  grid-row: 4;
+  background: var(--surface);
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+.lifecycle-you:hover {
+  border-color: var(--accent-blue);
+  box-shadow: 0 0 20px rgba(88, 166, 255, 0.15);
+}
+.lifecycle-you-action {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--accent-blue);
+}
+.lifecycle-you-hint {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  letter-spacing: 0.03em;
+}
+
+@media (max-width: 900px) {
+  .lifecycle {
+    grid-auto-flow: row;
+    grid-auto-columns: initial;
+    grid-template-rows: none;
+    grid-template-columns: minmax(0, 1fr);
+    row-gap: 10px;
+    max-width: 420px;
+    margin: 0 auto;
+  }
+  .lifecycle-phase,
+  .lifecycle-ai,
+  .lifecycle-handoff,
+  .lifecycle-you {
+    grid-row: auto;
+    grid-column: 1;
+  }
+  .lifecycle-phase {
+    text-align: left;
+    padding-bottom: 6px;
+    margin-top: 14px;
+  }
+  .lifecycle-phase:first-child { margin-top: 0; }
+  .lifecycle-handoff {
+    justify-content: flex-start;
+    padding: 2px 0 2px 8px;
+  }
+  .lifecycle-handoff::before,
+  .lifecycle-handoff::after {
+    width: 18px;
+    height: 1px;
+  }
+}
+
+@media (max-width: 380px) {
+  .lifecycle-phase { font-size: 0.68rem; letter-spacing: 0.08em; }
+  .lifecycle-ai-name { font-size: 0.9rem; }
+  .lifecycle-you-action { font-size: 0.8rem; }
 }

--- a/docs/style.css
+++ b/docs/style.css
@@ -395,8 +395,7 @@ footer {
    ========================================================================== */
 .lifecycle {
   display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(0, 1fr);
+  grid-template-columns: repeat(4, minmax(0, 1fr));
   grid-template-rows: auto auto auto auto;
   row-gap: 16px;
   column-gap: 16px;
@@ -435,6 +434,7 @@ footer {
   font-size: 0.95rem;
   font-weight: 600;
   color: var(--accent-green);
+  white-space: nowrap;
 }
 .lifecycle-ai-role {
   font-size: 0.72rem;
@@ -488,6 +488,8 @@ footer {
   font-weight: 600;
   color: var(--accent-blue);
 }
+.lifecycle-ai,
+.lifecycle-you { word-break: normal; overflow-wrap: normal; }
 .lifecycle-you-hint {
   font-size: 0.72rem;
   color: var(--text-muted);
@@ -496,8 +498,6 @@ footer {
 
 @media (max-width: 900px) {
   .lifecycle {
-    grid-auto-flow: row;
-    grid-auto-columns: initial;
     grid-template-rows: none;
     grid-template-columns: minmax(0, 1fr);
     row-gap: 10px;

--- a/docs/style.css
+++ b/docs/style.css
@@ -605,20 +605,18 @@ section + section { border-top: 1px solid var(--border); }
 .lifecycle-legend-dot.you { background: transparent; border: 1px dashed var(--text-muted); }
 .lifecycle-legend-dot.session { background: var(--sessionkit); box-shadow: 0 0 8px var(--glow-session); }
 
-/* Mobile fallback: hide SVG, show vertical list */
-.lifecycle-mobile { display: none; }
+/* Mobile fallback: hide by default, show vertical list under 760px */
+.lifecycle-mobile-list {
+  display: none;
+  flex-direction: column;
+  gap: 14px;
+  list-style: none;
+}
 
 @media (max-width: 760px) {
   .lifecycle-svg-wrap { display: none; }
   .lifecycle-panel { padding: 32px 20px 28px; }
-  .lifecycle-mobile { display: block; }
-}
-
-.lifecycle-mobile-list {
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-  list-style: none;
+  .lifecycle-mobile-list { display: flex; }
 }
 .lcm-phase-label {
   font-family: var(--mono);


### PR DESCRIPTION
Release from rc/2026-04-17.11

## Highlights

- **One-pager rebuild** — Astronomical Terminal aesthetic: Fraunces display serif for hero + kit names, Mona Sans for section/body, JetBrains Mono for code. Custom SVG subway-map lifecycle with per-kit color identity.
- Typography tuning: modern sans-serif section titles (Mona Sans bold), readable lifecycle labels, Mona Sans footer wordmark.
- Numeric marketing emphasis removed — no more "six plugins," "four phases," "infinite human checkpoints" framing.
- Mobile lifecycle fallback fixed (no longer leaks into desktop view).

## Commits in this release

- docs(web): scrub numeric emphasis throughout the one-pager
- fix(docs): swap footer wordmark to Mona Sans
- fix(docs): scale up lifecycle labels, swap section titles to Mona Sans
- fix(docs): hide mobile lifecycle fallback on desktop
- feat(docs): rebuild one-pager with Astronomical Terminal aesthetic
- fix(docs): repair lifecycle grid column alignment
- feat(docs): add two-track lifecycle viz CSS (#204) — closes #186, #187, #188, #189, #190, #191, #192, #193, #194, #195, #196