### PR TITLE
refactor(docs): drop "land/landing" metaphor from merge-code terminology

### DIFF
--- a/.claude/skills/bump-versions/SKILL.md
+++ b/.claude/skills/bump-versions/SKILL.md
@@ -107,7 +107,7 @@ Use a single commit message listing all bumped plugins, e.g.:
 
 ### Step 5 — Create git tags
 
-After the commit lands, create a tag for each bumped plugin pointing at that commit:
+After the commit is pushed, create a tag for each bumped plugin pointing at that commit:
 
 ```bash
 git tag {plugin-name}--v{new-version}

--- a/.claude/skills/ship-plugins/SKILL.md
+++ b/.claude/skills/ship-plugins/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: ship-plugins
-description: Project-local landing command for this plugin monorepo. Reentrant chain — merge-stack → bump-versions → cut → release. Each stage gracefully skips if there's nothing to do, so an interrupted run can be resumed by re-invoking.
+description: Project-local skill that chains merge-stack → bump-versions → cut → release for this plugin monorepo. Reentrant — each stage gracefully skips if there's nothing to do, so an interrupted run can be resumed by re-invoking.
 triggers:
   - "/ship-plugins"
   - "ship plugins"
-  - "land the plugins"
 ---
 
 # Ship Plugins
@@ -15,7 +14,7 @@ Lives in `.claude/skills/` because this chain only makes sense for this monorepo
 
 ## When to use
 
-- After a swarm: land the stack, bump affected plugins, cut an RC, ship to main
+- After a swarm: merge the stack, bump affected plugins, cut an RC, ship to main
 - After merging PRs manually: catch up the bump / cut / release tail
 - To resume an interrupted run: re-invoke and each stage detects whether its work is done
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Swarm complete — 4 PRs opened:
   #212 feat(notes): render tag chips on note cards            → worktree-agent-103
   #213 feat(notes): filter notes by tag from the sidebar      → worktree-agent-104
 
-Stack root: #210. Run /merge-stack to land top-down.
+Stack root: #210. Run /merge-stack to merge top-down.
 ```
 
 ### 4. Ship it (optional — use your own process if you prefer)
@@ -114,7 +114,7 @@ Once the PRs look right, merge and release them however you normally would. If y
 /plugin install flowkit@smallorbit-plugins
 ```
 
-Then land everything in three commands:
+Then merge everything in three commands:
 
 ```
 /merge-stack     # merge all swarm PRs top-down into develop

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -40,7 +40,7 @@ claude --plugin-dir /path/to/flowkit
 | **cut** | `/cut` | Create a `rc/YYYY-MM-DD.N` release candidate from `develop`; auto-stages if a staging branch exists. |
 | **stage** | `/stage` | Force-reset the `staging` branch to a release candidate. No-op if staging doesn't exist. |
 | **release** | `/release` | Detect staging at runtime, merge to `main`, tag, close issues, clean up RC branches. |
-| **ship** | `/ship` | Repo-level landing command: `merge-stack` → `cut` → `release`. Run after a swarm to land everything. |
+| **ship** | `/ship` | Repo-level skill: `merge-stack` → `cut` → `release`. Run after a swarm to merge everything. |
 | **hotfix** | `/hotfix` | Emergency fix: branch off `main`, apply fix, PR to `main`, tag, back-merge to `develop`. |
 | **pipeline-status** | `/pipeline-status` | Show the full release pipeline: open PRs in flight, `develop` awaiting a cut, RCs/staging awaiting release, and the most recent tag. |
 
@@ -155,7 +155,7 @@ Flowkit is opinionated. Understanding these assumptions upfront will save you fr
 
 ### Branching Model: `develop` → `main` (with optional staging)
 
-Feature work lands in `develop`. Release candidates are cut from `develop`. Staging (if present) is an intermediate promotion gate. `main` always reflects what's in production.
+Feature work merges into `develop`. Release candidates are cut from `develop`. Staging (if present) is an intermediate promotion gate. `main` always reflects what's in production.
 
 ### RC Naming: `rc/YYYY-MM-DD.N`
 

--- a/plugins/flowkit/skills/hotfix/SKILL.md
+++ b/plugins/flowkit/skills/hotfix/SKILL.md
@@ -119,7 +119,7 @@ Summarize:
 ## Constraints
 
 - Always wait for user confirmation between branch creation (step 2) and committing (step 4)
-- Always back-merge main into develop after the hotfix lands
+- Always back-merge main into develop after the hotfix merges
 - Tag directly on main — do not run a full RC cycle for hotfixes
 - No simplify-loop step — hotfix is an emergency flow
 - If any step fails, stop and report clearly — do not continue

--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-pr
-description: Push the current branch and open a GitHub pull request. Use after committing changes to land work on develop.
+description: Push the current branch and open a GitHub pull request. Use after committing changes to merge work into develop.
 triggers:
   - "/open-pr"
   - "open a PR"

--- a/plugins/flowkit/skills/ship/SKILL.md
+++ b/plugins/flowkit/skills/ship/SKILL.md
@@ -1,10 +1,9 @@
 ---
 name: ship
-description: Repo-level landing command — merge all open swarm PRs, cut a release candidate, and promote to main. Run this after a swarm to land everything in one shot.
+description: Repo-level skill that merges all open swarm PRs, cuts a release candidate, and promotes to main. Run this after a swarm to merge everything in one shot.
 triggers:
   - "/ship"
   - "ship everything"
-  - "land the swarm"
   - "merge stack and release"
   - "ship after swarm"
 allowed-tools: Bash
@@ -12,7 +11,7 @@ allowed-tools: Bash
 
 # Ship
 
-Land a completed swarm run in one shot: merge all open swarm PRs into develop, cut a release candidate, and promote it to main.
+Merge a completed swarm run in one shot: merge all open swarm PRs into develop, cut a release candidate, and promote it to main.
 
 ## Input
 

--- a/plugins/swarmkit/METHODOLOGY.md
+++ b/plugins/swarmkit/METHODOLOGY.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-Swarmkit resolves a batch of GitHub issues by spawning one agent per issue, each working in its own isolated git worktree. When issues are independent, the agents run fully in parallel and open pull requests that target the base branch directly. When issues depend on one another, the dependent agent branches from its dependency's branch tip instead of from the base, and opens its pull request against that dependency's branch — forming a stack. A separate merge step then collapses the stack top-down, accumulating issue references as it goes, and lands the whole thing in the base branch with a single reviewable history.
+Swarmkit resolves a batch of GitHub issues by spawning one agent per issue, each working in its own isolated git worktree. When issues are independent, the agents run fully in parallel and open pull requests that target the base branch directly. When issues depend on one another, the dependent agent branches from its dependency's branch tip instead of from the base, and opens its pull request against that dependency's branch — forming a stack. A separate merge step then collapses the stack top-down, accumulating issue references as it goes, and merges the whole thing into the base branch with a single reviewable history.
 
-This shape exists because large features rarely factor cleanly into one pull request. The traditional alternatives are both painful: either the author opens one huge PR that is slow to review and risky to land, or they open a sequence of PRs manually and spend significant effort keeping branches rebased against one another. Stacked pull requests — pioneered in tools like Gerrit and Phabricator and popularized on GitHub by Graphite and Aviator — solve this by treating each change as a small, independently reviewable unit that is explicitly stacked on its predecessor. Swarmkit takes the same idea and combines it with agent parallelism: independent work happens concurrently, dependent work is stacked, and both categories share a single merge strategy.
+This shape exists because large features rarely factor cleanly into one pull request. The traditional alternatives are both painful: either the author opens one huge PR that is slow to review and risky to merge, or they open a sequence of PRs manually and spend significant effort keeping branches rebased against one another. Stacked pull requests — pioneered in tools like Gerrit and Phabricator and popularized on GitHub by Graphite and Aviator — solve this by treating each change as a small, independently reviewable unit that is explicitly stacked on its predecessor. Swarmkit takes the same idea and combines it with agent parallelism: independent work happens concurrently, dependent work is stacked, and both categories share a single merge strategy.
 
-The four ideas that make this work together are worktree isolation (so agents cannot step on each other), the stacked branch strategy (so dependent work can start before its predecessor lands), top-down merging with reference accumulation (so GitHub does not auto-close dependent PRs and so issue references survive the collapse), and loop mode with failure handling (so a long queue of issues can be cleared without manual babysitting).
+The four ideas that make this work together are worktree isolation (so agents cannot step on each other), the stacked branch strategy (so dependent work can start before its predecessor merges), top-down merging with reference accumulation (so GitHub does not auto-close dependent PRs and so issue references survive the collapse), and loop mode with failure handling (so a long queue of issues can be cleared without manual babysitting).
 
 ## Quick Start
 
@@ -15,7 +15,7 @@ If you just want to run a swarm and merge the result, this is the full shape of 
 ```
 /next-issue          # see what is ready to work on
 /swarm 12 15 18      # spawn parallel agents for specific issues
-/merge-stack         # land all open swarm PRs top-down (use /merge-pr for a single PR)
+/merge-stack         # merge all open swarm PRs top-down (use /merge-pr for a single PR)
 /clean-worktrees     # remove the worktree directories and orphaned branches
 ```
 
@@ -23,7 +23,7 @@ If you just want to run a swarm and merge the result, this is the full shape of 
 
 Each agent does the same thing: creates a branch named `worktree-agent-<issue>`, makes the changes described in the issue, commits in conventional-commit format, pushes, and opens a pull request whose body includes `Closes #<issue>`. The agent then stops. Nothing is merged automatically — swarm agents open PRs and leave them open for your review.
 
-When you are ready to land the stack, run `/merge-stack`. It identifies every open pull request whose head branch starts with `worktree-agent-`, works out the stack graph from the head/base relationships, and merges top-down — leaf PRs first, root PRs last, with issue references accumulating into each surviving PR body as the stack collapses. The final PR into the base branch carries the full set of closing references for the entire chain.
+When you are ready to merge the stack, run `/merge-stack`. It identifies every open pull request whose head branch starts with `worktree-agent-`, works out the stack graph from the head/base relationships, and merges top-down — leaf PRs first, root PRs last, with issue references accumulating into each surviving PR body as the stack collapses. The final PR into the base branch carries the full set of closing references for the entire chain.
 
 ## How It Works
 
@@ -67,11 +67,11 @@ The reason this works as a concurrency primitive is that the dependent agent alr
 
 ### Top-Down Merge with Ref Accumulation
 
-The naive way to land a stack is bottom-up: merge the PR that targets `develop` first, then the one above it, then the one above that. This fails badly on GitHub. When the bottom PR merges and its branch is deleted, the PR immediately above it loses its base branch, and GitHub interprets the missing base as abandonment and auto-closes the dependent PR. You end up fighting the platform to re-open and re-target PRs that were perfectly healthy a minute earlier.
+The naive way to merge a stack is bottom-up: merge the PR that targets `develop` first, then the one above it, then the one above that. This fails badly on GitHub. When the bottom PR merges and its branch is deleted, the PR immediately above it loses its base branch, and GitHub interprets the missing base as abandonment and auto-closes the dependent PR. You end up fighting the platform to re-open and re-target PRs that were perfectly healthy a minute earlier.
 
 `/merge-stack` merges top-down instead: leaf PRs first, then the PR below each leaf, cascading down until the root PR finally merges into the base branch. Intermediate merges deliberately omit `--delete-branch` so the base branch of the PR below survives for the next merge step. Only the final merge into the base branch deletes its branch.
 
-As each intermediate PR merges, its closing issue references are extracted from its body and appended to the body of the next PR down in the chain. By the time the root PR is merged, its body carries the complete set of `Closes #N` references for every issue in the chain. This matters for two reasons: the PR that lands in the base branch contains a full audit trail of what it resolved, and if the merge halts partway down (for example, because of a conflict), the lowest unmerged PR in the chain already contains every reference that successfully landed above it. Nothing is lost mid-collapse.
+As each intermediate PR merges, its closing issue references are extracted from its body and appended to the body of the next PR down in the chain. By the time the root PR is merged, its body carries the complete set of `Closes #N` references for every issue in the chain. This matters for two reasons: the PR that merges into the base branch contains a full audit trail of what it resolved, and if the merge halts partway down (for example, because of a conflict), the lowest unmerged PR in the chain already contains every reference that successfully merged above it. Nothing is lost mid-collapse.
 
 Independent PRs — those whose base is already `develop` and that no other PR sits on top of — may be merged in any order after the stacked chains resolve. They do not need the ref-accumulation dance because they are not part of a chain.
 
@@ -85,7 +85,7 @@ Failure is handled explicitly rather than by retrying. If an issue fails during 
 
 A small set of failures are treated as unrecoverable and halt the loop immediately: an agent that crashed without producing a PR (there is nothing to review, so there is nothing to proceed from) and the base branch being deleted or corrupted externally (the premise of the loop is gone). Everything else is recoverable and surfaces in the checkpoint report.
 
-Loop mode sets `claude.prBase` as a local git config at the start and unsets it in teardown. While it is set, every pull request created in the repository targets that base, which is what keeps independent PRs landing in the intended base branch even when the command line that created them did not specify `--base`. The teardown unset is critical — leaving the config set leaks the scoped base into unrelated PR-creation commands in the same repository.
+Loop mode sets `claude.prBase` as a local git config at the start and unsets it in teardown. While it is set, every pull request created in the repository targets that base, which is what keeps independent PRs merging into the intended base branch even when the command line that created them did not specify `--base`. The teardown unset is critical — leaving the config set leaks the scoped base into unrelated PR-creation commands in the same repository.
 
 ## End-to-End Walkthrough
 
@@ -117,7 +117,7 @@ Chain 1:  PR #203 → PR #202 → PR #201 → develop
   Step 5. Merge PR #201 into develop
 ```
 
-Step 1 squash-merges #203 into `worktree-agent-102`. The `--delete-branch` flag is omitted because `worktree-agent-103` is not a base-branch target. In step 2, `Closes #103` is appended to the body of #202. Step 3 squash-merges #202 into `worktree-agent-101`, again without deleting the branch. Step 4 appends `Closes #102` and `Closes #103` to the body of #201. Step 5 squash-merges #201 into `develop` with `--delete-branch`, closing issues #101, #102, and #103 in a single landing. Finally `/clean-worktrees` removes the three worktree directories and the three local `worktree-agent-*` branches.
+Step 1 squash-merges #203 into `worktree-agent-102`. The `--delete-branch` flag is omitted because `worktree-agent-103` is not a base-branch target. In step 2, `Closes #103` is appended to the body of #202. Step 3 squash-merges #202 into `worktree-agent-101`, again without deleting the branch. Step 4 appends `Closes #102` and `Closes #103` to the body of #201. Step 5 squash-merges #201 into `develop` with `--delete-branch`, closing issues #101, #102, and #103 in a single merge. Finally `/clean-worktrees` removes the three worktree directories and the three local `worktree-agent-*` branches.
 
 If anything had gone wrong on the way down — a merge conflict on #202, for example — the merge would have stopped there and reported the chain as halted at #202 with #201 as blocked downstream. PR #201's body would still carry the accumulated `Closes #103` reference from the successful #203 merge, so nothing from the completed work above is lost.
 

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -68,7 +68,7 @@ These are called by the skills above — you don't invoke them directly.
 2. Fetches issues, analyzes dependencies, and presents a swarm plan
 3. Spawns one agent per issue (or grouped set) in isolated git worktrees
 4. Each agent: creates branch, makes changes, commits, pushes, opens PR — then stops
-5. Use `/merge-pr` (1 PR, from [flowkit](../flowkit)) or `/merge-stack` (2+ PRs) to land into `develop` — top-down: leaf PRs first, root last
+5. Use `/merge-pr` (1 PR, from [flowkit](../flowkit)) or `/merge-stack` (2+ PRs) to merge into `develop` — top-down: leaf PRs first, root last
 6. Cleans up worktrees and orphaned branches
 
 **One-shot mode**: `/swarm 12 15 18` — resolve those issues and stop.
@@ -88,7 +88,7 @@ Swarmkit is opinionated. Understanding these assumptions upfront will save you f
 
 By default, all PRs target a `develop` branch. If `develop` doesn't exist, `/swarm` creates it from `main` automatically.
 
-This assumes a **release-branch workflow**: feature work lands in `develop`, and a release process promotes `develop` → `main`. Issues are intentionally left open after their PRs merge to `develop`; they're closed when the release ships.
+This assumes a **release-branch workflow**: feature work merges into `develop`, and a release process promotes `develop` → `main`. Issues are intentionally left open after their PRs merge to `develop`; they're closed when the release ships.
 
 **If you use trunk-based development** (everything goes to `main`):
 

--- a/plugins/swarmkit/skills/merge-stack/SKILL.md
+++ b/plugins/swarmkit/skills/merge-stack/SKILL.md
@@ -11,7 +11,7 @@ This avoids the auto-close cascade caused by bottom-up merging: merging bottom-u
 
 ## When to use
 
-Run after `/swarm` finishes. All swarm agents have pushed branches and opened PRs; none have merged yet. You've reviewed the PRs and are ready to land them.
+Run after `/swarm` finishes. All swarm agents have pushed branches and opened PRs; none have merged yet. You've reviewed the PRs and are ready to merge them.
 
 ## Process
 
@@ -127,7 +127,7 @@ sleep 3
 
 After the chain's root PR merges into `$BASE`, delete every intermediate `worktree-agent-*` branch from the remote. Intermediate branches are every `headRefName` whose `baseRefName` was another `worktree-agent-*` branch — these were captured when building the stack graph in step 2.
 
-Run this sweep immediately after the root merge so partial runs still clean up the chains that did land. Skip if there are no intermediate branches (single-PR chain or independent PR).
+Run this sweep immediately after the root merge so partial runs still clean up the chains that did complete. Skip if there are no intermediate branches (single-PR chain or independent PR).
 
 When the full list is available up front, batch the deletes into one push call to minimize round-trips. Fall back to per-branch deletes if the batch call fails (e.g. mixed stale refs):
 

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -253,7 +253,7 @@ Run `/clean-worktrees` to remove agent worktrees and orphaned branches. This fre
 | #18, #19 | #26 | chore/clean-hooks   | Open |
 ```
 
-All PRs are left open for review. If 1 PR open: use `/merge-pr` to land it into `develop`. If 2+ PRs: use `/merge-stack` — merges top-down: leaf PRs first, root last.
+All PRs are left open for review. If 1 PR open: use `/merge-pr` to merge it into `develop`. If 2+ PRs: use `/merge-stack` — merges top-down: leaf PRs first, root last.
 
 ---
 
@@ -288,7 +288,7 @@ If no open issues remain, announce "Board is clear" and exit.
 
 **Step 2 — Swarm**
 
-Run the one-shot swarm flow above on the batch. Independent issues target `$BASE` (enforced by `claude.flowkit.prBase`). Dependent issues target their dependency's branch, forming a stacked-PR chain that ultimately lands in `$BASE` when `swarmkit:merge-stack` cascades the merges.
+Run the one-shot swarm flow above on the batch. Independent issues target `$BASE` (enforced by `claude.flowkit.prBase`). Dependent issues target their dependency's branch, forming a stacked-PR chain that ultimately merges into `$BASE` when `swarmkit:merge-stack` cascades the merges.
 
 **Step 3 — Checkpoint**
 
@@ -326,7 +326,7 @@ Issues addressed: #12, #14, #15 (PRs open, awaiting review)
 Issues remaining: #25
 Open PRs: #31, #32, #33
 
-Open PRs are ready for review. If 1 PR open: use `/merge-pr` to land it into `$BASE`. If 2+ PRs: use `/merge-stack` — merges top-down: leaf PRs first, root last.
+Open PRs are ready for review. If 1 PR open: use `/merge-pr` to merge it into `$BASE`. If 2+ PRs: use `/merge-stack` — merges top-down: leaf PRs first, root last.
 ─────────────────────────────────────────────
 ```
 
@@ -345,7 +345,7 @@ When an issue fails at any point:
 
 ## Constraints
 
-- Never merge into `main` — all PRs ultimately land in `$BASE`; stacked (dependent) PRs may target an intermediate dependency branch and cascade into `$BASE` via `swarmkit:merge-stack`
+- Never merge into `main` — all PRs ultimately merge into `$BASE`; stacked (dependent) PRs may target an intermediate dependency branch and cascade into `$BASE` via `swarmkit:merge-stack`
 - Never pause between loop cycles — proceed immediately after printing the checkpoint summary
 - Never skip a failed issue's dependents — always analyze and block them
 - Every agent must work in an isolated worktree


### PR DESCRIPTION
## Summary
- Replaced the verb "land/lands/landing" with "merge/merges/merging" across 11 docs and skill files, wherever it refers to PRs, branches, or the release stack reaching a target branch.
- Dropped the "landing command" framing from `/ship` and `/ship-plugins` descriptions; rephrased by describing the action (e.g. "Repo-level skill that merges all open swarm PRs…").
- Removed the `"land the plugins"` and `"land the swarm"` trigger aliases; slash commands remain the primary invocation path.
- Left "landing page" (marketing site), file-placement uses (`edits land in the worktree`, `artifacts land in Obsidian`), and the `squad/NOTES-context-signal.md` "platform support lands" line untouched per scope.

## Test plan
- `grep -rniE '\bland(ing|s|ed)?\b' --include='*.md' --include='*.css' .` from repo root — remaining matches are only the in-scope exceptions: `landing page`/`landing-hero`/`landing page stylesheet` in `README.md`, `CLAUDE.md`, `docs/style.css`; `edits land in the isolated worktree` in `plugins/swarmkit/skills/swarm/SKILL.md`; `land edits in the primary checkout` in `plugins/swarmkit/METHODOLOGY.md` (same file-placement context); `Two artifacts land in Obsidian` in `plugins/vaultkit/README.md`; and `until platform support lands` in `plugins/swarmkit/skills/squad/NOTES-context-signal.md` (feature availability, not code merging).
- Read the diff to confirm sentence flow is natural and no frontmatter YAML broke.
- Sanity-check the `/ship` and `/ship-plugins` skills: `description:` and `triggers:` remain valid YAML with the two removed trigger lines cleanly dropped.

Closes #502