### PR TITLE
refactor(flowkit): update hotfix cross-plugin reference to simplify-loop

### DIFF
--- a/plugins/flowkit/skills/hotfix/SKILL.md
+++ b/plugins/flowkit/skills/hotfix/SKILL.md
@@ -121,5 +121,5 @@ Summarize:
 - Always wait for user confirmation between branch creation (step 2) and committing (step 4)
 - Always back-merge main into develop after the hotfix lands
 - Tag directly on main — do not run a full RC cycle for hotfixes
-- No self-review step — hotfix is an emergency flow
+- No simplify-loop step — hotfix is an emergency flow
 - If any step fails, stop and report clearly — do not continue


### PR DESCRIPTION
## Summary
- Update hotfix SKILL.md to reference `simplify-loop` instead of renamed `self-review`
- Stacked on #478 (rename PR)

## Test plan
- `grep -i 'self[- ]review' plugins/flowkit/skills/hotfix/SKILL.md` returns zero hits
- Hotfix skill continues to document that it opts out of the simplification pass

Closes #472