### PR TITLE
docs(plugins): cross-link speckit and swarmkit READMEs to Getting Started

### DIFF
--- a/plugins/speckit/README.md
+++ b/plugins/speckit/README.md
@@ -2,6 +2,8 @@
 
 A Claude Code plugin for defining and capturing work. Interview a feature into existence, bulk-convert findings into issues, or quickly file a single issue — all from slash commands.
 
+> **New to smallorbit-plugins?** Start with the [Getting Started walkthrough](../../README.md#getting-started) — it covers install, `/spec`, and `/swarm` end to end.
+
 ## Installation
 
 Install from the `smallorbit-plugins` marketplace:

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -2,7 +2,9 @@
 
 A Claude Code plugin that resolves GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean — all from slash commands.
 
-**New to swarmkit?** Read [METHODOLOGY.md](./METHODOLOGY.md) for the full narrative on how the stacked agent/PR workflow fits together — worktree isolation, stacked branches, top-down merging with reference accumulation, and loop mode.
+> **New to smallorbit-plugins?** Start with the [Getting Started walkthrough](../../README.md#getting-started) — it covers install, `/spec`, and `/swarm` end to end.
+
+**Already here for swarmkit specifically?** Read [METHODOLOGY.md](./METHODOLOGY.md) for the full narrative on how the stacked agent/PR workflow fits together — worktree isolation, stacked branches, top-down merging with reference accumulation, and loop mode.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Add a one-line "new to smallorbit-plugins?" pointer near the top of `plugins/speckit/README.md` and `plugins/swarmkit/README.md`
- Links to the root README `#getting-started` anchor so users who land on a plugin README first get routed to the unified walkthrough
- Reframes the pre-existing "new to swarmkit?" line so the two pointers don't read as redundant

## Test plan
- Verify both pointers render correctly on GitHub
- Confirm the `../../README.md#getting-started` relative link resolves from each plugin subdir
- Check the swarmkit METHODOLOGY pointer still reads well after reframing

Stacks on #399. Closes #396