### PR TITLE
feat(hooks): pre-release version-bump check

### DIFF
--- a/.claude/hooks/check-plugin-bumps.sh
+++ b/.claude/hooks/check-plugin-bumps.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT=$(cat)
+SKILL=$(printf '%s' "$INPUT" | jq -r '.tool_input.skill // empty')
+
+case "$SKILL" in
+  flowkit:cut|flowkit:ship) ;;
+  *) exit 0 ;;
+esac
+
+REPO_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+cd "$REPO_ROOT"
+
+NEEDS_BUMP=()
+for manifest in plugins/*/.claude-plugin/plugin.json; do
+  [ -f "$manifest" ] || continue
+  name=$(jq -r '.name' "$manifest")
+  current=$(jq -r '.version' "$manifest")
+  plugin_dir=$(dirname "$(dirname "$manifest")")
+  last_tag=$(git tag --list "${name}--v*" | sort -V | tail -1)
+  [ -z "$last_tag" ] && continue
+  tag_version="${last_tag#${name}--v}"
+  if [ "$current" = "$tag_version" ]; then
+    count=$(git log "${last_tag}..HEAD" --oneline -- "$plugin_dir/" 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$count" -gt 0 ]; then
+      NEEDS_BUMP+=("${name} (${count} commits since ${last_tag}, still at v${current})")
+    fi
+  fi
+done
+
+if [ ${#NEEDS_BUMP[@]} -eq 0 ]; then
+  exit 0
+fi
+
+REASON="Plugin(s) have commits since last tag but no version bump:"$'\n'
+for p in "${NEEDS_BUMP[@]}"; do
+  REASON="${REASON}  - ${p}"$'\n'
+done
+REASON="${REASON}"$'\n'"Run /bump-versions first so clients pick up the updated code, then retry /${SKILL#flowkit:}."
+
+jq -n --arg reason "$REASON" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $reason
+  }
+}'

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/check-plugin-bumps.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .DS_Store
 .sessionkit/
+.claude/settings.local.json


### PR DESCRIPTION
## Summary

Adds a project-local `PreToolUse` hook on the `Skill` tool that fires before `flowkit:cut` or `flowkit:ship`. It checks every `plugins/*/.claude-plugin/plugin.json` for commits since its last per-plugin tag that landed without a version bump. If any plugin has drift, the hook blocks the skill with a clear message telling Claude to run `/bump-versions` first.

## Why

Three flowkit fix PRs (#234, #237, #240) shipped to `main` between `flowkit--v1.2.4` and the `v2026.4.18.3` release tag without anyone running `/bump-versions`, leaving clients stuck on 1.2.4 while newer code was on main. Caught and fixed in a follow-up (flowkit 1.2.5), but the manual-sync step was the root cause.

Per `CLAUDE.md`, `/bump-versions` is expected before every release but isn't invoked by `/cut`, `/release`, or `/ship`. Rather than building it into flowkit itself (flowkit is used in non-plugin repos), this hook is scoped to *this* repo via `.claude/settings.json`.

## Files

- `.claude/settings.json` (new, checked in) — wires the hook
- `.claude/hooks/check-plugin-bumps.sh` (new) — detection script; reads skill invocation from stdin, filters to flowkit:cut/ship, walks each plugin manifest, emits a `permissionDecision: "deny"` with reason if drift is detected
- `.gitignore` — adds `.claude/settings.local.json`

## Test plan

- [x] Raw pipe test: non-matching skill exits silent
- [x] Raw pipe test: matching skill with no drift exits silent
- [x] Raw pipe test: simulated drift (flowkit tag rolled back + version reset) produces correct deny JSON
- [ ] Live test: confirmed fires on next `/flowkit:cut` attempt (may need `/hooks` reload first — watcher caveat)