### PR TITLE
feat(flowkit:open-pr): emit canonical body and forward commit ref tokens

### DIFF
--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -64,24 +64,82 @@ Use the first applicable source:
 2. The most recent commit message subject line
 3. The branch name converted to title case (strip prefix, replace hyphens with spaces)
 
-### 5. Determine PR body
+### 5. Discover issue-ref tokens from commit messages
 
-Use the first applicable source:
-1. `$ARGUMENTS` if it contains a longer description
-2. The full body of the most recent commit message
-3. A minimal placeholder referencing the branch
+Scan every commit on the branch (since divergence from `$BASE`) for issue-reference tokens. Match case-insensitively against `closes|fixes|refs|resolves #<number>`, but emit each match **verbatim** (preserving the author's original casing). Deduplicate while keeping first-seen order.
 
-### 6. Open the PR
+```bash
+REFS=$(git log "origin/$BASE..HEAD" --pretty=format:'%B' \
+  | grep -oiE '(closes|fixes|refs|resolves) #[0-9]+' \
+  | awk '!seen[tolower($0)]++')
+```
+
+`$REFS` is a newline-delimited list of tokens (possibly empty). These are appended verbatim to the PR body footer. Do not re-derive closure rules — honor what the author wrote in the commits.
+
+### 6. Assemble the PR body
+
+Emit the canonical three-section body (see template below), followed by a blank line and the discovered ref tokens (if any).
+
+- `## Summary` — 1–3 sentences derived from the diff and the commit messages on the branch. If `$ARGUMENTS` contains a longer description, use it to inform the Summary. Otherwise, synthesize from `git log "origin/$BASE..HEAD"` and `git diff "origin/$BASE..HEAD" --stat`.
+- `## Changes` — bulleted list of concrete changes, one bullet per logical change (not per file). Derive from the diff and commit subjects.
+- `## Test plan` — bulleted checklist (`- [ ]`) of verification steps a reviewer or CI can actually check.
+- Footer — blank line, then `$REFS` verbatim, one token per line.
+
+#### Body template
+
+<!-- include: plugins/_shared/pr-body.md -->
+
+The canonical spec is duplicated inline below until publish-time include expansion lands. When that infrastructure ships, only the include marker above remains and this block is removed.
+
+> # Canonical PR Body Specification
+>
+> Every PR opened by plugins in this repo uses the shape defined here. This is the single source of truth — skills that emit PR bodies reference this document rather than carrying their own copy.
+>
+> ## Body shape
+>
+> A PR body has three sections in this order, followed by a footer of issue-reference tokens.
+>
+> ### `## Summary`
+>
+> 1–3 sentences derived from the diff and the commit messages on the branch. State what the change does and why. No bullets. No file paths. No restating the title.
+>
+> ### `## Changes`
+>
+> Bulleted list of concrete changes, each with a file reference where applicable. One bullet per logical change, not per file. Group related edits. Keep bullets tight — a reviewer should be able to scan the list and predict the diff.
+>
+> ### `## Test plan`
+>
+> Bulleted checklist (`- [ ]`) of verification steps. Each item is something a reviewer or CI can actually check. Prefer behavioral checks ("PR body renders with all three sections") over implementation checks ("function returns correct value"). If the change is pure docs or config, the checklist may be short — but it must exist.
+>
+> ## Issue-reference footer
+>
+> After the three sections, emit a blank line, then one token per line using GitHub's closing-keyword grammar.
+>
+> | Token | When to use |
+> |-------|-------------|
+> | `Closes #N` | The child issue `#N` is fully resolved by this PR. GitHub will auto-close it on merge to the default branch. |
+> | `Refs #N` | The parent epic `#N`, or any issue this PR only partially advances. Does not auto-close. |
+>
+> Rules:
+>
+> - Emit one `Closes #N` line per fully-resolved child issue.
+> - Emit one `Refs #N` line for the parent epic, if any.
+> - Emit additional `Refs #N` lines for partial-progress references (PR advances the issue but does not close it).
+> - Do not use `Fixes` or `Resolves` in newly authored bodies — they are accepted by downstream aggregators for back-compat but `Closes` is canonical here.
+
+**Override rule for `open-pr`**: when tokens come from commit messages on the branch, emit them **verbatim** — do not rewrite `Fixes`/`Resolves` into `Closes`. The canonical guidance above applies to newly authored bodies; `open-pr` forwards what the author committed.
+
+### 7. Open the PR
 
 ```bash
 gh pr create \
   --base "$BASE" \
   --head "$(git rev-parse --abbrev-ref HEAD)" \
   --title "<title>" \
-  --body "<body>"
+  --body "<assembled body from step 6>"
 ```
 
-### 7. Report
+### 8. Report
 
 Output the PR URL returned by `gh pr create`.
 


### PR DESCRIPTION
## Summary

Update `flowkit:open-pr` so every PR opened by `/pr` and `/open-pr` (including `flowkit:hotfix` and other callers) emits the canonical three-section body shape and forwards issue-ref tokens discovered in commit messages. This is the highest-leverage leaf skill for human-authored PRs — fixing it here standardizes bodies across every flowkit flow.

## Changes

- Replace the ad-hoc "use first applicable source" body heuristic in `plugins/flowkit/skills/open-pr/SKILL.md` with a canonical assembly step that emits `## Summary` + `## Changes` + `## Test plan`.
- Add a new step that scans `git log origin/$BASE..HEAD` for `closes|fixes|refs|resolves #N` tokens (case-insensitive, deduped), and forwards them verbatim to the PR body footer — honoring what the author wrote rather than re-deriving closure rules.
- Embed a `<!-- include: plugins/_shared/pr-body.md -->` marker and inline the canonical spec beneath it until publish-time include expansion ships.
- Preserve existing contract: base-branch resolution via `claude.flowkit.prBase`, protected-branch guard, plain `git push -u origin HEAD`, and `gh pr create` call site are unchanged.

## Test plan

- [ ] Run `/open-pr` on a branch with commits containing `Closes #123` and `Fixes #456`; confirm both tokens appear verbatim in the PR body footer.
- [ ] Confirm the emitted body has `## Summary`, `## Changes`, and `## Test plan` headings in that order.
- [ ] Confirm the skill file contains `<!-- include: plugins/_shared/pr-body.md -->` with the canonical spec duplicated inline below it.
- [ ] Confirm `claude.flowkit.prBase` override still targets the configured base branch.
- [ ] Confirm no regression for `flowkit:hotfix`, which calls `open-pr` as its leaf step.

Closes #521
Refs #526