### PR TITLE
chore: ignore .ideas.md private scratchpad

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .sessionkit/
 .claude/settings.local.json
+.ideas.md


### PR DESCRIPTION
Adds `.ideas.md` to `.gitignore` so a local private scratchpad for plugin ideas can live at the repo root without being tracked.