### PR TITLE
docs(polishkit): fix title casing to match plugin convention

### DIFF
--- a/plugins/polishkit/README.md
+++ b/plugins/polishkit/README.md
@@ -1,4 +1,4 @@
-# polishKit
+# Polishkit
 
 A Claude Code plugin for improving what you've already built. Assess code craft with a connoisseur's eye, sweep for accumulated cruft, and eliminate dead code — three focused skills for codebase quality.
 
@@ -71,7 +71,7 @@ claude --plugin-dir /path/to/polishkit
 
 ## Pairing with Other Plugins
 
-polishKit improves quality; [speckit](../speckit) defines the next work; [swarmkit](../swarmkit) executes it:
+Polishkit improves quality; [speckit](../speckit) defines the next work; [swarmkit](../swarmkit) executes it:
 
 ```
 /critique                       # Assess current quality


### PR DESCRIPTION
## Summary
- Replace "polishKit" (camelCase) with "Polishkit" (title case) to match the naming convention used by every other plugin in the repo

## Test plan
- Verify both occurrences on lines 1 and 74 are updated
- Confirm no other changes in the file

Closes #448