### PR TITLE
refactor(swarmkit): rename pick-issue skill to next-issue

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -235,13 +235,13 @@
             <p class="plugin-desc">Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs top-down — leaf first.</p>
             <ul class="skill-list">
               <li><code>/swarm</code> — spawn parallel agents for issues</li>
-              <li><code>/pick-issue</code> — rank and recommend what to work on</li>
+              <li><code>/next-issue</code> — rank and recommend what to work on</li>
               <li><code>/merge-pr</code> — merge a single PR directly into develop</li>
               <li><code>/merge-stack</code> — merge multiple PRs top-down: leaf first, root last</li>
               <li><code>/clean-worktrees</code> — remove agent worktrees and branches</li>
             </ul>
             <div class="transcript" role="group" aria-label="swarmkit example session">
-<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/pick-issue</span></span>
+<span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/next-issue</span></span>
 <span class="transcript-line">  <span class="transcript-annotate">top: #156 (api), #157 (ui), #158 (docs) — #157 blocks #158</span></span>
 <span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/swarm</span> 156 157 158</span>
 <span class="transcript-line"><span class="transcript-prompt">►</span> <span class="transcript-annotate">spawning 3 agents in isolated worktrees...</span></span>

--- a/plugins/swarmkit/METHODOLOGY.md
+++ b/plugins/swarmkit/METHODOLOGY.md
@@ -13,7 +13,7 @@ The four ideas that make this work together are worktree isolation (so agents ca
 If you just want to run a swarm and merge the result, this is the full shape of the workflow:
 
 ```
-/pick-issue          # see what is ready to work on
+/next-issue          # see what is ready to work on
 /swarm 12 15 18      # spawn parallel agents for specific issues
 /merge-stack         # land all open swarm PRs top-down (use /merge-pr for a single PR)
 /clean-worktrees     # remove the worktree directories and orphaned branches
@@ -79,7 +79,7 @@ Independent PRs — those whose base is already `develop` and that no other PR s
 
 Loop mode is what turns swarmkit from "resolve these three issues" into "clear the board." When `/swarm` is invoked with no issue numbers (and optionally a single label filter), it repeats the following cycle until there are no open issues left.
 
-Each cycle fetches the current open issues, ranks them, and selects a batch that can safely parallelize: no two issues touching the same files, no unresolved dependencies within the batch. The batch is presented in the pick-issue table format, agents spawn, pull requests open. A checkpoint summary prints — how many PRs opened, which issues failed, which issues are now blocked because a dependency failed, how many issues remain — and the loop proceeds immediately to the next cycle.
+Each cycle fetches the current open issues, ranks them, and selects a batch that can safely parallelize: no two issues touching the same files, no unresolved dependencies within the batch. The batch is presented in the next-issue table format, agents spawn, pull requests open. A checkpoint summary prints — how many PRs opened, which issues failed, which issues are now blocked because a dependency failed, how many issues remain — and the loop proceeds immediately to the next cycle.
 
 Failure is handled explicitly rather than by retrying. If an issue fails during a cycle, every remaining issue in this and future cycles is checked for file overlap with the failed issue or explicit references to it. Anything that overlaps is marked blocked and skipped, with the block reported at each checkpoint. The loop continues with everything that is not blocked.
 

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -34,7 +34,7 @@ claude --plugin-dir /path/to/swarmkit
 | Skill | Invoke | What it does |
 |-------|--------|--------------|
 | **swarm** | `/swarm` | Spawn parallel isolated-worktree agents to resolve GitHub issues. Supports one-shot mode (specific issues) and loop mode (clear the board). Auto-creates PRs targeting `develop`. |
-| **pick-issue** | `/pick-issue` | Fetches open issues, ranks them by priority, specificity, and architectural impact, and recommends what to work on next. |
+| **next-issue** | `/next-issue` | Fetches open issues, ranks them by priority, specificity, and architectural impact, and recommends what to work on next. |
 | **merge-stack** | `/merge-stack` | Merges all open swarm PRs top-down (leaf PRs first, root last). |
 | **clean-worktrees** | `/clean-worktrees` | Removes all agent worktrees and their orphaned `worktree-agent-*` branches. |
 
@@ -46,13 +46,13 @@ These are called by the skills above — you don't invoke them directly.
 |-------|---------|---------|
 | **self-review** | swarm | Runs iterative `/simplify` passes on changed files before PR creation. |
 | **conventional-commit-message** | swarm | Enforces `type(scope): description` commit format. |
-| **gh-fetch-issues** | pick-issue, swarm | Fetches open issues and filters out `on-hold` labeled ones. |
-| **issue-rank** | pick-issue, swarm | Ranks issues by priority labels, specificity, and architectural impact. |
+| **gh-fetch-issues** | next-issue, swarm | Fetches open issues and filters out `on-hold` labeled ones. |
+| **issue-rank** | next-issue, swarm | Ranks issues by priority labels, specificity, and architectural impact. |
 
 ## Typical Workflow
 
 ```
-/pick-issue                          # See what's ready to work on
+/next-issue                          # See what's ready to work on
 /swarm 12 15 18                      # Resolve specific issues in parallel
 /merge-pr       # If one PR — merge it directly
 /merge-stack    # If two or more PRs — merges top-down: leaf PRs first, root last
@@ -111,7 +111,7 @@ Common types: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`. The `conventio
 
 ### Label: `status:in-progress`
 
-When an agent is spawned for an issue, swarmkit applies `status:in-progress` to it. This prevents `gh-fetch-issues` and `pick-issue` from re-selecting it in subsequent swarm cycles. GitHub auto-closes the issue when its PR merges (via `Closes #N`), so no manual label cleanup is needed.
+When an agent is spawned for an issue, swarmkit applies `status:in-progress` to it. This prevents `gh-fetch-issues` and `next-issue` from re-selecting it in subsequent swarm cycles. GitHub auto-closes the issue when its PR merges (via `Closes #N`), so no manual label cleanup is needed.
 
 
 ### Issue Lifecycle
@@ -121,7 +121,7 @@ Swarmkit **never closes issues** — that's intentional. Closing is left to the 
 ## Configuration Notes
 
 - **`swarm`** has `disable-model-invocation: true` — it only runs when you explicitly type `/swarm`, never auto-triggered by Claude. This prevents accidental mass agent spawning.
-- **`pick-issue`** and **`clean-worktrees`** allow model invocation, so Claude can suggest or invoke them contextually.
+- **`next-issue`** and **`clean-worktrees`** allow model invocation, so Claude can suggest or invoke them contextually.
 
 ## Pairing with Other Plugins
 
@@ -129,7 +129,7 @@ Swarmkit executes work; [speckit](../speckit) defines it. Use them together for 
 
 ```
 /spec add CSV export              # Plan the feature, file issues
-/pick-issue                       # Confirm what to work on
+/next-issue                       # Confirm what to work on
 /swarm                            # Resolve with parallel agents
 /clean-worktrees                  # Clean up
 ```

--- a/plugins/swarmkit/skills/gh-fetch-issues/SKILL.md
+++ b/plugins/swarmkit/skills/gh-fetch-issues/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gh-fetch-issues
-description: Fetch open GitHub issues and filter out on-hold labeled issues. Sub-skill used by pick-issue, swarm, and catalog.
+description: Fetch open GitHub issues and filter out on-hold labeled issues. Sub-skill used by next-issue, swarm, and catalog.
 ---
 
 # gh-fetch-issues

--- a/plugins/swarmkit/skills/issue-rank/SKILL.md
+++ b/plugins/swarmkit/skills/issue-rank/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: issue-rank
-description: Canonical ranking table for prioritizing GitHub issues by priority labels, specificity, architectural impact, and testability. Sub-skill used by pick-issue and swarm.
+description: Canonical ranking table for prioritizing GitHub issues by priority labels, specificity, architectural impact, and testability. Sub-skill used by next-issue and swarm.
 ---
 
 # Issue Rank Sub-Skill

--- a/plugins/swarmkit/skills/next-issue/SKILL.md
+++ b/plugins/swarmkit/skills/next-issue/SKILL.md
@@ -1,16 +1,16 @@
 ---
-name: pick-issue
+name: next-issue
 description: List open GitHub issues and recommend the best one(s) to work on next, based on priority, implementation specificity, and architectural impact.
 triggers:
   - "what should I work on next"
   - "recommend an issue"
   - "list open issues"
   - "what's next"
-  - "pick an issue"
+  - "next issue"
   - "which issue should I tackle"
 ---
 
-# Pick Issue Skill
+# Next Issue Skill
 
 Fetches open GitHub issues, analyzes them, and recommends the best next task.
 

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -280,7 +280,7 @@ This is unset in the teardown step below. Leaving it set will cause subsequent P
 Follow `gh-fetch-issues` to fetch open issues (apply label filter if given), then follow `issue-rank` to rank and select all issues that can safely parallelize this cycle:
 - No two issues touch the same files
 - No unresolved dependencies within the batch
-- Present the batch in the standard pick-issue table format; note any deferred issues and why
+- Present the batch in the standard next-issue table format; note any deferred issues and why
 
 If no open issues remain, announce "Board is clear" and exit.
 


### PR DESCRIPTION
## Summary
- Renamed `plugins/swarmkit/skills/pick-issue/` directory to `plugins/swarmkit/skills/next-issue/`
- Updated SKILL.md frontmatter `name:` field from `pick-issue` to `next-issue`
- Refreshed natural-language trigger phrases to align with the new name (`"pick an issue"` → `"next issue"`)

## Test plan
- Verify `plugins/swarmkit/skills/next-issue/SKILL.md` exists with correct frontmatter
- Verify `plugins/swarmkit/skills/pick-issue/` no longer exists
- Verify trigger phrases reference "next issue" instead of "pick an issue"

Closes #406