### PR TITLE
docs(readme): add Getting Started walkthrough for new users

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 Monorepo hosting Claude Code plugins. See the [repo README](./README.md#available-plugins) for the current plugin catalog — it's the canonical source and stays in sync as plugins ship.
 
+## User-Facing Docs
+
+The root [README](./README.md) owns two canonical anchors that other surfaces cross-link to rather than duplicate:
+
+- `#available-plugins` — plugin catalog.
+- `#getting-started` — end-to-end walkthrough for new users (prereqs → install → `/spec` → `/swarm` → ship).
+
+The landing page (`docs/index.html`) and each plugin README link back to these anchors instead of carrying parallel copies. When updating onboarding narrative, edit the root README and let the teasers point to it — don't fork the walkthrough into individual plugin READMEs.
+
 ## Release Process
 
 Before every release, run `/bump-versions` to increment `plugin.json` versions for any plugins that have changed. This is required — without a version bump, existing users' clients won't pick up the updated code.

--- a/README.md
+++ b/README.md
@@ -32,6 +32,100 @@ Claude Code plugins for plan, execute, and ship — each keeping you at the hand
 |--------|---------|-------------|
 | **vaultkit** | `/plugin install vaultkit@smallorbit-plugins` | Obsidian vault skills — read, search, edit notes, and capture decisions |
 
+## Getting Started
+
+A short walkthrough that takes you from idea to shipped change using `/spec` and `/swarm` — the two kits at the heart of the workflow.
+
+### Prerequisites
+
+- [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and signed in
+- [GitHub CLI](https://cli.github.com/) authenticated (`gh auth status` should return green)
+- A GitHub repository you can push to
+- A `develop` branch on that repo (swarmkit targets it by default)
+
+### 1. Install speckit and swarmkit
+
+These two are the essential kits to start with — speckit plans the work, swarmkit resolves it. Install both from the marketplace:
+
+```
+/plugin install speckit@smallorbit-plugins
+/plugin install swarmkit@smallorbit-plugins
+```
+
+### 2. Plan the feature with `/spec`
+
+Say you're building a small notes app and want to add tags to notes. Kick off an interview:
+
+```
+/spec add tags to notes
+```
+
+`/spec` reads your codebase first, then asks focused questions to pin the feature down:
+
+> **Claude:** Notes are stored in `notes.ts` with `id`, `title`, and `body` fields. Where should tags attach — on each note, or in a separate collection?
+>
+> **You:** On each note. One note can have many tags.
+>
+> **Claude:** Should tags be free-form strings the user types, or chosen from a controlled list?
+>
+> **You:** Free-form for now.
+>
+> **Claude:** Where should tags surface in the UI — inside `ui/NoteEditor.tsx`, a sidebar, both?
+>
+> **You:** Both. Edit tags in the editor, filter from the sidebar.
+
+…a few rounds later, after nailing down persistence, filter UX, and the migration story, `/spec` shows the plan for approval and — on your OK — files it:
+
+```
+Filed epic: #101 Epic: Add tags to notes             label: epic:tags-notes
+Filed children:
+  #102 Extend Note schema with tags field            priority:high   type:feature
+  #103 Add tag input to NoteEditor                   priority:high   type:feature
+  #104 Render tag chips on note cards                priority:medium type:feature
+  #105 Filter notes by tag from the sidebar          priority:medium type:feature
+```
+
+### 3. Resolve the epic with `/swarm`
+
+Swarm the child issues in parallel:
+
+```
+/swarm 102 103 104 105
+```
+
+swarmkit spawns one isolated-worktree agent per issue, each on its own `worktree-agent-<n>` branch. Agents work concurrently, commit with conventional-commit messages, and open stacked PRs:
+
+```
+Swarm complete — 4 PRs opened:
+
+  #210 feat(notes): extend Note schema with tags field        → develop
+  #211 feat(notes): add tag input to NoteEditor               → worktree-agent-102
+  #212 feat(notes): render tag chips on note cards            → worktree-agent-103
+  #213 feat(notes): filter notes by tag from the sidebar      → worktree-agent-104
+
+Stack root: #210. Run /merge-stack to land top-down.
+```
+
+### 4. Ship it
+
+Once the PRs look right:
+
+```
+/merge-stack     # merge all swarm PRs top-down into develop
+/cut             # create a release candidate from develop
+/release         # promote to main, tag the release, close referenced issues
+```
+
+Or collapse all three into a single `/ship`. See the [flowkit README](./plugins/flowkit/README.md) for the full lifecycle, RC naming, and staging support.
+
+### What's next
+
+- **polishkit** — run `/critique`, `/tidy-codebase`, and `/dead-code` as a quality gate before shipping.
+- **sessionkit** — use `/handoff` when a spec or swarm session outgrows one context, and `/skillit` to capture patterns worth keeping.
+- **vaultkit** — drop decisions and notes into an Obsidian vault alongside the work.
+
+Each plugin's README goes deeper. For the stacked-PR mental model behind `/swarm`, read [swarmkit's METHODOLOGY](./plugins/swarmkit/METHODOLOGY.md).
+
 ## How the Plugins Compose
 
 The development-lifecycle plugins form a complete loop from idea to release:

--- a/README.md
+++ b/README.md
@@ -106,9 +106,15 @@ Swarm complete — 4 PRs opened:
 Stack root: #210. Run /merge-stack to land top-down.
 ```
 
-### 4. Ship it
+### 4. Ship it (optional — use your own process if you prefer)
 
-Once the PRs look right:
+Once the PRs look right, merge and release them however you normally would. If you'd like a streamlined flow, install **flowkit**:
+
+```
+/plugin install flowkit@smallorbit-plugins
+```
+
+Then land everything in three commands:
 
 ```
 /merge-stack     # merge all swarm PRs top-down into develop
@@ -117,14 +123,6 @@ Once the PRs look right:
 ```
 
 Or collapse all three into a single `/ship`. See the [flowkit README](./plugins/flowkit/README.md) for the full lifecycle, RC naming, and staging support.
-
-### What's next
-
-- **polishkit** — run `/critique`, `/tidy-codebase`, and `/dead-code` as a quality gate before shipping.
-- **sessionkit** — use `/handoff` when a spec or swarm session outgrows one context, and `/skillit` to capture patterns worth keeping.
-- **vaultkit** — drop decisions and notes into an Obsidian vault alongside the work.
-
-Each plugin's README goes deeper. For the stacked-PR mental model behind `/swarm`, read [swarmkit's METHODOLOGY](./plugins/swarmkit/METHODOLOGY.md).
 
 ## How the Plugins Compose
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -409,6 +409,14 @@
         <h2 id="install-title" class="section-title reveal" data-delay="1">Install and run.</h2>
         <p class="install-intro reveal" data-delay="2">Add the marketplace, then install the plugins you want. Everything below runs in a Claude Code session.</p>
 
+        <a class="gs-teaser reveal" data-delay="2" href="https://github.com/smallorbit/smallorbit-plugins#getting-started">
+          <div class="gs-teaser-body">
+            <h3 class="gs-teaser-title">New here? Start with the walkthrough.</h3>
+            <p class="gs-teaser-pitch">A five-minute tour from <code>/spec</code> to a shipped release — prereqs, install, and your first swarm.</p>
+          </div>
+          <span class="gs-teaser-cta">Read it<span class="gs-teaser-glyph" aria-hidden="true">↗</span></span>
+        </a>
+
         <div class="install-steps">
           <div class="install-step reveal" data-delay="3">
             <div class="install-step-n">01</div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -856,8 +856,59 @@ section + section { border-top: 1px solid var(--border); }
   font-size: 1.02rem;
   color: var(--text-muted);
   max-width: 56ch;
-  margin-bottom: 44px;
+  margin-bottom: 28px;
 }
+
+.gs-teaser {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 20px 26px;
+  margin-bottom: 36px;
+  background: linear-gradient(180deg, var(--surface), var(--bg-raised));
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  color: var(--text);
+  text-decoration: none;
+  transition: border-color 0.2s var(--ease), transform 0.2s var(--ease);
+}
+.gs-teaser:hover {
+  border-color: var(--border-strong);
+  transform: translateY(-1px);
+}
+.gs-teaser-body { min-width: 0; }
+.gs-teaser-title {
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 1.08rem;
+  color: var(--text-strong);
+  letter-spacing: -0.01em;
+  margin: 0 0 4px;
+}
+.gs-teaser-pitch {
+  font-family: var(--sans);
+  font-size: 0.94rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+.gs-teaser-pitch code {
+  font-family: var(--mono);
+  font-size: 0.88em;
+  color: var(--text);
+}
+.gs-teaser-cta {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-strong);
+}
+.gs-teaser-glyph { font-size: 0.9rem; }
 
 .install-steps {
   display: grid;

--- a/plugins/speckit/README.md
+++ b/plugins/speckit/README.md
@@ -2,6 +2,8 @@
 
 A Claude Code plugin for defining and capturing work. Interview a feature into existence, bulk-convert findings into issues, or quickly file a single issue — all from slash commands.
 
+> **New to smallorbit-plugins?** Start with the [Getting Started walkthrough](../../README.md#getting-started) — it covers install, `/spec`, and `/swarm` end to end.
+
 ## Installation
 
 Install from the `smallorbit-plugins` marketplace:

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -2,7 +2,9 @@
 
 A Claude Code plugin that resolves GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean — all from slash commands.
 
-**New to swarmkit?** Read [METHODOLOGY.md](./METHODOLOGY.md) for the full narrative on how the stacked agent/PR workflow fits together — worktree isolation, stacked branches, top-down merging with reference accumulation, and loop mode.
+> **New to smallorbit-plugins?** Start with the [Getting Started walkthrough](../../README.md#getting-started) — it covers install, `/spec`, and `/swarm` end to end.
+
+**Already here for swarmkit specifically?** Read [METHODOLOGY.md](./METHODOLOGY.md) for the full narrative on how the stacked agent/PR workflow fits together — worktree isolation, stacked branches, top-down merging with reference accumulation, and loop mode.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Add a Getting Started section to the root README walking new users through /spec → /swarm → ship
- Covers prereqs, install, abbreviated interview transcript, stacked-PR output, and ship-it epilogue
- Uses abstract blog/notes app examples without committing to a real stack

## Test plan
- Verify markdown renders correctly on GitHub
- Confirm anchor #getting-started works
- Check all internal links resolve

Closes #394

Closes #395

Closes #396

Closes #397