### PR TITLE
docs(flowkit): refresh hotfix tag paragraph and prune phantom sub-skill row

### DIFF
--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -50,7 +50,6 @@ These are called by the skills above — you don't invoke them directly.
 |-------|---------|---------|
 | **git-sync-main** | release, hotfix | Checkout `main` and pull latest from origin. |
 | **git-sync-develop** | sync, release, hotfix | Checkout `develop` and pull latest from origin. |
-| **gh-close-referenced-issues** | release, hotfix | Parse merged PR bodies; close referenced issues and resolved epics. |
 | **pr-base-scope** | swarm | Set/unset `claude.flowkit.prBase` git config for scoped PR targeting. |
 
 ## Typical Workflows
@@ -160,9 +159,9 @@ Release candidates are named by date and sequence number (e.g., `rc/2026-04-16.1
 
 Production releases are tagged with a calendar-versioned tag (e.g., `v2026.4.16`). Multiple releases on the same day append a counter (e.g., `v2026.4.16-2`).
 
-### Hotfix Tags: `vYYYY.M.D-hotfix`
+### Hotfix Tags: `vYYYY.M.D[.N]` + companion `hotfix/vYYYY.M.D[.N]`
 
-Hotfixes are tagged separately (e.g., `v2026.4.16-hotfix`) to distinguish them from scheduled releases and preserve the release history.
+Hotfixes use the same CalVer MICRO-increment tag as scheduled releases (e.g., `v2026.4.16.1`) so the two sort together in the release history. A companion tag (e.g., `hotfix/v2026.4.16.1`) is pushed to the same commit to keep hotfixes discoverable via `git tag --list 'hotfix/*'`.
 
 ### Commit Format: Conventional Commits
 


### PR DESCRIPTION
## Summary

- Rewrite the **Hotfix Tags** subsection in `plugins/flowkit/README.md` to describe the real shipped scheme: canonical `vYYYY.M.D[.N]` (same CalVer MICRO loop as scheduled releases) plus a companion `hotfix/vYYYY.M.D[.N]` tag at the same commit for `git tag --list 'hotfix/*'` discoverability.
- Remove the phantom `gh-close-referenced-issues` row from the Sub-Skills table. No such directory exists under `plugins/flowkit/skills/`; the close-issues logic is inlined in the `release` skill (step 4) and referenced by name in `hotfix` without a standalone sub-skill on disk.

Closes #371
Closes #372