### PR TITLE
fix(docs): polish hero descenders, anchor landings, and AI legend dot

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -285,6 +285,8 @@ section + section { border-top: 1px solid var(--border); }
   display: block;
   font-style: italic;
   font-weight: 300;
+  line-height: 1.12;
+  padding-bottom: 0.12em;
   background: linear-gradient(120deg, var(--speckit) 0%, var(--flowkit) 60%, var(--vaultkit) 100%);
   -webkit-background-clip: text;
   background-clip: text;
@@ -360,7 +362,7 @@ section + section { border-top: 1px solid var(--border); }
 .hero-secondary a:hover { color: var(--flowkit); border-color: var(--flowkit); text-decoration: none; }
 
 /* ---------- Lifecycle (centerpiece) --------------------------------------- */
-#lifecycle { padding-top: 120px; padding-bottom: 140px; }
+#lifecycle { padding-top: 48px; padding-bottom: 140px; scroll-margin-top: 12px; }
 .lifecycle-wrap {
   position: relative;
   margin-top: 8px;
@@ -569,7 +571,10 @@ section + section { border-top: 1px solid var(--border); }
   border-radius: 50%;
   background: var(--border-strong);
 }
-.lifecycle-legend-dot.ai { background: var(--swarmkit); box-shadow: 0 0 8px var(--glow-swarm); }
+.lifecycle-legend-dot.ai {
+  background: conic-gradient(from 220deg, var(--speckit), var(--swarmkit), var(--polishkit), var(--flowkit), var(--speckit));
+  box-shadow: 0 0 8px rgba(188, 140, 255, 0.35);
+}
 .lifecycle-legend-dot.you { background: transparent; border: 1px dashed var(--text-muted); }
 .lifecycle-legend-dot.session { background: var(--sessionkit); box-shadow: 0 0 8px var(--glow-session); }
 
@@ -850,8 +855,9 @@ section + section { border-top: 1px solid var(--border); }
 
 /* ---------- Install ------------------------------------------------------- */
 #install {
-  padding-top: 110px;
+  padding-top: 48px;
   padding-bottom: 130px;
+  scroll-margin-top: 12px;
 }
 .install-intro {
   font-family: var(--sans);


### PR DESCRIPTION
## Summary

- **Hero descender clipping** — `line-height: 0.98` plus `background-clip: text` was cutting off the bottoms of italic descenders (`y` in *you*, `p` in *loop*) on the line-two heading. Loosened `line-height` to `1.12` and added `padding-bottom: 0.12em` so the gradient text has room for its own descenders.
- **Anchor landings** — `#lifecycle` and `#install` had 120px / 110px top padding, so clicking the in-page anchors landed the viewport in dead space with the diagram cut off below the fold. Trimmed both to `padding-top: 48px` and added `scroll-margin-top: 12px` for a tighter anchor target.
- **AI legend dot** — the legend dot was solid green (swarmkit), implying every AI station should be green, but the SVG colors each station per kit (purple / green / orange / blue). Replaced the dot with a conic gradient across all four kit colors so the legend matches what's drawn.

## Test plan

- [ ] Reload the docs page; confirm italic descenders on "With you in the loop." are no longer clipped at the bottom.
- [ ] Click "see the flow" in the hero; confirm the lifecycle title sits near the top with the full diagram visible in the viewport.
- [ ] Click "Get started"; confirm the install section lands the same way.
- [ ] Inspect the lifecycle legend; confirm the AI agent dot now reads as a multi-color gradient consistent with the per-kit station coloring.