### PR TITLE
fix(flowkit:release): resolve recurring jq control-char errors at the root — zsh echo un-escapes JSON

### DIFF
--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -88,23 +88,36 @@ echo "$ISSUE_REFS" | grep -oE '[0-9]+' | sort -u | while read CHILD_N; do
 done
 
 if [ -n "$ISSUE_REFS" ]; then
+  SKIPPED_EPICS_FILE=$(mktemp)
   gh issue list --label "epic" --state open --json number --jq '.[].number' \
   | while read EPIC_N; do
-    SUB_ISSUES=$(gh api "repos/$REPO/issues/$EPIC_N/sub_issues" 2>/dev/null || echo '[]')
-    SUB_ISSUES=$(printf '%s' "$SUB_ISSUES" | tr -d '\000-\010\013-\037')
-    TOTAL=$(echo "$SUB_ISSUES" | jq 'length')
-    [ "$TOTAL" = "0" ] && continue
+    # Let gh invoke jq internally. Never round-trip JSON through a shell
+    # variable: zsh's `echo` un-escapes backslash sequences by default, so
+    # `echo "$SUB_ISSUES" | jq` turns escaped control chars (\n, \t, \")
+    # inside string values into raw control bytes — invalid JSON. This is
+    # the root cause behind prior recurrences (#328, #355, #482); a `tr`
+    # filter cannot fix it because the hazardous bytes are 0x09 / 0x0a,
+    # which are legitimate JSON whitespace between tokens.
+    CHILDREN=$(gh api "repos/$REPO/issues/$EPIC_N/sub_issues" \
+      --jq 'if length > 0 and all(.state == "closed") then .[].number else empty end' \
+      2>/dev/null)
+    if [ $? -ne 0 ]; then
+      echo "$EPIC_N" >> "$SKIPPED_EPICS_FILE"
+      echo "Warning: failed to fetch or parse sub_issues for epic #$EPIC_N — skipping (will be listed in release report)" >&2
+      continue
+    fi
 
-    OPEN_COUNT=$(echo "$SUB_ISSUES" | jq '[.[] | select(.state == "open")] | length')
-    [ "$OPEN_COUNT" != "0" ] && continue
+    [ -z "$CHILDREN" ] && continue
 
-    for CHILD_N in $(echo "$SUB_ISSUES" | jq -r '.[].number'); do
+    for CHILD_N in $CHILDREN; do
       if echo "$ISSUE_REFS" | grep -qiE "(closes|fixes|resolves) #${CHILD_N}\\b"; then
         echo "Closes #$EPIC_N" >> "$EPIC_REFS_FILE"
         break
       fi
     done
   done
+
+  SKIPPED_EPICS=$(sort -u "$SKIPPED_EPICS_FILE" 2>/dev/null); rm -f "$SKIPPED_EPICS_FILE"
 fi
 
 EPIC_REFS=$(sort -u "$EPIC_REFS_FILE"); rm -f "$EPIC_REFS_FILE"
@@ -272,6 +285,7 @@ Output:
 - PR number and URL
 - Issues closed
 - RC branches deleted
+- Epics skipped due to sub_issues parse error, if any — read `$SKIPPED_EPICS` (set in step 4). When non-empty, list each epic number and remind the operator to check manually and add `Closes #N` to the release PR body if needed.
 
 ## Constraints
 


### PR DESCRIPTION
## Summary

Third recurrence of the jq control-character parse error during epic-closing ref aggregation (#328, #355). Root cause is not a missing `tr` filter — it's that zsh's `echo` interprets backslash escapes by default, so `echo "$SUB_ISSUES" | jq` converted escaped control chars (`\n`, `\t`, `\"`) inside JSON string values into raw control bytes, producing invalid JSON. The existing `tr -d '\000-\010\013-\037'` preserved `\t` (0x09) and `\n` (0x0a) — exactly the bytes echo was producing — and cannot be tightened further because those bytes are legitimate JSON whitespace between tokens. That's why two prior surface-level `tr` fixes both regressed.

Fix stops round-tripping JSON through a shell variable entirely. `gh api` now feeds gh's embedded jq directly via `--jq '<filter>'`, so the JSON bytes stream from gh's stdout into jq without ever passing through zsh word-splitting. Parse or fetch failures log the offending epic number and surface it in the release report so silent-skip no longer masks real misses.

## Changes

- Rewrite the native sub-issues API block in `plugins/flowkit/skills/release/SKILL.md` step 4 to call `gh api ... --jq 'if length > 0 and all(.state == "closed") then .[].number else empty end'`, replacing the `echo "$SUB_ISSUES" | jq` pipeline and the upstream `printf | tr` sanitiser.
- Capture the combined fetch+parse exit status; on failure append the epic number to `$SKIPPED_EPICS_FILE`, emit a warning on stderr, and skip the epic. After the loop, read the deduped list into `$SKIPPED_EPICS` for downstream use.
- Add a comment explaining the zsh-echo root cause so the next reader does not reach for another `tr` flag.
- Extend step 12 (Report) with an "Epics skipped due to sub_issues parse error" line that surfaces `$SKIPPED_EPICS` when non-empty, reminding the operator to add `Closes #N` manually.

## Test plan

- [ ] Exercise the new block against current open epics (e.g. `#256`, `#459`) and confirm zero jq errors on stderr plus the expected `Closes #N` entries for epics whose children are all closed.
- [ ] Call `gh api` with a bogus epic number to force a non-zero exit and confirm the epic lands in `$SKIPPED_EPICS` with the warning printed.
- [ ] Confirm the `gh api --jq` filter returns empty output (not an error) for an epic with zero sub_issues.
- [ ] Cut a real release via `/flowkit:release` and confirm the report step lists skipped epics when any, omits the line when none.

Closes #482
Refs #328
Refs #355