### PR TITLE
refactor(flowkit): rework /ship as a repo-level landing command

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -304,7 +304,7 @@
               <li><code>/pr</code> — branch → commit → open PR in one command</li>
               <li><code>/cut</code> — create a release candidate from develop</li>
               <li><code>/release</code> — merge RC to main, tag, close issues</li>
-              <li><code>/ship</code> — full one-shot ship cycle</li>
+              <li><code>/ship</code> — merge swarm PRs → cut → release in one command</li>
               <li><code>/hotfix</code> — emergency fix bypassing develop</li>
             </ul>
             <div class="transcript" role="group" aria-label="flowkit example session">

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -38,7 +38,7 @@ claude --plugin-dir /path/to/flowkit
 | **cut** | `/cut` | Create a `rc/YYYY-MM-DD.N` release candidate from `develop`; auto-stages if a staging branch exists. |
 | **stage** | `/stage` | Force-reset the `staging` branch to a release candidate. No-op if staging doesn't exist. |
 | **release** | `/release` | Detect staging at runtime, merge to `main`, tag, close issues, clean up RC branches. |
-| **ship** | `/ship` | Full one-shot cycle: `pr` → `merge-pr` → `sync` → `cut` → `release`. |
+| **ship** | `/ship` | Repo-level landing command: `merge-stack` → `cut` → `release`. Run after a swarm to land everything. |
 | **hotfix** | `/hotfix` | Emergency fix: branch off `main`, apply fix, PR to `main`, tag, back-merge to `develop`. |
 | **release-status** | `/release-status` | Show what's in staging awaiting release and what's in `develop` awaiting a cut. |
 
@@ -51,17 +51,17 @@ These are called by the skills above — you don't invoke them directly.
 | **git-sync-main** | release, hotfix | Checkout `main` and pull latest from origin. |
 | **git-sync-develop** | sync, release, hotfix | Checkout `develop` and pull latest from origin. |
 | **gh-close-referenced-issues** | release, hotfix | Parse merged PR bodies; close referenced issues and resolved epics. |
-| **pr-base-scope** | ship, swarm | Set/unset `claude.prBase` git config for scoped PR targeting. |
+| **pr-base-scope** | swarm | Set/unset `claude.prBase` git config for scoped PR targeting. |
 
 ## Typical Workflows
 
 ```
-# Standard release from develop
+# After a swarm run — land everything in one shot
+/ship                            # merge-stack → cut → release
+
+# Standard release from develop (no swarm)
 /cut                             # cut a release candidate from develop
 /release                         # ship to main, tag, close issues
-
-# Full one-command ship cycle
-/ship                            # branch → commit → PR → merge → cut → release
 
 # Check before acting
 /release-status                  # see what's staging vs. what's in develop
@@ -85,11 +85,13 @@ Step-by-step feature flow:
 
 ## How Ship Works
 
-`/ship` runs the full pipeline in a single command: it creates a branch, commits staged changes, opens a PR, squash-merges it, syncs `develop`, cuts a release candidate, and promotes it to `main`.
+`/ship` is a repo-level landing command designed to run after a swarm. It composes three existing skills in sequence:
 
-The pipeline is scoped with `claude.prBase`: before spawning sub-agents, `/ship` (and `/swarm`) set this config so every PR in the run targets the correct base branch. It is unset when the run completes.
+1. **`swarmkit:merge-stack`** — merges all open `worktree-agent-*` PRs top-down into `develop`, accumulating issue refs as the stack collapses. Skips gracefully if no swarm PRs are open.
+2. **`flowkit:cut`** — creates an `rc/YYYY-MM-DD.N` branch from `origin/develop`, and auto-stages it if `origin/staging` exists.
+3. **`flowkit:release`** — merges the RC (or staging) to `main`, tags the release, closes referenced issues, and cleans up RC branches.
 
-Self-review is intentionally excluded from `/ship`. The command is a release pipeline, not a quality gate — code review happens before merge, not during ship.
+Branch creation, commits, and PR opening are not part of `/ship` — those belong to `/pr` and `/swarm`. If `merge-stack` encounters a conflict, `/ship` stops before cutting or releasing.
 
 ## How Runtime Staging Detection Works
 
@@ -147,8 +149,7 @@ Flowkit handles the shipping half of the development loop. Use it with speckit a
 ```
 /spec add CSV export              # Plan the feature, file issues  (speckit)
 /swarm                            # Resolve issues with parallel agents  (swarmkit)
-/cut                              # Cut a release candidate  (flowkit)
-/release                          # Ship to main  (flowkit)
+/ship                             # Merge stack → cut → release  (flowkit)
 ```
 
 The natural sequence is **speckit → swarmkit → flowkit**: speckit defines the work, swarmkit executes it, flowkit ships it. Use [sessionkit](../sessionkit)'s `/handoff` if a release session runs long, and `/skillit` afterwards to capture any new conventions or one-off scripts worth keeping.

--- a/plugins/flowkit/skills/ship/SKILL.md
+++ b/plugins/flowkit/skills/ship/SKILL.md
@@ -1,69 +1,56 @@
 ---
 name: ship
-description: Full one-shot ship cycle — branch → commit → PR → merge → RC → release. Runs the complete flowkit pipeline from wherever you are on a branch.
+description: Repo-level landing command — merge all open swarm PRs, cut a release candidate, and promote to main. Run this after a swarm to land everything in one shot.
 triggers:
   - "/ship"
-  - "ship this"
-  - "ship it"
-  - "ship the work"
-  - "full ship cycle"
+  - "ship everything"
+  - "land the swarm"
+  - "merge stack and release"
+  - "ship after swarm"
 allowed-tools: Bash
 ---
 
 # Ship
 
-Run the full release pipeline from current branch state to a tagged release on main. Handles branching, committing, opening/merging a PR, cutting an RC, and releasing.
+Land a completed swarm run in one shot: merge all open swarm PRs into develop, cut a release candidate, and promote it to main.
 
 ## Input
 
-`$ARGUMENTS` — optional description or context passed to `/open-pr` as the PR description. If omitted, the PR description is inferred from commits.
+`$ARGUMENTS` — optional notes passed through to `/release` as release context. If omitted, everything is auto-derived.
 
 ## Process
 
-### 1. Scope the PR base
+### 1. Merge open swarm PRs
 
-Follow the `pr-base-scope` sub-skill to set `claude.prBase = develop`. This ensures all PR operations in this pipeline target `develop`.
+Follow `swarmkit:merge-stack`.
 
-### 2. Get work onto develop via PR
+- If no `worktree-agent-*` PRs are open, `merge-stack` will report "No open swarm PRs found" and stop gracefully — continue to step 2.
+- If any merge fails with a conflict, stop immediately and report which PR is blocked. Do not proceed to cut or release until conflicts are resolved.
 
-Detect the current state and act accordingly:
+### 2. Cut a release candidate
 
-- **On `develop`, `main`, or `staging`**: follow `/pr $ARGUMENTS` — this will create a branch, commit, and open a PR targeting develop.
-- **On a feature branch with uncommitted changes**: follow `/commit`, then follow `/open-pr`.
-- **On a feature branch with an open PR already**: skip directly to step 3.
-- **On a feature branch, changes committed, no open PR**: follow `/open-pr`.
+Follow `flowkit:cut` to create an `rc/YYYY-MM-DD.N` branch from `origin/develop`.
 
-### 3. Merge the PR into develop
+- If `origin/staging` exists, `/cut` will auto-stage the RC.
 
-Follow `/merge-pr` to squash-merge the open PR into `develop`.
+### 3. Release
 
-### 4. Sync develop
+Follow `flowkit:release` to merge the RC (or staging) to `main`, create the version tag, close referenced issues, and clean up RC branches.
 
-Follow `/sync` to check out `develop`, pull latest, and prune stale branches.
+Pass `$ARGUMENTS` as the argument if provided.
 
-### 5. Cut a release candidate
-
-Follow `/cut` to create an `rc/YYYY-MM-DD.N` branch from `origin/develop`. If `origin/staging` exists, `/cut` will auto-stage it.
-
-### 6. Release
-
-Follow `/release` to merge to `main`, create the version tag, close referenced issues, and clean up RC branches.
-
-### 7. Unset the PR base scope
-
-Follow the `pr-base-scope` sub-skill to unset `claude.prBase`.
-
-### 8. Report
+### 4. Report
 
 Summarize what happened:
-- Which PR was merged and into which base
+
+- How many swarm PRs were merged (or that the step was skipped)
 - Which RC was created
 - Which tag was created on main
 - Which issues were closed
 
 ## Constraints
 
-- Always set `claude.prBase` at the start and unset it at the end — never leave it set
-- No self-review step — `/ship` is a pipeline, not a quality gate
-- If any step fails, stop immediately and report what failed and why — do not attempt to continue past a failure
+- If `merge-stack` encounters a conflict, stop — do not cut or release with unresolved conflicts
 - Never commit directly to `develop` or `main`
+- No branch/commit/PR creation — those belong to `/pr` and `/swarm`
+- If any step fails, stop immediately and report what failed and why


### PR DESCRIPTION
## Summary
- Rewrite flowkit:ship as a repo-level landing command: merge-stack → cut → release
- Remove branch/commit/PR/merge steps (those belong to /pr)
- Update flowkit README, root README, and docs/index.html to reflect new semantics
- Skip merge-stack gracefully if no worktree-agent-* PRs are open

## Test plan
- Verify ship SKILL.md contains only merge-stack → cut → release steps
- Verify frontmatter description/triggers reflect the new behavior
- Verify README files and docs/index.html mention the new landing-command semantics
- Run /ship in a clean develop state — merge-stack should skip, cut + release should proceed

Closes #333