### PR TITLE
refactor(swarmkit): rename exp-swarm-teams skill to squad

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Run it before staging and committing the release.
 
 ## Plugins
 
-`swarmkit` includes an experimental `exp-swarm-teams` skill gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`. See `plugins/swarmkit/README.md` for details.
+`swarmkit` includes an experimental `squad` skill gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`. See `plugins/swarmkit/README.md` for details.
 
 ## GitHub Pages
 

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -134,7 +134,7 @@ Swarmkit executes work; [speckit](../speckit) defines it. Use them together for 
 
 ## Experimental features
 
-### `exp-swarm-teams`
+### `squad`
 
 An [Agent Teams](https://code.claude.com/docs/en/agent-teams)-based variant of `/swarm`. Instead of fully independent isolated agents, it runs a structured team: a lead (the main session) coordinates N builder teammates and 1 dedicated reviewer teammate. The reviewer runs continuously alongside the builders — providing feedback before any PR is pushed — and uses peer notifications to stay in sync.
 
@@ -147,7 +147,7 @@ export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
 Then invoke it the same way as `/swarm`:
 
 ```
-/exp-swarm-teams 12 15 18
+/squad 12 15 18
 ```
 
 **Known limits**:

--- a/plugins/swarmkit/skills/squad/SKILL.md
+++ b/plugins/swarmkit/skills/squad/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: exp-swarm-teams
+name: squad
 description: "EXPERIMENTAL — requires CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1. Spawn parallel agents for GitHub issues using the Agent Teams API instead of isolated worktrees. Same arg grammar as swarmkit:swarm. See epic #285 and https://code.claude.com/docs/en/agent-teams."
 ---
 
-# exp-swarm-teams Skill (Experimental)
+# squad Skill (Experimental)
 
 > **Experimental**: This skill uses the Claude Code Agent Teams API, which must be explicitly enabled.
 > Reference: [Agent Teams docs](https://code.claude.com/docs/en/agent-teams) | Epic: #285
@@ -287,7 +287,7 @@ The lead polls teammate health via the Agent Teams API (mailbox responsiveness o
 On halt, the lead prints:
 
 ```
-── exp-swarm-teams halted ────────────────────
+── squad halted ──────────────────────────────
 Cause: <what crashed and how>
 PRs opened this run: <list with URLs>
 In-flight builders: <list with issue numbers and worktree paths>
@@ -297,7 +297,7 @@ Recovery:
   1. Review opened PRs — they are safe to merge
   2. Inspect in-flight worktrees under .claude/worktrees/ for partial work
   3. Run: /clean-worktrees to discard partial state
-  4. Re-run: /exp-swarm-teams <args> to resume
+  4. Re-run: /squad <args> to resume
 ──────────────────────────────────────────────
 ```
 
@@ -341,7 +341,7 @@ Runs **regardless of success or halt**. Every step must be idempotent — runnin
 4. **Final summary** — print what ran, which PRs are open for review, and any in-flight work needing manual inspection (in halt case):
 
    ```
-   ── exp-swarm-teams complete ──────────────────
+   ── squad complete ────────────────────────────
    Issues resolved: <count>
    PRs open for review: <list with URLs>
    In-flight worktrees requiring inspection: <list or "none">


### PR DESCRIPTION
## Summary
- Renames skills/exp-swarm-teams/ → skills/squad/ and updates the SKILL.md frontmatter name
- Updates all doc references (swarmkit README, root CLAUDE.md, root README) from exp-swarm-teams to squad
- Keeps the CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS gate and all skill logic unchanged

## Test plan
- No files remain with "exp-swarm-teams" references (verify with grep)
- SKILL.md frontmatter reads `name: squad`
- CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS preflight check still present and unchanged

Closes #312