### PR TITLE
docs(speckit): force single-turn plan+approval in spec step 3

### DIFF
--- a/plugins/speckit/skills/catalog/SKILL.md
+++ b/plugins/speckit/skills/catalog/SKILL.md
@@ -91,11 +91,40 @@ Epic: epic:<slug> (applied to every issue below)
 
 If `--auto` was passed in `$ARGUMENTS`, skip the approval step and proceed directly to issue creation.
 
-Otherwise, wait for user approval. The user may ask to:
+Otherwise, **in a single assistant turn**, emit (a) the catalog table above and (b) an `AskUserQuestion` call. Never end the turn after presenting the table without the tool call — a prose-only prompt like "let me know if you'd like changes" is a defect.
+
+**Wrong shape** (never do this):
+
+```
+| # | Title | Category | Priority | Labels |
+...
+Let me know if you'd like any adjustments.
+← turn ends here; silent wait
+```
+
+**Right shape** (always do this):
+
+```
+| # | Title | Category | Priority | Labels |
+...
+← immediately followed by AskUserQuestion in the same turn:
+AskUserQuestion("File these issues?", [
+  "Approve and file",
+  "Adjust priorities / titles",
+  "Remove some findings",
+  "Cancel"
+])
+```
+
+**Pre-end self-check**: Before ending the turn in step 3, verify that the last action is an `AskUserQuestion` call. If the table was shown but no tool call was made, emit the call immediately.
+
+The user may ask to:
 - Remove findings they don't want filed
 - Adjust priorities
 - Change titles or descriptions
 - Add additional context
+
+If adjustments are requested, update the table and re-present with a new `AskUserQuestion` in the same turn.
 
 ### 4. Create issues
 
@@ -142,6 +171,7 @@ Output the created issues as a table with links:
 ## Constraints
 
 - Never create issues without showing the user the catalog first (unless `--auto` was passed)
+- The catalog table and the `AskUserQuestion` approval call must be emitted in the **same assistant turn** — showing the table and ending the turn without calling `AskUserQuestion` is a defect
 - Never create duplicate issues — check `gh issue list` for similar titles before creating
 - Keep issue bodies concise — problem + impact + fix, nothing more
 - Match the label style already in the repo (don't impose a new scheme)

--- a/plugins/speckit/skills/issue/SKILL.md
+++ b/plugins/speckit/skills/issue/SKILL.md
@@ -59,7 +59,33 @@ Labels:   <type>, priority:<level>
 <body>
 ```
 
-After showing the preview, call the `AskUserQuestion` tool to request approval — a single question such as "File this issue?" with options like `File as shown`, `Adjust title / labels / body`, and `Cancel`. Do not proceed to step 5 until the user has answered via `AskUserQuestion` — prose-only prompts like "reply with any changes" are not sufficient. If the user selects an adjust or cancel option, loop back (update the draft or abort) before re-asking.
+**In a single assistant turn**, emit (a) the preview above and (b) an `AskUserQuestion` call. Never end the turn after the preview without the tool call.
+
+**Wrong shape** (never do this):
+
+```
+Title: Harden approval gates
+Labels: enhancement, priority:medium
+---
+## Problem ...
+Let me know if you'd like changes.
+← turn ends; silent wait
+```
+
+**Right shape** (always do this):
+
+```
+Title: Harden approval gates
+Labels: enhancement, priority:medium
+---
+## Problem ...
+← immediately followed by AskUserQuestion in the same turn:
+AskUserQuestion("File this issue?", ["File as shown", "Adjust title / labels / body", "Cancel"])
+```
+
+**Pre-end self-check**: Before ending the turn in step 4, verify that the last action is an `AskUserQuestion` call. If the preview was shown but no tool call was made, emit the call immediately.
+
+If the user selects an adjust or cancel option, loop back (update the draft or abort) before re-asking.
 
 ### 5. Ensure labels exist
 
@@ -77,7 +103,7 @@ Output the created issue URL.
 
 ## Constraints
 
-- After presenting a plan or draft, always request approval via the `AskUserQuestion` tool — not prose. A silent wait with no tool call (or a prose-only "let me know what you think") is a defect.
+- The draft preview and the `AskUserQuestion` approval call must be emitted in the **same assistant turn** — showing the preview and ending the turn without calling `AskUserQuestion` is a defect, even if a prose invitation is included.
 - Never create the issue without showing the preview first
 - Never skip the duplicate check
 - Keep body concise — problem + impact + fix only

--- a/plugins/speckit/skills/spec/SKILL.md
+++ b/plugins/speckit/skills/spec/SKILL.md
@@ -99,7 +99,40 @@ Always append the following documentation task as the final row, unless the spec
 
 Include the `## Epic label` section **only when the plan produces an epic** (2+ tasks). Omit it for single-issue plans. Render the derived label as a single, editable line, for example: `Epic label: epic:catalog-epic-labels`.
 
-Present the plan inline. Then call the `AskUserQuestion` tool to request approval — a single question such as "Approve this plan and file the issues?" with options like `Approve and file issues`, `Edit epic label`, `Adjust priorities / tasks`, and `Cancel`. Do not proceed to step 4 until the user has answered via `AskUserQuestion` — prose-only prompts like "reply with any changes" are not sufficient, since they don't surface an expected input in the UI. If the user selects an adjust, edit-label, or cancel option, loop back (update the plan, revise the slug, or abort) before re-asking.
+**In a single assistant turn**, emit (a) the plan markdown and (b) an `AskUserQuestion` call. Never end the turn after (a); always follow with (b) in the same response. A turn that presents the plan and stops — even with a prose invitation like "let me know what you think" — is a defect. The `AskUserQuestion` call is the only valid approval gate.
+
+The question must be "Approve this plan and file the issues?" with options: `Approve and file issues`, `Edit epic label`, `Adjust priorities / tasks`, `Cancel`.
+
+**Wrong shape** (never do this):
+
+```
+Here is the plan:
+## Goal
+Harden approval gates in speckit skills.
+...
+Let me know if you'd like changes.
+← turn ends here; silent wait
+```
+
+**Right shape** (always do this):
+
+```
+Here is the plan:
+## Goal
+Harden approval gates in speckit skills.
+...
+← immediately followed by AskUserQuestion in the same turn:
+AskUserQuestion("Approve this plan and file the issues?", [
+  "Approve and file issues",
+  "Edit epic label",
+  "Adjust priorities / tasks",
+  "Cancel"
+])
+```
+
+**Pre-end self-check**: Before ending the turn in step 3, verify that the last action in the turn is an `AskUserQuestion` call with approval options. If the plan was presented but no `AskUserQuestion` was called, emit the call immediately — do not end the turn without it.
+
+Do not proceed to step 4 until the user has answered via `AskUserQuestion`. If the user selects an adjust, edit-label, or cancel option, loop back (update the plan, revise the slug, or abort) before re-asking.
 
 The slug the user approves in this step is the single source of truth for the epic label and must be used verbatim in step 4 (catalog handoff for children) and step 5 (epic tracking issue).
 
@@ -187,7 +220,7 @@ Epic:  #N  epic: <title>
 
 ## Constraints
 
-- After presenting a plan or draft, always request approval via the `AskUserQuestion` tool — not prose. A silent wait with no tool call (or a prose-only "let me know what you think") is a defect.
+- The plan and the `AskUserQuestion` approval call must be emitted in the **same assistant turn** — presenting the plan and ending the turn without calling `AskUserQuestion` is a defect, even if a prose invitation is included.
 - Never create issues without showing the plan and getting approval first
 - Never write plan files to disk — the plan lives in the conversation only
 - Only create an epic if there are 2 or more child issues — skip step 5 entirely for single-issue plans


### PR DESCRIPTION
## Summary
- Rewrite `speckit:spec` step 3 so the plan and `AskUserQuestion` call are emitted in a single assistant turn
- Add a before/after example contrasting the silent-wait failure mode with the correct shape
- Add a pre-end self-check requiring the last action in step 3 to be an `AskUserQuestion` call
- Audit sibling speckit skills with approval gates (catalog, issue) and apply the same pattern where applicable

## Sibling skills audited
- `speckit:catalog` step 3 — had the same prose-then-turn-end anti-pattern; hardened with bundled directive, before/after example, and pre-end self-check
- `speckit:issue` step 4 — same anti-pattern; same fix applied
- `speckit:interview` — no approval gate (by design; it is a sub-skill that returns output, not a user-facing approval step); no change needed

## Test plan
- Read the revised step 3 out of context and confirm the single-turn requirement is unmissable
- Confirm the before/after example shows the wrong shape (prose → turn end) vs right shape (prose + tool call)
- Confirm the pre-end self-check is present and references `AskUserQuestion`
- Confirm catalog step 3 and issue step 4 received the same treatment
- Confirm interview was reviewed and left unchanged (no approval gate)

Closes #460