### PR TITLE
fix(landing): add Open Graph and Twitter Card meta tags

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,6 +4,14 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="smallorbit-plugins — Claude Code plugins for the end-to-end AI development lifecycle, keeping you in the loop at every handoff.">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="smallorbit-plugins · From idea to release. With you in the loop.">
+  <meta property="og:description" content="Claude Code plugins for the end-to-end AI development lifecycle, keeping you in the loop at every handoff.">
+  <meta property="og:url" content="https://smallorbit.github.io/smallorbit-plugins/">
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="smallorbit-plugins · From idea to release. With you in the loop.">
+  <meta name="twitter:description" content="Claude Code plugins for the end-to-end AI development lifecycle, keeping you in the loop at every handoff.">
+  <meta name="theme-color" content="#0a0d13">
   <title>smallorbit-plugins · From idea to release. With you in the loop.</title>
   <script>document.documentElement.classList.add('js');</script>
   <link rel="stylesheet" href="style.css">


### PR DESCRIPTION
## Summary
- Add Open Graph meta tags (og:type, og:title, og:description, og:url) for rich link previews on social platforms
- Add Twitter Card meta tags (twitter:card, twitter:title, twitter:description)
- Add theme-color meta tag for browser chrome theming

## Test plan
- Verify meta tags are present in page source
- Test with social media debugger tools (Twitter Card Validator, Facebook Sharing Debugger)
- Confirm no other sections of the page were affected

Closes #427