### PR TITLE
refactor(flowkit:hotfix): align tagging with CalVer MICRO + companion tag

### DIFF
--- a/plugins/flowkit/skills/hotfix/SKILL.md
+++ b/plugins/flowkit/skills/hotfix/SKILL.md
@@ -68,13 +68,25 @@ Follow the `pr-base-scope` sub-skill to unset `claude.prBase`.
 
 ### 10. Tag the hotfix on main
 
-Create and push a hotfix tag directly on main (no RC cycle):
+Tag the hotfix directly on main using the same CalVer MICRO-increment scheme as `/release`, so hotfix tags sort naturally alongside planned release tags. A companion `hotfix/` tag at the same commit preserves discoverability via `git tag --list 'hotfix/*'`.
 
 ```bash
-TAG="v$(date +%Y.%-m.%-d)-hotfix"
-git tag "$TAG" main
+BASE_TAG="v$(date +%Y.%-m.%-d)"
+N=1
+TAG="$BASE_TAG"
+while git ls-remote --exit-code origin "refs/tags/$TAG" &>/dev/null; do
+  TAG="$BASE_TAG.$N"
+  N=$((N + 1))
+done
+git tag -a "$TAG" main -m "Hotfix: <one-line reason from PR title>"
 git push origin "$TAG"
+
+COMPANION="hotfix/$TAG"
+git tag "$COMPANION" "$TAG"
+git push origin "$COMPANION"
 ```
+
+The annotation message preserves the "hotfix" signal for `git tag -n` queries; the companion tag keeps the canonical version tag clean while still flagging the commit as an emergency fix.
 
 ### 11. Close referenced issues
 
@@ -100,7 +112,7 @@ Follow the `git-sync-develop` sub-skill to confirm a clean local develop state.
 
 Summarize:
 - Hotfix PR merged into main
-- Tag created (include the tag name)
+- Tags created (include both the canonical version tag and the `hotfix/` companion tag)
 - Referenced issues closed
 - develop updated with back-merge
 


### PR DESCRIPTION
## Summary

- Replace ad-hoc `v{Y}.{M}.{D}-hotfix` scheme with the same MICRO-increment loop used in `/release` so hotfix tags sort naturally alongside planned releases and same-day hotfixes stop colliding.
- Add a companion `hotfix/v{Y}.{M}.{D}[.N]` tag at the same commit, preserving "this was an emergency fix" discoverability via `git tag --list 'hotfix/*'` without polluting the canonical version string.
- Switch to annotated tag (`git tag -a`) so the hotfix reason survives in `git tag -n` output; update the Report step to mention both tags.

## Test plan

- [ ] Collision check: run step 10's snippet on a day where `v{Y}.{M}.{D}` already exists — confirm TAG becomes `v{Y}.{M}.{D}.1`, `.2`, etc.
- [ ] Companion format: after the loop lands on (e.g.) `v2026.4.19.3`, confirm `COMPANION=hotfix/v2026.4.19.3` is created at the same commit as the canonical tag.
- [ ] Annotation preserved: `git tag -n "$TAG"` shows the "Hotfix: ..." message.
- [ ] Both tags pushed: `git ls-remote --tags origin` shows `refs/tags/$TAG` and `refs/tags/hotfix/$TAG` pointing at the same SHA.

Closes #215