### PR TITLE
release: 2026-04-19

### DIFF
--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sessionkit",
   "description": "Session continuity and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, plan through structured interviews, discover reusable skills, and reduce permission noise.",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/sessionkit/README.md
+++ b/plugins/sessionkit/README.md
@@ -27,8 +27,8 @@ claude --plugin-dir /path/to/sessionkit
 
 | Skill | Invoke | What it does |
 |-------|--------|--------------|
-| **handoff** | `/handoff` | Captures session goal, progress, git state, and remaining work into `.sessionkit/HANDOFF.md`. Use when context is running low or when switching agents. |
-| **pickup** | `/pickup` | Loads `.sessionkit/HANDOFF.md` at the start of a new session and orients the agent to continue seamlessly. |
+| **handoff** | `/handoff` | Captures session goal, progress, git state, remaining work, and active tasks into `.sessionkit/HANDOFF.md`. Use when context is running low or when switching agents. |
+| **pickup** | `/pickup` | Loads `.sessionkit/HANDOFF.md` at the start of a new session, orients the agent, and hydrates pending/in-progress tasks back into the task system. |
 | **skillit** | `/skillit` | Reflects on the current session to identify patterns worth encoding as reusable skills. Checks for existing overlap before proposing anything new. |
 | **suggest-permissions** | `/suggest-permissions` | Scans recent session history for repeatedly approved permissions and proposes additions to `.claude/settings.json` to reduce future prompts. |
 
@@ -62,15 +62,37 @@ claude --plugin-dir /path/to/sessionkit
 
 ## How Handoff / Pickup Works
 
-`/handoff` collects git state, todo files, and conversation history, synthesizes them into a structured document, prints it inline, then writes it immediately to `.sessionkit/HANDOFF.md` — no approval step. The only prompt is a one-time confirmation before adding `.sessionkit/` to `.gitignore`, if the entry is not already present.
+`/handoff` collects git state, todo files, conversation history, and the active task list, synthesizes them into a structured document, prints it inline, then writes it immediately to `.sessionkit/HANDOFF.md` — no approval step. The only prompt is a one-time confirmation before adding `.sessionkit/` to `.gitignore`, if the entry is not already present.
 
-`/pickup` reads that document at the start of a fresh session and produces an orientation summary — goal, progress, git state, remaining work, and key context — without re-executing anything.
+`/pickup` reads that document at the start of a fresh session, produces an orientation summary — goal, progress, git state, remaining work, and key context — and hydrates any serialized tasks back into the task system via `TaskCreate` and `TaskUpdate`.
 
 The two skills are intentionally separate: handoff writes, pickup reads. The handoff file is never modified or deleted by pickup.
 
+### Task Round-Trip
+
+`/handoff` snapshots every non-deleted task into a `## Task List` fenced JSON block inside `HANDOFF.md`. `/pickup` reads that block and recreates the tasks in the new session.
+
+**What survives the round-trip** (fields preserved verbatim):
+
+| Field | Notes |
+|-------|-------|
+| `id` | Carried in the snapshot to allow `blockedBy` rewiring; the new session assigns a fresh ID |
+| `subject` | Task title |
+| `description` | Full task description |
+| `activeForm` | The task's active form/view state |
+| `status` | Original status (`pending` or `in_progress`) — all recreated tasks start as `pending` |
+| `blockedBy` | Dependency edges; remapped to new IDs after all tasks are created |
+| `blocks` | Listed in the snapshot for reference; not re-wired (the inverse of `blockedBy` is implicit) |
+
+**What is not preserved**: `owner`, `metadata`.
+
+**Which tasks are restored**: only tasks with `status` of `pending` or `in_progress`. Completed tasks appear in the orientation summary as history but are not recreated.
+
+**Back-compat**: legacy `HANDOFF.md` files that were written before task-list support was added (i.e. no `## Task List` section) are fully valid. `/pickup` emits one warning line — `No task list snapshot — skipping hydration` — and continues with the orientation summary.
+
 ## Handoff Document Structure
 
-`.sessionkit/HANDOFF.md` is a structured Markdown file with these sections:
+`.sessionkit/HANDOFF.md` is a structured Markdown file with these sections, in order:
 
 | Section | Contents |
 |---------|----------|
@@ -78,6 +100,7 @@ The two skills are intentionally separate: handoff writes, pickup reads. The han
 | **Progress** | Bullet list of completed steps and key decisions made |
 | **Git State** | Current branch, staged/unstaged files, recent commits |
 | **Remaining Work** | Prioritized list of what still needs to be done |
+| **Task List** | Fenced JSON array of task objects (see Task Round-Trip above) |
 | **Context** | Gotchas, constraints, or non-obvious state the next agent must know |
 
 You can manually edit `.sessionkit/HANDOFF.md` between sessions — `/pickup` reads whatever is there.

--- a/plugins/sessionkit/skills/handoff/SKILL.md
+++ b/plugins/sessionkit/skills/handoff/SKILL.md
@@ -7,7 +7,7 @@ triggers:
   - "create handoff"
   - "save handoff"
   - "context is running low"
-allowed-tools: Bash, Read, Write
+allowed-tools: Bash, Read, Write, TaskList, TaskGet
 ---
 
 # Handoff
@@ -35,6 +35,8 @@ git log --oneline -5
 git diff --cached
 ```
 
+Also invoke `TaskList` to get all task IDs, then call `TaskGet` once per task ID to fetch full details. Collect every task that is **not** deleted (i.e. `status !== "deleted"`). This runs in parallel with the bash commands above.
+
 ### 2. Draft the document
 
 Synthesize the collected data plus conversation history into this exact structure:
@@ -61,6 +63,21 @@ How far we got — what's been completed, what's been decided.
 ## Remaining Work
 Outstanding todos and next steps in priority order.
 
+## Task List
+```json
+[
+  {
+    "id": "<task-id>",
+    "subject": "<subject>",
+    "description": "<description>",
+    "activeForm": "<activeForm>",
+    "status": "<status>",
+    "blockedBy": [],
+    "blocks": []
+  }
+]
+```
+
 ## Context
 Key decisions made, gotchas encountered, important notes the next agent must know.
 ```
@@ -69,6 +86,7 @@ Inference rules:
 - **Goal** — derive from branch name, recent commits, and the arc of the conversation.
 - **Progress** — what's been completed, decided, or abandoned this session.
 - **Remaining Work** — pull from the todo file and from any unfinished threads in the conversation; order by priority.
+- **Task List** — serialize the tasks collected in step 1 as a single fenced `json` code block. The JSON is an array of task objects. Include only these fields: `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, `blocks`. Exclude `owner`, `metadata`, and any deleted tasks. If no tasks exist, write an empty array `[]`. The `id` field preserves the original task ID so `/pickup` can wire `blockedBy` relationships in a follow-up pass.
 - **Context** — decisions, gotchas, dead ends, external references. Keep it to what the next agent genuinely needs.
 
 If `$ARGUMENTS` is provided, weave its guidance into the relevant sections (often Goal or Context).
@@ -108,3 +126,5 @@ Report the absolute path of the file written and suggest:
 - After presenting the draft, write it immediately — do not pause for approval
 - Keep the document concise — it's a recall aid, not full documentation
 - `.sessionkit/HANDOFF.md` in the working directory is the canonical location — never write elsewhere
+- Section order in HANDOFF.md is fixed: Goal → Progress → Git State → Remaining Work → Task List → Context
+- Legacy HANDOFFs that lack a `## Task List` section remain valid inputs to `/pickup` — its absence is not an error

--- a/plugins/sessionkit/skills/pickup/SKILL.md
+++ b/plugins/sessionkit/skills/pickup/SKILL.md
@@ -7,7 +7,7 @@ triggers:
   - "load handoff"
   - "resume from handoff"
   - "continue previous session"
-allowed-tools: Bash, Read
+allowed-tools: Bash, Read, TaskCreate, TaskUpdate, TaskList
 ---
 
 # Pickup
@@ -44,7 +44,35 @@ Output a structured summary to orient the agent. Surface essentials, not the doc
 - **Remaining Work** — list in priority order
 - **Context** — surface any important gotchas or notes the next agent must know
 
-### 4. Restore git state (if needed)
+### 4. Hydrate task list
+
+Parse the `## Task List` section from `.sessionkit/HANDOFF.md`:
+
+1. Locate the fenced ` ```json ` block immediately following the `## Task List` heading.
+2. If no `## Task List` section exists, or the JSON block is absent or unparseable, emit exactly one line in the orientation summary:
+   > `No task list snapshot — skipping hydration`
+   Then skip the remaining steps in this section and continue with step 5.
+
+**Pass 1 — create tasks:**
+
+For each task object in the array whose `status` is `pending` or `in_progress`:
+
+- Call `TaskCreate` with `subject`, `description`, and `activeForm` from the JSON object.
+  - `TaskCreate` always creates tasks as `pending`; do not attempt to force `in_progress` status.
+- Record the mapping `oldId → newId` (old `id` comes from the JSON; new `id` is returned by `TaskCreate`).
+
+Skip tasks whose `status` is `completed` — they are history and are already surfaced in the orientation summary.
+
+**Pass 2 — restore blockedBy edges:**
+
+After all `TaskCreate` calls complete, iterate the same set of created tasks. For each task that had a non-empty `blockedBy` array in the JSON:
+
+- Remap each old ID in `blockedBy` to its new ID using the map built in Pass 1.
+- Call `TaskUpdate` with `addBlockedBy` for the new task ID.
+
+Do not wire `blocks` — the inverse relationship is implicit and wiring both directions would double-write the graph.
+
+### 5. Restore git state (if needed)
 
 Compare the handoff's branch against the current branch:
 
@@ -60,7 +88,7 @@ git checkout <branch-from-handoff>
 
 Only suggest this when there's a mismatch. Do not switch branches automatically.
 
-### 5. Confirm readiness
+### 6. Confirm readiness
 
 End with:
 


### PR DESCRIPTION
## Release summary

**Built from**: `rc/2026-04-19.18`

### Version bumps
- chore(plugins): bump sessionkit@1.4.0

### Changes

**sessionkit**
- feat(sessionkit): snapshot TaskList into handoff (#487)
- feat(sessionkit): hydrate TaskList on pickup (#488)
- docs(sessionkit): document handoff/pickup task round-trip (#489)

Closes #483
Closes #484
Closes #485
Closes #486