### PR TITLE
docs(readme): link plugin names to their directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,17 +20,17 @@ Claude Code plugins for plan, execute, and ship — each keeping you at the hand
 
 | Plugin | Install | Description |
 |--------|---------|-------------|
-| **speckit** | `/plugin install speckit@smallorbit-plugins` | Define and capture work through interviews and issue filing |
-| **swarmkit** | `/plugin install swarmkit@smallorbit-plugins` | Resolve GitHub issues with parallel worktree agents. See [METHODOLOGY.md](./plugins/swarmkit/METHODOLOGY.md) for the stacked agent/PR workflow in depth. For the experimental Agent Teams-based `/squad` variant, see [plugins/swarmkit/SETUP.md](./plugins/swarmkit/SETUP.md). |
-| **polishkit** | `/plugin install polishkit@smallorbit-plugins` | Critique code quality, sweep for cruft, and eliminate dead code |
-| **flowkit** | `/plugin install flowkit@smallorbit-plugins` | Manage the full git lifecycle from branch to release |
-| **sessionkit** | `/plugin install sessionkit@smallorbit-plugins` | Session continuity, context handoffs, and meta-learning |
+| **[speckit](./plugins/speckit/)** | `/plugin install speckit@smallorbit-plugins` | Define and capture work through interviews and issue filing |
+| **[swarmkit](./plugins/swarmkit/)** | `/plugin install swarmkit@smallorbit-plugins` | Resolve GitHub issues with parallel worktree agents. See [METHODOLOGY.md](./plugins/swarmkit/METHODOLOGY.md) for the stacked agent/PR workflow in depth. For the experimental Agent Teams-based `/squad` variant, see [plugins/swarmkit/SETUP.md](./plugins/swarmkit/SETUP.md). |
+| **[polishkit](./plugins/polishkit/)** | `/plugin install polishkit@smallorbit-plugins` | Critique code quality, sweep for cruft, and eliminate dead code |
+| **[flowkit](./plugins/flowkit/)** | `/plugin install flowkit@smallorbit-plugins` | Manage the full git lifecycle from branch to release |
+| **[sessionkit](./plugins/sessionkit/)** | `/plugin install sessionkit@smallorbit-plugins` | Session continuity, context handoffs, and meta-learning |
 
 ### Utilities & Productivity
 
 | Plugin | Install | Description |
 |--------|---------|-------------|
-| **vaultkit** | `/plugin install vaultkit@smallorbit-plugins` | Obsidian vault skills — read, search, edit notes, and capture decisions |
+| **[vaultkit](./plugins/vaultkit/)** | `/plugin install vaultkit@smallorbit-plugins` | Obsidian vault skills — read, search, edit notes, and capture decisions |
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- Wrap each plugin name in the Available Plugins tables with a relative link to its directory
- Applies to both Development Lifecycle and Utilities & Productivity tables
- Uses relative paths (`./plugins/<name>/`) for GitHub, landing page, and local preview compatibility

## Test plan
- Verify all 6 plugin name links render as clickable on GitHub
- Confirm each link resolves to the correct plugin directory
- Check that bold formatting is preserved on the linked names

Closes #393