### PR TITLE
docs(repo): refresh compose narrative, CLAUDE.md plugin list, and authoring conventions location

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # smallorbit-plugins
 
-Monorepo hosting Claude Code plugins: swarmkit, flowkit, sessionkit, and speckit.
+Monorepo hosting Claude Code plugins. See the [repo README](./README.md#available-plugins) for the current plugin catalog — it's the canonical source and stays in sync as plugins ship.
 
 ## Release Process
 
@@ -17,3 +17,7 @@ Run it before staging and committing the release.
 ## Plugins
 
 `swarmkit` includes an experimental `squad` skill gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`. See `plugins/swarmkit/README.md` for details.
+
+## Skill Authoring Conventions
+
+**Bash loop convention**: Never use `for N in $VAR` to iterate over newline-delimited output — word splitting is unreliable across shell contexts. Always pipe directly: `some-command | while read N; do ... done`.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The development-lifecycle plugins form a complete loop from idea to release:
 /release       → ship merged work to production (flowkit)
 ```
 
+**polishkit** sits between `/swarm` and `/release` as a quality gate: use `/critique` to assess elegance and craft, `/tidy-codebase` to sweep for stale files and cruft, and `/dead-code` to eliminate unused exports before shipping.
+
 **sessionkit** acts as connective tissue throughout: use `/handoff` to preserve state across agent context limits, `/skillit` to capture reusable patterns after a swarm, and `/suggest-permissions` to reduce approval friction over time.
 
 **metakit** (pre-release) sits above the loop as an orchestrator: it detects which sibling kits are installed and composes them into multi-step scenarios (e.g. `/polish-cycle`, `/handoff-cycle`), skipping missing steps and pausing on risky ones rather than failing outright.
@@ -54,10 +56,6 @@ The development-lifecycle plugins form a complete loop from idea to release:
 Each plugin's README describes how it pairs with the others.
 
 See each plugin's README for detailed usage.
-
-## Skill Authoring Conventions
-
-**Bash loop convention**: Never use `for N in $VAR` to iterate over newline-delimited output — word splitting is unreliable across shell contexts. Always pipe directly: `some-command | while read N; do ... done`.
 
 ## License
 


### PR DESCRIPTION
## Summary

- **README.md** — added a polishkit paragraph to *How the Plugins Compose*, slotting it between the lifecycle diagram and the sessionkit block and matching the sessionkit/metakit/vaultkit voice.
- **CLAUDE.md** — dropped the stale four-plugin enumeration (which omitted polishkit, metakit, vaultkit) and pointed readers at the repo README's plugin tables as the canonical catalog.
- **README.md → CLAUDE.md** — relocated the orphaned *Skill Authoring Conventions* stub out of the user-facing README into contributor guidance in `CLAUDE.md`, preserving the bash-loop tip verbatim.

## Test plan

- [ ] `README.md` *How the Plugins Compose* section shows a polishkit paragraph between the diagram and the sessionkit paragraph.
- [ ] `CLAUDE.md` line 3 no longer names specific plugins and links to `./README.md#available-plugins`.
- [ ] `README.md` no longer contains a *Skill Authoring Conventions* section; the bash-loop tip now lives under `## Skill Authoring Conventions` in `CLAUDE.md`.
- [ ] Rendered markdown: anchors resolve on GitHub (`README.md#available-plugins`).

Closes #373
Closes #374
Closes #376