### PR TITLE
fix(flowkit:release): limit source detection to branch refs

### DIFF
--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -38,7 +38,7 @@ git ls-remote --exit-code origin staging &>/dev/null && STAGING_EXISTS=true || S
 if [ "$STAGING_EXISTS" = "true" ]; then
   SOURCE="staging"
 else
-  SOURCE=$(git ls-remote --sort=-version:refname origin "rc/*" \
+  SOURCE=$(git ls-remote --heads --sort=-version:refname origin "rc/*" \
     | head -1 \
     | awk '{print $2}' \
     | sed 's|refs/heads/||')


### PR DESCRIPTION
## Summary

Add `--heads` to the `git ls-remote` call in step 3 source-branch detection so it only returns branch refs (`refs/heads/rc/...`), not tag refs (`refs/tags/rc/...`). Matches the #232 fix for step 9.

Without `--heads`, a high-sorting tag ref was being returned — `sed 's|refs/heads/||'` is a no-op on a tag ref, so `SOURCE` would come back as e.g. `refs/tags/rc/2026-04-18.2` instead of `rc/2026-04-18.2`.

## Test plan

- [ ] Run `git ls-remote --heads origin 'rc/*'` on a repo with both RC branches and RC tags — verify only branch refs returned.
- [ ] Inspect the single-line diff in `plugins/flowkit/skills/release/SKILL.md` step 3.

Closes #236