### PR TITLE
feat(swarmkit): add clean-remote-worktrees sub-skill for orphaned remote branches

### DIFF
--- a/plugins/swarmkit/skills/clean-remote-worktrees/SKILL.md
+++ b/plugins/swarmkit/skills/clean-remote-worktrees/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: clean-remote-worktrees
+description: Sweep orphaned remote worktree-agent-* branches. Deletes only branches whose most-recent PR is merged; skips OPEN, CLOSED-not-merged, and no-PR branches. Complements swarmkit:clean-worktrees, which handles local state.
+---
+
+# Clean Remote Worktrees Skill
+
+Sweep orphaned remote `worktree-agent-*` branches left behind by merged PRs, crashed swarm runs, or merges that skipped `--delete-branch`.
+
+Counterpart to `swarmkit:clean-worktrees` — this skill never touches local state.
+
+## Arguments
+
+Parse `$ARGUMENTS`:
+
+- **No arguments** → **interactive**: fetch, classify, present plan, proceed to deletion on confirmation
+- `--yes` → **non-interactive**: skip confirmation (for automation contexts)
+
+## Process
+
+1. **Fetch and prune** remote-tracking refs:
+   ```bash
+   git fetch origin --prune
+   ```
+
+2. **Enumerate candidates** — list every remote branch matching `worktree-agent-*` once, then reuse that list for classification:
+   ```bash
+   CANDIDATES=$(git ls-remote --heads origin 'worktree-agent-*' | awk '{print $2}' | sed 's|refs/heads/||')
+   ```
+
+   If `CANDIDATES` is empty, report "no remote worktree-agent-* branches" and exit.
+
+3. **Classify each candidate** by the state of its most-recent PR. Pipe the candidate list into a `while read` loop (do not use `for BRANCH in $CANDIDATES` — word-splitting on newline-delimited output is unreliable):
+   ```bash
+   printf '%s\n' "$CANDIDATES" | while read BRANCH; do
+     gh pr list --state all --head "$BRANCH" --json number,state,title --limit 1
+   done
+   ```
+
+   Bucket each branch by its most-recent PR state:
+
+   | Bucket | PR state | Action |
+   |--------|----------|--------|
+   | MERGED | `MERGED` | queue for deletion |
+   | CLOSED | `CLOSED` (not merged) | skip — branch holds the only copy of rejected work |
+   | OPEN | `OPEN` | skip — deletion would kill an active PR |
+   | No PR | empty array | skip — could be crashed-run debris; surface for inspection |
+
+4. **Present the plan** — counts per bucket, plus branch names in the three skipped buckets so the user can spot anything unexpected:
+   ```
+   MERGED (to delete): 12
+   CLOSED (skipped):   2
+     - worktree-agent-47
+     - worktree-agent-89
+   OPEN (skipped):     3
+     - worktree-agent-101
+     - worktree-agent-102
+     - worktree-agent-103
+   No PR (skipped):    1
+     - worktree-agent-55
+   ```
+
+   If the MERGED bucket is empty, report and exit — nothing to delete.
+
+   In interactive mode, ask for confirmation before proceeding. With `--yes`, proceed immediately.
+
+5. **Delete all MERGED branches in a single push** — one refspec per branch, one network round-trip:
+   ```bash
+   git push origin :worktree-agent-12 :worktree-agent-15 :worktree-agent-18 ...
+   ```
+
+   Build the refspec list from the MERGED bucket. Do not loop per-branch — batch deletion is both faster and atomic in output.
+
+6. **Report**:
+   ```
+   Deleted: 12 remote branches
+   Skipped: 6 branches (2 CLOSED, 3 OPEN, 1 no-PR)
+
+   Skipped branches:
+     CLOSED (rejected work, preserved):
+       - worktree-agent-47
+       - worktree-agent-89
+     OPEN (active PR):
+       - worktree-agent-101
+       ...
+     No PR (inspect manually):
+       - worktree-agent-55
+   ```
+
+## Constraints
+
+- Never delete a branch that is the head of an OPEN PR
+- Never delete a branch whose most-recent PR is CLOSED (non-merged) — the branch contains rejected work that persists nowhere else
+- Always use refspec syntax (`git push origin :branch1 :branch2 ...`) for batch deletion; never loop `git push --delete` per branch
+- Never touch local state — worktrees and local branches are `swarmkit:clean-worktrees`'s concern
+- Idempotent: running twice on a clean repo is a no-op

--- a/plugins/swarmkit/skills/clean-worktrees/SKILL.md
+++ b/plugins/swarmkit/skills/clean-worktrees/SKILL.md
@@ -7,6 +7,8 @@ description: Remove all agent worktrees and their orphaned local branches (workt
 
 Remove all agent worktrees and their orphaned local branches.
 
+For remote branch cleanup, see `swarmkit:clean-remote-worktrees`.
+
 ## Process
 
 0. Capture the current branch: run `git branch --show-current` and store the result as `<caller-branch>`

--- a/plugins/swarmkit/skills/squad/SKILL.md
+++ b/plugins/swarmkit/skills/squad/SKILL.md
@@ -484,10 +484,12 @@ Runs **regardless of success or halt**. Every step must be idempotent — runnin
    ──────────────────────────────────────────────
    ```
 
+Optionally, run `swarmkit:clean-remote-worktrees` afterwards to sweep orphaned remote `worktree-agent-*` branches left behind by merged PRs. This is not automatic — invoke it when you want to tidy up.
+
 ### Out of scope
 
 - Closing or merging PRs — left open for human review
-- Deleting remote branches — only local worktrees and local branches are cleaned
+- Deleting remote branches — only local worktrees and local branches are cleaned by this skill's teardown; `swarmkit:clean-remote-worktrees` handles remote sweep on demand
 
 ---
 

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -312,6 +312,9 @@ Proceed immediately to the next cycle after printing the checkpoint summary. The
    ```bash
    git config --local --unset claude.flowkit.prBase
    ```
+
+Optionally, run `swarmkit:clean-remote-worktrees` afterwards to sweep orphaned remote `worktree-agent-*` branches left behind by merged PRs. This is not automatic — invoke it when you want to tidy up.
+
 3. Final summary:
 
 ```


### PR DESCRIPTION
## Summary
- Adds `plugins/swarmkit/skills/clean-remote-worktrees/SKILL.md` — classifies remote `worktree-agent-*` branches by PR state and deletes only MERGED orphans in a single refspec-batch push.
- Safety rules: never delete branches with OPEN or CLOSED-not-merged PRs, and never touch local state.
- Supports `--yes` for non-interactive automation.
- Cross-references the new skill from `clean-worktrees`, `swarm`, and `squad` sub-skills as an optional post-run hygiene step (not automatic).

## Test plan
- Run `/swarmkit:clean-remote-worktrees` on a repo with mixed orphans → plan lists counts per bucket and only MERGED are proposed for deletion.
- Confirm → a single `git push origin :b1 :b2 ...` deletes all MERGED remotes in one round-trip.
- Skipped CLOSED and OPEN branches are surfaced in the report with reasons.
- Run on a clean repo → no-op report.
- Run with `--yes` in a CI/automation context → proceeds without confirmation.

Closes #384