### PR TITLE
docs: sweep documentation for simplify-loop rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ The development-lifecycle plugins form a complete loop from idea to release:
 /release       → ship merged work to production (flowkit)
 ```
 
+**swarmkit** runs a built-in `simplify-loop` after each agent finishes — iterative `/simplify` passes that tighten the code before opening the PR. This is a lightweight pre-PR sanity check, not a code review.
+
 **polishkit** sits between `/swarm` and `/release` as a quality gate: use `/critique` to assess elegance and craft, `/tidy-codebase` to sweep for stale files and cruft, and `/dead-code` to eliminate unused exports before shipping.
 
 **sessionkit** acts as connective tissue throughout: use `/handoff` to preserve state across agent context limits, `/skillit` to capture reusable patterns after a swarm, and `/suggest-permissions` to reduce approval friction over time.


### PR DESCRIPTION
## Summary

- Swept all documentation surfaces (root README, CLAUDE.md, plugin READMEs, docs/index.html, all other .md files) for stale `self-review` references
- Confirmed zero hits outside the already-handled `plugins/swarmkit/` (owned by #470) and `plugins/flowkit/skills/hotfix/` (owned by #472) directories — the rename was fully contained within swarmkit internals
- Added a sentence to the root README's "How the Plugins Compose" section clarifying that `simplify-loop` is an iterative `/simplify` pass (lightweight pre-PR sanity check), not a code review — making the rename semantics visible at the top-level docs surface

## Test plan

- `grep -rni -E 'self[- ]review' . --exclude-dir=.git --exclude-dir=.claude | grep -v 'plugins/swarmkit/' | grep -v 'plugins/flowkit/skills/hotfix/'` returns zero hits
- Root README reads correctly with the new `simplify-loop` description
- Compose section accurately distinguishes the built-in simplify-loop step from polishkit's quality gate

## Breaking change note

Next swarmkit release requires a **major** bump — skill slug `swarmkit:self-review` → `swarmkit:simplify-loop` breaks any caller referencing the old slug.

Closes #471