### PR TITLE
refactor(flowkit): migrate claude.prBase to claude.flowkit.prBase namespacing

### DIFF
--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -31,7 +31,7 @@ claude --plugin-dir /path/to/flowkit
 |-------|--------|--------------|
 | **commit** | `/commit` | Stage and commit changes with conventional commit format. Infers logical groupings and writes `type(scope): description` messages. |
 | **create-branch** | `/create-branch` | Create a new git branch off `develop` with an inferred or provided name. |
-| **open-pr** | `/open-pr` | Push current branch and open a GitHub PR. Respects `claude.prBase` for branch targeting. |
+| **open-pr** | `/open-pr` | Push current branch and open a GitHub PR. Respects `claude.flowkit.prBase` for branch targeting. |
 | **pr** | `/pr` | Combined: `create-branch` → `commit` → `open-pr` in one step. |
 | **merge-pr** | `/merge-pr` | Squash-merge the open PR for the current branch; labels referenced issues with `merged-to-develop`. |
 | **sync** | `/sync` | Checkout `develop`, pull latest, prune stale branches. |
@@ -51,7 +51,7 @@ These are called by the skills above — you don't invoke them directly.
 | **git-sync-main** | release, hotfix | Checkout `main` and pull latest from origin. |
 | **git-sync-develop** | sync, release, hotfix | Checkout `develop` and pull latest from origin. |
 | **gh-close-referenced-issues** | release, hotfix | Parse merged PR bodies; close referenced issues and resolved epics. |
-| **pr-base-scope** | swarm | Set/unset `claude.prBase` git config for scoped PR targeting. |
+| **pr-base-scope** | swarm | Set/unset `claude.flowkit.prBase` git config for scoped PR targeting. |
 
 ## Typical Workflows
 
@@ -107,6 +107,42 @@ git checkout -b staging main && git push -u origin staging
 ```
 
 From that point on, all release skills pick it up automatically.
+
+## Configuration
+
+Flowkit reads one repo-local git config key:
+
+| Key | Purpose | Default |
+|-----|---------|---------|
+| `claude.flowkit.prBase` | Target base branch for `/open-pr` when no override is passed. Set automatically by `/ship` and `/swarm` loop mode; unset on teardown. | `develop` |
+
+Inspect or set manually:
+
+```bash
+# Show the effective setting (empty = falls through to default)
+git config claude.flowkit.prBase
+
+# Pin PRs to a non-default base for the current repo
+git config claude.flowkit.prBase main
+
+# Revert to the default
+git config --unset claude.flowkit.prBase
+```
+
+### Migrating from `claude.prBase`
+
+The legacy key `claude.prBase` is still read as a fallback so existing setups don't break. When flowkit falls back to the legacy key, it emits a one-line deprecation notice with the exact commands below. Migrate at your convenience:
+
+```bash
+# Read whatever was set on the legacy key
+LEGACY=$(git config claude.prBase)
+
+# Remove the legacy key and write the new one
+git config --unset claude.prBase
+git config claude.flowkit.prBase "$LEGACY"
+```
+
+The legacy fallback is a soft deprecation and will be kept indefinitely — no hard break is planned. The new key aligns with the `claude.<plugin>.<key>` convention used across smallorbit plugins.
 
 ## Assumptions & Conventions
 

--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -32,8 +32,21 @@ If the current branch is `develop`, `main`, `master`, or `staging`, stop immedia
 
 ### 2. Determine base branch
 
+Resolve the base branch using the `pr-base-scope` read order: new key → legacy key (with deprecation notice) → `develop` default.
+
 ```bash
-BASE=$(git config claude.prBase 2>/dev/null || echo "develop")
+BASE=$(git config claude.flowkit.prBase 2>/dev/null)
+if [ -z "$BASE" ]; then
+  LEGACY=$(git config claude.prBase 2>/dev/null)
+  if [ -n "$LEGACY" ]; then
+    BASE="$LEGACY"
+    echo "note: claude.prBase is deprecated. Migrate with:" >&2
+    echo "  git config --unset claude.prBase" >&2
+    echo "  git config claude.flowkit.prBase $LEGACY" >&2
+  else
+    BASE="develop"
+  fi
+fi
 ```
 
 Use `$BASE` as the PR target. This respects any scoped override set by the `pr-base-scope` sub-skill.
@@ -74,7 +87,7 @@ Output the PR URL returned by `gh pr create`.
 
 ## Constraints
 
-- Never target `main` directly unless `claude.prBase` is explicitly set to `main`
+- Never target `main` directly unless `claude.flowkit.prBase` (or legacy `claude.prBase`) is explicitly set to `main`
 - Never open a PR from a protected branch (`develop`, `main`, `master`, `staging`)
 - If `gh` is not installed or not authenticated, report the error and stop — do not attempt workarounds
 - Do not force-push; use a plain `git push -u origin HEAD`

--- a/plugins/flowkit/skills/pr-base-scope/SKILL.md
+++ b/plugins/flowkit/skills/pr-base-scope/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: pr-base-scope
-description: Set or unset the claude.prBase git config key to scope the PR target branch for a session. Sub-skill used by ship and swarm loop mode.
+description: Set or unset the claude.flowkit.prBase git config key to scope the PR target branch for a session. Sub-skill used by ship and swarm loop mode.
 ---
 
 # pr-base-scope
 
-Set or unset `claude.prBase` — a local git config key that tells `/open-pr` which branch to target when creating a pull request. Used by `/ship` to pin PRs to `develop` during the ship flow, and by swarm loop mode to scope multi-PR sessions.
+Set or unset `claude.flowkit.prBase` — a local git config key that tells `/open-pr` which branch to target when creating a pull request. Used by `/ship` to pin PRs to `develop` during the ship flow, and by swarm loop mode to scope multi-PR sessions.
+
+The legacy key `claude.prBase` is still read as a fallback for backward compatibility, but is never written. When read, it emits a one-line deprecation notice pointing at the migration commands.
 
 ## Operations
 
@@ -14,13 +16,13 @@ Set or unset `claude.prBase` — a local git config key that tells `/open-pr` wh
 Pin the PR target branch for the current session:
 
 ```bash
-git config claude.prBase <branch>
+git config claude.flowkit.prBase <branch>
 ```
 
 Example — pin to develop:
 
 ```bash
-git config claude.prBase develop
+git config claude.flowkit.prBase develop
 ```
 
 ### Unset
@@ -28,28 +30,43 @@ git config claude.prBase develop
 Revert to the default target (`develop`):
 
 ```bash
-git config --unset claude.prBase
+git config --unset claude.flowkit.prBase
 ```
 
 ### Read
 
-Resolve the current target branch (used by `/open-pr`):
+Resolve the current target branch (used by `/open-pr`). Apply this resolution order:
+
+1. `claude.flowkit.prBase` — primary source of truth
+2. `claude.prBase` — legacy fallback (emits deprecation notice when hit)
+3. Built-in default: `develop`
 
 ```bash
-git config claude.prBase 2>/dev/null || echo "develop"
+BASE=$(git config claude.flowkit.prBase 2>/dev/null)
+if [ -z "$BASE" ]; then
+  LEGACY=$(git config claude.prBase 2>/dev/null)
+  if [ -n "$LEGACY" ]; then
+    BASE="$LEGACY"
+    echo "note: claude.prBase is deprecated. Migrate with:" >&2
+    echo "  git config --unset claude.prBase" >&2
+    echo "  git config claude.flowkit.prBase $LEGACY" >&2
+  else
+    BASE="develop"
+  fi
+fi
 ```
-
-If the key is not set, this returns `develop` as the default.
 
 ## Usage by Callers
 
 | Caller | Action |
 |--------|--------|
-| `/ship` | Sets `claude.prBase develop` before opening PRs, then unsets after the flow completes |
-| `/swarm` loop mode | Sets `claude.prBase` to the appropriate integration branch for the loop session |
-| `/open-pr` | Reads `claude.prBase` to resolve the target branch before creating the PR |
+| `/ship` | Sets `claude.flowkit.prBase develop` before opening PRs, then unsets after the flow completes |
+| `/swarm` loop mode | Sets `claude.flowkit.prBase` to the appropriate integration branch for the loop session |
+| `/open-pr` | Reads the resolved base (new key → legacy key → `develop`) before creating the PR |
 
 ## Constraints
 
 - This key is local to the repo — it is never committed or pushed
 - Always unset after a scoped flow completes to avoid stale targeting in future sessions
+- Never write to the legacy `claude.prBase` key. All set/unset operations target `claude.flowkit.prBase` only
+- The legacy fallback is a soft deprecation — keep it indefinitely

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -265,10 +265,10 @@ Used when no issue numbers are given (no args or label filter). Continuously cle
 git fetch origin
 ```
 
-Set `claude.prBase` to scope the PR base for this operation:
+Set `claude.flowkit.prBase` to scope the PR base for this operation:
 
 ```bash
-git config --local claude.prBase $BASE
+git config --local claude.flowkit.prBase $BASE
 ```
 
 This is unset in the teardown step below. Leaving it set will cause subsequent PR creation (even in unrelated workflows) to target the wrong base, so cleanup is critical.
@@ -286,7 +286,7 @@ If no open issues remain, announce "Board is clear" and exit.
 
 **Step 2 — Swarm**
 
-Run the one-shot swarm flow above on the batch. Independent issues target `$BASE` (enforced by `claude.prBase`). Dependent issues target their dependency's branch, forming a stacked-PR chain that ultimately lands in `$BASE` when `swarmkit:merge-stack` cascades the merges.
+Run the one-shot swarm flow above on the batch. Independent issues target `$BASE` (enforced by `claude.flowkit.prBase`). Dependent issues target their dependency's branch, forming a stacked-PR chain that ultimately lands in `$BASE` when `swarmkit:merge-stack` cascades the merges.
 
 **Step 3 — Checkpoint**
 
@@ -308,9 +308,9 @@ Proceed immediately to the next cycle after printing the checkpoint summary. The
    ```bash
    git checkout $BASE && git pull origin $BASE
    ```
-3. Unset `claude.prBase` to clear the scoped PR base:
+3. Unset `claude.flowkit.prBase` to clear the scoped PR base:
    ```bash
-   git config --local --unset claude.prBase
+   git config --local --unset claude.flowkit.prBase
    ```
 3. Final summary:
 


### PR DESCRIPTION
## Summary

- Rewrite `plugins/flowkit/skills/pr-base-scope/SKILL.md` so Set/Unset target `claude.flowkit.prBase`; Read uses a 3-tier resolution order (new key → legacy `claude.prBase` with one-line deprecation notice → `develop` default). Legacy key is never written.
- Update `plugins/flowkit/skills/open-pr/SKILL.md` step 2 to use the same 3-tier resolution when computing the PR target, emitting the deprecation notice on legacy hits.
- Update `plugins/swarmkit/skills/swarm/SKILL.md` loop-mode setup/teardown to set/unset `claude.flowkit.prBase`.
- Document the new key and migration path in `plugins/flowkit/README.md` (new Configuration section + updated skill-table references).
- Soft deprecation only: legacy fallback kept indefinitely.

## Test plan

- In a repo with neither key set: `/open-pr` targets `develop`. Verify no deprecation notice.
- Set `git config claude.flowkit.prBase main`: `/open-pr` targets `main`. No deprecation notice.
- Unset the new key and set `git config claude.prBase main`: `/open-pr` still targets `main` but stderr shows the deprecation notice with the exact `git config --unset claude.prBase` / `git config claude.flowkit.prBase main` migration commands.
- With both keys set, the new key wins and no deprecation notice is emitted.
- `/ship` and `/swarm` loop mode set `claude.flowkit.prBase` (not the legacy key) and unset it on teardown — verify via `git config --list | grep claude.flowkit` during the flow and that nothing remains after.

Closes #220