### PR TITLE
fix(flowkit:release): use gh --jq flag in epic-closing pipelines

### DIFF
--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -77,10 +77,9 @@ EPIC_REFS_FILE=$(mktemp)
 
 echo "$ISSUE_REFS" | grep -oE '[0-9]+' | sort -u | while read CHILD_N; do
   gh issue list --label "epic" --state open --json number,body \
-    | tr -d '\000-\010\013-\037' \
-    | jq -r ".[] | select(.body | test(\"- \\\\[[ x]\\\\] #${CHILD_N}\"))" \
-  | grep -oE '"number":[0-9]+' | grep -oE '[0-9]+' | while read EPIC_N; do
-    EPIC_BODY=$(gh issue view "$EPIC_N" --json body | tr -d '\000-\010\013-\037' | jq -r '.body')
+      --jq ".[] | select(.body | test(\"- \\\\[[ x]\\\\] #${CHILD_N}\")) | .number" \
+  | while read EPIC_N; do
+    EPIC_BODY=$(gh issue view "$EPIC_N" --json body --jq '.body')
     OPEN_CHILDREN=$(echo "$EPIC_BODY" | grep -oE '- \[ \] #[0-9]+')
     [ -z "$OPEN_CHILDREN" ] && echo "Closes #$EPIC_N" >> "$EPIC_REFS_FILE"
   done


### PR DESCRIPTION
## Summary
- Replace the two `tr -d '\000-\010\013-\037' | jq ...` pipelines in release step 4 (epic-closing aggregation) with gh's embedded `--jq` flag, eliminating the shell-pipe sanitization hop that produced parse errors on epic bodies containing unescaped control bytes.
- Collapse the downstream `grep -oE '"number":[0-9]+' | grep -oE '[0-9]+'` extraction in pipeline A by having `--jq` emit `.number` directly.

## Test plan
- Ran pipeline A (`gh issue list --label epic --state open --json number,body --jq '...'`) against the live repo with a sample CHILD_N — no jq parse errors on stderr, numeric output emitted cleanly.
- Ran pipeline B (`gh issue view <epic> --json body --jq '.body'`) against a live epic issue — body returned without parse errors.
- Next `/flowkit:release` cycle should no longer surface the two `jq: parse error` lines observed during `v2026.4.19.1`.

Closes #355