### PR TITLE
release: 2026-04-18

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,3 @@ Run it before staging and committing the release.
 ## Plugins
 
 `swarmkit` includes an experimental `squad` skill gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`. See `plugins/swarmkit/README.md` for details.
-
-## GitHub Pages
-
-`docs/index.html` is the source for the GitHub Pages landing page at https://smallorbit.github.io/smallorbit-plugins/. When plugin versions change, update the version badges in the plugin cards section of that file to keep the site in sync.

--- a/docs/index.html
+++ b/docs/index.html
@@ -198,7 +198,6 @@
                 <span class="plugin-role">plan it</span>
               </div>
               <div class="plugin-meta">
-                <span class="badge">v1.2.7</span>
                 <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/speckit" target="_blank" rel="noopener">README ↗</a>
               </div>
             </div>
@@ -230,7 +229,6 @@
                 <span class="plugin-role">execute it</span>
               </div>
               <div class="plugin-meta">
-                <span class="badge">v2.4.1</span>
                 <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/swarmkit" target="_blank" rel="noopener">README ↗</a>
               </div>
             </div>
@@ -264,7 +262,6 @@
                 <span class="plugin-role">polish it</span>
               </div>
               <div class="plugin-meta">
-                <span class="badge">v1.0.1</span>
                 <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/polishkit" target="_blank" rel="noopener">README ↗</a>
               </div>
             </div>
@@ -295,7 +292,6 @@
                 <span class="plugin-role">ship it</span>
               </div>
               <div class="plugin-meta">
-                <span class="badge">v2.0.0</span>
                 <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/flowkit" target="_blank" rel="noopener">README ↗</a>
               </div>
             </div>
@@ -330,7 +326,6 @@
                 <span class="plugin-role">throughout</span>
               </div>
               <div class="plugin-meta">
-                <span class="badge">v1.2.1</span>
                 <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/sessionkit" target="_blank" rel="noopener">README ↗</a>
               </div>
             </div>
@@ -371,7 +366,6 @@
                 <span class="plugin-role">capture it</span>
               </div>
               <div class="plugin-meta">
-                <span class="badge">v1.0.1</span>
                 <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/vaultkit" target="_blank" rel="noopener">README ↗</a>
               </div>
             </div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -753,14 +753,6 @@ section + section { border-top: 1px solid var(--border); }
   align-items: center;
   gap: 10px;
 }
-.badge {
-  font-family: var(--mono);
-  font-size: 0.7rem;
-  padding: 3px 8px;
-  color: var(--text-muted);
-  border: 1px solid var(--border-strong);
-  border-radius: 999px;
-}
 .plugin-readme {
   font-family: var(--mono);
   font-size: 0.74rem;


### PR DESCRIPTION
## Release summary

**Built from**: `rc/2026-04-18.22`

### Changes
- chore(docs): remove per-plugin version badges from landing page (#344)

Closes #233