### PR TITLE
fix(speckit): prevent #N auto-link foot-gun in issue bodies

### DIFF
--- a/plugins/speckit/skills/catalog/SKILL.md
+++ b/plugins/speckit/skills/catalog/SKILL.md
@@ -84,3 +84,4 @@ Output the created issues as a table with links:
 - Never create duplicate issues — check `gh issue list` for similar titles before creating
 - Keep issue bodies concise — problem + impact + fix, nothing more
 - Match the label style already in the repo (don't impose a new scheme)
+- Never write `#<number>` tokens in issue bodies unless you intend a real cross-reference to that exact issue — GitHub auto-links them, so a token like `#3` in a body about "task 3" will link to unrelated issue 3 in the repo. When referring to sibling tasks from a plan, use "task 3" (no hash) or omit the reference entirely — task-to-task dependencies are wired by the caller (e.g. `/spec`) via the native GitHub blocked-by API, not via issue-body text.

--- a/plugins/speckit/skills/issue/SKILL.md
+++ b/plugins/speckit/skills/issue/SKILL.md
@@ -81,3 +81,4 @@ Output the created issue URL.
 - Never skip the duplicate check
 - Keep body concise — problem + impact + fix only
 - Match the label style already in the repo
+- Never write `#<number>` tokens in the issue body unless you intend a real cross-reference to that exact issue — GitHub auto-links them, so a stray `#3` will silently link to unrelated issue 3 in the repo. Strip or rewrite any such token inherited from `$ARGUMENTS` before filing (use "task 3" or "issue 3" without the hash).

--- a/plugins/speckit/skills/spec/SKILL.md
+++ b/plugins/speckit/skills/spec/SKILL.md
@@ -81,6 +81,8 @@ user to adjust priorities, remove tasks, or add tasks before proceeding.
 
 Pass the full task list from the plan to `/catalog` in a single call. `/catalog` handles duplicate detection, label creation, and issue body format.
 
+Do not instruct `/catalog` to embed `Depends on #N` lines (or any other `#<number>` task-reference) in issue bodies. GitHub auto-links `#N` tokens, so a body that says "Depends on task #3" will link to unrelated issue 3 in the repo. Task-to-task dependencies are wired in step 5 via the native GitHub blocked-by API — keep them out of the issue body.
+
 ### 5. Create the epic tracking issue
 
 Before creating, check for an existing epic: `gh issue list --search "epic: <title>" --state open`. Skip creation and report the existing issue number if found.


### PR DESCRIPTION
## Summary

- Adds a constraint to `plugins/speckit/skills/catalog/SKILL.md` forbidding `#<number>` tokens in issue bodies — GitHub auto-links them to unrelated repo issues.
- Reinforces the rule in `plugins/speckit/skills/spec/SKILL.md` step 4 so the orchestrator never passes `Depends on #N` strings to `/catalog`. Task-to-task dependencies stay wired via the native GitHub blocked-by API in step 5.
- Adds the same constraint to `plugins/speckit/skills/issue/SKILL.md` so single-issue filing strips/rewrites any `#N` token inherited from user input.

## Context

Surfaced while running `/spec` for a new plugin: the plan produced tasks with "Depends on task #3" in their bodies. GitHub auto-linked `#3` to an unrelated historical issue. The canonical dependency was already wired through the native API, so the body text was both redundant and misleading.

## Test plan

- [ ] Next `/spec` run produces child issues with no `#N` tokens in their bodies
- [ ] Next `/issue` run strips any `#N` tokens from the supplied description before filing
- [ ] `/spec` step 5 continues to wire dependencies via the blocked-by API (unchanged behaviour)