### PR TITLE
fix(swarmkit): resolve loop mode merge ambiguity

### DIFF
--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -66,7 +66,7 @@ These are called by the skills above — you don't invoke them directly.
 6. Cleans up worktrees and orphaned branches
 
 **One-shot mode**: `/swarm 12 15 18` — resolve those issues and stop.
-**Loop mode**: `/swarm` — fetch, swarm, merge, repeat until the board is clear.
+**Loop mode**: `/swarm` — fetch, swarm, open PRs, repeat until the board is clear.
 **Label filter**: `/swarm bug` — loop mode, but only `bug`-labeled issues.
 
 ### Flags

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -270,25 +270,18 @@ If no open issues remain, announce "Board is clear" and exit.
 
 Run the one-shot swarm flow above on the batch. Independent issues target `$BASE` (enforced by `claude.prBase`). Dependent issues target their dependency's branch, forming a stacked-PR chain that ultimately lands in `$BASE` when `swarmkit:merge-stack` cascades the merges.
 
-**Step 3 — Pull base**
-
-```bash
-git checkout $BASE
-git pull origin $BASE
-```
-
-**Step 4 — Checkpoint**
+**Step 3 — Checkpoint**
 
 ```
 ── Cycle N complete ──────────────────────────
-✓ Merged: #12, #15
-✗ Failed: #14 (merge conflict)
+✓ PRs opened: #25 (→ #12), #26 (→ #15)
+✗ Failed: #14 (agent crash, no PR produced)
 ⊘ Blocked: #20 (depends on #14)
 ⧖ Remaining open issues: 5
 ──────────────────────────────────────────────
 ```
 
-Proceed immediately to the next cycle after printing the checkpoint summary. The loop halts only on unrecoverable failures: merge conflict on `$BASE`, agent crash with no PR produced, or push rejected on `$BASE`.
+Proceed immediately to the next cycle after printing the checkpoint summary. The loop halts only on unrecoverable failures: an agent crash with no PR produced.
 
 ### Teardown
 
@@ -306,11 +299,11 @@ Proceed immediately to the next cycle after printing the checkpoint summary. The
 ```
 ── swarm complete ────────────────────────────
 Cycles: 3
-Issues addressed: #12, #14, #15 (will close when released to main)
+Issues addressed: #12, #14, #15 (PRs open, awaiting review)
 Issues remaining: #25
 Open PRs: #31, #32, #33
 
-develop is ready for testing. Cut a release candidate when ready.
+Open PRs are ready for review. Use `swarmkit:merge-stack` to land them into `$BASE` when ready.
 ─────────────────────────────────────────────
 ```
 
@@ -322,9 +315,7 @@ When an issue fails at any point:
 3. Report blocked issues at each checkpoint
 
 **Unrecoverable failures** (exit loop immediately):
-- Three consecutive merge failures on the same PR
 - Agent produced no PR (crash, timeout, no push)
-- `git push` rejected on `$BASE` after fetch
 - `$BASE` branch deleted or corrupted externally
 
 ---


### PR DESCRIPTION
Closes #265

Applies Option B from the issue: loop mode no longer merges between cycles.

- Removes the 'Pull base' step from loop mode (nothing to pull — no merges occur)
- Rewrites the checkpoint template to track 'PRs opened' instead of 'Merged'
- Drops smart-failure rules for merge conflicts and $BASE push rejections (can't occur)
- Updates final summary and README to reflect that loop mode opens PRs; swarmkit:merge-stack remains the merge step

Preserves the 'Never merge a PR mid-swarm' constraint and aligns loop mode with one-shot mode: all PRs are left open for review.