### PR TITLE
docs(speckit): document epic-scoped labeling

### DIFF
--- a/plugins/speckit/README.md
+++ b/plugins/speckit/README.md
@@ -50,6 +50,7 @@ claude --plugin-dir /path/to/speckit
 ```
 /catalog                          # Pick up findings from earlier in the conversation
 /catalog findings.md              # Or point at a file
+/catalog --epic dark-mode         # Scope findings to an existing epic
 ```
 
 ### File a quick issue
@@ -75,9 +76,117 @@ Child issues are created via `/catalog`. An epic tracking issue is created last,
 
 `/catalog` accepts findings from three sources (checked in order): explicit input in `$ARGUMENTS`, findings from earlier in the conversation, or a file path. It parses them into discrete issues, checks for existing duplicates and labels, shows a summary table for approval, then creates all issues in priority order (high first).
 
+You can pass `--epic <slug>` to scope all created issues to an existing epic label:
+
+```
+/catalog --epic dark-mode
+```
+
+This attaches the `epic:dark-mode` label to every issue created in that run, without re-running the full `/spec` interview.
+
 ## How Issue Works
 
 `/issue` is the lightweight path. Give it a description, and it drafts a title, infers type and priority, checks for duplicates, and shows a preview before filing. Use it when you know exactly what to file and don't need an interview.
+
+## Epic Labeling
+
+When `/spec` produces a plan, it derives an `epic:<slug>` label and applies it to the epic tracking issue and every child issue. This makes the epic and all its work filterable in GitHub's issue list with a single label query.
+
+### Slug Derivation
+
+The slug is derived from the feature title or goal:
+
+1. Lowercase the title.
+2. Strip filler words: `the`, `a`, `an`, `enhance`, `add`, `update`, `to`, `for`, `of`, `in`.
+3. Replace spaces and non-alphanumeric characters with hyphens; collapse runs of hyphens.
+4. Trim to 30 characters (not counting the `epic:` prefix).
+
+Examples:
+
+| Input title | Derived slug | Full label |
+|-------------|-------------|------------|
+| Add dark mode support | `dark-mode-support` | `epic:dark-mode-support` |
+| Update the CSV export pipeline | `csv-export-pipeline` | `epic:csv-export-pipeline` |
+| Enhance authentication for SSO | `authentication-sso` | `epic:authentication-sso` |
+
+### Plan-Approval Step
+
+Before any issues are filed, `/spec` shows the full plan and surfaces an editable line:
+
+```
+Epic label: epic:dark-mode-support
+```
+
+You can change the slug at this point — edit the line and confirm. The label shown is exactly what will be created and applied to every issue in the run.
+
+### Label Color and Description Convention
+
+All `epic:<slug>` labels share:
+
+- **Color**: `#5319e7` (purple)
+- **Description**: `Belongs to epic: <epic title>` (the original, un-slugged title)
+
+This gives all epic labels a consistent visual identity in the GitHub UI and makes the source title recoverable from the label description.
+
+### Collision Warning
+
+If a label named `epic:<slug>` already exists in the repository, `/spec` surfaces a warning before proceeding:
+
+```
+⚠ Label epic:dark-mode-support already exists.
+  Use it, or edit the Epic label line above to choose a different slug.
+```
+
+You can accept the existing label (issues will simply receive it) or rename the slug before confirming the plan.
+
+## End-to-End Example
+
+**Scenario**: You want to add dark-mode support to your app.
+
+```
+/spec add dark mode support
+```
+
+1. `/spec` interviews you: target platforms, toggle placement, persistence strategy.
+2. It synthesizes a plan and shows it for approval:
+
+   ```
+   Goal: Ship a user-togglable dark mode backed by a persisted theme preference.
+   
+   Tasks:
+     1. Add ThemeContext and useTheme hook
+     2. Implement CSS variable switching in the root layout
+     3. Persist preference to localStorage
+     4. Add toggle button to the nav bar
+   
+   Epic label: epic:dark-mode-support
+   ```
+
+3. You confirm (or edit the `Epic label:` line).
+4. `/spec` delegates to `/catalog`, which files issues in priority order:
+
+   | # | Title | Labels |
+   |---|-------|--------|
+   | #42 | Add ThemeContext and useTheme hook | `priority:high`, `type:feature`, `epic:dark-mode-support` |
+   | #43 | Implement CSS variable switching in root layout | `priority:high`, `type:feature`, `epic:dark-mode-support` |
+   | #44 | Persist theme preference to localStorage | `priority:medium`, `type:feature`, `epic:dark-mode-support` |
+   | #45 | Add dark mode toggle to nav bar | `priority:medium`, `type:feature`, `epic:dark-mode-support` |
+
+5. The epic tracking issue is filed last (so it can link to all children):
+
+   | # | Title | Labels |
+   |---|-------|--------|
+   | #46 | Epic: Add dark mode support | `type:epic`, `epic:dark-mode-support` |
+
+   The epic body contains a checklist:
+   ```
+   - [ ] #42 Add ThemeContext and useTheme hook
+   - [ ] #43 Implement CSS variable switching in root layout
+   - [ ] #44 Persist theme preference to localStorage
+   - [ ] #45 Add dark mode toggle to nav bar
+   ```
+
+All five issues share the `epic:dark-mode-support` label (color `#5319e7`). Filtering by that label in GitHub shows the full scope of the epic at a glance.
 
 ## Assumptions & Conventions
 
@@ -85,6 +194,7 @@ Child issues are created via `/catalog`. An epic tracking issue is created last,
 - **Approval gate**: no issues are ever created without your explicit approval. `/spec` and `/catalog` both show a preview table before filing anything.
 - **`/catalog` is the implementation**: `/spec` delegates issue creation to `/catalog`. This means catalog settings (duplicate detection, label inference, priority ordering) apply to spec-generated issues too.
 - **Duplicate detection**: before filing any issue, `/catalog` and `/issue` check for open issues with similar titles. Potential duplicates are surfaced for your review before creation proceeds.
+- **Epic label consistency**: all `epic:<slug>` labels use color `#5319e7` and a `Belongs to epic: <title>` description, regardless of which skill created them.
 
 ## Pairing with Other Plugins
 


### PR DESCRIPTION
Closes #286

## Summary

- Added **Epic Labeling** section to `plugins/speckit/README.md` covering:
  - Slug derivation rules (lowercase kebab-case, filler-word stripping, 30-char cap)
  - The plan-approval `Epic label:` editable line surfaced by `/spec`
  - `--epic <slug>` argument for standalone `/catalog` runs
  - Shared label color (`#5319e7`) and description convention
  - Collision-warning behavior when a slug already exists
- Added end-to-end example: `/spec add dark mode support` producing 4 child issues + 1 epic, all labeled `epic:dark-mode-support`
- Updated **Assumptions & Conventions** with epic label consistency note
- Root `README.md` and `CLAUDE.md` left unchanged (neither references speckit labeling)

## Test plan

- [ ] Read the new **Epic Labeling** section and verify slug derivation rules are clear with examples
- [ ] Confirm the plan-approval step description matches the `Epic label:` line shown in the end-to-end example
- [ ] Verify `--epic` flag usage in the Catalog workflow snippet and How Catalog Works section
- [ ] Confirm the end-to-end example shows 2+ child issues all sharing the `epic:dark-mode-support` label