### PR TITLE
docs(sessionkit): update README to reflect touchless handoff

### DIFF
--- a/plugins/sessionkit/README.md
+++ b/plugins/sessionkit/README.md
@@ -62,7 +62,7 @@ claude --plugin-dir /path/to/sessionkit
 
 ## How Handoff / Pickup Works
 
-`/handoff` collects git state, todo files, and conversation history, synthesizes them into a structured document, and writes it to `.sessionkit/HANDOFF.md` only after you approve the draft.
+`/handoff` collects git state, todo files, and conversation history, synthesizes them into a structured document, prints it inline, then writes it immediately to `.sessionkit/HANDOFF.md` — no approval step. The only prompt is a one-time confirmation before adding `.sessionkit/` to `.gitignore`, if the entry is not already present.
 
 `/pickup` reads that document at the start of a fresh session and produces an orientation summary — goal, progress, git state, remaining work, and key context — without re-executing anything.
 


### PR DESCRIPTION
## Summary
- Updated handoff workflow description to reflect print-then-write behavior (no approval gate)
- Noted that .gitignore is the only remaining user prompt during handoff
- Kept all other README sections unchanged

## Test plan
- Verify README accurately describes the new touchless handoff flow
- Verify no mention of "approval" or "confirmation" for the write step remains
- Verify .gitignore gate is documented as the only remaining prompt

Closes #412