### PR TITLE
release: 2026-04-19

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship — with runtime staging detection and a one-command hotfix flow.",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -77,10 +77,9 @@ EPIC_REFS_FILE=$(mktemp)
 
 echo "$ISSUE_REFS" | grep -oE '[0-9]+' | sort -u | while read CHILD_N; do
   gh issue list --label "epic" --state open --json number,body \
-    | tr -d '\000-\010\013-\037' \
-    | jq -r ".[] | select(.body | test(\"- \\\\[[ x]\\\\] #${CHILD_N}\"))" \
-  | grep -oE '"number":[0-9]+' | grep -oE '[0-9]+' | while read EPIC_N; do
-    EPIC_BODY=$(gh issue view "$EPIC_N" --json body | tr -d '\000-\010\013-\037' | jq -r '.body')
+      --jq ".[] | select(.body | test(\"- \\\\[[ x]\\\\] #${CHILD_N}\")) | .number" \
+  | while read EPIC_N; do
+    EPIC_BODY=$(gh issue view "$EPIC_N" --json body --jq '.body')
     OPEN_CHILDREN=$(echo "$EPIC_BODY" | grep -oE '- \[ \] #[0-9]+')
     [ -z "$OPEN_CHILDREN" ] && echo "Closes #$EPIC_N" >> "$EPIC_REFS_FILE"
   done


### PR DESCRIPTION
## Release summary

**Built from**: `rc/2026-04-19.3`

### Version bumps
- chore(plugins): bump flowkit@2.0.1

### Changes

**flowkit**
- fix(flowkit:release): use gh --jq flag in epic-closing pipelines (#356)

Closes #355