### PR TITLE
feat(metakit): scaffold plugin directory and register in monorepo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Claude Code plugins for plan, execute, and ship — each keeping you at the hand
 | **polishkit** | `/plugin install polishkit@smallorbit-plugins` | Critique code quality, sweep for cruft, and eliminate dead code |
 | **flowkit** | `/plugin install flowkit@smallorbit-plugins` | Manage the full git lifecycle from branch to release |
 | **sessionkit** | `/plugin install sessionkit@smallorbit-plugins` | Session continuity, context handoffs, and meta-learning |
+| **metakit** _(pre-release 0.1.0)_ | `/plugin install metakit@smallorbit-plugins` | Dynamic orchestrator that composes sibling kits into multi-step scenarios with graceful degradation |
 
 ### Utilities & Productivity
 
@@ -45,6 +46,8 @@ The development-lifecycle plugins form a complete loop from idea to release:
 ```
 
 **sessionkit** acts as connective tissue throughout: use `/handoff` to preserve state across agent context limits, `/skillit` to capture reusable patterns after a swarm, and `/suggest-permissions` to reduce approval friction over time.
+
+**metakit** (pre-release) sits above the loop as an orchestrator: it detects which sibling kits are installed and composes them into multi-step scenarios (e.g. `/polish-cycle`, `/handoff-cycle`), skipping missing steps and pausing on risky ones rather than failing outright.
 
 **vaultkit** lives outside the loop — it's a utility for capturing decisions, notes, and archives into an Obsidian vault alongside any work, dev or otherwise. Requires Obsidian and the Obsidian CLI.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -351,6 +351,24 @@
             </div>
           </article>
 
+          <article class="plugin-card reveal" data-delay="6" data-kit="metakit">
+            <div class="plugin-card-head">
+              <div class="plugin-card-id">
+                <span class="plugin-name">metakit</span>
+                <span class="plugin-role">compose it</span>
+              </div>
+              <div class="plugin-meta">
+                <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/metakit" target="_blank" rel="noopener">README ↗</a>
+              </div>
+            </div>
+            <p class="plugin-desc">Dynamic orchestrator that composes sibling kits into multi-step scenarios. Detects what's installed, previews the plan, skips missing steps, pauses on risky ones, and halts with a state report on failure. <em>Pre-release.</em></p>
+            <ul class="skill-list">
+              <li><code>/kits</code> — report installed kits and runnable scenarios <em>(coming soon)</em></li>
+              <li><code>/polish-cycle</code> — critique → dead-code → tidy → file findings <em>(coming soon)</em></li>
+              <li><code>/handoff-cycle</code> — handoff → skillit → archive decisions <em>(coming soon)</em></li>
+            </ul>
+          </article>
+
         </div>
 
         <header class="plugin-category reveal">
@@ -436,6 +454,10 @@
                 <div class="code-copy-wrapper">
                   <pre><code>claude plugin install sessionkit@smallorbit-plugins</code></pre>
                   <button class="copy-btn" data-copy="claude plugin install sessionkit@smallorbit-plugins" aria-label="Copy sessionkit install command">copy</button>
+                </div>
+                <div class="code-copy-wrapper">
+                  <pre><code>claude plugin install metakit@smallorbit-plugins</code></pre>
+                  <button class="copy-btn" data-copy="claude plugin install metakit@smallorbit-plugins" aria-label="Copy metakit install command">copy</button>
                 </div>
                 <div class="install-sublabel">Utilities &amp; productivity</div>
                 <div class="code-copy-wrapper">

--- a/plugins/metakit/.claude-plugin/plugin.json
+++ b/plugins/metakit/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "metakit",
+  "description": "Dynamic orchestrator that composes sibling kits (speckit, swarmkit, polishkit, flowkit, sessionkit, vaultkit) into multi-step scenarios with graceful degradation.",
+  "version": "0.1.0",
+  "license": "MIT",
+  "author": {
+    "name": "Román M. Pacheco"
+  }
+}

--- a/plugins/metakit/README.md
+++ b/plugins/metakit/README.md
@@ -1,0 +1,56 @@
+# metakit
+
+A Claude Code plugin that composes sibling kits into multi-step scenarios. metakit detects which kits are installed at runtime, renders a plan preview, skips missing steps, pauses on risky ones for confirmation, and halts with a state report on failure — so the same command does the right thing whether you have the full suite or just a subset.
+
+> **Status:** early scaffold (v0.1.0). The plugin shell exists; the scenario skills below are coming soon.
+
+## Installation
+
+Install from the `smallorbit-plugins` marketplace:
+
+```
+/plugin marketplace add smallorbit/smallorbit-plugins
+/plugin install metakit@smallorbit-plugins
+```
+
+Or load directly for a single session:
+
+```bash
+claude --plugin-dir /path/to/metakit
+```
+
+### Prerequisites
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed
+- One or more sibling kits from `smallorbit-plugins` (speckit, swarmkit, polishkit, flowkit, sessionkit, vaultkit). metakit detects what's available and degrades gracefully when kits are missing.
+
+## Skills
+
+| Skill | Invoke | What it does |
+|-------|--------|--------------|
+| **kits** | `/kits` | _Coming soon._ Report which sibling kits are installed and what scenarios are currently runnable. |
+| **polish-cycle** | `/polish-cycle` | _Coming soon._ Run a full quality pass — critique, dead-code sweep, tidy — then file findings as issues and optionally swarm fixes. |
+| **handoff-cycle** | `/handoff-cycle` | _Coming soon._ Close out a session cleanly — capture state, suggest skills worth keeping, archive decisions into the vault if present. |
+
+## Graceful-Degradation Contract
+
+Every metakit scenario follows the same shape:
+
+1. **Detect** which sibling kits are installed.
+2. **Preview** the plan — show the ordered step list and mark any steps that will be skipped because the required kit is missing.
+3. **Skip missing steps** silently after the preview is approved; never fail because a kit isn't present.
+4. **Pause on risky steps** (destructive operations, PR merges, releases) for explicit confirmation.
+5. **Halt on failure** with a state report — what ran, what didn't, what the next agent needs to know to resume.
+
+This means `/polish-cycle` works whether you have all of polishkit + speckit + swarmkit or just polishkit — the scenario adapts to what's available instead of refusing to run.
+
+## Pairing with Other Plugins
+
+metakit is an orchestrator — it doesn't replace any sibling kit, it composes them:
+
+- **[speckit](../speckit)** — metakit scenarios file findings as issues via `/issue` or `/catalog`.
+- **[swarmkit](../swarmkit)** — metakit scenarios can hand filed issues off to `/swarm` for parallel resolution.
+- **[polishkit](../polishkit)** — `/polish-cycle` drives `/critique`, `/dead-code`, and `/tidy-codebase` in sequence.
+- **[flowkit](../flowkit)** — metakit scenarios defer to flowkit for PR, cut, and release operations.
+- **[sessionkit](../sessionkit)** — `/handoff-cycle` uses `/handoff` and `/skillit` to capture and carry state.
+- **[vaultkit](../vaultkit)** — when present, metakit scenarios can archive plans and decisions via `/jot` or `/archive-export`.


### PR DESCRIPTION
## Summary
- Adds plugins/metakit/ with plugin.json (v0.1.0), skills/ placeholder, and a README stub describing v1 commands and the graceful-degradation contract
- Registers metakit in the monorepo README's plugin table and composition notes
- Adds a metakit card to docs/index.html matching the current badge-free card shape

## Test plan
- Validate plugin.json parses and matches sibling field shape
- Confirm docs/index.html still contains zero per-plugin version badges (no #344 regression)
- Open the landing page locally and confirm the metakit card renders in line with existing cards

Closes #247