### PR TITLE
docs(swarmkit): surface bypassPermissions recommendation with safety caveats

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Claude Code plugins for plan, execute, and ship — each keeping you at the hand
 | Plugin | Install | Description |
 |--------|---------|-------------|
 | **[speckit](./plugins/speckit/)** | `/plugin install speckit@smallorbit-plugins` | Define and capture work through interviews and issue filing |
-| **[swarmkit](./plugins/swarmkit/)** | `/plugin install swarmkit@smallorbit-plugins` | Resolve GitHub issues with parallel worktree agents. See [METHODOLOGY.md](./plugins/swarmkit/METHODOLOGY.md) for the stacked agent/PR workflow in depth. For the experimental Agent Teams-based `/squad` variant, see [plugins/swarmkit/SETUP.md](./plugins/swarmkit/SETUP.md). |
+| **[swarmkit](./plugins/swarmkit/)** | `/plugin install swarmkit@smallorbit-plugins` | Resolve GitHub issues with parallel worktree agents. _Recommends elevated session permissions — see the plugin's [Permissions](./plugins/swarmkit/README.md#permissions) section._ See [METHODOLOGY.md](./plugins/swarmkit/METHODOLOGY.md) for the stacked agent/PR workflow in depth. For the experimental Agent Teams-based `/squad` variant, see [plugins/swarmkit/SETUP.md](./plugins/swarmkit/SETUP.md). |
 | **[polishkit](./plugins/polishkit/)** | `/plugin install polishkit@smallorbit-plugins` | Critique code quality, sweep for cruft, and eliminate dead code |
 | **[flowkit](./plugins/flowkit/)** | `/plugin install flowkit@smallorbit-plugins` | Manage the full git lifecycle from branch to release |
 | **[sessionkit](./plugins/sessionkit/)** | `/plugin install sessionkit@smallorbit-plugins` | Session continuity, context handoffs, and meta-learning |

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -27,6 +27,23 @@ claude --plugin-dir /path/to/swarmkit
 - [GitHub CLI](https://cli.github.com/) (`gh`) authenticated with repo access
 - Git configured with push access to your target repos
 
+## Permissions
+
+Swarmkit is designed to run best when agents don't have to pause for per-command approvals.
+
+**Recommendation.** Run your Claude Code session in `bypassPermissions` mode, or pre-approve an allowlist covering the commands swarm agents rely on (`git`, `gh`, and `bash` for internal tooling). See the Anthropic docs on [Claude Code permission modes](https://code.claude.com/docs/en/permission-modes) for the authoritative how-to — setting a default mode, starting a session with `--permission-mode`, and configuring allow/ask/deny rules.
+
+**Why.** Parallel agents working in isolated worktrees cannot usefully pause for per-command approvals — the whole point of the swarm is that they run concurrently, and interactive prompts defeat that.
+
+**Safety caveats.** These share billing with the recommendation, not footnote status:
+
+- Only use `bypassPermissions` on trusted repositories.
+- Only use it when you're willing for agents to push branches and open PRs without per-action review.
+- Isolated-worktree scoping limits blast radius to the repo, but a buggy or malicious agent could still commit and push harmful code.
+- Swarmkit leaves PRs open for human review by design — do not skip reviewing PRs before merging.
+
+**Agent-level bypass is already applied.** Swarm spawns each agent internally with `mode: "bypassPermissions"` so the agent itself runs without prompts; the user-facing question is whether you also want the same mode at the session level that orchestrates them.
+
 ## Skills
 
 ### User-Facing

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -5,6 +5,8 @@ description: Spawn parallel isolated-worktree agents for GitHub issues, open sta
 
 # Swarm Skill
 
+> See the swarmkit README's [Permissions](../../README.md#permissions) section for session-level permission guidance before first use.
+
 Spawn parallel agents for GitHub issues: $ARGUMENTS
 
 ## Arguments


### PR DESCRIPTION
## Summary
- Added a Permissions section near the top of `plugins/swarmkit/README.md` explaining swarmkit works best with `bypassPermissions` at the session level (or an equivalent allowlist), with the recommendation, rationale, and safety caveats sharing inline visual weight; linked to the official [Claude Code permission-modes docs](https://code.claude.com/docs/en/permission-modes) as the authoritative source.
- Added a one-line breadcrumb under the `# Swarm Skill` heading in `plugins/swarmkit/skills/swarm/SKILL.md` pointing to the new section, so users invoking `/swarm` directly land on the guidance before first use.
- Added an inline marker to the swarmkit row in the root `README.md` "Available plugins" table noting that it recommends elevated session permissions, with a link into the plugin's Permissions section.

## Test plan
- Read `plugins/swarmkit/README.md` top-to-bottom as a first-time user and confirm the Permissions section is reached before the Skills table and any walkthrough of the swarm flow.
- Click the Anthropic docs link and confirm it resolves to the canonical "Choose a permission mode" page (HTTP 200, covers `bypassPermissions` and session-level defaults).
- Parse `plugins/swarmkit/skills/swarm/SKILL.md` as YAML frontmatter + Markdown and confirm the frontmatter still has `name` and `description` keys intact.
- Confirm the recommendation and safety caveats share visual weight (both rendered as top-level bullets/bolded leads in the same section, not collapsed to a footnote).

Closes #507