### PR TITLE
docs(readme): document PR-body standard and canonical spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,3 +30,5 @@ Run it before staging and committing the release.
 ## Skill Authoring Conventions
 
 **Bash loop convention**: Never use `for N in $VAR` to iterate over newline-delimited output — word splitting is unreliable across shell contexts. Always pipe directly: `some-command | while read N; do ... done`.
+
+**PR body standard**: All PRs opened by agents in this repo must follow the canonical three-section shape (`## Summary`, `## Changes`, `## Test plan`) plus an issue-reference footer. The spec lives at [`plugins/_shared/pr-body.md`](./plugins/_shared/pr-body.md) — reference it instead of inventing a local format.

--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ Each plugin's README describes how it pairs with the others.
 
 See each plugin's README for detailed usage.
 
+## Conventions
+
+### PR body
+
+All PRs opened by agents in this repo follow a canonical three-section shape (`## Summary`, `## Changes`, `## Test plan`) plus an issue-reference footer. See [`plugins/_shared/pr-body.md`](./plugins/_shared/pr-body.md) for the full spec.
+
+### Commit messages
+
+Agents use [Conventional Commits](https://www.conventionalcommits.org/) (`type(scope): description`). The swarmkit conventional-commit-message skill documents the exact rules.
+
 ## License
 
 MIT — see [LICENSE](./LICENSE).


### PR DESCRIPTION
## Summary

Document the PR-body standard shipped in epic #526 at the repo's top-level entry points so new contributors discover the convention without reading individual skill files. Both README.md and CLAUDE.md now link to the canonical spec rather than duplicating it.

## Changes

- Add a **Conventions** section to `README.md` that links to `plugins/_shared/pr-body.md` and briefly describes the three-section body shape. Also notes the conventional-commits rule alongside.
- Add a **PR body standard** bullet to `CLAUDE.md` under Skill Authoring Conventions, pointing at the same canonical spec so agents opening PRs pick up the rule from global context.

## Test plan

- [ ] `README.md` renders with the new Conventions section and the link to `plugins/_shared/pr-body.md` resolves on GitHub.
- [ ] `CLAUDE.md` contains the PR body standard bullet under Skill Authoring Conventions.
- [ ] Neither file duplicates the spec contents — both are pointer edits.

Closes #525
Refs #526