### PR TITLE
feat(flowkit:release): prepend narrative Summary to release PR body

### DIFF
--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -165,8 +165,25 @@ $UNSCOPED_COMMITS
 "
 fi
 
+# --- narrative summary ---
+# Synthesize a 1–3 sentence narrative from the collected merged-PR summaries
+# and version bumps. State what this release contains overall — e.g.
+# "Ship swarmkit stacked-merge bugfix alongside flowkit hotfix workflow tidy-up."
+# Do not list individual file paths or repeat the title. Keep it to 3 sentences max.
+NARRATIVE_SUMMARY="<!-- Write 1–3 sentences summarising what this release contains.
+Derive the narrative from the version bumps and grouped changes computed above.
+Example: "Ship swarmkit stacked-merge bugfix alongside flowkit hotfix workflow tidy-up." -->"
+
 # --- assemble PR body ---
-PR_BODY="## Release summary
+# <!-- include: plugins/_shared/pr-body.md -->
+# The body shape below follows the canonical PR body spec defined in
+# plugins/_shared/pr-body.md: Summary → Release summary → Version bumps →
+# Changes → issue-reference footer. Keep that order.
+PR_BODY="## Summary
+
+$NARRATIVE_SUMMARY
+
+## Release summary
 
 **Built from**: \`$SOURCE\`"
 


### PR DESCRIPTION
## Summary

- Prepends a `## Summary` section (1–3 sentence narrative synthesized from merged-PR summaries and version bumps) to the release PR body, above the existing release-summary / version-bumps / grouped-changes sections.
- Embeds an include marker `<!-- include: plugins/_shared/pr-body.md -->` near the body-template section, with inline spec content preserved below it until publish-time expansion lands.
- Preserves the existing `Closes #N` aggregation from merged PRs unchanged.

## Test plan

- [ ] Release PR body now begins with `## Summary` followed by existing sections.
- [ ] Version-bump table and grouped changes are unchanged.
- [ ] `Closes` refs from merged PRs still aggregate into the footer.
- [ ] Include marker present and points at `plugins/_shared/pr-body.md`.

Closes #522
Refs #526