### PR TITLE
release: 2026-04-18 (docs badges)

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -230,7 +230,7 @@
                 <span class="plugin-role">execute it</span>
               </div>
               <div class="plugin-meta">
-                <span class="badge">v2.4.0</span>
+                <span class="badge">v2.4.1</span>
                 <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/swarmkit" target="_blank" rel="noopener">README ↗</a>
               </div>
             </div>
@@ -295,7 +295,7 @@
                 <span class="plugin-role">ship it</span>
               </div>
               <div class="plugin-meta">
-                <span class="badge">v1.3.1</span>
+                <span class="badge">v2.0.0</span>
                 <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/flowkit" target="_blank" rel="noopener">README ↗</a>
               </div>
             </div>


### PR DESCRIPTION
## Release summary

**Built from**: `rc/2026-04-18.21`

### Changes
- chore(docs): update version badges swarmkit@2.4.1, flowkit@2.0.0

Badge-only release — catches up docs/index.html to the plugin versions released in v2026.4.18.19.