### PR TITLE
feat(metakit): add /polish-cycle command

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # smallorbit-plugins
 
-Monorepo hosting Claude Code plugins: swarmkit, flowkit, sessionkit, and speckit.
+Monorepo hosting Claude Code plugins. See the [repo README](./README.md#available-plugins) for the current plugin catalog — it's the canonical source and stays in sync as plugins ship.
 
 ## Release Process
 
@@ -17,3 +17,7 @@ Run it before staging and committing the release.
 ## Plugins
 
 `swarmkit` includes an experimental `squad` skill gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`. See `plugins/swarmkit/README.md` for details.
+
+## Skill Authoring Conventions
+
+**Bash loop convention**: Never use `for N in $VAR` to iterate over newline-delimited output — word splitting is unreliable across shell contexts. Always pipe directly: `some-command | while read N; do ... done`.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The development-lifecycle plugins form a complete loop from idea to release:
 /release       → ship merged work to production (flowkit)
 ```
 
+**polishkit** sits between `/swarm` and `/release` as a quality gate: use `/critique` to assess elegance and craft, `/tidy-codebase` to sweep for stale files and cruft, and `/dead-code` to eliminate unused exports before shipping.
+
 **sessionkit** acts as connective tissue throughout: use `/handoff` to preserve state across agent context limits, `/skillit` to capture reusable patterns after a swarm, and `/suggest-permissions` to reduce approval friction over time.
 
 **metakit** (pre-release) sits above the loop as an orchestrator: it detects which sibling kits are installed and composes them into multi-step scenarios (e.g. `/polish-cycle`, `/handoff-cycle`), skipping missing steps and pausing on risky ones rather than failing outright.
@@ -54,10 +56,6 @@ The development-lifecycle plugins form a complete loop from idea to release:
 Each plugin's README describes how it pairs with the others.
 
 See each plugin's README for detailed usage.
-
-## Skill Authoring Conventions
-
-**Bash loop convention**: Never use `for N in $VAR` to iterate over newline-delimited output — word splitting is unreliable across shell contexts. Always pipe directly: `some-command | while read N; do ... done`.
 
 ## License
 

--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship — with runtime staging detection and a one-command hotfix flow.",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship — with runtime staging detection and a one-command hotfix flow.",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -31,7 +31,7 @@ claude --plugin-dir /path/to/flowkit
 |-------|--------|--------------|
 | **commit** | `/commit` | Stage and commit changes with conventional commit format. Infers logical groupings and writes `type(scope): description` messages. |
 | **create-branch** | `/create-branch` | Create a new git branch off `develop` with an inferred or provided name. |
-| **open-pr** | `/open-pr` | Push current branch and open a GitHub PR. Respects `claude.prBase` for branch targeting. |
+| **open-pr** | `/open-pr` | Push current branch and open a GitHub PR. Respects `claude.flowkit.prBase` for branch targeting. |
 | **pr** | `/pr` | Combined: `create-branch` → `commit` → `open-pr` in one step. |
 | **merge-pr** | `/merge-pr` | Squash-merge the open PR for the current branch; labels referenced issues with `merged-to-develop`. |
 | **sync** | `/sync` | Checkout `develop`, pull latest, prune stale branches. |
@@ -51,7 +51,7 @@ These are called by the skills above — you don't invoke them directly.
 | **git-sync-main** | release, hotfix | Checkout `main` and pull latest from origin. |
 | **git-sync-develop** | sync, release, hotfix | Checkout `develop` and pull latest from origin. |
 | **gh-close-referenced-issues** | release, hotfix | Parse merged PR bodies; close referenced issues and resolved epics. |
-| **pr-base-scope** | swarm | Set/unset `claude.prBase` git config for scoped PR targeting. |
+| **pr-base-scope** | swarm | Set/unset `claude.flowkit.prBase` git config for scoped PR targeting. |
 
 ## Typical Workflows
 
@@ -107,6 +107,42 @@ git checkout -b staging main && git push -u origin staging
 ```
 
 From that point on, all release skills pick it up automatically.
+
+## Configuration
+
+Flowkit reads one repo-local git config key:
+
+| Key | Purpose | Default |
+|-----|---------|---------|
+| `claude.flowkit.prBase` | Target base branch for `/open-pr` when no override is passed. Set automatically by `/ship` and `/swarm` loop mode; unset on teardown. | `develop` |
+
+Inspect or set manually:
+
+```bash
+# Show the effective setting (empty = falls through to default)
+git config claude.flowkit.prBase
+
+# Pin PRs to a non-default base for the current repo
+git config claude.flowkit.prBase main
+
+# Revert to the default
+git config --unset claude.flowkit.prBase
+```
+
+### Migrating from `claude.prBase`
+
+The legacy key `claude.prBase` is still read as a fallback so existing setups don't break. When flowkit falls back to the legacy key, it emits a one-line deprecation notice with the exact commands below. Migrate at your convenience:
+
+```bash
+# Read whatever was set on the legacy key
+LEGACY=$(git config claude.prBase)
+
+# Remove the legacy key and write the new one
+git config --unset claude.prBase
+git config claude.flowkit.prBase "$LEGACY"
+```
+
+The legacy fallback is a soft deprecation and will be kept indefinitely — no hard break is planned. The new key aligns with the `claude.<plugin>.<key>` convention used across smallorbit plugins.
 
 ## Assumptions & Conventions
 

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -50,7 +50,6 @@ These are called by the skills above — you don't invoke them directly.
 |-------|---------|---------|
 | **git-sync-main** | release, hotfix | Checkout `main` and pull latest from origin. |
 | **git-sync-develop** | sync, release, hotfix | Checkout `develop` and pull latest from origin. |
-| **gh-close-referenced-issues** | release, hotfix | Parse merged PR bodies; close referenced issues and resolved epics. |
 | **pr-base-scope** | swarm | Set/unset `claude.flowkit.prBase` git config for scoped PR targeting. |
 
 ## Typical Workflows
@@ -160,9 +159,9 @@ Release candidates are named by date and sequence number (e.g., `rc/2026-04-16.1
 
 Production releases are tagged with a calendar-versioned tag (e.g., `v2026.4.16`). Multiple releases on the same day append a counter (e.g., `v2026.4.16-2`).
 
-### Hotfix Tags: `vYYYY.M.D-hotfix`
+### Hotfix Tags: `vYYYY.M.D[.N]` + companion `hotfix/vYYYY.M.D[.N]`
 
-Hotfixes are tagged separately (e.g., `v2026.4.16-hotfix`) to distinguish them from scheduled releases and preserve the release history.
+Hotfixes use the same CalVer MICRO-increment tag as scheduled releases (e.g., `v2026.4.16.1`) so the two sort together in the release history. A companion tag (e.g., `hotfix/v2026.4.16.1`) is pushed to the same commit to keep hotfixes discoverable via `git tag --list 'hotfix/*'`.
 
 ### Commit Format: Conventional Commits
 

--- a/plugins/flowkit/skills/hotfix/SKILL.md
+++ b/plugins/flowkit/skills/hotfix/SKILL.md
@@ -68,13 +68,25 @@ Follow the `pr-base-scope` sub-skill to unset `claude.prBase`.
 
 ### 10. Tag the hotfix on main
 
-Create and push a hotfix tag directly on main (no RC cycle):
+Tag the hotfix directly on main using the same CalVer MICRO-increment scheme as `/release`, so hotfix tags sort naturally alongside planned release tags. A companion `hotfix/` tag at the same commit preserves discoverability via `git tag --list 'hotfix/*'`.
 
 ```bash
-TAG="v$(date +%Y.%-m.%-d)-hotfix"
-git tag "$TAG" main
+BASE_TAG="v$(date +%Y.%-m.%-d)"
+N=1
+TAG="$BASE_TAG"
+while git ls-remote --exit-code origin "refs/tags/$TAG" &>/dev/null; do
+  TAG="$BASE_TAG.$N"
+  N=$((N + 1))
+done
+git tag -a "$TAG" main -m "Hotfix: <one-line reason from PR title>"
 git push origin "$TAG"
+
+COMPANION="hotfix/$TAG"
+git tag "$COMPANION" "$TAG"
+git push origin "$COMPANION"
 ```
+
+The annotation message preserves the "hotfix" signal for `git tag -n` queries; the companion tag keeps the canonical version tag clean while still flagging the commit as an emergency fix.
 
 ### 11. Close referenced issues
 
@@ -100,7 +112,7 @@ Follow the `git-sync-develop` sub-skill to confirm a clean local develop state.
 
 Summarize:
 - Hotfix PR merged into main
-- Tag created (include the tag name)
+- Tags created (include both the canonical version tag and the `hotfix/` companion tag)
 - Referenced issues closed
 - develop updated with back-merge
 

--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -32,8 +32,21 @@ If the current branch is `develop`, `main`, `master`, or `staging`, stop immedia
 
 ### 2. Determine base branch
 
+Resolve the base branch using the `pr-base-scope` read order: new key → legacy key (with deprecation notice) → `develop` default.
+
 ```bash
-BASE=$(git config claude.prBase 2>/dev/null || echo "develop")
+BASE=$(git config claude.flowkit.prBase 2>/dev/null)
+if [ -z "$BASE" ]; then
+  LEGACY=$(git config claude.prBase 2>/dev/null)
+  if [ -n "$LEGACY" ]; then
+    BASE="$LEGACY"
+    echo "note: claude.prBase is deprecated. Migrate with:" >&2
+    echo "  git config --unset claude.prBase" >&2
+    echo "  git config claude.flowkit.prBase $LEGACY" >&2
+  else
+    BASE="develop"
+  fi
+fi
 ```
 
 Use `$BASE` as the PR target. This respects any scoped override set by the `pr-base-scope` sub-skill.
@@ -74,7 +87,7 @@ Output the PR URL returned by `gh pr create`.
 
 ## Constraints
 
-- Never target `main` directly unless `claude.prBase` is explicitly set to `main`
+- Never target `main` directly unless `claude.flowkit.prBase` (or legacy `claude.prBase`) is explicitly set to `main`
 - Never open a PR from a protected branch (`develop`, `main`, `master`, `staging`)
 - If `gh` is not installed or not authenticated, report the error and stop — do not attempt workarounds
 - Do not force-push; use a plain `git push -u origin HEAD`

--- a/plugins/flowkit/skills/pr-base-scope/SKILL.md
+++ b/plugins/flowkit/skills/pr-base-scope/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: pr-base-scope
-description: Set or unset the claude.prBase git config key to scope the PR target branch for a session. Sub-skill used by ship and swarm loop mode.
+description: Set or unset the claude.flowkit.prBase git config key to scope the PR target branch for a session. Sub-skill used by ship and swarm loop mode.
 ---
 
 # pr-base-scope
 
-Set or unset `claude.prBase` — a local git config key that tells `/open-pr` which branch to target when creating a pull request. Used by `/ship` to pin PRs to `develop` during the ship flow, and by swarm loop mode to scope multi-PR sessions.
+Set or unset `claude.flowkit.prBase` — a local git config key that tells `/open-pr` which branch to target when creating a pull request. Used by `/ship` to pin PRs to `develop` during the ship flow, and by swarm loop mode to scope multi-PR sessions.
+
+The legacy key `claude.prBase` is still read as a fallback for backward compatibility, but is never written. When read, it emits a one-line deprecation notice pointing at the migration commands.
 
 ## Operations
 
@@ -14,13 +16,13 @@ Set or unset `claude.prBase` — a local git config key that tells `/open-pr` wh
 Pin the PR target branch for the current session:
 
 ```bash
-git config claude.prBase <branch>
+git config claude.flowkit.prBase <branch>
 ```
 
 Example — pin to develop:
 
 ```bash
-git config claude.prBase develop
+git config claude.flowkit.prBase develop
 ```
 
 ### Unset
@@ -28,28 +30,43 @@ git config claude.prBase develop
 Revert to the default target (`develop`):
 
 ```bash
-git config --unset claude.prBase
+git config --unset claude.flowkit.prBase
 ```
 
 ### Read
 
-Resolve the current target branch (used by `/open-pr`):
+Resolve the current target branch (used by `/open-pr`). Apply this resolution order:
+
+1. `claude.flowkit.prBase` — primary source of truth
+2. `claude.prBase` — legacy fallback (emits deprecation notice when hit)
+3. Built-in default: `develop`
 
 ```bash
-git config claude.prBase 2>/dev/null || echo "develop"
+BASE=$(git config claude.flowkit.prBase 2>/dev/null)
+if [ -z "$BASE" ]; then
+  LEGACY=$(git config claude.prBase 2>/dev/null)
+  if [ -n "$LEGACY" ]; then
+    BASE="$LEGACY"
+    echo "note: claude.prBase is deprecated. Migrate with:" >&2
+    echo "  git config --unset claude.prBase" >&2
+    echo "  git config claude.flowkit.prBase $LEGACY" >&2
+  else
+    BASE="develop"
+  fi
+fi
 ```
-
-If the key is not set, this returns `develop` as the default.
 
 ## Usage by Callers
 
 | Caller | Action |
 |--------|--------|
-| `/ship` | Sets `claude.prBase develop` before opening PRs, then unsets after the flow completes |
-| `/swarm` loop mode | Sets `claude.prBase` to the appropriate integration branch for the loop session |
-| `/open-pr` | Reads `claude.prBase` to resolve the target branch before creating the PR |
+| `/ship` | Sets `claude.flowkit.prBase develop` before opening PRs, then unsets after the flow completes |
+| `/swarm` loop mode | Sets `claude.flowkit.prBase` to the appropriate integration branch for the loop session |
+| `/open-pr` | Reads the resolved base (new key → legacy key → `develop`) before creating the PR |
 
 ## Constraints
 
 - This key is local to the repo — it is never committed or pushed
 - Always unset after a scoped flow completes to avoid stale targeting in future sessions
+- Never write to the legacy `claude.prBase` key. All set/unset operations target `claude.flowkit.prBase` only
+- The legacy fallback is a soft deprecation — keep it indefinitely

--- a/plugins/metakit/README.md
+++ b/plugins/metakit/README.md
@@ -29,7 +29,7 @@ claude --plugin-dir /path/to/metakit
 | Skill | Invoke | What it does |
 |-------|--------|--------------|
 | **kits** | `/kits` | _Coming soon._ Report which sibling kits are installed and what scenarios are currently runnable. |
-| **polish-cycle** | `/polish-cycle` | _Coming soon._ Run a full quality pass — critique, dead-code sweep, tidy — then file findings as issues and optionally swarm fixes. |
+| **polish-cycle** | `/polish-cycle` | _Coming soon._ Run a full quality loop — `polishkit:critique` to surface findings, `speckit:catalog` to file them as issues, `swarmkit:swarm` to spawn fixes — pausing before each risky step. |
 | **handoff-cycle** | `/handoff-cycle` | _Coming soon._ Close out a session cleanly — capture state, suggest skills worth keeping, archive decisions into the vault if present. |
 
 ## Graceful-Degradation Contract
@@ -50,7 +50,7 @@ metakit is an orchestrator — it doesn't replace any sibling kit, it composes t
 
 - **[speckit](../speckit)** — metakit scenarios file findings as issues via `/issue` or `/catalog`.
 - **[swarmkit](../swarmkit)** — metakit scenarios can hand filed issues off to `/swarm` for parallel resolution.
-- **[polishkit](../polishkit)** — `/polish-cycle` drives `/critique`, `/dead-code`, and `/tidy-codebase` in sequence.
+- **[polishkit](../polishkit)** — `/polish-cycle` drives `/critique` to surface findings before handing them to speckit and swarmkit.
 - **[flowkit](../flowkit)** — metakit scenarios defer to flowkit for PR, cut, and release operations.
 - **[sessionkit](../sessionkit)** — `/handoff-cycle` uses `/handoff` and `/skillit` to capture and carry state.
 - **[vaultkit](../vaultkit)** — when present, metakit scenarios can archive plans and decisions via `/jot` or `/archive-export`.

--- a/plugins/metakit/skills/polish-cycle/SKILL.md
+++ b/plugins/metakit/skills/polish-cycle/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: polish-cycle
+description: Run a full quality loop across polishkit, speckit, and swarmkit — critique the code, catalog findings as GitHub issues, then swarm parallel agents to resolve them. Detects which sibling kits are installed and degrades gracefully when any are missing. Use when the user asks to "run a polish cycle", "do a quality pass", or "critique and fix" a codebase. Invoke as `/polish-cycle`.
+---
+
+# Polish Cycle
+
+End-to-end quality loop that orchestrates three sibling kits:
+
+1. **polishkit:critique** — produce a code-quality report (low-risk, runs automatically)
+2. **speckit:catalog** — file the report's findings as GitHub issues (risky, pause for confirm)
+3. **swarmkit:swarm** — spawn parallel agents to resolve the newly-filed issues (risky, pause for confirm)
+
+Following the metakit contract: detect → preview → execute with pauses on risky steps → halt-and-report on failure.
+
+## Prerequisites
+
+- **polishkit must be installed.** Without it, there is nothing to critique — the scenario is unavailable. Report it and stop.
+- **speckit and swarmkit are optional.** If either is missing, the corresponding step is skipped; the user is told which downstream steps cannot run.
+
+## Process
+
+### 1. Detect installed kits
+
+Invoke the `detect-kits` sub-skill via the Skill tool. Capture the returned detection map.
+
+### 2. Gate on polishkit
+
+If `detectionMap["polishkit"]` is falsy:
+
+```
+Scenario unavailable: /polish-cycle requires polishkit (for the /critique step) and
+it is not installed in this environment. Install polishkit and re-run.
+```
+
+Stop. Do not continue to plan-preview.
+
+### 3. Build the scenario and render the plan
+
+Compose the ordered step list:
+
+```json
+[
+  { "stepName": "critique codebase",       "owningKit": "polishkit", "riskLevel": "safe" },
+  { "stepName": "catalog findings as issues", "owningKit": "speckit",   "riskLevel": "risky" },
+  { "stepName": "swarm issues in parallel",   "owningKit": "swarmkit",  "riskLevel": "risky" }
+]
+```
+
+Invoke the `plan-preview` sub-skill via the Skill tool, passing this scenario and the detection map from step 1.
+
+If `plan-preview` returns `proceed: false`, exit cleanly. Do not invoke any step.
+
+### 4. Execute steps in order
+
+Track completed steps in a running list so halt-and-report can surface them on failure:
+
+```json
+[]
+```
+
+For each step in the plan:
+
+#### 4a. If `action === "skip"` (kit missing)
+
+Announce the skip and note which downstream capability is lost:
+
+| Missing kit | Downstream impact |
+|---|---|
+| `speckit` missing | Findings will not be filed as issues. The swarm step also cannot run (it needs filed issues to dispatch). |
+| `swarmkit` missing | Filed issues remain open; no parallel resolution. |
+
+Append a synthetic entry to `completed_steps` with `outputSummary: "skipped — <kit> not installed"` so the state is visible in any later halt report. Continue to the next step.
+
+#### 4b. If `action === "run"` (safe step — polishkit:critique)
+
+Invoke `polishkit:critique` via the Skill tool. On success, capture the critique report path or summary in `outputSummary` and append to `completed_steps`. On failure, invoke `halt-and-report` (see step 5) and stop.
+
+#### 4c. If `action === "pause"` (risky step)
+
+Re-confirm with the user before running this specific step. Prefer `AskUserQuestion`; fall back to a plain prompt:
+
+```
+About to run <stepName> (<owningKit>). This will <side-effect>. Proceed? (yes / no)
+```
+
+Side-effect descriptions per step:
+
+| Step | Side-effect phrase |
+|---|---|
+| `catalog findings as issues` | "file GitHub issues for each critique finding" |
+| `swarm issues in parallel`   | "spawn parallel worktree agents and open stacked PRs" |
+
+If the user declines, append `outputSummary: "declined by user"` to `completed_steps` and continue to the next step. If the user confirms, invoke the owning skill:
+
+- `catalog findings as issues` → `speckit:catalog` via the Skill tool, passing the critique report from the previous step
+- `swarm issues in parallel` → `swarmkit:swarm` via the Skill tool, passing the issue numbers filed by the catalog step
+
+On success, capture the result summary in `outputSummary` and append to `completed_steps`. On failure, invoke halt-and-report (step 5).
+
+### 5. On any step failure — halt and report
+
+Invoke the `halt-and-report` sub-skill via the Skill tool with this payload:
+
+```json
+{
+  "scenario": "polish-cycle",
+  "completed_steps": [ { "stepName": "...", "outputSummary": "..." } ],
+  "failed_step": {
+    "stepName": "<current step's stepName>",
+    "owningKit": "<current step's owningKit>",
+    "error": "<error string from the failing skill>",
+    "skillState": { }
+  }
+}
+```
+
+Stop after halt-and-report prints. Do not attempt further steps, retries, or cleanup — recovery is the user's decision.
+
+### 6. On clean completion
+
+When every step has either run, skipped, or been declined without error, print a one-line summary:
+
+```
+/polish-cycle complete — <N> ran, <N> skipped, <N> declined.
+```
+
+List any skipped steps' downstream-impact notes so the user knows what was not done.
+
+## Notes
+
+- This skill is a thin orchestrator; all heavy lifting (critique, catalog, swarm) lives in the owning kits.
+- A risky step that is *skipped* because its kit is missing does not trigger a confirmation pause — only risky steps whose kit is present do.
+- `plan-preview` gates the plan as a whole; individual risky steps must still be re-confirmed per the caller contract (see `plan-preview` notes).
+- Never chain around a failure. Halt-and-report is the only failure path.

--- a/plugins/metakit/skills/polish-cycle/SKILL.md
+++ b/plugins/metakit/skills/polish-cycle/SKILL.md
@@ -41,9 +41,9 @@ Compose the ordered step list:
 
 ```json
 [
-  { "stepName": "critique codebase",       "owningKit": "polishkit", "riskLevel": "safe" },
-  { "stepName": "catalog findings as issues", "owningKit": "speckit",   "riskLevel": "risky" },
-  { "stepName": "swarm issues in parallel",   "owningKit": "swarmkit",  "riskLevel": "risky" }
+  { "stepName": "critique codebase",          "owningKit": "polishkit", "riskLevel": "safe" },
+  { "stepName": "catalog findings as issues",  "owningKit": "speckit",   "riskLevel": "risky" },
+  { "stepName": "swarm issues in parallel",    "owningKit": "swarmkit",  "riskLevel": "risky" }
 ]
 ```
 
@@ -105,31 +105,40 @@ Invoke the `halt-and-report` sub-skill via the Skill tool with this payload:
 ```json
 {
   "scenario": "polish-cycle",
-  "completed_steps": [ { "stepName": "...", "outputSummary": "..." } ],
+  "completed_steps": "<the running list from step 4>",
   "failed_step": {
-    "stepName": "<current step's stepName>",
-    "owningKit": "<current step's owningKit>",
-    "error": "<error string from the failing skill>",
-    "skillState": { }
+    "stepName": "<name of the step that threw>",
+    "owningKit": "<owningKit from the plan>",
+    "error": "<raw error string>",
+    "skillState": "<any structured output the failing skill returned, or {}>"
   }
 }
 ```
 
-Stop after halt-and-report prints. Do not attempt further steps, retries, or cleanup — recovery is the user's decision.
+After invoking halt-and-report, stop. Take no further action.
 
-### 6. On clean completion
+### 6. Completion summary
 
-When every step has either run, skipped, or been declined without error, print a one-line summary:
+After all steps finish (run, skipped, or declined), print:
 
 ```
-/polish-cycle complete — <N> ran, <N> skipped, <N> declined.
+/polish-cycle complete.
+
+  ✓ <stepName>  —  <outputSummary>     (completed steps)
+  ⊘ <stepName>  —  skipped             (missing-kit steps)
+  ○ <stepName>  —  declined by user    (user-declined steps)
 ```
 
-List any skipped steps' downstream-impact notes so the user knows what was not done.
+If any steps were skipped due to missing kits, append:
+
+```
+Note: the following steps could not run because their kit was not found:
+  ⊘ <stepName>  —  <owningKit> not found in environment
+```
 
 ## Notes
 
-- This skill is a thin orchestrator; all heavy lifting (critique, catalog, swarm) lives in the owning kits.
-- A risky step that is *skipped* because its kit is missing does not trigger a confirmation pause — only risky steps whose kit is present do.
-- `plan-preview` gates the plan as a whole; individual risky steps must still be re-confirmed per the caller contract (see `plan-preview` notes).
-- Never chain around a failure. Halt-and-report is the only failure path.
+- `polishkit` is the only hard requirement. Missing it makes the scenario unavailable, not degraded.
+- Per-step confirmation (`pause`) is independent of the overall plan gate from `plan-preview`. Both must pass before a risky step runs.
+- The `speckit:catalog` step receives the critique report as context; `swarmkit:swarm` receives the issue numbers from catalog. If catalog was skipped or declined, swarm has no input — treat it as if its kit were missing (skip it and note the upstream dependency).
+- This skill never modifies repository state directly — all mutations are delegated to the invoked skills.

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -154,4 +154,5 @@ Once enabled, invoke it the same way as `/swarm`:
 - **No session resumption** — if the Claude Code session dies, the entire team goes with it. There is no way to reconnect or hand off to a new session.
 - **Halt-only on teammate crash** — if a builder or reviewer crashes, the swarm halts. There is no automatic respawning in v1.
 - **Reviewer is pre-push only** — the reviewer teammate provides feedback before PRs are opened. It does not perform GitHub-side code review after the PR is created.
+- **In-process backend ignores `isolation: "worktree"`** — today's default Agent Teams backend silently drops the flag, leaving builders in the orchestrator's cwd. The squad builder contract includes a temporary manual-worktree fallback that creates the worktree itself when this happens. See [#362](https://github.com/smallorbit/smallorbit-plugins/issues/362) — the fallback will be removed once the backend honors the flag.
 - **Experimental** — API and behavior may change without notice as the Agent Teams feature evolves.

--- a/plugins/swarmkit/skills/squad/SKILL.md
+++ b/plugins/swarmkit/skills/squad/SKILL.md
@@ -111,7 +111,7 @@ The Agent Teams API is built from existing Claude Code primitives — there is n
 Notes:
 
 - **`TeamCreate` registers the orchestrator as `team-lead`**, not `lead`. Always address the orchestrator with `SendMessage({to: "team-lead", ...})`.
-- **`isolation: "worktree"` on the `Agent` tool is what gives the builder its isolated git worktree.** This is what makes the builder's git-based worktree safety check pass (see Builder Teammate Contract, step 2). Builders must be spawned with this flag; the reviewer must not (it audits inside the builders' worktrees, not its own).
+- **`isolation: "worktree"` on the `Agent` tool is what gives the builder its isolated git worktree.** Builders must be spawned with this flag; the reviewer must not (it audits inside the builders' worktrees, not its own). Today's in-process Agent Teams backend silently ignores the flag — see #362 — so the builder contract includes a manual-worktree fallback (see Builder Teammate Contract, step 2). Once the backend honors `isolation: "worktree"`, the fallback is a no-op.
 - **Only actual squad members join the team.** The reviewer and the builders use `team_name`. Any utility/research subagents the lead spawns for its own work (codebase exploration, etc.) must be plain `Agent({...})` calls **without** `team_name` — otherwise they pollute the team mailbox.
 
 ### 1. Initial fetch
@@ -185,24 +185,51 @@ A builder is a teammate responsible for shipping one or more issues. It is spawn
 
 1. **Claim the assigned issue** on the Agent Teams shared task list. The claim is atomic — if another teammate has already claimed this issue, abort.
 
-2. **Worktree setup** — identical to `swarmkit:swarm`:
-   - Independent issues branch from `develop`:
+2. **Worktree setup** — detect whether `isolation: "worktree"` actually took effect, then either use the pre-created worktree or fall back to manual setup:
+
+   - **Isolation probe.** Compare `--git-dir` and `--git-common-dir`. Inside a linked worktree, `--git-dir` points at `.git/worktrees/<name>` while `--git-common-dir` points at the main repo's `.git`. Equal paths ⇒ not in a linked worktree:
      ```bash
-     git checkout -b worktree-agent-<issue> origin/develop
-     ```
-   - Downstream issues branch from their upstream's agent branch:
-     ```bash
-     git checkout -b worktree-agent-<issue> origin/worktree-agent-<upstream-issue>
-     ```
-   - Safety check — abort if not running inside an isolated worktree. If this check fails it means the builder was **not** spawned with `isolation: "worktree"`, so it will never reach a state where it can send an audit request. Before exiting, notify the lead so it can respawn under a new name rather than waiting for an audit request that will never arrive. Unlike `swarmkit:swarm`, this probe cannot rely on `$PWD` — under team-mode `Agent` spawns, the shell's working directory does not reliably track the worktree path. Compare the current worktree's toplevel against the main checkout's toplevel instead:
-     ```bash
-     TOP=$(git rev-parse --show-toplevel)
-     MAIN=$(git rev-parse --path-format=absolute --git-common-dir | xargs dirname)
-     if [[ "$TOP" == "$MAIN" ]]; then
-       SendMessage({to: "team-lead", message: "builder-<issue> dead-on-arrival: operating in main checkout. Respawn under a new name."})
-       echo "ERROR: Operating in main checkout, not an isolated worktree. Aborting."
-       exit 1
+     if [[ "$(git rev-parse --git-common-dir 2>/dev/null)" == "$(git rev-parse --git-dir 2>/dev/null)" ]]; then
+       IN_WORKTREE=0
+     else
+       IN_WORKTREE=1
      fi
+     ```
+
+   - **Isolation took effect (`IN_WORKTREE=1`).** Create the agent branch inside the pre-created worktree, identical to `swarmkit:swarm`:
+     - Independent issues branch from `develop`:
+       ```bash
+       git checkout -b worktree-agent-<issue> origin/develop
+       ```
+     - Downstream issues branch from their upstream's agent branch:
+       ```bash
+       git checkout -b worktree-agent-<issue> origin/worktree-agent-<upstream-issue>
+       ```
+
+   - **Isolation was ignored (`IN_WORKTREE=0`) — manual fallback.** TEMPORARY: remove once the Agent Teams backend honors `isolation: "worktree"`. See #362. The in-process backend silently drops the flag, leaving the builder in the orchestrator's cwd (the main checkout). Create the worktree explicitly, then `cd` into it before proceeding:
+     ```bash
+     # --- BEGIN manual-worktree fallback (remove when #362 is fixed) ---
+     WORKTREE_ROOT=$(git rev-parse --show-toplevel)/.claude/worktrees
+     mkdir -p "$WORKTREE_ROOT" || {
+       SendMessage({to: "team-lead", message: "builder-<issue> dead-on-arrival: cannot create worktree root under .claude/worktrees/. Respawn under a new name."})
+       echo "ERROR: Failed to create $WORKTREE_ROOT. Aborting."
+       exit 1
+     }
+     # Independent issue: branch from origin/<base> (typically origin/develop)
+     # Downstream issue: branch from origin/worktree-agent-<upstream-issue> instead
+     git worktree add -b worktree-agent-<issue> "$WORKTREE_ROOT/worktree-agent-<issue>" origin/<base> || {
+       SendMessage({to: "team-lead", message: "builder-<issue> dead-on-arrival: git worktree add failed. Respawn under a new name."})
+       echo "ERROR: git worktree add failed. Aborting."
+       exit 1
+     }
+     cd "$WORKTREE_ROOT/worktree-agent-<issue>"
+     # Branch is created by `git worktree add -b`, so skip the separate `git checkout -b` step above.
+     # --- END manual-worktree fallback ---
+     ```
+
+   - **Neither path succeeded — dead-on-arrival.** If the fallback itself fails (e.g. git unavailable, permission error, `git worktree add` fails), notify the lead so it can respawn under a new name rather than waiting for an audit request that will never arrive, then exit:
+     ```
+     SendMessage({to: "team-lead", message: "builder-<issue> dead-on-arrival: unable to establish isolated worktree. Respawn under a new name."})
      ```
 
 3. **Implement the issue changes.** Use relative paths only from CWD. Stay scoped to the issue's acceptance criteria.
@@ -375,7 +402,7 @@ A builder can fail to start at all — for example, when the tmux shell is misco
 tmux/.tmux.conf:4: not a suitable shell
 ```
 
-A builder can also fail its worktree-isolation safety check (see Builder Teammate Contract, step 2). Note that squad's DOA signal here differs from `swarmkit:swarm`'s: under team-mode `Agent` spawns, `$PWD` does not reliably track the worktree path, so the builder uses a git-based probe (`git rev-parse --show-toplevel` vs. the main checkout's toplevel) instead of the `$PWD`-based check swarm uses.
+A builder can also fail its worktree setup step (see Builder Teammate Contract, step 2). Note that squad's DOA path here differs from `swarmkit:swarm`'s: under team-mode `Agent` spawns, `$PWD` does not reliably track the worktree path, so the builder uses a git-based probe (`git rev-parse --git-dir` vs. `--git-common-dir`) to decide whether `isolation: "worktree"` took effect. If it did not (the in-process Agent Teams backend silently ignores the flag today — see #362), the builder falls back to creating its own worktree under `<repo>/.claude/worktrees/`; DOA only fires when **both** isolation and manual setup fail (e.g. git unavailable, permission error).
 
 When this happens the builder process exits immediately without ever joining the team mailbox. Its `isActive` flag in the team config file (`~/.claude/teams/<team>/config.json`) remains `true` because no graceful shutdown message was exchanged. Any subsequent `TeamDelete` call will be blocked with:
 

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -265,10 +265,10 @@ Used when no issue numbers are given (no args or label filter). Continuously cle
 git fetch origin
 ```
 
-Set `claude.prBase` to scope the PR base for this operation:
+Set `claude.flowkit.prBase` to scope the PR base for this operation:
 
 ```bash
-git config --local claude.prBase $BASE
+git config --local claude.flowkit.prBase $BASE
 ```
 
 This is unset in the teardown step below. Leaving it set will cause subsequent PR creation (even in unrelated workflows) to target the wrong base, so cleanup is critical.
@@ -286,7 +286,7 @@ If no open issues remain, announce "Board is clear" and exit.
 
 **Step 2 — Swarm**
 
-Run the one-shot swarm flow above on the batch. Independent issues target `$BASE` (enforced by `claude.prBase`). Dependent issues target their dependency's branch, forming a stacked-PR chain that ultimately lands in `$BASE` when `swarmkit:merge-stack` cascades the merges.
+Run the one-shot swarm flow above on the batch. Independent issues target `$BASE` (enforced by `claude.flowkit.prBase`). Dependent issues target their dependency's branch, forming a stacked-PR chain that ultimately lands in `$BASE` when `swarmkit:merge-stack` cascades the merges.
 
 **Step 3 — Checkpoint**
 
@@ -308,9 +308,9 @@ Proceed immediately to the next cycle after printing the checkpoint summary. The
    ```bash
    git checkout $BASE && git pull origin $BASE
    ```
-3. Unset `claude.prBase` to clear the scoped PR base:
+3. Unset `claude.flowkit.prBase` to clear the scoped PR base:
    ```bash
-   git config --local --unset claude.prBase
+   git config --local --unset claude.flowkit.prBase
    ```
 3. Final summary:
 

--- a/plugins/vaultkit/.claude-plugin/plugin.json
+++ b/plugins/vaultkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vaultkit",
   "description": "Obsidian vault skills for Claude Code. Read, search, edit notes, manage projects, capture decisions, and archive conversations — all via the Obsidian CLI.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/vaultkit/README.md
+++ b/plugins/vaultkit/README.md
@@ -1,31 +1,107 @@
-# vaultkit
+# Vaultkit
 
 Obsidian vault skills for Claude Code. Read, search, edit notes, manage projects, capture decisions, and archive conversations — all via the Obsidian CLI.
 
+## Installation
+
+Install from the `smallorbit-plugins` marketplace:
+
+```
+/plugin marketplace add smallorbit/smallorbit-plugins
+/plugin install vaultkit@smallorbit-plugins
+```
+
+Or load directly for a single session:
+
+```bash
+claude --plugin-dir /path/to/vaultkit
+```
+
+### Prerequisites
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed
+- [Obsidian](https://obsidian.md/) desktop app running (the CLI requires an open Obsidian instance)
+- Obsidian CLI installed and authenticated against your vault (`obsidian vaults` should list your vault)
+
 ## Skills
 
-### User-facing
-| Skill | Description |
-|-------|-------------|
-| `vaultkit:obsidian` | Interface with Obsidian vaults via the CLI |
-| `vaultkit:jot` | Quickly capture a decision, task, or note into the active project |
-| `vaultkit:archive-export` | Archive the latest /export output into the active Obsidian project |
-| `vaultkit:project` | Manage Obsidian projects — create, load, and update project notes |
+### User-Facing
 
-### Sub-skills (internal)
-| Skill | Description |
-|-------|-------------|
-| `vaultkit:load-project` | Load a named Obsidian project into context |
-| `vaultkit:list-projects` | List all projects in the vault's Projects folder |
-| `vaultkit:file-edit` | Edit a vault file while preserving its filesystem birth time |
+| Skill | Invoke | What it does |
+|-------|--------|--------------|
+| **obsidian** | `/obsidian` | Interface with Obsidian vaults via the CLI — read, search, tag, edit notes, manage templates, and vault maintenance. |
+| **jot** | `/jot` | Quickly capture a decision, task, or note into the active project. Thin entry point over the `project` skill's update operation. |
+| **archive-export** | `/archive-export` | File the latest `/export session` output into the active Obsidian project's `Conversations/` folder. |
+| **project** | `/project` | Manage a `Projects/` second brain: load context, initialize new projects from template, and update project files. |
 
-## Requirements
+### Sub-Skills (internal)
 
-Obsidian must be open and the Obsidian CLI must be installed for vault operations to work.
+These are called by the skills above — you don't invoke them directly. The `vaultkit:` prefix reflects how sibling skills reference them.
 
-## Install
+| Skill | Invoke | What it does |
+|-------|--------|--------------|
+| **load-project** | `vaultkit:load-project` | Load a named Obsidian project into context; lists and recommends one if no name is supplied. |
+| **list-projects** | `vaultkit:list-projects` | List all projects in the vault's `Projects/` folder, sorted by status, with a count summary. |
+| **file-edit** | `vaultkit:file-edit` | Edit a vault file in place so filesystem birth time — the source of Obsidian's `created` metadata — is preserved. |
 
-Add to your Claude Code plugin list:
+## Typical Workflows
+
+### Capture a decision mid-session
+
 ```
-smallorbit/smallorbit-plugins/plugins/vaultkit
+/jot decided to use CalVer for release tagging; rationale in plugin-release.md
 ```
+
+The active project is inferred from conversation context (or you'll be prompted to pick one), and the note is appended without disturbing the file's `created` timestamp.
+
+### Archive a conversation export
+
+```
+/export session                    # writes ./session.txt in the cwd
+/archive-export                    # files it into the active project's Conversations/
+```
+
+Two artifacts land in Obsidian: a `.txt` copy for plain-text viewing and a `.md` companion with the session ID embedded for resuming.
+
+### Load a project at the start of a session
+
+```
+/load-project smallorbit-plugins   # pulls project notes, status, and context
+```
+
+If no name is provided, the skill lists available projects and recommends the most contextually relevant one.
+
+## How Jot Works
+
+`/jot` is a thin entry point into the `vaultkit:project` skill's update operation. It:
+
+1. Identifies the active project from conversation context, or prompts if unclear.
+2. Reads the target file before editing, then determines what changed — decisions, tasks, status, blockers.
+3. Writes the edit in place via `vaultkit:file-edit` so Obsidian's `created` metadata is preserved.
+4. Keeps entries concise — recall notes, not documentation.
+
+Because it delegates to the `project` skill, `/jot` benefits from the same project-awareness and file-hygiene conventions that `/project` applies.
+
+## How Archive Export Works
+
+`/archive-export` picks up the latest `/export session` output from the current working directory and files it into the active project's `Conversations/` folder. The convention is strict: `/export session` always writes `./session.txt` in the cwd, and `archive-export` looks only there.
+
+Two copies are created:
+
+- **`.txt`** — plain text, formatted for native viewing.
+- **`.md`** — Obsidian-renderable, searchable, embedding the `.txt` as an attachment and recording the session ID so the conversation can be resumed later.
+
+Editing flows through `vaultkit:file-edit` to preserve birth time — important because Obsidian surfaces the `created` field in dataview queries, sort orders, and plugin behaviors.
+
+## Pairing with Other Plugins
+
+Vaultkit captures what happens during and after a session into a durable Obsidian second brain.
+
+**With [sessionkit](../sessionkit)**
+
+- Run `/handoff` to capture a session's state to `.sessionkit/HANDOFF.md`, then `/archive-export` to file the conversation export into the active project — the handoff lives on disk next to the code, the archive lives in Obsidian for long-term recall.
+- Use `/pickup` in the next session to restore context, then `/jot` to record what you decide as you go.
+
+**With metakit (`/handoff-cycle`)**
+
+- `/handoff-cycle` composes `/handoff` → `/archive-export` → `/pickup` into a single cycle, wrapping sessionkit and vaultkit into a hands-free context-rotation flow. Use it when a session is approaching its context limit and you want to continue seamlessly in a fresh one.


### PR DESCRIPTION
## Summary
- Add `plugins/metakit/skills/polish-cycle/SKILL.md` orchestrating polishkit:critique -> speckit:catalog -> swarmkit:swarm via metakit's detect / plan-preview / halt-and-report contract.
- Low-risk critique runs automatically; catalog and swarm pause for per-step confirmation before mutating GitHub or spawning agents.
- Gate on polishkit presence (scenario unavailable without it); speckit and swarmkit missing -> skip the step and surface downstream impact (catalog missing also disables swarm).

## Test plan
- [ ] Run `/polish-cycle` with all three kits installed; verify plan-preview lists 3 steps, critique runs, catalog and swarm each prompt to confirm.
- [ ] Run `/polish-cycle` without polishkit installed; verify "scenario unavailable" message and clean stop before plan-preview.
- [ ] Run `/polish-cycle` with polishkit only; verify catalog and swarm steps render as `skip (kit missing)` in the preview and are skipped at execution with downstream-impact notes.
- [ ] Simulate a critique failure; verify halt-and-report is invoked with the completed_steps list and the scenario stops without retry.

Closes #252