### PR TITLE
release: 2026-04-18

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Run it before staging and committing the release.
 
 ## Plugins
 
-`swarmkit` includes an experimental `exp-swarm-teams` skill gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`. See `plugins/swarmkit/README.md` for details.
+`swarmkit` includes an experimental `squad` skill gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`. See `plugins/swarmkit/README.md` for details.
 
 ## GitHub Pages
 

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -134,7 +134,7 @@ Swarmkit executes work; [speckit](../speckit) defines it. Use them together for 
 
 ## Experimental features
 
-### `exp-swarm-teams`
+### `squad`
 
 An [Agent Teams](https://code.claude.com/docs/en/agent-teams)-based variant of `/swarm`. Instead of fully independent isolated agents, it runs a structured team: a lead (the main session) coordinates N builder teammates and 1 dedicated reviewer teammate. The reviewer runs continuously alongside the builders — providing feedback before any PR is pushed — and uses peer notifications to stay in sync.
 
@@ -147,7 +147,7 @@ export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
 Then invoke it the same way as `/swarm`:
 
 ```
-/exp-swarm-teams 12 15 18
+/squad 12 15 18
 ```
 
 **Known limits**:

--- a/plugins/swarmkit/skills/squad/SKILL.md
+++ b/plugins/swarmkit/skills/squad/SKILL.md
@@ -180,7 +180,24 @@ A builder is a short-lived teammate responsible for shipping exactly one issue. 
 5. **On `approve`**:
    - Commit using `swarmkit:conventional-commit-message` format. No Claude mentions, no co-author lines.
    - Push the branch
-   - Create the PR targeting the correct base (`develop` for independent issues, `worktree-agent-<upstream>` for stacked)
+   - Create the PR targeting the correct base (`develop` for independent issues, `worktree-agent-<upstream>` for stacked) with a richer body synthesized from the issue spec and your diff:
+
+     ```bash
+     gh pr create --base <base> --head <head> \
+       --title "<type>(<scope>): <description>" \
+       --body "$(cat <<'EOF'
+     ## Summary
+     <1–3 bullets synthesizing what was changed, derived from the issue acceptance criteria and the diff>
+
+     ## Test plan
+     <how to verify the changes satisfy the acceptance criteria>
+
+     Closes #<issue>
+     EOF
+     )"
+     ```
+
+     The `<...>` placeholders are instructions, not literal text — replace each with content you derive from the issue spec and your diff. Do not copy the placeholder strings into the PR body.
 
 6. **On `revise: <reasons>`**:
    - Address the feedback

--- a/plugins/swarmkit/skills/squad/SKILL.md
+++ b/plugins/swarmkit/skills/squad/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: exp-swarm-teams
+name: squad
 description: "EXPERIMENTAL — requires CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1. Spawn parallel agents for GitHub issues using the Agent Teams API instead of isolated worktrees. Same arg grammar as swarmkit:swarm. See epic #285 and https://code.claude.com/docs/en/agent-teams."
 ---
 
-# exp-swarm-teams Skill (Experimental)
+# squad Skill (Experimental)
 
 > **Experimental**: This skill uses the Claude Code Agent Teams API, which must be explicitly enabled.
 > Reference: [Agent Teams docs](https://code.claude.com/docs/en/agent-teams) | Epic: #285
@@ -287,7 +287,7 @@ The lead polls teammate health via the Agent Teams API (mailbox responsiveness o
 On halt, the lead prints:
 
 ```
-── exp-swarm-teams halted ────────────────────
+── squad halted ──────────────────────────────
 Cause: <what crashed and how>
 PRs opened this run: <list with URLs>
 In-flight builders: <list with issue numbers and worktree paths>
@@ -297,7 +297,7 @@ Recovery:
   1. Review opened PRs — they are safe to merge
   2. Inspect in-flight worktrees under .claude/worktrees/ for partial work
   3. Run: /clean-worktrees to discard partial state
-  4. Re-run: /exp-swarm-teams <args> to resume
+  4. Re-run: /squad <args> to resume
 ──────────────────────────────────────────────
 ```
 
@@ -341,7 +341,7 @@ Runs **regardless of success or halt**. Every step must be idempotent — runnin
 4. **Final summary** — print what ran, which PRs are open for review, and any in-flight work needing manual inspection (in halt case):
 
    ```
-   ── exp-swarm-teams complete ──────────────────
+   ── squad complete ────────────────────────────
    Issues resolved: <count>
    PRs open for review: <list with URLs>
    In-flight worktrees requiring inspection: <list or "none">

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -202,16 +202,34 @@ Each agent prompt MUST include these **workflow steps** (in order):
    git add <files> && git commit -m "<type>(<scope>): <description>"
 4. Push the branch:
    git push -u origin worktree-agent-<issue>
-5. Create PR targeting the appropriate base:
+5. Create PR targeting the appropriate base. The body MUST be a richer summary, not just `Closes #<issue>` — synthesize the `## Summary` bullets from the issue's acceptance criteria and your diff, and describe the `## Test plan` in terms of those acceptance criteria. Fill in the angle-bracket placeholders; do not copy them literally.
    # For independent issues:
    gh pr create --base develop --head worktree-agent-<issue> \
      --title "<type>(<scope>): <description>" \
-     --body "Closes #<issue>"
+     --body "$(cat <<'EOF'
+   ## Summary
+   <1–3 bullets synthesizing what was changed, derived from the issue acceptance criteria and the diff>
+
+   ## Test plan
+   <how to verify the changes satisfy the acceptance criteria>
+
+   Closes #<issue>
+   EOF
+   )"
 
    # For dependent issues:
    gh pr create --base worktree-agent-<dependency-issue> --head worktree-agent-<issue> \
      --title "<type>(<scope>): <description>" \
-     --body "Closes #<issue>"
+     --body "$(cat <<'EOF'
+   ## Summary
+   <1–3 bullets synthesizing what was changed, derived from the issue acceptance criteria and the diff>
+
+   ## Test plan
+   <how to verify the changes satisfy the acceptance criteria>
+
+   Closes #<issue>
+   EOF
+   )"
 ```
 
 ### 5. Handle completions

--- a/plugins/vaultkit/.claude-plugin/plugin.json
+++ b/plugins/vaultkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vaultkit",
   "description": "Obsidian vault skills for Claude Code. Read, search, edit notes, manage projects, capture decisions, and archive conversations — all via the Obsidian CLI.",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/vaultkit/skills/archive-export/SKILL.md
+++ b/plugins/vaultkit/skills/archive-export/SKILL.md
@@ -72,13 +72,13 @@ This base name is used for both files:
 - `YYYY-MM-DD-HHMM-slug.txt` — plain text copy
 - `YYYY-MM-DD-HHMM-slug.md` — Obsidian markdown copy
 
-### 6. Copy the .txt file and set birth time
+### 6. Copy the .txt file and stamp birth time
 
 ```bash
 cp ./session.txt "$VAULT/Projects/ProjectName/Conversations/$BASENAME.txt"
-# New file — set birth time to now (no prior birth time to preserve; see vaultkit:file-edit for editing existing files)
-SetFile -d "$(date '+%m/%d/%Y %H:%M:%S')" "$VAULT/Projects/ProjectName/Conversations/$BASENAME.txt"
 ```
+
+Follow the `vaultkit:file-edit` sub-skill's new-file guidance to stamp the birth time on the copied `.txt`.
 
 ### 7. Create the .md file with session ID, attachment link + full content
 
@@ -103,12 +103,7 @@ Use the Bash tool to build and write the file in one step:
 } > "$VAULT/Projects/ProjectName/Conversations/$BASENAME.md"
 ```
 
-Then set its birth time:
-
-```bash
-# New file — set birth time to now (no prior birth time to preserve; see vaultkit:file-edit for editing existing files)
-SetFile -d "$(date '+%m/%d/%Y %H:%M:%S')" "$VAULT/Projects/ProjectName/Conversations/$BASENAME.md"
-```
+Then stamp its birth time per the `vaultkit:file-edit` sub-skill's new-file guidance.
 
 ### 8. Clean up the source file
 

--- a/plugins/vaultkit/skills/file-edit/SKILL.md
+++ b/plugins/vaultkit/skills/file-edit/SKILL.md
@@ -1,32 +1,47 @@
 ---
 name: file-edit
-description: Edit an Obsidian vault file while preserving its filesystem birth time. Use whenever editing an existing vault file via the Edit tool — macOS resets birth time on file rename (which Edit uses internally).
+description: Edit an Obsidian vault file while preserving its filesystem birth time. Use whenever modifying an existing vault file — Claude's Edit/Write tools atomic-rename and reset birth time on macOS, which breaks Obsidian's `created` metadata.
 ---
 
 # Obsidian File Edit
 
-Edits an Obsidian vault file while preserving its filesystem birth time. The Edit tool on macOS uses a temp-file-rename strategy that resets the file's birth time — this skill wraps that operation to restore it.
+Edits an Obsidian vault file in place so its filesystem birth time is preserved. Claude's `Edit` and `Write` tools use a temp-file-rename strategy on macOS that resets birth time — this sub-skill writes through a process that modifies the existing inode instead.
+
+Obsidian uses filesystem birth time for the `created` field in dataview queries, sort orders, and plugin behaviors. Every rename-based write corrupts that timeline.
 
 ## When to use
 
-Invoke this sub-skill any time you need to edit an existing file in an Obsidian vault. For **new files** created with the Write tool, use `SetFile -d "$(date '+%m/%d/%Y %H:%M:%S')" "$PATH"` directly — there is no prior birth time to preserve.
+Invoke this sub-skill any time you need to edit an existing file in an Obsidian vault. For **new files**, use the `Write` tool then run `SetFile -d "$(date '+%m/%d/%Y %H:%M:%S')" "$PATH"` directly — there is no prior birth time to preserve.
 
-## Steps
+This does not apply to `obsidian append`/`obsidian prepend` CLI commands — those preserve metadata natively.
 
-### 1. Capture birth time (before editing)
+## Happy path: in-place write
+
+### 1. Read the file
+
+Use the `Read` tool to load the current file contents.
+
+### 2. Compute the new content in memory
+
+Apply your edits to the content as a string. Do not call `Edit` or `Write` — they reset birth time.
+
+### 3. Write in place
+
+Pipe the full new content to the file via shell redirect. This modifies the existing inode and preserves birth time:
 
 ```bash
-BIRTH=$(stat -f "%SB" -t "%m/%d/%Y %H:%M:%S" "$VAULT_PATH/path/to/file.md")
+cat > "$VAULT_PATH/path/to/file.md" <<'VAULTKIT_EOF'
+<full new file content here>
+VAULTKIT_EOF
 ```
 
-### 2. Edit the file
-
-Use the Edit tool to make the change.
-
-### 3. Restore birth time
+For content that may contain the heredoc marker, or for binary-safe writes, use python3:
 
 ```bash
-SetFile -d "$BIRTH" "$VAULT_PATH/path/to/file.md"
+python3 -c 'import sys; open(sys.argv[1], "w").write(sys.stdin.read())' \
+  "$VAULT_PATH/path/to/file.md" <<'VAULTKIT_EOF'
+<full new file content here>
+VAULTKIT_EOF
 ```
 
 ### 4. Verify
@@ -35,8 +50,22 @@ SetFile -d "$BIRTH" "$VAULT_PATH/path/to/file.md"
 stat -f "Birth: %SB | %N" "$VAULT_PATH/path/to/file.md"
 ```
 
+Birth time should match what it was before the edit.
+
+## Fallback: targeted diff-style edit on a very large file
+
+If rewriting the whole file is genuinely wasteful (e.g. a multi-megabyte note where you are changing a handful of lines), the old three-step pattern still works:
+
+```bash
+BIRTH=$(stat -f "%SB" -t "%m/%d/%Y %H:%M:%S" "$VAULT_PATH/path/to/file.md")
+# ...use the Edit tool to apply the targeted change...
+SetFile -d "$BIRTH" "$VAULT_PATH/path/to/file.md"
+```
+
+Prefer the in-place write above for anything typical. Reach for this fallback only when the file is large enough that reading and re-writing the whole thing is measurably expensive.
+
 ## Notes
 
 - `$VAULT_PATH` is the vault root obtained via `obsidian vault=<VAULT> vault`
-- Always capture birth time **before** any edit — not after
-- This does not apply to `obsidian append`/`obsidian prepend` CLI commands — those preserve metadata natively
+- `Edit`, `Write`, and the `SetFile -d` dance are no longer part of the happy path — they are documented only as a fallback
+- Shell `>` redirect, `cat > file <<EOF`, `python3 open(p, "w")`, and `node fs.writeFileSync` all write in place on macOS; `Edit` and `Write` do not

--- a/plugins/vaultkit/skills/jot/SKILL.md
+++ b/plugins/vaultkit/skills/jot/SKILL.md
@@ -22,6 +22,6 @@ Invoke the `vaultkit:project` skill, Operation 3: **Update Project Files**.
 That operation handles:
 - Identifying the active project (from conversation context or by prompting)
 - Reading the relevant file before editing
-- Capturing birth time, making the edit, restoring birth time (via `vaultkit:file-edit`)
+- Writing the edit in place to preserve birth time (via `vaultkit:file-edit`)
 - Determining what changed: decisions, tasks, status, blockers
 - Keeping entries concise — recall notes, not documentation

--- a/plugins/vaultkit/skills/obsidian/SKILL.md
+++ b/plugins/vaultkit/skills/obsidian/SKILL.md
@@ -120,46 +120,57 @@ obsidian vault=<VAULT> plugin:install id=<id> enable # Install + enable a plugin
 
 ## Edit Strategy
 
-Choose the right approach based on the type of change:
+The mental model here is **write strategy**, not "CLI vs direct FS". A tool preserves a vault file's filesystem birth time if and only if it writes **in place** (opens the existing inode and mutates it). A tool that writes to a temp file and **atomic-renames** it over the original replaces the inode, and macOS resets the birth time to now.
 
-### 1. Frontmatter-only changes → use CLI `property:set`
-Preserves all file metadata. Preferred when only updating YAML properties.
+Pick the tool whose write strategy matches what you need. Body edits default to in-place; reach for Claude's `Edit`/`Write` only when no in-place path exists, and pair them with a `SetFile` restore.
+
+### Measured tool behavior (verified 2026-04-17)
+
+| Tool | Strategy | Birth time |
+|---|---|---|
+| Claude `Edit` / `Write` | Atomic rename | **Resets** |
+| `python3 open(p, "w")` | In-place | Preserved |
+| `node fs.writeFileSync` | In-place | Preserved |
+| Shell `>` redirect | In-place | Preserved |
+| `obsidian append` / `prepend` | In-place | Preserved |
+| `obsidian property:set` | In-place | Preserved |
+| `obsidian rename` / `move` | In-place + wikilink updates | Preserved |
+
+### Choosing a tool
+
+- **Frontmatter (YAML properties)** → `obsidian property:set`. Uses the CLI's YAML-safe writer and edits in place.
+  ```bash
+  obsidian vault=<VAULT> property:set name="status" value="done" path="Notes/my-note.md"
+  ```
+- **Append or prepend to a note** → `obsidian append` / `obsidian prepend` (`obsidian daily:append` for today's daily note). In-place.
+  ```bash
+  obsidian vault=<VAULT> daily:append content="- Follow up with Adam"
+  ```
+- **Rename or move a note** → `obsidian rename` / `obsidian move`. In-place and updates wikilinks across the vault.
+- **In-body content edits (find & replace, tag renames, structural rewrites)** → the CLI has no `replace`/`patch` command, so write directly. Prefer an in-place writer (`python3`, `node fs.writeFileSync`, shell `>` redirect) so birth time is preserved with no follow-up step. Reach for Claude's `Edit`/`Write` only when you need its diff-editing ergonomics, and treat every invocation on a vault file as an atomic rename that you must compensate for (see next section).
+
+See `vaultkit:file-edit` for the canonical body-edit recipe.
+
+### When using Claude `Edit` or `Write` on a vault file
+
+Claude's `Edit` and `Write` tools atomic-rename, which resets the filesystem birth time on macOS. Every use on a vault file must be paired with a `SetFile` restore.
+
+**For existing files — capture birth time *before* editing:**
 ```bash
-obsidian vault=<VAULT> property:set name="status" value="done" path="Notes/my-note.md"
-```
-
-### 2. Append/prepend operations → use CLI `append` or `prepend`
-Preserves all file metadata. Use when adding content to start or end of a file.
-```bash
-obsidian vault=<VAULT> daily:append content="- Follow up with Adam"
-```
-
-### 3. In-body content edits (find & replace, tag renames, etc.) → use Edit tool + restore birth time
-The Edit tool writes via a temp file + rename on macOS, which **resets the filesystem birth time**. Capture the birth time **before** editing, then restore it exactly afterward.
-
-**For existing files:**
-```bash
-# Step 1: Capture birth time before editing
 BIRTH=$(stat -f "%SB" -t "%m/%d/%Y %H:%M:%S" "$VAULT/<path>")
-
-# Step 2: Make the edit (Edit tool)
-
-# Step 3: Restore exact birth time
+# ...make the edit with Edit...
 SetFile -d "$BIRTH" "$VAULT/<path>"
 ```
 
-**For new files just created (Write tool):**
+**For new files just created with Write** (no prior birth time to preserve — set it to now):
 ```bash
 SetFile -d "$(date '+%m/%d/%Y %H:%M:%S')" "$VAULT/<path>"
 ```
 
-**Always verify after restoring:**
+**Verify:**
 ```bash
 stat -f "Birth: %SB | %N" "$VAULT/<path>"
 ```
-
-### Known Limitation
-There is no CLI command for in-body text replacement (no `replace` or `patch` command). The Obsidian CLI only supports `append` and `prepend` for writing to existing file bodies. Any find-and-replace operation requires direct file editing and subsequent birth time restoration.
 
 ## Tag Conventions
 

--- a/plugins/vaultkit/skills/project/SKILL.md
+++ b/plugins/vaultkit/skills/project/SKILL.md
@@ -34,7 +34,7 @@ obsidian vaults
 
 Present the list to the user and ask them to specify which vault to use before continuing.
 
-To resolve the vault's filesystem path (needed for `mkdir`, `stat`, `SetFile`):
+To resolve the vault's filesystem path (needed for `mkdir` and direct file edits):
 ```bash
 obsidian vault="<VAULT>" vault  # prints the vault root path
 ```
@@ -154,10 +154,7 @@ After splitting, remove the section from `Overview.md` and add a link: `See [[Ta
 
 4. Also update `Last updated:` in `Overview.md` if you edited any project file.
 
-**For new project files** (created with Write tool), use the actual current time instead:
-```bash
-SetFile -d "$(date '+%m/%d/%Y %H:%M:%S')" "$VAULT_PATH/Projects/ProjectName/FileName.md"
-```
+**For new project files** (created with the Write tool), follow the `vaultkit:file-edit` sub-skill's new-file guidance to stamp the birth time.
 
 ---
 


### PR DESCRIPTION
## Release summary

**Built from**: `rc/2026-04-18.17`

### Version bumps
- chore(plugins): bump vaultkit@1.1.0
- chore(plugins): bump swarmkit@2.2.0

### Changes

**swarmkit**
- feat(swarmkit): require richer PR body in squad builder contract (#319)
- refactor(swarmkit): rename exp-swarm-teams skill to squad (#318)
- feat(swarmkit): require richer PR body in swarm agent prompt template (#317)

**vaultkit**
- refactor(vaultkit): update callers to reference refreshed file-edit sub-skill (#314)
- docs(vaultkit): reframe obsidian Edit Strategy around write-strategy (#313)
- fix(vaultkit): rewrite file-edit sub-skill to use in-place writes (#311)

Closes #222
Closes #223
Closes #224
Closes #225
Closes #312
Closes #315
Closes #316