### PR TITLE
docs(pr-body): author canonical PR body specification

### DIFF
--- a/plugins/_shared/pr-body.md
+++ b/plugins/_shared/pr-body.md
@@ -20,7 +20,7 @@ Bulleted checklist (`- [ ]`) of verification steps. Each item is something a rev
 
 ## Issue-reference footer
 
-After the three sections, emit a blank line, then one token per line. Tokens use GitHub's closing-keyword grammar and appear at the end of the body.
+After the three sections, emit a blank line, then one token per line using GitHub's closing-keyword grammar.
 
 | Token | When to use |
 |-------|-------------|

--- a/plugins/_shared/pr-body.md
+++ b/plugins/_shared/pr-body.md
@@ -1,0 +1,63 @@
+# Canonical PR Body Specification
+
+Every PR opened by plugins in this repo uses the shape defined here. This is the single source of truth — skills that emit PR bodies reference this document rather than carrying their own copy.
+
+## Body shape
+
+A PR body has three sections in this order, followed by a footer of issue-reference tokens.
+
+### `## Summary`
+
+1–3 sentences derived from the diff and the commit messages on the branch. State what the change does and why. No bullets. No file paths. No restating the title.
+
+### `## Changes`
+
+Bulleted list of concrete changes, each with a file reference where applicable. One bullet per logical change, not per file. Group related edits. Keep bullets tight — a reviewer should be able to scan the list and predict the diff.
+
+### `## Test plan`
+
+Bulleted checklist (`- [ ]`) of verification steps. Each item is something a reviewer or CI can actually check. Prefer behavioral checks ("PR body renders with all three sections") over implementation checks ("function returns correct value"). If the change is pure docs or config, the checklist may be short — but it must exist.
+
+## Issue-reference footer
+
+After the three sections, emit a blank line, then one token per line. Tokens use GitHub's closing-keyword grammar and appear at the end of the body.
+
+| Token | When to use |
+|-------|-------------|
+| `Closes #N` | The child issue `#N` is fully resolved by this PR. GitHub will auto-close it on merge to the default branch. |
+| `Refs #N` | The parent epic `#N`, or any issue this PR only partially advances. Does not auto-close. |
+
+Rules:
+
+- Emit one `Closes #N` line per fully-resolved child issue.
+- Emit one `Refs #N` line for the parent epic, if any.
+- Emit additional `Refs #N` lines for partial-progress references (PR advances the issue but does not close it).
+- Do not use `Fixes` or `Resolves` in newly authored bodies — they are accepted by downstream aggregators for back-compat but `Closes` is canonical here.
+
+## Worked example
+
+```markdown
+## Summary
+
+Standardize the PR body shape across flowkit and swarmkit so reviewers see the same three sections on every PR and release-time ref aggregation picks up every `Closes` token. The convention now lives in one file instead of being duplicated across skills.
+
+## Changes
+
+- Author `plugins/_shared/pr-body.md` as the canonical spec (this file).
+- Update `plugins/flowkit/skills/open-pr/SKILL.md` to reference the canonical shape and forward commit-message tokens to the footer.
+- Update `plugins/swarmkit/skills/swarm/SKILL.md` agent template to reference the canonical Summary rules.
+
+## Test plan
+
+- [ ] Open a PR via `flowkit:open-pr` and confirm the body has `## Summary`, `## Changes`, and `## Test plan`.
+- [ ] Include `Closes #123` in a commit message; confirm it appears in the PR footer.
+- [ ] Run `flowkit:release` and confirm ref aggregation still collects `Closes` tokens from merged PRs.
+- [ ] Spawn a `swarmkit:swarm` agent and confirm its PR emits `## Summary` + `## Test plan` + `Closes #<issue>`.
+
+Closes #521
+Closes #522
+Refs #526
+Refs #530
+```
+
+In this example: `#521` and `#522` are fully-resolved child issues that auto-close on merge; `#526` is the parent epic (kept open); `#530` is a related issue this PR advances but does not finish.

--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -64,24 +64,82 @@ Use the first applicable source:
 2. The most recent commit message subject line
 3. The branch name converted to title case (strip prefix, replace hyphens with spaces)
 
-### 5. Determine PR body
+### 5. Discover issue-ref tokens from commit messages
 
-Use the first applicable source:
-1. `$ARGUMENTS` if it contains a longer description
-2. The full body of the most recent commit message
-3. A minimal placeholder referencing the branch
+Scan every commit on the branch (since divergence from `$BASE`) for issue-reference tokens. Match case-insensitively against `closes|fixes|refs|resolves #<number>`, but emit each match **verbatim** (preserving the author's original casing). Deduplicate while keeping first-seen order.
 
-### 6. Open the PR
+```bash
+REFS=$(git log "origin/$BASE..HEAD" --pretty=format:'%B' \
+  | grep -oiE '(closes|fixes|refs|resolves) #[0-9]+' \
+  | awk '!seen[tolower($0)]++')
+```
+
+`$REFS` is a newline-delimited list of tokens (possibly empty). These are appended verbatim to the PR body footer. Do not re-derive closure rules — honor what the author wrote in the commits.
+
+### 6. Assemble the PR body
+
+Emit the canonical three-section body (see template below), followed by a blank line and the discovered ref tokens (if any).
+
+- `## Summary` — 1–3 sentences derived from the diff and the commit messages on the branch. If `$ARGUMENTS` contains a longer description, use it to inform the Summary. Otherwise, synthesize from `git log "origin/$BASE..HEAD"` and `git diff "origin/$BASE..HEAD" --stat`.
+- `## Changes` — bulleted list of concrete changes, one bullet per logical change (not per file). Derive from the diff and commit subjects.
+- `## Test plan` — bulleted checklist (`- [ ]`) of verification steps a reviewer or CI can actually check.
+- Footer — blank line, then `$REFS` verbatim, one token per line.
+
+#### Body template
+
+<!-- include: plugins/_shared/pr-body.md -->
+
+The canonical spec is duplicated inline below until publish-time include expansion lands. When that infrastructure ships, only the include marker above remains and this block is removed.
+
+> # Canonical PR Body Specification
+>
+> Every PR opened by plugins in this repo uses the shape defined here. This is the single source of truth — skills that emit PR bodies reference this document rather than carrying their own copy.
+>
+> ## Body shape
+>
+> A PR body has three sections in this order, followed by a footer of issue-reference tokens.
+>
+> ### `## Summary`
+>
+> 1–3 sentences derived from the diff and the commit messages on the branch. State what the change does and why. No bullets. No file paths. No restating the title.
+>
+> ### `## Changes`
+>
+> Bulleted list of concrete changes, each with a file reference where applicable. One bullet per logical change, not per file. Group related edits. Keep bullets tight — a reviewer should be able to scan the list and predict the diff.
+>
+> ### `## Test plan`
+>
+> Bulleted checklist (`- [ ]`) of verification steps. Each item is something a reviewer or CI can actually check. Prefer behavioral checks ("PR body renders with all three sections") over implementation checks ("function returns correct value"). If the change is pure docs or config, the checklist may be short — but it must exist.
+>
+> ## Issue-reference footer
+>
+> After the three sections, emit a blank line, then one token per line using GitHub's closing-keyword grammar.
+>
+> | Token | When to use |
+> |-------|-------------|
+> | `Closes #N` | The child issue `#N` is fully resolved by this PR. GitHub will auto-close it on merge to the default branch. |
+> | `Refs #N` | The parent epic `#N`, or any issue this PR only partially advances. Does not auto-close. |
+>
+> Rules:
+>
+> - Emit one `Closes #N` line per fully-resolved child issue.
+> - Emit one `Refs #N` line for the parent epic, if any.
+> - Emit additional `Refs #N` lines for partial-progress references (PR advances the issue but does not close it).
+> - Do not use `Fixes` or `Resolves` in newly authored bodies — they are accepted by downstream aggregators for back-compat but `Closes` is canonical here.
+
+**Override rule for `open-pr`**: when tokens come from commit messages on the branch, emit them **verbatim** — do not rewrite `Fixes`/`Resolves` into `Closes`. The canonical guidance above applies to newly authored bodies; `open-pr` forwards what the author committed.
+
+### 7. Open the PR
 
 ```bash
 gh pr create \
   --base "$BASE" \
   --head "$(git rev-parse --abbrev-ref HEAD)" \
   --title "<title>" \
-  --body "<body>"
+  --body "<assembled body from step 6>"
 ```
 
-### 7. Report
+### 8. Report
 
 Output the PR URL returned by `gh pr create`.
 

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -165,8 +165,25 @@ $UNSCOPED_COMMITS
 "
 fi
 
+# --- narrative summary ---
+# Synthesize a 1–3 sentence narrative from the collected merged-PR summaries
+# and version bumps. State what this release contains overall — e.g.
+# "Ship swarmkit stacked-merge bugfix alongside flowkit hotfix workflow tidy-up."
+# Do not list individual file paths or repeat the title. Keep it to 3 sentences max.
+NARRATIVE_SUMMARY="<!-- Write 1–3 sentences summarising what this release contains.
+Derive the narrative from the version bumps and grouped changes computed above.
+Example: "Ship swarmkit stacked-merge bugfix alongside flowkit hotfix workflow tidy-up." -->"
+
 # --- assemble PR body ---
-PR_BODY="## Release summary
+# <!-- include: plugins/_shared/pr-body.md -->
+# The body shape below follows the canonical PR body spec defined in
+# plugins/_shared/pr-body.md: Summary → Release summary → Version bumps →
+# Changes → issue-reference footer. Keep that order.
+PR_BODY="## Summary
+
+$NARRATIVE_SUMMARY
+
+## Release summary
 
 **Built from**: \`$SOURCE\`"
 

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -205,6 +205,10 @@ Each agent prompt MUST include these **workflow steps** (in order):
 5. Push final branch state (unconditional — idempotent if simplify-loop already pushed the last pass):
    git push -u origin worktree-agent-<issue>
 6. Create PR targeting the appropriate base. The body MUST be a richer summary, not just `Closes #<issue>` — synthesize the `## Summary` bullets from the issue's acceptance criteria and your diff, and describe the `## Test plan` in terms of those acceptance criteria. Fill in the angle-bracket placeholders; do not copy them literally.
+
+   <!-- include: plugins/_shared/pr-body.md -->
+   <!-- Summary-content rules derive from the canonical doc; `## Changes` is intentionally omitted for single-issue swarm PRs — Summary is sufficient when the scope is one issue. -->
+
    # For independent issues:
    gh pr create --base develop --head worktree-agent-<issue> \
      --title "<type>(<scope>): <description>" \


### PR DESCRIPTION
## Summary

- Adds `plugins/_shared/pr-body.md` as the single source of truth for PR body shape across all plugins (unblocks #521, #522, #523, #525).
- Specifies the three required sections (`## Summary`, `## Changes`, `## Test plan`) and the footer token grammar (`Closes #N` for resolved children, `Refs #N` for epic parents / partial progress).
- Includes a concrete worked example covering both token types.

## Test plan

- [ ] File exists at `plugins/_shared/pr-body.md` and is not under an individual plugin directory.
- [ ] All three body sections are described with their purpose and derivation rules.
- [ ] Footer grammar distinguishes `Closes` from `Refs` with a usage rubric.
- [ ] Worked example shows all three sections plus both token types in a realistic PR body.

Closes #520

Closes #521
Refs #526
Closes #523
Refs #526
Closes #522
Refs #526
