### PR TITLE
add .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Román M. Pacheco <rmpacheco@gmail.com> Roman Pacheco <117180808+romanp-olo@users.noreply.github.com>


### PR DESCRIPTION
## Summary
- Adds a `.mailmap` entry so `git log`, `git blame`, `git shortlog`, and GitHub's commit listings resolve two older commits to the canonical author identity.

## Test plan
- [x] `git log --format='%h %aN <%aE>' <affected-sha>` shows the mapped identity
- [x] `git log --format='%h %an <%ae>' <affected-sha>` still shows the original (mailmap is display-only)