### PR TITLE
fix(flowkit:release): tag-safe RC cleanup and release-scoped LAST_TAG

### DIFF
--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -169,7 +169,7 @@ git push origin "$TAG"
 
 ```bash
 TODAY=$(date +%Y-%m-%d)
-git ls-remote origin "rc/$TODAY*" \
+git ls-remote --heads origin "rc/$TODAY*" \
   | awk '{print $2}' \
   | sed 's|refs/heads/||' \
   | while read rc; do

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -52,7 +52,7 @@ If `SOURCE` is empty, abort with an error — there is nothing to release.
 Find the last release tag and collect all `Closes/Fixes/Resolves #N` references from PRs merged into `develop` since that tag's date. The tag-date filter ensures only PRs from the current release cycle are included, not all PRs ever merged:
 
 ```bash
-LAST_TAG=$(git tag --sort=-version:refname | head -1)
+LAST_TAG=$(git tag --list 'v[0-9]*' --sort=-version:refname | head -1)
 
 if [ -n "$LAST_TAG" ]; then
   TAG_DATE=$(git log -1 --format=%aI "$LAST_TAG")


### PR DESCRIPTION
## Summary

Two independent one-line fixes to `plugins/flowkit/skills/release/SKILL.md`:

- **#232**: Add `--heads` to `git ls-remote` in the RC cleanup loop so it no longer deletes RC tags alongside branches.
- **#214**: Scope `LAST_TAG` resolution to release-pattern tags (`v[0-9]*`) so per-plugin tags (e.g. `vaultkit--v1.0.0`) don't win the `--sort=-version:refname` comparison.

## Test plan

- [ ] Inspect the two changed lines in `plugins/flowkit/skills/release/SKILL.md` against the fixes described in #232 and #214.
- [ ] Dry-run `git ls-remote --heads origin 'rc/*'` to confirm tag refs are excluded.
- [ ] Dry-run `git tag --list 'v[0-9]*' --sort=-version:refname | head -1` to confirm it resolves to the latest release tag.

Closes #232
Closes #214