### PR TITLE
release: 2026-04-18

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -294,7 +294,7 @@
                 <span class="plugin-role">ship it</span>
               </div>
               <div class="plugin-meta">
-                <span class="badge">v1.2.4</span>
+                <span class="badge">v1.2.5</span>
                 <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/flowkit" target="_blank" rel="noopener">README ↗</a>
               </div>
             </div>

--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship — with runtime staging detection and a one-command hotfix flow.",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
Release from rc/2026-04-18.5

Bumps flowkit to v1.2.5 (patch release of 3 fixes to flowkit:release already on main):
- #234 tag-safe RC cleanup and release-scoped LAST_TAG
- #237 limit source detection to branch refs
- #240 repair step 4 PR aggregation jq invocation