### PR TITLE
fix(speckit): enforce AskUserQuestion on plan presentation; forbid sub-skill handoff prose

### DIFF
--- a/plugins/speckit/README.md
+++ b/plugins/speckit/README.md
@@ -64,7 +64,7 @@ claude --plugin-dir /path/to/speckit
 
 ## How Spec Works
 
-`/spec` runs a structured interview using `AskUserQuestion` (1–4 questions per round), grounding each question in the actual codebase before asking. It continues until all ambiguities are resolved, then synthesizes a plan with goal, background, requirements, out-of-scope boundaries, and a task breakdown. The plan is shown for approval before any issues are filed.
+`/spec` runs a structured interview using `AskUserQuestion` (1–4 questions per round), grounding each question in the actual codebase before asking. It continues until all ambiguities are resolved, then synthesizes a plan with goal, background, requirements, out-of-scope boundaries, and a task breakdown. The plan and its approval prompt are always emitted in the same turn — the plan never appears without an immediate `AskUserQuestion` call to approve, adjust, re-scope, or cancel.
 
 Child issues are created via `/catalog`. An epic tracking issue is created last, after all child issue numbers are known. No issues are ever created without your explicit approval.
 
@@ -72,7 +72,9 @@ Child issues are created via `/catalog`. An epic tracking issue is created last,
 
 Before running the full interview, `/spec` classifies the request as **simple** or **full** based on a quick codebase scan. A request qualifies as simple when it is a single conceptual change AND touches a single file (or a few tightly co-located files in one skill/module directory).
 
-Classification is silent when the heuristic is confident. `/spec` narrates the routing inline (e.g. "This looks like a single-file, single-concept change — running simple path") and proceeds. An upfront `AskUserQuestion` prompt fires only when the heuristic is genuinely ambiguous — for example, a single file containing multiple plausibly-independent concepts, or an input that under-specifies scope. The user's escape hatch is the final plan-approval prompt in step 3, which includes a re-scope option on both paths (`Run full interview instead` on a simple-path plan, `Condense to single issue` on a full-path plan).
+Classification is silent when the heuristic is confident. `/spec` narrates the routing inline (e.g. "This looks like a single-file, single-concept change — running simple path") and proceeds. An upfront `AskUserQuestion` prompt fires only when the heuristic is genuinely ambiguous — for example, a single file containing multiple plausibly-independent concepts, or an input that under-specifies scope.
+
+On both paths the plan-presentation turn always ends with an `AskUserQuestion` approval call — it's the single, mandatory approval gate. The prompt includes a re-scope option on both paths (`Run full interview instead` on a simple-path plan, `Condense to single issue` on a full-path plan), so the final approval is also the escape hatch.
 
 On the simple path, `/spec` runs a single lightweight interview round (1–3 questions), drafts a one-task plan, and hands it to `/catalog` with **no `--epic` flag**. One standalone issue is filed — no epic tracking issue, no sub-issue wiring, no auto-appended documentation task (docs fold into the single issue's acceptance criteria). This keeps trivial changes from being inflated into multi-task epics.
 

--- a/plugins/speckit/skills/interview/SKILL.md
+++ b/plugins/speckit/skills/interview/SKILL.md
@@ -117,13 +117,17 @@ Present the plan inline.
 
 ### 4. Hand off
 
-If you were invoked as a sub-skill (e.g. from `/speckit:spec`), return the
-structured plan output and stop — do not emit any hand-off suggestion. The
-orchestrating skill handles next steps.
+**When invoked as a sub-skill** (e.g. from `/speckit:spec`), the final output
+of this skill is the structured plan and nothing else. Do NOT emit any
+trailing sentence, next-steps paragraph, `/catalog` suggestion, or hand-off
+prose. The orchestrating skill owns the handoff — your response ends at the
+Tasks table. Any trailing prose is a defect: it bleeds into the orchestrator's
+output and strands the user with no approval call.
 
-If you were invoked standalone, end the response by stating that the plan is
-ready to feed into `/speckit:catalog` to file the task list as prioritised,
-labelled GitHub issues. Do not file issues from this skill — hand off cleanly.
+**When invoked standalone** (via `/interview`), end the response by stating
+that the plan is ready to feed into `/speckit:catalog` to file the task list as
+prioritised, labelled GitHub issues. Do not file issues from this skill — hand
+off cleanly.
 
 ## Constraints
 

--- a/plugins/speckit/skills/spec/SKILL.md
+++ b/plugins/speckit/skills/spec/SKILL.md
@@ -47,6 +47,12 @@ contain the following sections, which become the basis for the plan in step 3:
 - **Out of Scope** — explicit exclusions
 - **Tasks** — decomposed work items
 
+Parse the structured sections (Goal, Background, Requirements, Out of Scope,
+Tasks) from the sub-skill output. Ignore any prose that appears after the
+Tasks table — it belongs to the sub-skill's standalone mode and must not
+influence the orchestrator's next action. The orchestrator owns the handoff
+from here: step 3 is the only approval gate.
+
 Do not proceed to step 3 until `/speckit:interview` has produced a complete,
 unambiguous output with all five sections present.
 
@@ -175,7 +181,15 @@ Always append the following documentation task as the final row, unless the spec
 
 Include the `## Epic label` section **only when the plan produces an epic** (2+ tasks). Omit it for single-issue plans. Render the derived label as a single, editable line, for example: `Epic label: epic:catalog-epic-labels`.
 
-**In a single assistant turn**, emit (a) the plan markdown and (b) an `AskUserQuestion` call. Never end the turn after (a); always follow with (b) in the same response. A turn that presents the plan and stops — even with a prose invitation like "let me know what you think" — is a defect. The `AskUserQuestion` call is the only valid approval gate and is the sole plan-filing approval for the skill on both paths.
+**Required turn shape**: the turn that presents the plan MUST contain, in
+this exact order, (a) the plan markdown and (b) exactly one `AskUserQuestion`
+tool call. Any turn that emits the plan and ends without the tool call is a
+defect and must be corrected by immediately emitting the `AskUserQuestion`
+call. This is non-negotiable — no prose ending (silent wait, `/catalog`
+hand-off suggestion, encouragement to reply, or any other text) is acceptable
+in place of the tool call. The `AskUserQuestion` call is the only valid
+approval gate and is the sole plan-filing approval for the skill on both
+paths.
 
 The options depend on whether the plan is a simple-path single issue or a
 full-path epic. `AskUserQuestion` supports max 4 options total (including
@@ -202,7 +216,7 @@ full-path epic. `AskUserQuestion` supports max 4 options total (including
   - On `Adjust plan`: revise the plan (priorities, tasks, or the epic label),
     then re-show with the same options.
 
-**Wrong shape** (never do this):
+**Wrong shape — silent wait** (never do this):
 
 ```
 Here is the plan:
@@ -212,6 +226,22 @@ Harden approval gates in speckit skills.
 Let me know if you'd like changes.
 ← turn ends here; silent wait
 ```
+
+**Wrong shape — `/catalog` hand-off prose** (never do this):
+
+```
+Here is the plan:
+## Goal
+Harden approval gates in speckit skills.
+...
+Plan ready to feed into `/speckit:catalog` to file as a single prioritised, labelled GitHub issue.
+← turn ends here
+```
+
+This is a defect — the `/catalog` hand-off prose was inherited from the
+interview sub-skill's standalone-mode wording and must not be propagated. The
+orchestrator owns the handoff and the only legitimate way to end this turn is
+with an `AskUserQuestion` call.
 
 **Right shape — full-path plan** (always do this):
 
@@ -239,8 +269,6 @@ AskUserQuestion("Approve this plan and file the issue?", [
   "Cancel"
 ])
 ```
-
-**Pre-end self-check**: Before ending the turn in step 3, verify that the last action in the turn is an `AskUserQuestion` call with approval options matching the path (simple or full). If the plan was presented but no `AskUserQuestion` was called, emit the call immediately — do not end the turn without it.
 
 Do not proceed to step 4 until the user has answered via `AskUserQuestion`. If the user selects an adjust, re-scope, or cancel option, loop back (revise the plan, fall through to the other path, or abort) before re-asking.
 
@@ -330,6 +358,7 @@ Epic:  #N  epic: <title>
 
 ## Constraints
 
+- A turn that presents the plan and ends without an `AskUserQuestion` call is a defect — whether the ending prose is silent waiting, a `/catalog` hand-off suggestion, or any other text.
 - The plan and the `AskUserQuestion` approval call must be emitted in the **same assistant turn** — presenting the plan and ending the turn without calling `AskUserQuestion` is a defect, even if a prose invitation is included.
 - Never create issues without showing the plan and getting approval first
 - Never write plan files to disk — the plan lives in the conversation only


### PR DESCRIPTION
## Summary
- Hardened `plugins/speckit/skills/interview/SKILL.md` step 4 so the sub-skill branch explicitly forbids any trailing handoff prose; the skill output ends at the Tasks table when invoked from `/speckit:spec`.
- Rewrote `plugins/speckit/skills/spec/SKILL.md` step 3's approval gate as a hard "Required turn shape" rule: the plan-presentation turn MUST include the `AskUserQuestion` tool call — no prose ending is acceptable. Added a third "Wrong shape" example showing today's `/catalog`-handoff defect.
- Spec step 2's interview-return paragraph now instructs the orchestrator to parse the structured sections and ignore any trailing prose from the sub-skill's standalone mode.
- Added a Constraints bullet making the defect-pattern explicit, and updated `plugins/speckit/README.md` to document the hardened rule.
- Step 2a's silent-on-confident classification (shipped in 1.4.1) is untouched — this fix hardens the single approval gate without reintroducing a second prompt.

## Test plan
- Manual regression: run `/spec` with a full-path (multi-file, multi-concept) input. Verify the plan-presentation turn ends with an `AskUserQuestion` call.
- Manual regression: run `/spec` with a clearly-simple input. Verify only one approval prompt appears (at step 3); no routing prompt at step 2a.
- Manual check: trigger an ambiguous classification; verify step 2a prompts once and step 3 prompts once (2 total), unchanged from current behaviour.

Closes #503