### PR TITLE
release: 2026-04-19

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # smallorbit-plugins
 
-Monorepo hosting Claude Code plugins: swarmkit, flowkit, sessionkit, and speckit.
+Monorepo hosting Claude Code plugins. See the [repo README](./README.md#available-plugins) for the current plugin catalog — it's the canonical source and stays in sync as plugins ship.
 
 ## Release Process
 
@@ -17,3 +17,7 @@ Run it before staging and committing the release.
 ## Plugins
 
 `swarmkit` includes an experimental `squad` skill gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`. See `plugins/swarmkit/README.md` for details.
+
+## Skill Authoring Conventions
+
+**Bash loop convention**: Never use `for N in $VAR` to iterate over newline-delimited output — word splitting is unreliable across shell contexts. Always pipe directly: `some-command | while read N; do ... done`.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ The development-lifecycle plugins form a complete loop from idea to release:
 /release       → ship merged work to production (flowkit)
 ```
 
+**polishkit** sits between `/swarm` and `/release` as a quality gate: use `/critique` to assess elegance and craft, `/tidy-codebase` to sweep for stale files and cruft, and `/dead-code` to eliminate unused exports before shipping.
+
 **sessionkit** acts as connective tissue throughout: use `/handoff` to preserve state across agent context limits, `/skillit` to capture reusable patterns after a swarm, and `/suggest-permissions` to reduce approval friction over time.
 
 **metakit** (pre-release) sits above the loop as an orchestrator: it detects which sibling kits are installed and composes them into multi-step scenarios (e.g. `/polish-cycle`, `/handoff-cycle`), skipping missing steps and pausing on risky ones rather than failing outright.
@@ -54,10 +56,6 @@ The development-lifecycle plugins form a complete loop from idea to release:
 Each plugin's README describes how it pairs with the others.
 
 See each plugin's README for detailed usage.
-
-## Skill Authoring Conventions
-
-**Bash loop convention**: Never use `for N in $VAR` to iterate over newline-delimited output — word splitting is unreliable across shell contexts. Always pipe directly: `some-command | while read N; do ... done`.
 
 ## License
 

--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship — with runtime staging detection and a one-command hotfix flow.",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -50,7 +50,6 @@ These are called by the skills above — you don't invoke them directly.
 |-------|---------|---------|
 | **git-sync-main** | release, hotfix | Checkout `main` and pull latest from origin. |
 | **git-sync-develop** | sync, release, hotfix | Checkout `develop` and pull latest from origin. |
-| **gh-close-referenced-issues** | release, hotfix | Parse merged PR bodies; close referenced issues and resolved epics. |
 | **pr-base-scope** | swarm | Set/unset `claude.flowkit.prBase` git config for scoped PR targeting. |
 
 ## Typical Workflows
@@ -160,9 +159,9 @@ Release candidates are named by date and sequence number (e.g., `rc/2026-04-16.1
 
 Production releases are tagged with a calendar-versioned tag (e.g., `v2026.4.16`). Multiple releases on the same day append a counter (e.g., `v2026.4.16-2`).
 
-### Hotfix Tags: `vYYYY.M.D-hotfix`
+### Hotfix Tags: `vYYYY.M.D[.N]` + companion `hotfix/vYYYY.M.D[.N]`
 
-Hotfixes are tagged separately (e.g., `v2026.4.16-hotfix`) to distinguish them from scheduled releases and preserve the release history.
+Hotfixes use the same CalVer MICRO-increment tag as scheduled releases (e.g., `v2026.4.16.1`) so the two sort together in the release history. A companion tag (e.g., `hotfix/v2026.4.16.1`) is pushed to the same commit to keep hotfixes discoverable via `git tag --list 'hotfix/*'`.
 
 ### Commit Format: Conventional Commits
 

--- a/plugins/metakit/README.md
+++ b/plugins/metakit/README.md
@@ -29,7 +29,7 @@ claude --plugin-dir /path/to/metakit
 | Skill | Invoke | What it does |
 |-------|--------|--------------|
 | **kits** | `/kits` | _Coming soon._ Report which sibling kits are installed and what scenarios are currently runnable. |
-| **polish-cycle** | `/polish-cycle` | _Coming soon._ Run a full quality pass — critique, dead-code sweep, tidy — then file findings as issues and optionally swarm fixes. |
+| **polish-cycle** | `/polish-cycle` | _Coming soon._ Run a full quality loop — `polishkit:critique` to surface findings, `speckit:catalog` to file them as issues, `swarmkit:swarm` to spawn fixes — pausing before each risky step. |
 | **handoff-cycle** | `/handoff-cycle` | _Coming soon._ Close out a session cleanly — capture state, suggest skills worth keeping, archive decisions into the vault if present. |
 
 ## Graceful-Degradation Contract
@@ -50,7 +50,7 @@ metakit is an orchestrator — it doesn't replace any sibling kit, it composes t
 
 - **[speckit](../speckit)** — metakit scenarios file findings as issues via `/issue` or `/catalog`.
 - **[swarmkit](../swarmkit)** — metakit scenarios can hand filed issues off to `/swarm` for parallel resolution.
-- **[polishkit](../polishkit)** — `/polish-cycle` drives `/critique`, `/dead-code`, and `/tidy-codebase` in sequence.
+- **[polishkit](../polishkit)** — `/polish-cycle` drives `/critique` to surface findings before handing them to speckit and swarmkit.
 - **[flowkit](../flowkit)** — metakit scenarios defer to flowkit for PR, cut, and release operations.
 - **[sessionkit](../sessionkit)** — `/handoff-cycle` uses `/handoff` and `/skillit` to capture and carry state.
 - **[vaultkit](../vaultkit)** — when present, metakit scenarios can archive plans and decisions via `/jot` or `/archive-export`.

--- a/plugins/vaultkit/.claude-plugin/plugin.json
+++ b/plugins/vaultkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vaultkit",
   "description": "Obsidian vault skills for Claude Code. Read, search, edit notes, manage projects, capture decisions, and archive conversations — all via the Obsidian CLI.",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/vaultkit/README.md
+++ b/plugins/vaultkit/README.md
@@ -1,31 +1,107 @@
-# vaultkit
+# Vaultkit
 
 Obsidian vault skills for Claude Code. Read, search, edit notes, manage projects, capture decisions, and archive conversations — all via the Obsidian CLI.
 
+## Installation
+
+Install from the `smallorbit-plugins` marketplace:
+
+```
+/plugin marketplace add smallorbit/smallorbit-plugins
+/plugin install vaultkit@smallorbit-plugins
+```
+
+Or load directly for a single session:
+
+```bash
+claude --plugin-dir /path/to/vaultkit
+```
+
+### Prerequisites
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed
+- [Obsidian](https://obsidian.md/) desktop app running (the CLI requires an open Obsidian instance)
+- Obsidian CLI installed and authenticated against your vault (`obsidian vaults` should list your vault)
+
 ## Skills
 
-### User-facing
-| Skill | Description |
-|-------|-------------|
-| `vaultkit:obsidian` | Interface with Obsidian vaults via the CLI |
-| `vaultkit:jot` | Quickly capture a decision, task, or note into the active project |
-| `vaultkit:archive-export` | Archive the latest /export output into the active Obsidian project |
-| `vaultkit:project` | Manage Obsidian projects — create, load, and update project notes |
+### User-Facing
 
-### Sub-skills (internal)
-| Skill | Description |
-|-------|-------------|
-| `vaultkit:load-project` | Load a named Obsidian project into context |
-| `vaultkit:list-projects` | List all projects in the vault's Projects folder |
-| `vaultkit:file-edit` | Edit a vault file while preserving its filesystem birth time |
+| Skill | Invoke | What it does |
+|-------|--------|--------------|
+| **obsidian** | `/obsidian` | Interface with Obsidian vaults via the CLI — read, search, tag, edit notes, manage templates, and vault maintenance. |
+| **jot** | `/jot` | Quickly capture a decision, task, or note into the active project. Thin entry point over the `project` skill's update operation. |
+| **archive-export** | `/archive-export` | File the latest `/export session` output into the active Obsidian project's `Conversations/` folder. |
+| **project** | `/project` | Manage a `Projects/` second brain: load context, initialize new projects from template, and update project files. |
 
-## Requirements
+### Sub-Skills (internal)
 
-Obsidian must be open and the Obsidian CLI must be installed for vault operations to work.
+These are called by the skills above — you don't invoke them directly. The `vaultkit:` prefix reflects how sibling skills reference them.
 
-## Install
+| Skill | Invoke | What it does |
+|-------|--------|--------------|
+| **load-project** | `vaultkit:load-project` | Load a named Obsidian project into context; lists and recommends one if no name is supplied. |
+| **list-projects** | `vaultkit:list-projects` | List all projects in the vault's `Projects/` folder, sorted by status, with a count summary. |
+| **file-edit** | `vaultkit:file-edit` | Edit a vault file in place so filesystem birth time — the source of Obsidian's `created` metadata — is preserved. |
 
-Add to your Claude Code plugin list:
+## Typical Workflows
+
+### Capture a decision mid-session
+
 ```
-smallorbit/smallorbit-plugins/plugins/vaultkit
+/jot decided to use CalVer for release tagging; rationale in plugin-release.md
 ```
+
+The active project is inferred from conversation context (or you'll be prompted to pick one), and the note is appended without disturbing the file's `created` timestamp.
+
+### Archive a conversation export
+
+```
+/export session                    # writes ./session.txt in the cwd
+/archive-export                    # files it into the active project's Conversations/
+```
+
+Two artifacts land in Obsidian: a `.txt` copy for plain-text viewing and a `.md` companion with the session ID embedded for resuming.
+
+### Load a project at the start of a session
+
+```
+/load-project smallorbit-plugins   # pulls project notes, status, and context
+```
+
+If no name is provided, the skill lists available projects and recommends the most contextually relevant one.
+
+## How Jot Works
+
+`/jot` is a thin entry point into the `vaultkit:project` skill's update operation. It:
+
+1. Identifies the active project from conversation context, or prompts if unclear.
+2. Reads the target file before editing, then determines what changed — decisions, tasks, status, blockers.
+3. Writes the edit in place via `vaultkit:file-edit` so Obsidian's `created` metadata is preserved.
+4. Keeps entries concise — recall notes, not documentation.
+
+Because it delegates to the `project` skill, `/jot` benefits from the same project-awareness and file-hygiene conventions that `/project` applies.
+
+## How Archive Export Works
+
+`/archive-export` picks up the latest `/export session` output from the current working directory and files it into the active project's `Conversations/` folder. The convention is strict: `/export session` always writes `./session.txt` in the cwd, and `archive-export` looks only there.
+
+Two copies are created:
+
+- **`.txt`** — plain text, formatted for native viewing.
+- **`.md`** — Obsidian-renderable, searchable, embedding the `.txt` as an attachment and recording the session ID so the conversation can be resumed later.
+
+Editing flows through `vaultkit:file-edit` to preserve birth time — important because Obsidian surfaces the `created` field in dataview queries, sort orders, and plugin behaviors.
+
+## Pairing with Other Plugins
+
+Vaultkit captures what happens during and after a session into a durable Obsidian second brain.
+
+**With [sessionkit](../sessionkit)**
+
+- Run `/handoff` to capture a session's state to `.sessionkit/HANDOFF.md`, then `/archive-export` to file the conversation export into the active project — the handoff lives on disk next to the code, the archive lives in Obsidian for long-term recall.
+- Use `/pickup` in the next session to restore context, then `/jot` to record what you decide as you go.
+
+**With metakit (`/handoff-cycle`)**
+
+- `/handoff-cycle` composes `/handoff` → `/archive-export` → `/pickup` into a single cycle, wrapping sessionkit and vaultkit into a hands-free context-rotation flow. Use it when a session is approaching its context limit and you want to continue seamlessly in a fresh one.


### PR DESCRIPTION
## Release summary

**Built from**: `rc/2026-04-19.6`

### Version bumps
- chore(plugins): bump flowkit@2.0.3, vaultkit@1.1.1

### Changes

**flowkit**
- docs(flowkit): refresh hotfix tag paragraph and prune phantom sub-skill row (#378)

**other**
- docs(repo): refresh compose narrative, CLAUDE.md plugin list, and authoring conventions location (#380)
- docs(vaultkit): bring README up to sibling parity (#379)
- docs(metakit): reconcile /polish-cycle scope with spec (#377)

Closes #369
Closes #370
Closes #371
Closes #372
Closes #373
Closes #374
Closes #376