### PR TITLE
release: 2026-04-20

### DIFF
--- a/plugins/speckit/.claude-plugin/plugin.json
+++ b/plugins/speckit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "speckit",
   "description": "Define and capture work as GitHub issues. Interview a feature into existence with /spec, bulk-convert findings with /catalog, or quickly file a single issue with /issue.",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/speckit/README.md
+++ b/plugins/speckit/README.md
@@ -68,6 +68,23 @@ claude --plugin-dir /path/to/speckit
 
 Child issues are created via `/catalog`. An epic tracking issue is created last, after all child issue numbers are known. No issues are ever created without your explicit approval.
 
+### Simple-path shortcut
+
+Before running the full interview, `/spec` classifies the request as **simple** or **full** based on a quick codebase scan. A request qualifies as simple when it is a single conceptual change AND touches a single file (or a few tightly co-located files in one skill/module directory). `/spec` surfaces the proposed classification via `AskUserQuestion` before committing — the decision is never silent.
+
+On simple-path confirmation, `/spec` runs a single lightweight interview round (1–3 questions), drafts a one-task plan, and hands it to `/catalog` with **no `--epic` flag**. One standalone issue is filed — no epic tracking issue, no sub-issue wiring, no auto-appended documentation task (docs fold into the single issue's acceptance criteria). This keeps trivial changes from being inflated into multi-task epics.
+
+On rejection, the flow falls through to the full interview + epic path unchanged.
+
+### Consolidation signals
+
+When `/spec` runs the full interview path, the interview skill applies a silent consolidation pass before presenting the plan, so related tasks don't appear as separate issues when they should ship together. Four merge signals:
+
+1. **Same file + same logical change** — two tasks touching the same file and the same function or config block merge.
+2. **Strict ordering, no standalone value** — a task that can't ship without its predecessor and adds no independent acceptance criteria merges back into that predecessor.
+3. **Soft cap on epic size** — if the task count is still greater than 4 after signals 1 and 2, a second merge pass re-examines under looser interpretations of 1 and 2. The cap is a prompt to re-examine, not a hard limit — genuinely independent tasks are never forced together.
+4. **Docs-only tail merge** — if the auto-appended documentation task is the only non-implementation task remaining and the impl task(s) cover the same surface, docs fold into impl.
+
 ## How Catalog Works
 
 `/catalog` accepts findings from three sources (checked in order): explicit input in `$ARGUMENTS`, findings from earlier in the conversation, or a file path. It parses them into discrete issues, checks for existing duplicates and labels, shows a summary table for approval, then creates all issues in priority order (high first).

--- a/plugins/speckit/skills/interview/SKILL.md
+++ b/plugins/speckit/skills/interview/SKILL.md
@@ -77,10 +77,12 @@ Always append the following documentation task as the final row, unless the plan
 
 After drafting the candidate tasks table and before presenting the plan, run a silent consolidation pass. This pass merges over-decomposed tasks so the approval step shows a clean, actionable plan. The user sees only the consolidated result; they can still request splits during approval if needed.
 
-**Merge signals** — merge two tasks if EITHER fires:
+**Merge signals** — merge two tasks if ANY fires:
 
 1. **Same file + same logical change** — both tasks touch only the same single file and address related changes to the same function, section, or config block.
 2. **Strict ordering, no standalone value** — one task cannot ship without the other and provides no independent acceptance criteria (e.g. "wire up the X added in task A").
+3. **Soft cap on epic size** — after applying signals 1 and 2, if the consolidated task count is still **>4**, run a second merge pass that re-examines the table under looser interpretations of signals 1 and 2. In this pass, prefer broader task descriptions with multiple sub-bullets over fine-grained separate tasks. Stop when no further defensible merges remain — do **not** force the count below 4 if the remaining tasks are genuinely independent (different files, different surfaces, independent acceptance criteria). The soft cap is a prompt to re-examine, not a hard limit.
+4. **Docs-only tail merge** — if after the main pass the auto-appended "Update documentation" task is the only remaining non-implementation task AND the remaining implementation task(s) touch the same conceptual surface that the docs would cover, fold the docs task into the implementation task by adding a documentation bullet to its description. This signal only fires when there is one clear implementation task, or a small group of impl tasks touching the same surface — do not apply it when impl work spans multiple unrelated surfaces.
 
 Only merge when a signal clearly applies. Tasks that are legitimately independent — even if related — must not be merged. The goal is to eliminate redundant decomposition, not to collapse distinct work items.
 

--- a/plugins/speckit/skills/spec/SKILL.md
+++ b/plugins/speckit/skills/spec/SKILL.md
@@ -30,6 +30,10 @@ results before writing the plan in step 3.
 
 ### 2. Interview
 
+> **Path gate**: run step 2a first. It classifies the request and may
+> short-circuit the skill. Only run this step when step 2a selects
+> `Full interview`.
+
 Invoke `/speckit:interview` as a sub-skill, passing the freeform description from
 `$ARGUMENTS` as its input. Do not run inline `AskUserQuestion` rounds yourself —
 delegate the entire interview to `/speckit:interview` and wait for it to complete.
@@ -45,6 +49,56 @@ contain the following sections, which become the basis for the plan in step 3:
 
 Do not proceed to step 3 until `/speckit:interview` has produced a complete,
 unambiguous output with all five sections present.
+
+### 2a. Classify simple vs. full path
+
+**Execution order**: this step runs BEFORE step 2. Numbered 2a to keep later
+step numbers stable, but it is the first gate after step 1. The simple path
+exists to keep trivial changes from being inflated into multi-task epics.
+
+Using the codebase scan from step 1 and the shape of `$ARGUMENTS`, classify
+the request as **simple** or **full**.
+
+**Simple-path heuristic** — a request qualifies as simple only if BOTH hold:
+
+- **Single conceptual change** — one cohesive behaviour, fix, or tweak. Not a
+  bundle of independent changes hiding behind a shared theme.
+- **Single file, or tightly co-located files in one skill/module directory** —
+  the work touches one file, or a small number of files inside one
+  skill/module directory (e.g. `plugins/foo/skills/bar/*`).
+
+If either test fails (multiple conceptual changes, or changes spanning unrelated
+modules), the request is a full-path request.
+
+**Proposing the classification** — present the inferred classification to the
+user via a single `AskUserQuestion` call. Do not infer silently. State the
+inferred file(s) and one-line scope so the user can sanity-check the heuristic
+before choosing. Example:
+
+> "This looks like a small, single-file change. File as one standalone issue
+> via the simple path, or run the full interview?"
+>
+> Options: `Simple path — one issue`, `Full interview — epic path`, `Cancel`.
+
+**On `Simple path` confirmation** — short-circuit the rest of this skill:
+
+1. Run one lightweight interview round **inline in this skill** — a single
+   `AskUserQuestion` call with 1–3 questions covering the tightest remaining
+   gaps (scope, acceptance criteria, any blocking decision). Do NOT invoke
+   `speckit:interview` — keep the interview inline to preserve the short-circuit.
+2. Draft a single-issue plan with Goal, Background, Requirements, Out of Scope,
+   and exactly one task. Fold any documentation updates into that task's
+   acceptance criteria — do NOT append the auto-documentation task from the
+   full-interview flow.
+3. Show the plan and call `AskUserQuestion` for approval in the same turn (same
+   shape rules as step 3).
+4. On approval, hand the single task to `/catalog` with **no `--epic` flag**.
+   Catalog files one standalone issue. Skip step 2.5, step 5 (no epic tracking
+   issue), and the sub-issue / blocked-by wiring.
+5. Jump to step 6 to report the filed issue, then stop.
+
+**On `Full interview`**: fall through to step 2 (invoke `/speckit:interview`)
+unchanged. **On `Cancel`**: abort the skill.
 
 ### 2.5. Derive the epic slug
 


### PR DESCRIPTION
## Release summary

**Built from**: `rc/2026-04-20.1`

### Version bumps
- chore(plugins): bump speckit@1.4.0

### Changes

**speckit**
- feat(speckit): smarter /spec granularity with simple-path shortcut and tighter consolidation (#497)

Closes #496