### PR TITLE
refactor(swarmkit:swarm): reference canonical PR body spec from agent template

### DIFF
--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -205,6 +205,10 @@ Each agent prompt MUST include these **workflow steps** (in order):
 5. Push final branch state (unconditional — idempotent if simplify-loop already pushed the last pass):
    git push -u origin worktree-agent-<issue>
 6. Create PR targeting the appropriate base. The body MUST be a richer summary, not just `Closes #<issue>` — synthesize the `## Summary` bullets from the issue's acceptance criteria and your diff, and describe the `## Test plan` in terms of those acceptance criteria. Fill in the angle-bracket placeholders; do not copy them literally.
+
+   <!-- include: plugins/_shared/pr-body.md -->
+   <!-- Summary-content rules derive from the canonical doc; `## Changes` is intentionally omitted for single-issue swarm PRs — Summary is sufficient when the scope is one issue. -->
+
    # For independent issues:
    gh pr create --base develop --head worktree-agent-<issue> \
      --title "<type>(<scope>): <description>" \


### PR DESCRIPTION
## Summary

- Adds an `<!-- include: plugins/_shared/pr-body.md -->` marker with an inline explanatory note directly above the agent PR template in SKILL.md step 6, so Summary-content rules are sourced from the canonical doc rather than maintained inline.
- Preserves the exact template shape (`## Summary` + `## Test plan` + `Closes #<issue>`) with no `## Changes` section — intentionally omitted for single-issue swarm PRs where Summary is sufficient.
- The skill continues to instruct agents to synthesize `## Summary` bullets from the issue's acceptance criteria and the diff; only the authority for those rules now points to the canonical source.

## Test plan

- [ ] Open `plugins/swarmkit/skills/swarm/SKILL.md` and confirm the include marker `<!-- include: plugins/_shared/pr-body.md -->` appears just above the `# For independent issues:` line in step 6.
- [ ] Confirm the inline note explains that Summary-content rules derive from the canonical doc and that `## Changes` is intentionally omitted.
- [ ] Confirm the template body still contains exactly `## Summary`, `## Test plan`, and `Closes #<issue>` — no `## Changes` section added.
- [ ] Spawn a swarmkit agent and verify its PR body emits the three expected sections without `## Changes`.

Closes #523
Refs #526