### PR TITLE
fix(flowkit): pick LAST_TAG by creation date, not version refname

### DIFF
--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -52,7 +52,9 @@ If `SOURCE` is empty, abort with an error — there is nothing to release.
 Find the last release tag and collect all `Closes/Fixes/Resolves #N` references from PRs merged into `develop` since that tag's date. The tag-date filter ensures only PRs from the current release cycle are included, not all PRs ever merged:
 
 ```bash
-LAST_TAG=$(git tag --list 'v[0-9]*' --sort=-version:refname | head -1)
+LAST_TAG=$(git for-each-ref --sort=-creatordate \
+  --format='%(refname:short)' \
+  'refs/tags/v[0-9]*' | head -1)
 
 if [ -n "$LAST_TAG" ]; then
   TAG_DATE=$(git log -1 --format=%aI "$LAST_TAG" \


### PR DESCRIPTION
## Summary
- Replace `git tag --list --sort=-version:refname` with `git for-each-ref --sort=-creatordate` when picking the most-recent release tag in step 4
- Prevents the issue-ref aggregator from using a stale floor when the `v{YYYY}.{M}.{D}.{N}` counter fills gaps (a later release may have a lower N than an older tag)

## Test plan
- Confirm step 4's `LAST_TAG` block uses creator date, not version refname
- Confirm step 8's tag increment logic is untouched
- Walk through the 2026-04-19 repro scenario from #466 mentally: with the fix, `LAST_TAG` on the second release would resolve to `v2026.4.19.12` (last created) rather than `v2026.4.19.14` (highest version), so the TAG_DATE floor would correctly exclude #461/#462's already-swept issue refs

Closes #466