### PR TITLE
docs(landing): add Getting Started teaser linking to README walkthrough

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -409,6 +409,14 @@
         <h2 id="install-title" class="section-title reveal" data-delay="1">Install and run.</h2>
         <p class="install-intro reveal" data-delay="2">Add the marketplace, then install the plugins you want. Everything below runs in a Claude Code session.</p>
 
+        <a class="gs-teaser reveal" data-delay="2" href="https://github.com/smallorbit/smallorbit-plugins#getting-started">
+          <div class="gs-teaser-body">
+            <h3 class="gs-teaser-title">New here? Start with the walkthrough.</h3>
+            <p class="gs-teaser-pitch">A five-minute tour from <code>/spec</code> to a shipped release — prereqs, install, and your first swarm.</p>
+          </div>
+          <span class="gs-teaser-cta">Read it<span class="gs-teaser-glyph" aria-hidden="true">↗</span></span>
+        </a>
+
         <div class="install-steps">
           <div class="install-step reveal" data-delay="3">
             <div class="install-step-n">01</div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -856,8 +856,59 @@ section + section { border-top: 1px solid var(--border); }
   font-size: 1.02rem;
   color: var(--text-muted);
   max-width: 56ch;
-  margin-bottom: 44px;
+  margin-bottom: 28px;
 }
+
+.gs-teaser {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 20px 26px;
+  margin-bottom: 36px;
+  background: linear-gradient(180deg, var(--surface), var(--bg-raised));
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  color: var(--text);
+  text-decoration: none;
+  transition: border-color 0.2s var(--ease), transform 0.2s var(--ease);
+}
+.gs-teaser:hover {
+  border-color: var(--border-strong);
+  transform: translateY(-1px);
+}
+.gs-teaser-body { min-width: 0; }
+.gs-teaser-title {
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 1.08rem;
+  color: var(--text-strong);
+  letter-spacing: -0.01em;
+  margin: 0 0 4px;
+}
+.gs-teaser-pitch {
+  font-family: var(--sans);
+  font-size: 0.94rem;
+  color: var(--text-muted);
+  margin: 0;
+}
+.gs-teaser-pitch code {
+  font-family: var(--mono);
+  font-size: 0.88em;
+  color: var(--text);
+}
+.gs-teaser-cta {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-strong);
+}
+.gs-teaser-glyph { font-size: 0.9rem; }
 
 .install-steps {
   display: grid;


### PR DESCRIPTION
## Summary
- Add a compact teaser card in `docs/index.html` under the getting-started / install section
- Deep-links to the root README `#getting-started` anchor (single source of truth stays in the README)
- Matching styles added to `docs/style.css` — gradient surface card with CTA affordance, matching the existing install-step aesthetic

## Test plan
- Verify the teaser renders correctly on the landing page
- Confirm the link resolves to the README walkthrough anchor
- Check hover/focus styling matches the rest of the page

Stacks on #399. Closes #395