### PR TITLE
fix(flowkit:merge-pr): inline label step after gh-label-merged-issues removal

### DIFF
--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -45,7 +45,21 @@ gh pr merge "$PR_NUM" --squash --delete-branch
 
 ### 4. Label referenced issues
 
-Follow the `gh-label-merged-issues` sub-skill, passing `PR_NUM` as input. It will parse the PR body for `Closes/Fixes/Resolves #N` references and apply the `merged-to-develop` label to each referenced issue (skipping any with the `on-hold` label).
+Parse the PR body for `Closes/Fixes/Resolves #N` references (case-insensitive) and apply the `merged-to-develop` label to each referenced issue. Skip any issue labeled `on-hold`.
+
+```bash
+gh label list | grep -q "^merged-to-develop" || \
+  gh label create "merged-to-develop" --description "PR merged to develop; awaiting release" --color "0E8A16"
+
+gh pr view "$PR_NUM" --json body --jq .body \
+  | grep -oiE '(closes|fixes|resolves) #[0-9]+' \
+  | grep -oE '[0-9]+' \
+  | sort -u \
+  | while read N; do
+      gh issue view "$N" --json labels --jq '.labels[].name' | grep -q "^on-hold$" && continue
+      gh issue edit "$N" --add-label "merged-to-develop"
+    done
+```
 
 ### 5. Report
 


### PR DESCRIPTION
## Summary

- `flowkit:merge-pr` step 4 referenced `gh-label-merged-issues`, a sub-skill that lived at `plugins/swarmkit/skills/gh-label-merged-issues/` and was removed in PR #103 alongside swarmkit's auto-merge flow. The cross-plugin reference was left dangling.
- Inline the labeling logic directly into `merge-pr/SKILL.md` — parse the PR body for `Closes/Fixes/Resolves #N` tokens (case-insensitive), ensure the `merged-to-develop` label exists, and apply it to each referenced issue while skipping any `on-hold` issues.
- Since `merge-pr` was the only remaining caller, inlining removes the dangling reference without losing any reuse.

## Background

Discovered during a `/flowkit:merge-pr 530` run today: the skill instructions pointed at a sub-skill that doesn't exist in the installed plugin cache. Git archaeology traced it to commit `5b9cef9` (PR #103, 2026-04-17), which intentionally removed the sub-skill but scoped its cleanup to swarmkit and missed flowkit's reference. No existing skill reads the `merged-to-develop` label, so nothing else broke — the labeling step was just silently skipped whenever `merge-pr` ran.

## Test plan

- [ ] Run `/merge-pr <PR>` against a PR whose body contains `Closes #N` — verify `#N` gains `merged-to-develop` after merge.
- [ ] Run it against a PR that closes multiple issues — verify all are labeled.
- [ ] Run it against a PR that references an `on-hold` issue — verify that issue is skipped.
- [ ] Run it against a PR with no closure tokens — verify it exits cleanly.
- [ ] Verify the `merged-to-develop` label is auto-created if missing.