### PR TITLE
docs(claude): note root README owns #getting-started as single source of truth

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 Monorepo hosting Claude Code plugins. See the [repo README](./README.md#available-plugins) for the current plugin catalog — it's the canonical source and stays in sync as plugins ship.
 
+## User-Facing Docs
+
+The root [README](./README.md) owns two canonical anchors that other surfaces cross-link to rather than duplicate:
+
+- `#available-plugins` — plugin catalog.
+- `#getting-started` — end-to-end walkthrough for new users (prereqs → install → `/spec` → `/swarm` → ship).
+
+The landing page (`docs/index.html`) and each plugin README link back to these anchors instead of carrying parallel copies. When updating onboarding narrative, edit the root README and let the teasers point to it — don't fork the walkthrough into individual plugin READMEs.
+
 ## Release Process
 
 Before every release, run `/bump-versions` to increment `plugin.json` versions for any plugins that have changed. This is required — without a version bump, existing users' clients won't pick up the updated code.


### PR DESCRIPTION
## Summary
- Add a "User-Facing Docs" section to `CLAUDE.md` calling out the two canonical anchors owned by the root README: `#available-plugins` and the new `#getting-started`
- Direct future contributors to edit the root README and let teasers cross-link, rather than forking the walkthrough into individual plugin READMEs
- No other contributor-facing docs needed changes — only `CLAUDE.md` exists at the repo root

## Test plan
- Verify the new section renders correctly on GitHub
- Confirm the convention is stated plainly enough to guide future drift prevention

Stacks on #399. Closes #397