### PR TITLE
docs(swarmkit): add SETUP.md for squad Agent Teams configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Claude Code plugins for plan, execute, and ship — each keeping you at the hand
 | Plugin | Install | Description |
 |--------|---------|-------------|
 | **speckit** | `/plugin install speckit@smallorbit-plugins` | Define and capture work through interviews and issue filing |
-| **swarmkit** | `/plugin install swarmkit@smallorbit-plugins` | Resolve GitHub issues with parallel worktree agents. See [METHODOLOGY.md](./plugins/swarmkit/METHODOLOGY.md) for the stacked agent/PR workflow in depth. |
+| **swarmkit** | `/plugin install swarmkit@smallorbit-plugins` | Resolve GitHub issues with parallel worktree agents. See [METHODOLOGY.md](./plugins/swarmkit/METHODOLOGY.md) for the stacked agent/PR workflow in depth. For the experimental Agent Teams-based `/squad` variant, see [plugins/swarmkit/SETUP.md](./plugins/swarmkit/SETUP.md). |
 | **polishkit** | `/plugin install polishkit@smallorbit-plugins` | Critique code quality, sweep for cruft, and eliminate dead code |
 | **flowkit** | `/plugin install flowkit@smallorbit-plugins` | Manage the full git lifecycle from branch to release |
 | **sessionkit** | `/plugin install sessionkit@smallorbit-plugins` | Session continuity, context handoffs, and meta-learning |

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -140,13 +140,9 @@ Swarmkit executes work; [speckit](../speckit) defines it. Use them together for 
 
 An [Agent Teams](https://code.claude.com/docs/en/agent-teams)-based variant of `/swarm`. Instead of fully independent isolated agents, it runs a structured team: a lead (the main session) coordinates N builder teammates and 1 dedicated reviewer teammate. The reviewer runs continuously alongside the builders — providing feedback before any PR is pushed — and uses peer notifications to stay in sync.
 
-**Enable it** by setting the environment variable before starting Claude Code:
+**Setup**: `/squad` requires the Agent Teams API to be enabled. See [SETUP.md](./SETUP.md) for the three ways to set `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` and how to verify it.
 
-```bash
-export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
-```
-
-Then invoke it the same way as `/swarm`:
+Once enabled, invoke it the same way as `/swarm`:
 
 ```
 /squad 12 15 18

--- a/plugins/swarmkit/SETUP.md
+++ b/plugins/swarmkit/SETUP.md
@@ -1,0 +1,65 @@
+# Swarmkit — Agent Teams setup for `/squad`
+
+**Official docs**: [Agent Teams on code.claude.com](https://code.claude.com/docs/en/agent-teams)
+
+> **Experimental**: The Agent Teams API is experimental; its API and behavior may change without notice.
+
+`/squad` is swarmkit's Agent Teams-based variant of `/swarm`. It requires the Agent Teams API to be enabled via the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` environment variable. This document is the canonical setup guide for turning it on.
+
+## Enable `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`
+
+Pick one of the three methods below. The variable must be set to `1` (or any non-empty value) in the environment Claude Code runs in.
+
+### Method 1 — Shell export (bash/zsh)
+
+Add the export to your shell profile (`~/.bashrc`, `~/.zshrc`, or equivalent) so every new shell session picks it up:
+
+```bash
+export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+```
+
+Reload the shell (`source ~/.zshrc`) or open a new terminal, then start Claude Code as usual.
+
+### Method 2 — Claude Code `settings.json`
+
+Set it under the `env` block of your Claude Code settings file (`~/.claude/settings.json` for global, or `.claude/settings.json` in a project for scoped):
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  }
+}
+```
+
+Claude Code will export the variable into its own process environment on startup.
+
+### Method 3 — Per-invocation inline
+
+Set the variable only for a single Claude Code invocation, leaving your global environment untouched:
+
+```bash
+CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 claude
+```
+
+Useful for one-off trials of `/squad` without committing to a persistent shell or settings change.
+
+## Verify it's working
+
+With the variable set, run `/squad` inside Claude Code. Its preflight check reads the environment and lets the skill continue. For example:
+
+```
+/squad 12 15 18
+```
+
+If the variable is **unset or empty**, the preflight aborts immediately with this exact message:
+
+```
+Agent Teams API is not enabled.
+
+Run: export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
+
+Then re-run this skill.
+```
+
+Seeing that message means the variable did not reach Claude Code's process — re-check the method above you chose (shell profile loaded? `settings.json` parsed? inline prefix attached to the right command?) and try again.


### PR DESCRIPTION
## Summary
- Add plugins/swarmkit/SETUP.md as the canonical setup guide for enabling the Agent Teams feature with /squad
- Documents three methods to set CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1 (shell export, settings.json, per-invocation)
- Includes official docs link, experimental caveat, and "Verify it's working" section with exact preflight error message
- Update plugins/swarmkit/README.md to link to SETUP.md and trim the stale "Enable it" block
- Add one-liner to root README.md under swarmkit blurb pointing to SETUP.md

## Test plan
- Verify plugins/swarmkit/SETUP.md exists and covers all 7 acceptance criteria
- Verify no references to exp-swarm-teams in SETUP.md
- Verify README files link to SETUP.md correctly
- Verify the old "Enable it" block in plugins/swarmkit/README.md is trimmed/replaced

Closes #324