### PR TITLE
release: 2026-04-19

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ The development-lifecycle plugins form a complete loop from idea to release:
 /release       → ship merged work to production (flowkit)
 ```
 
+**swarmkit** runs a built-in `simplify-loop` after each agent finishes — iterative `/simplify` passes that tighten the code before opening the PR. This is a lightweight pre-PR sanity check, not a code review.
+
 **polishkit** sits between `/swarm` and `/release` as a quality gate: use `/critique` to assess elegance and craft, `/tidy-codebase` to sweep for stale files and cruft, and `/dead-code` to eliminate unused exports before shipping.
 
 **sessionkit** acts as connective tissue throughout: use `/handoff` to preserve state across agent context limits, `/skillit` to capture reusable patterns after a swarm, and `/suggest-permissions` to reduce approval friction over time.

--- a/docs/reviewkit-tracker.md
+++ b/docs/reviewkit-tracker.md
@@ -1,0 +1,1 @@
+Future work: reviewkit plugin — tracked in https://github.com/smallorbit/smallorbit-plugins/issues/476.

--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship — with runtime staging detection and a one-command hotfix flow.",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/flowkit/skills/hotfix/SKILL.md
+++ b/plugins/flowkit/skills/hotfix/SKILL.md
@@ -121,5 +121,5 @@ Summarize:
 - Always wait for user confirmation between branch creation (step 2) and committing (step 4)
 - Always back-merge main into develop after the hotfix lands
 - Tag directly on main — do not run a full RC cycle for hotfixes
-- No self-review step — hotfix is an emergency flow
+- No simplify-loop step — hotfix is an emergency flow
 - If any step fails, stop and report clearly — do not continue

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "2.7.2",
+  "version": "3.0.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -46,7 +46,7 @@ These are called by the skills above — you don't invoke them directly.
 
 | Skill | Used by | Purpose |
 |-------|---------|---------|
-| **self-review** | swarm | Runs iterative `/simplify` passes on changed files before PR creation. |
+| **simplify-loop** | swarm | Runs iterative `/simplify` passes on changed files before PR creation. |
 | **conventional-commit-message** | swarm | Enforces `type(scope): description` commit format. |
 | **gh-fetch-issues** | next-issue, swarm | Fetches open issues and filters out `on-hold` labeled ones. |
 | **issue-rank** | next-issue, swarm | Ranks issues by priority labels, specificity, and architectural impact. |

--- a/plugins/swarmkit/skills/simplify-loop/SKILL.md
+++ b/plugins/swarmkit/skills/simplify-loop/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: self-review
-description: Run up to 3 passes of /simplify on changed files, committing and pushing between passes. Sub-skill used by ship and swarm agents.
+name: simplify-loop
+description: Run up to 3 iterative /simplify passes on changed files, committing and pushing between passes. Sub-skill used by swarmkit:swarm.
 ---
 
-# Self-Review
+# Simplify Loop
 
 Iterative quality pass on changed files. Runs `/simplify` in a loop, committing improvements between passes.
 

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -199,8 +199,8 @@ Each agent prompt MUST include these **workflow steps** (in order):
 3. Stage and commit using conventional-commit-message format:
    - No Claude mentions, no co-author lines
    git add <files> && git commit -m "<type>(<scope>): <description>"
-4. Run self-review (invoke `swarmkit:self-review` on changed files). Self-review runs up to 3 simplification passes, committing and pushing between passes. When it converges it returns here — continue with the remaining steps below.
-5. Push final branch state (unconditional — idempotent if self-review already pushed the last pass):
+4. Run simplify loop (invoke `swarmkit:simplify-loop` on changed files). It runs up to 3 iterative /simplify passes, committing and pushing between passes. When it converges it returns here — continue with the remaining steps below.
+5. Push final branch state (unconditional — idempotent if simplify-loop already pushed the last pass):
    git push -u origin worktree-agent-<issue>
 6. Create PR targeting the appropriate base. The body MUST be a richer summary, not just `Closes #<issue>` — synthesize the `## Summary` bullets from the issue's acceptance criteria and your diff, and describe the `## Test plan` in terms of those acceptance criteria. Fill in the angle-bracket placeholders; do not copy them literally.
    # For independent issues:


### PR DESCRIPTION
## Release summary

**Built from**: `rc/2026-04-19.17`

### Version bumps
- chore(plugins): bump swarmkit@3.0.0 (MAJOR — breaking skill slug rename), flowkit@3.0.2 (patch — hotfix skill ref update)

### Changes

**flowkit**
- refactor(flowkit): update hotfix cross-plugin reference to simplify-loop (#472, stacked under #478)

**swarmkit**
- refactor(swarmkit): rename self-review to simplify-loop (#478) — breaking slug rename

**other**
- docs: sweep documentation for simplify-loop rename (#471, stacked under #478)
- docs: add reviewkit tracking pointer (#476, #477)

### Breaking changes
`swarmkit:self-review` skill slug has been renamed to `swarmkit:simplify-loop`. Any external callers referencing the old slug must update. Plugin cache may serve stale skill names until `/reload-plugins` or a new session.

Closes #470
Closes #471
Closes #472
Closes #473
Closes #474