### PR TITLE
docs(landing): remove metakit card and install command

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -359,23 +359,6 @@
             </div>
           </article>
 
-          <article class="plugin-card reveal" data-delay="6" data-kit="metakit">
-            <div class="plugin-card-head">
-              <div class="plugin-card-id">
-                <span class="plugin-name">metakit</span>
-                <span class="plugin-role">compose it</span>
-              </div>
-              <div class="plugin-meta">
-              </div>
-            </div>
-            <p class="plugin-desc">Dynamic orchestrator that composes sibling kits into multi-step scenarios. Detects what's installed, previews the plan, skips missing steps, pauses on risky ones, and halts with a state report on failure. <em>Pre-release.</em></p>
-            <ul class="skill-list">
-              <li><code>/kits</code> — report installed kits and runnable scenarios <em>(coming soon)</em></li>
-              <li><code>/polish-cycle</code> — critique → dead-code → tidy → file findings <em>(coming soon)</em></li>
-              <li><code>/handoff-cycle</code> — handoff → skillit → archive decisions <em>(coming soon)</em></li>
-            </ul>
-          </article>
-
         </div>
 
         <header class="plugin-category reveal">
@@ -469,10 +452,6 @@
                 <div class="code-copy-wrapper">
                   <pre><code>claude plugin install sessionkit@smallorbit-plugins</code></pre>
                   <button class="copy-btn" data-copy="claude plugin install sessionkit@smallorbit-plugins" aria-label="Copy sessionkit install command">copy</button>
-                </div>
-                <div class="code-copy-wrapper">
-                  <pre><code>claude plugin install metakit@smallorbit-plugins</code></pre>
-                  <button class="copy-btn" data-copy="claude plugin install metakit@smallorbit-plugins" aria-label="Copy metakit install command">copy</button>
                 </div>
                 <div class="install-sublabel">Utilities &amp; productivity</div>
                 <div class="code-copy-wrapper">


### PR DESCRIPTION
## Summary
- Remove the metakit plugin card (`<article class="plugin-card" data-kit="metakit">`) from the plugins section of `docs/index.html`.
- Remove the metakit `claude plugin install` block from the Install section.
- Verified no remaining `metakit` references in `docs/index.html`.

## Why
Metakit is parked on `origin/parked/metakit` and is not part of the released plugin catalog. The landing page was the only surface still advertising it, contradicting the root `README.md` (canonical source per `CLAUDE.md`) and offering visitors a copy-paste install command for a plugin that cannot be installed.

## Test plan
- Open `docs/index.html` in a browser and visually confirm no metakit card renders in the plugin grid and no metakit install command appears in the Install section.
- Confirm the `data-delay` staggered-reveal animation still works on sibling cards (metakit was `data-delay="6"`, last in its category — no renumbering was required).
- `grep -n metakit docs/index.html` returns no matches.

Closes #493