### PR TITLE
feat(swarmkit): add dispatch plan table to squad one-shot mode

### DIFF
--- a/plugins/swarmkit/skills/squad/SKILL.md
+++ b/plugins/swarmkit/skills/squad/SKILL.md
@@ -137,7 +137,24 @@ For each issue number in the target set:
 gh issue edit <issue> --add-label "status:in-progress"
 ```
 
-### 5. Create team and spawn teammates
+### 5. Present dispatch plan
+
+Before spawning any teammates, print a summary table of builder assignments so the operator has a clear view of what is about to run. Proceed immediately — no approval gate.
+
+```
+| Builder | Issue(s) | Branch | Model | Notes |
+|---------|----------|--------|-------|-------|
+| builder-16 | #16 | worktree-agent-16 | sonnet | Independent |
+| builder-18 | #18 | worktree-agent-18 | opus | Blocked by #16 |
+```
+
+Include:
+- **Suggested merge order** — leaf PRs first (no dependents), root PRs last
+- **Any issues too ambiguous to delegate** — list them with a brief reason; they are excluded from the dispatch but not from the target set
+
+After printing the table, continue immediately to the next step.
+
+### 6. Create team and spawn teammates
 
 Create the team:
 
@@ -179,7 +196,7 @@ Agent({
 
 Builders self-claim the next unblocked task from the TaskList when they finish (see Builder Teammate Contract, step 8), so a pool smaller than the unblocked count still processes every issue — it just takes more rounds.
 
-### 6. Monitor and exit
+### 7. Monitor and exit
 
 Enter the Dispatch Loop (watch phase). The lead monitors the mailbox for completion messages and crash signals.
 
@@ -239,6 +256,8 @@ gh issue edit <issue> --add-label "status:in-progress"
 ```
 
 **Step 4 — Create team and spawn**
+
+Before spawning, print the dispatch plan table (same format as One-Shot Mode step 5: Builder / Issue(s) / Branch / Model / Notes, with suggested merge order). Proceed immediately — no approval gate.
 
 Create the team (once per loop-mode run, reused across cycles):
 


### PR DESCRIPTION
## Summary
- Added "Present dispatch plan" step (step 5) to One-Shot Mode showing builder assignments, branches, model selection, and suggested merge order before spawning
- Added brief reference in Loop Mode Step 4 to print the same dispatch plan table at each cycle's spawn step
- No approval gate — table is informational, lead proceeds immediately

## Test plan
- Verify One-Shot Mode includes the new step 5 "Present dispatch plan" with example table and merge order guidance
- Verify subsequent steps are renumbered correctly (old 5→6, old 6→7)
- Verify Loop Mode Step 4 references the dispatch plan with the same table format

Closes #421