### PR TITLE
docs(swarmkit): complete skill tables and attribute flowkit commands

### DIFF
--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -37,6 +37,8 @@ claude --plugin-dir /path/to/swarmkit
 | **next-issue** | `/next-issue` | Fetches open issues, ranks them by priority, specificity, and architectural impact, and recommends what to work on next. |
 | **merge-stack** | `/merge-stack` | Merges all open swarm PRs top-down (leaf PRs first, root last). |
 | **clean-worktrees** | `/clean-worktrees` | Removes all agent worktrees and their orphaned `worktree-agent-*` branches. |
+| **clean-remote-worktrees** | `/clean-remote-worktrees` | Sweeps orphaned remote `worktree-agent-*` branches from the remote. |
+| **squad** (experimental) | `/squad` | Agent Teams variant of `/swarm` — runs a structured lead/builder/reviewer team. See [Experimental features](#experimental-features). |
 
 ### Sub-Skills (internal)
 
@@ -54,7 +56,7 @@ These are called by the skills above — you don't invoke them directly.
 ```
 /next-issue                          # See what's ready to work on
 /swarm 12 15 18                      # Resolve specific issues in parallel
-/merge-pr       # If one PR — merge it directly
+/merge-pr       # If one PR — merge it directly (flowkit skill)
 /merge-stack    # If two or more PRs — merges top-down: leaf PRs first, root last
 /swarm                               # Or clear the entire board in a loop
 /clean-worktrees                     # Tidy up after a swarm run
@@ -66,7 +68,7 @@ These are called by the skills above — you don't invoke them directly.
 2. Fetches issues, analyzes dependencies, and presents a swarm plan
 3. Spawns one agent per issue (or grouped set) in isolated git worktrees
 4. Each agent: creates branch, makes changes, commits, pushes, opens PR — then stops
-5. Use `/merge-pr` (1 PR) or `/merge-stack` (2+ PRs) to land into `develop` — top-down: leaf PRs first, root last
+5. Use `/merge-pr` (1 PR, from [flowkit](../flowkit)) or `/merge-stack` (2+ PRs) to land into `develop` — top-down: leaf PRs first, root last
 6. Cleans up worktrees and orphaned branches
 
 **One-shot mode**: `/swarm 12 15 18` — resolve those issues and stop.


### PR DESCRIPTION
## Summary
- Add `clean-remote-worktrees` and `squad` (experimental) to the User-Facing skill table so all user-invocable skills are discoverable from the README
- Attribute `/merge-pr` references as a flowkit command in both the Typical Workflow and How Swarm Works sections

## Test plan
- Verify the skill table renders correctly with proper column alignment
- Confirm `/merge-pr` attributions link to flowkit and are clear without being verbose
- Check no unintended content changes elsewhere in the README

Closes #432
Closes #433