### PR TITLE
fix(landing): remove broken metakit README link and add missing delay-6 rule

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -358,7 +358,6 @@
                 <span class="plugin-role">compose it</span>
               </div>
               <div class="plugin-meta">
-                <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/metakit" target="_blank" rel="noopener">README ↗</a>
               </div>
             </div>
             <p class="plugin-desc">Dynamic orchestrator that composes sibling kits into multi-step scenarios. Detects what's installed, previews the plan, skips missing steps, pauses on risky ones, and halts with a state report on failure. <em>Pre-release.</em></p>

--- a/docs/style.css
+++ b/docs/style.css
@@ -1092,6 +1092,7 @@ footer {
 .reveal[data-delay="3"] { transition-delay: 0.2s; }
 .reveal[data-delay="4"] { transition-delay: 0.3s; }
 .reveal[data-delay="5"] { transition-delay: 0.4s; }
+.reveal[data-delay="6"] { transition-delay: 0.5s; }
 @media (prefers-reduced-motion: reduce) {
   .reveal { opacity: 1; transform: none; transition: none; }
 }


### PR DESCRIPTION
## Summary
- Remove the broken README link from the metakit card (metakit is parked on a separate branch, the link was a 404)
- Add missing `.reveal[data-delay="6"]` CSS rule so the metakit card animates with proper stagger timing

## Test plan
- Verify metakit card no longer has a README link
- Verify metakit card reveal animation has a visible stagger delay after the sessionkit card
- Confirm no other cards or styles were affected

Closes #428