### PR TITLE
release: 2026-04-19

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship — with runtime staging detection and a one-command hotfix flow.",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/polishkit/.claude-plugin/plugin.json
+++ b/plugins/polishkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polishkit",
   "description": "Codebase quality toolkit. Assess code craft with a connoisseur's eye, sweep for cruft and hygiene issues, and eliminate dead code — three focused skills for improving what you've already built.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/speckit/.claude-plugin/plugin.json
+++ b/plugins/speckit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "speckit",
   "description": "Define and capture work as GitHub issues. Interview a feature into existence with /spec, bulk-convert findings with /catalog, or quickly file a single issue with /issue.",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/speckit/skills/catalog/SKILL.md
+++ b/plugins/speckit/skills/catalog/SKILL.md
@@ -91,11 +91,40 @@ Epic: epic:<slug> (applied to every issue below)
 
 If `--auto` was passed in `$ARGUMENTS`, skip the approval step and proceed directly to issue creation.
 
-Otherwise, wait for user approval. The user may ask to:
+Otherwise, **in a single assistant turn**, emit (a) the catalog table above and (b) an `AskUserQuestion` call. Never end the turn after presenting the table without the tool call — a prose-only prompt like "let me know if you'd like changes" is a defect.
+
+**Wrong shape** (never do this):
+
+```
+| # | Title | Category | Priority | Labels |
+...
+Let me know if you'd like any adjustments.
+← turn ends here; silent wait
+```
+
+**Right shape** (always do this):
+
+```
+| # | Title | Category | Priority | Labels |
+...
+← immediately followed by AskUserQuestion in the same turn:
+AskUserQuestion("File these issues?", [
+  "Approve and file",
+  "Adjust priorities / titles",
+  "Remove some findings",
+  "Cancel"
+])
+```
+
+**Pre-end self-check**: Before ending the turn in step 3, verify that the last action is an `AskUserQuestion` call. If the table was shown but no tool call was made, emit the call immediately.
+
+The user may ask to:
 - Remove findings they don't want filed
 - Adjust priorities
 - Change titles or descriptions
 - Add additional context
+
+If adjustments are requested, update the table and re-present with a new `AskUserQuestion` in the same turn.
 
 ### 4. Create issues
 
@@ -142,6 +171,7 @@ Output the created issues as a table with links:
 ## Constraints
 
 - Never create issues without showing the user the catalog first (unless `--auto` was passed)
+- The catalog table and the `AskUserQuestion` approval call must be emitted in the **same assistant turn** — showing the table and ending the turn without calling `AskUserQuestion` is a defect
 - Never create duplicate issues — check `gh issue list` for similar titles before creating
 - Keep issue bodies concise — problem + impact + fix, nothing more
 - Match the label style already in the repo (don't impose a new scheme)

--- a/plugins/speckit/skills/issue/SKILL.md
+++ b/plugins/speckit/skills/issue/SKILL.md
@@ -59,7 +59,33 @@ Labels:   <type>, priority:<level>
 <body>
 ```
 
-After showing the preview, call the `AskUserQuestion` tool to request approval — a single question such as "File this issue?" with options like `File as shown`, `Adjust title / labels / body`, and `Cancel`. Do not proceed to step 5 until the user has answered via `AskUserQuestion` — prose-only prompts like "reply with any changes" are not sufficient. If the user selects an adjust or cancel option, loop back (update the draft or abort) before re-asking.
+**In a single assistant turn**, emit (a) the preview above and (b) an `AskUserQuestion` call. Never end the turn after the preview without the tool call.
+
+**Wrong shape** (never do this):
+
+```
+Title: Harden approval gates
+Labels: enhancement, priority:medium
+---
+## Problem ...
+Let me know if you'd like changes.
+← turn ends; silent wait
+```
+
+**Right shape** (always do this):
+
+```
+Title: Harden approval gates
+Labels: enhancement, priority:medium
+---
+## Problem ...
+← immediately followed by AskUserQuestion in the same turn:
+AskUserQuestion("File this issue?", ["File as shown", "Adjust title / labels / body", "Cancel"])
+```
+
+**Pre-end self-check**: Before ending the turn in step 4, verify that the last action is an `AskUserQuestion` call. If the preview was shown but no tool call was made, emit the call immediately.
+
+If the user selects an adjust or cancel option, loop back (update the draft or abort) before re-asking.
 
 ### 5. Ensure labels exist
 
@@ -77,7 +103,7 @@ Output the created issue URL.
 
 ## Constraints
 
-- After presenting a plan or draft, always request approval via the `AskUserQuestion` tool — not prose. A silent wait with no tool call (or a prose-only "let me know what you think") is a defect.
+- The draft preview and the `AskUserQuestion` approval call must be emitted in the **same assistant turn** — showing the preview and ending the turn without calling `AskUserQuestion` is a defect, even if a prose invitation is included.
 - Never create the issue without showing the preview first
 - Never skip the duplicate check
 - Keep body concise — problem + impact + fix only

--- a/plugins/speckit/skills/spec/SKILL.md
+++ b/plugins/speckit/skills/spec/SKILL.md
@@ -99,7 +99,40 @@ Always append the following documentation task as the final row, unless the spec
 
 Include the `## Epic label` section **only when the plan produces an epic** (2+ tasks). Omit it for single-issue plans. Render the derived label as a single, editable line, for example: `Epic label: epic:catalog-epic-labels`.
 
-Present the plan inline. Then call the `AskUserQuestion` tool to request approval — a single question such as "Approve this plan and file the issues?" with options like `Approve and file issues`, `Edit epic label`, `Adjust priorities / tasks`, and `Cancel`. Do not proceed to step 4 until the user has answered via `AskUserQuestion` — prose-only prompts like "reply with any changes" are not sufficient, since they don't surface an expected input in the UI. If the user selects an adjust, edit-label, or cancel option, loop back (update the plan, revise the slug, or abort) before re-asking.
+**In a single assistant turn**, emit (a) the plan markdown and (b) an `AskUserQuestion` call. Never end the turn after (a); always follow with (b) in the same response. A turn that presents the plan and stops — even with a prose invitation like "let me know what you think" — is a defect. The `AskUserQuestion` call is the only valid approval gate.
+
+The question must be "Approve this plan and file the issues?" with options: `Approve and file issues`, `Edit epic label`, `Adjust priorities / tasks`, `Cancel`.
+
+**Wrong shape** (never do this):
+
+```
+Here is the plan:
+## Goal
+Harden approval gates in speckit skills.
+...
+Let me know if you'd like changes.
+← turn ends here; silent wait
+```
+
+**Right shape** (always do this):
+
+```
+Here is the plan:
+## Goal
+Harden approval gates in speckit skills.
+...
+← immediately followed by AskUserQuestion in the same turn:
+AskUserQuestion("Approve this plan and file the issues?", [
+  "Approve and file issues",
+  "Edit epic label",
+  "Adjust priorities / tasks",
+  "Cancel"
+])
+```
+
+**Pre-end self-check**: Before ending the turn in step 3, verify that the last action in the turn is an `AskUserQuestion` call with approval options. If the plan was presented but no `AskUserQuestion` was called, emit the call immediately — do not end the turn without it.
+
+Do not proceed to step 4 until the user has answered via `AskUserQuestion`. If the user selects an adjust, edit-label, or cancel option, loop back (update the plan, revise the slug, or abort) before re-asking.
 
 The slug the user approves in this step is the single source of truth for the epic label and must be used verbatim in step 4 (catalog handoff for children) and step 5 (epic tracking issue).
 
@@ -187,7 +220,7 @@ Epic:  #N  epic: <title>
 
 ## Constraints
 
-- After presenting a plan or draft, always request approval via the `AskUserQuestion` tool — not prose. A silent wait with no tool call (or a prose-only "let me know what you think") is a defect.
+- The plan and the `AskUserQuestion` approval call must be emitted in the **same assistant turn** — presenting the plan and ending the turn without calling `AskUserQuestion` is a defect, even if a prose invitation is included.
 - Never create issues without showing the plan and getting approval first
 - Never write plan files to disk — the plan lives in the conversation only
 - Only create an epic if there are 2 or more child issues — skip step 5 entirely for single-issue plans

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/swarmkit/skills/squad/NOTES-context-signal.md
+++ b/plugins/swarmkit/skills/squad/NOTES-context-signal.md
@@ -1,0 +1,96 @@
+# Agent Teams context-usage signal — investigation
+
+## Goal
+
+Determine whether a `/squad` teammate can read its own context usage (tokens used, percentage of budget, or equivalent) from inside its own turn so the squad skill can implement preemptive handoff (epic #459) before the teammate hits its context limit.
+
+## Investigation steps
+
+All steps are reproducible against the official Claude Code documentation and the local repo on the date below. Fetched pages are the authoritative source; the findings below cite them directly.
+
+### 1. Agent Teams API surface
+
+Fetched <https://code.claude.com/docs/en/agent-teams> in full. The page describes the team model (lead, teammates, shared task list, mailbox) and every API primitive squad currently uses — `TeamCreate`, `Agent`/`Teammate` (spawn), `SendMessage`, `TeamDelete`, idle notifications — but defines no field, tool call, or event that exposes per-teammate token counts or context-usage percentages. The only teammate-health signals it documents are:
+
+- `idle_notification` — fires when a teammate stops (no token payload).
+- `isActive` in `~/.claude/teams/<team>/config.json` — boolean liveness flag, no usage data.
+- The page's own **Limitations** section, which lists no context-usage tooling.
+
+### 2. Task tool schemas (`TaskList`, `TaskGet`, `TaskCreate`, `TaskUpdate`)
+
+Third-party docs that describe the Agent Teams tool surface in more detail than the official page — the [Agent Teams tool reference gist](https://gist.github.com/kieranklaassen/4f2aba89594a4aea4ad64d753984b2ea) and the [superpowers issue #429 tool list](https://github.com/obra/superpowers/issues/429) — enumerate the returned fields:
+
+- `TaskGet` → `id, subject, description, status, owner, activeForm, blockedBy, blocks, createdAt, updatedAt`.
+- `TaskList` → formatted rows with `id, status, subject, owner`.
+- `TaskCreate` / `TaskUpdate` → no documented return schema beyond the task object.
+
+**No token count, no context percentage, no remaining-budget field on any of them.** Tasks carry work metadata only; they are not a teammate-health surface.
+
+### 3. Hooks
+
+Fetched <https://code.claude.com/docs/en/hooks> and <https://code.claude.com/docs/en/agent-sdk/hooks>. Every hook input payload was inspected for token fields. Result:
+
+- `TeammateIdle`, `TaskCreated`, `TaskCompleted` — fire around teammate lifecycle and task state, but their JSON payloads contain only `session_id, transcript_path, cwd, permission_mode, hook_event_name, teammate_name, team_name, idle_reason, task_id, task_subject, task_description`. No token/context field.
+- `PreCompact` / `PostCompact` — fire around auto-compaction (which is a *proxy* for approaching the context limit), but they carry only `session_id, transcript_path, cwd, hook_event_name, trigger` ∈ {`"manual"`, `"auto"`}. No token value is attached.
+- Every other hook (`PreToolUse`, `PostToolUse`, `SubagentStop`, `Stop`, `Notification`, `UserPromptSubmit`, `SessionStart`, `SessionEnd`, `ConfigChange`, `WorktreeCreate`, `WorktreeRemove`) — same story: session metadata plus event-specific data, no token-usage field.
+
+There is no hook that fires at a context threshold (e.g. 75%, 90%). `PreCompact` fires at the *auto-compact* point, which the harness decides and does not pre-announce.
+
+### 4. In-process signals available to the teammate itself
+
+Surveyed every place the teammate could read its own state from inside its turn:
+
+- **Env vars** (<https://code.claude.com/docs/en/env-vars> referenced from the commands page): `CLAUDE_CODE_*` vars exist for feature flags and limits, but none exposes the live context-usage counter.
+- **Slash commands** — `/context`, `/cost`, `/stats`, `/status` all surface context or token data, but they are **user-facing UI commands**; the commands page at <https://code.claude.com/docs/en/commands> describes them as interactive visualizations, and the skills page at <https://code.claude.com/docs/en/skills> explicitly notes that only a small allowlist of built-ins is invocable via the `Skill` tool (`/init`, `/review`, `/security-review`) — `/compact`, `/context`, `/cost`, `/stats` are not on that list. A teammate cannot invoke them and parse their output from within its own agent loop.
+- **Tool-result metadata** — no tool return documented in the Claude Code tools reference attaches a token-usage field to its result payload.
+- **System-reminder injection** — Claude Code auto-compaction produces a summary system message when the limit is reached, but that is a one-shot post-hoc event, not a pre-threshold signal the teammate can poll.
+
+### 5. Out-of-process signals that *do* exist (but aren't teammate-callable)
+
+Documented for completeness:
+
+- **Status line** (<https://code.claude.com/docs/en/statusline>) receives a JSON blob on stdin containing `context_window.used_percentage`, `context_window.remaining_percentage`, `context_window.total_input_tokens`, `context_window.total_output_tokens`, `context_window.context_window_size`, `context_window.current_usage.{input_tokens,output_tokens,cache_creation_input_tokens,cache_read_input_tokens}`, and `exceeds_200k_tokens`. This proves the harness *knows* per-session context usage — but only pushes it to an external display script, never to the model's own turn.
+- **Agent SDK `query()` result message** (<https://code.claude.com/docs/en/agent-sdk/cost-tracking>) exposes `total_cost_usd`, `modelUsage`, and per-step `usage.{input_tokens,output_tokens,cache_*}` to the SDK *caller*, not to the agent inside its own loop. A teammate is a Claude Code session, not the SDK caller, so it cannot read its own `ResultMessage`.
+
+### 6. Local repo search
+
+`Grep` for `context.?usage|token.?count|token.?budget|tokens.?used|context.?budget|context.?window|context.?limit|contextPercent|tokenCount` across the repo returns exactly one hit — a narrative reference to "agent context limits" in the root `README.md`. No existing squad or swarmkit code reads a context-usage field. `Grep` for `TaskList|TaskGet|TaskCreate|TaskUpdate|Teammate|team_name|isActive|used_percentage` across the repo returns only `plugins/swarmkit/skills/squad/SKILL.md`. There is no hidden prior art in this codebase that contradicts the findings above.
+
+## Findings
+
+**No signal exists at time of writing (2026-04-19).**
+
+Evidence:
+
+- The official Agent Teams page (<https://code.claude.com/docs/en/agent-teams>) defines no per-teammate context-usage API.
+- Every documented Agent Teams tool (`TaskList`, `TaskGet`, `TaskCreate`, `TaskUpdate`, `SendMessage`, `TeamCreate`, `TeamDelete`, `Teammate`) returns work-state or liveness data only.
+- Every hook event (`TeammateIdle`, `TaskCreated`, `TaskCompleted`, `PreCompact`, `PostCompact`, plus all non-teams hooks) omits any token-usage field from its input payload.
+- No bundled slash command that surfaces context data (`/context`, `/cost`, `/stats`) is callable from inside an agent turn — those UIs render to the user, not to a tool result the teammate can read.
+- Harness-level signals that *do* carry `context_window.used_percentage` (statusline stdin, SDK `ResultMessage.usage`) are one-way pushes to external consumers (shell scripts, SDK callers), not to the teammate's own turn.
+
+**Implication:** epic #459 cannot be built on a first-party, in-turn context-usage read. Any "teammate detects it is at 75% and warns the lead" mechanism needs a platform feature that does not exist today. Downstream squad tasks must either:
+
+1. Wait for the Claude Code platform to expose a per-session token/context read to the agent itself (e.g. a new tool like `ContextGet`, a reserved env var populated each turn, or a hook fired at a configurable threshold), **or**
+2. Fall back to a proxy heuristic. Candidates in descending order of signal quality:
+   - **Task-count heuristic** — the teammate tracks how many tasks / issues it has self-claimed since spawn and pushes a `teammate_warning` after N (e.g. 3 for builders). Crude but requires zero platform support.
+   - **Turn-count heuristic** — the teammate tracks its own assistant-turn count and warns above a threshold (each turn is a rough proxy for context consumed). Less crude than task count for the long-running reviewer, still zero-dependency.
+   - **Wall-clock heuristic** — warn after M minutes of active work. Weakest proxy because slow tasks consume less context than fast tool-heavy tasks.
+   - **`PreCompact` hook as a warning signal** — register a `PreCompact` hook in the squad spawn prompt and have it emit a `teammate_warning`; this fires only when auto-compact is about to run, so it is a *reactive* signal at ≈100% capacity, not the preemptive 75% trigger the epic specifies. Useful as a last-ditch backstop, not as the primary threshold check.
+
+None of the above can meet the epic's current acceptance criterion 2 ("context usage crosses a hard-coded 75% threshold"). The criterion is grounded in a signal that does not exist.
+
+## Implications for epic #459
+
+| Child | State | Action |
+|---|---|---|
+| #454 — "teammate threshold check" | **Blocked as specified.** | Re-scope before starting. Either wait on a platform feature or rewrite the acceptance criterion around a heuristic (task count is the cleanest proxy for builders; turn count works for the reviewer). |
+| #455 — "teammate-warning push to lead" | **Partly unblocked.** | The payload, successor-spawn flow, and naming scheme (`<role>-hN`) are independent of the signal — that work can proceed on top of whatever trigger #454 ends up using. Only the trigger source is blocked. |
+| Epic #459 acceptance #1 ("`SKILL.md` documents how a teammate reads its own context-usage signal") | **Must be rewritten.** | Current criterion assumes an API read. The real deliverable is "documents the heuristic it uses and why no direct read exists." This note is the citable source. |
+| Epic #459 acceptance #2 ("hard-coded 75% threshold") | **Must be rewritten.** | 75% of what is unmeasurable today. Replace with a heuristic threshold (e.g. "after 3 self-claimed tasks" for builders, "after 40 served audit requests" for the reviewer) or hold the whole epic until platform support lands. |
+| Epic #459 acceptance #3–8 (payload shape, teardown auto-force-clear, `-hN` naming, queue-drain policy) | **Unblocked.** | Independent of the signal source. |
+
+Recommended next step before unblocking #454 / #455: file a platform feature request upstream (Claude Code issue tracker) for a per-teammate context-usage read, and in parallel decide whether to ship the v1 of preemptive handoff on the task-count heuristic or wait. The task-count path is low-risk and testable today; the platform path is higher-quality but has no ETA.
+
+## Date
+
+2026-04-19


### PR DESCRIPTION
## Release summary

**Built from**: `rc/2026-04-19.14`

### Version bumps
- chore(plugins): bump swarmkit@2.7.1, flowkit@2.0.4, speckit@1.3.2, polishkit@1.0.2

### Changes

**speckit**
- docs(speckit): force single-turn plan+approval in spec step 3 (#461)

**swarmkit**
- docs(swarmkit): investigate Agent Teams context-usage signal (#462)

Closes #452
Closes #460