### PR TITLE
fix(flowkit:release): repair step 4 PR aggregation jq invocation

### DIFF
--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -55,10 +55,11 @@ Find the last release tag and collect all `Closes/Fixes/Resolves #N` references 
 LAST_TAG=$(git tag --list 'v[0-9]*' --sort=-version:refname | head -1)
 
 if [ -n "$LAST_TAG" ]; then
-  TAG_DATE=$(git log -1 --format=%aI "$LAST_TAG")
+  TAG_DATE=$(git log -1 --format=%aI "$LAST_TAG" \
+    | python3 -c "import sys; from datetime import datetime, timezone; print(datetime.fromisoformat(sys.stdin.read().strip()).astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))")
   MERGED_PRS=$(gh pr list --base develop --state merged --json body,mergedAt \
-    --jq --arg td "$TAG_DATE" \
-    '.[] | select((.mergedAt | fromdateiso8601) > ($td | fromdateiso8601)) | .body')
+    | jq --arg td "$TAG_DATE" -r \
+        '.[] | select((.mergedAt | fromdateiso8601) > ($td | fromdateiso8601)) | .body')
   ISSUE_REFS=$(echo "$MERGED_PRS" | grep -oiE '(closes|fixes|resolves) #[0-9]+' | sort -u)
 fi
 ```


### PR DESCRIPTION
## Summary

Fix two independent defects in the step 4 PR-aggregation block that caused `ISSUE_REFS` to silently come back empty on every release:

1. `gh pr list --jq` does not accept `--arg` bindings — piped into standalone `jq` instead so `--arg td` works as expected.
2. `fromdateiso8601` rejects numeric-offset ISO-8601 dates (what `git log --format=%aI` emits) — normalize `TAG_DATE` to Zulu UTC via a `python3` one-liner before the comparison.

Without this fix, every `/release` run produces a PR body with no `Closes #N` lines, so no issues get closed by the release merge into main — a silent regression from the #226 fix.

## Test plan

- [ ] On a repo with multiple PRs merged into develop since the last release tag, run the replaced block interactively and verify `ISSUE_REFS` contains the expected `Closes #N` lines (not empty).
- [ ] Verify `TAG_DATE` after normalization ends in `Z`, not `-HH:MM`.
- [ ] Dry-run `jq --arg td "<Z-date>" ...` against a captured `gh pr list --json body,mergedAt` sample to confirm the filter returns the expected subset.

Closes #239