### PR TITLE
feat(swarmkit): scaffold swarm-experimental skill with preflight script

### DIFF
--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -51,6 +51,7 @@ Swarmkit is designed to run best when agents don't have to pause for per-command
 | Skill | Invoke | What it does |
 |-------|--------|--------------|
 | **swarm** | `/swarm` | Spawn parallel isolated-worktree agents to resolve GitHub issues. Supports one-shot mode (specific issues) and loop mode (clear the board). Auto-creates PRs targeting `develop`. |
+| **swarm-experimental** | `/swarm-experimental` | Experimental parallel variant of `/swarm`. Script-backed mechanical phases (preflight, teardown) reduce model round-trips. Same arg grammar and behavior as `/swarm` — prefer `/swarm` for stable workflows. |
 | **next-issue** | `/next-issue` | Fetches open issues, ranks them by priority, specificity, and architectural impact, and recommends what to work on next. |
 | **merge-stack** | `/merge-stack` | Merges all open swarm PRs top-down (leaf PRs first, root last). |
 | **clean-worktrees** | `/clean-worktrees` | Removes all agent worktrees and their orphaned `worktree-agent-*` branches. |
@@ -155,6 +156,18 @@ Swarmkit executes work; [speckit](../speckit) defines it. Use them together for 
 [Sessionkit](../sessionkit) complements swarmkit throughout: use `/handoff` to preserve state when context runs low mid-swarm, and `/skillit` after a swarm to capture reusable patterns that emerged.
 
 ## Experimental features
+
+### `swarm-experimental`
+
+A parallel, experimental variant of `/swarm`. It accepts the same arguments and produces the same outcomes, but collapses deterministic mechanical phases — preflight, issue gathering, post-agent verification, and loop-mode teardown — into shell scripts rather than conversational model steps. This reduces model round-trips for work that doesn't require judgment.
+
+**When to use it**: dogfooding script-extraction changes or benchmarking round-trip reduction. `/swarm` remains the stable entry point — if anything misbehaves, fall back to it.
+
+```
+/swarm-experimental 12 15 18
+```
+
+No special setup is required beyond what `/swarm` needs. See [Prerequisites](#prerequisites) and [Permissions](#permissions).
 
 ### `squad`
 

--- a/plugins/swarmkit/skills/swarm-experimental/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-experimental/SKILL.md
@@ -333,14 +333,7 @@ Proceed immediately to the next cycle after printing the checkpoint summary. The
 ### Teardown
 
 1. Run the `clean-worktrees` skill
-2. Restore the base branch (worktree removal may drift the shell to a detached HEAD or a different branch):
-   ```bash
-   git checkout $BASE && git pull origin $BASE
-   ```
-3. Unset `claude.flowkit.prBase` to clear the scoped PR base:
-   ```bash
-   git config --local --unset claude.flowkit.prBase
-   ```
+2. Run `scripts/teardown.sh` (optionally `--base <branch>` to override the default `develop`). Parse the returned JSON and confirm `base_restored: true`. If `config_unset: false`, log that `claude.flowkit.prBase` was already clear — this is not a failure.
 
 Optionally, run `swarmkit:clean-remote-worktrees` afterwards to sweep orphaned remote `worktree-agent-*` branches left behind by merged PRs. This is not automatic — invoke it when you want to tidy up.
 

--- a/plugins/swarmkit/skills/swarm-experimental/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-experimental/SKILL.md
@@ -196,14 +196,9 @@ Each agent prompt MUST include these **workflow steps** (in order):
 3. Stage and commit using conventional-commit-message format:
    - No Claude mentions, no co-author lines
    git add <files> && git commit -m "<type>(<scope>): <description>"
-4. Iterative simplify pass — run inline, not as a sub-skill call. Track a pass count starting at 0 (max 3). This is part of this workflow; there is no separate caller/callee to return to.
-   4a. Run `/simplify` on the changed files.
-   4b. Check for changes with `git diff`.
-       - If changes were produced AND pass count < 3: commit the simplification (conventional-commit format, no Claude mentions), push with `git push -u origin worktree-agent-<issue>`, increment the pass count, go back to 4a.
-       - If no changes were produced OR pass count >= 3: the pass has converged. Proceed immediately to step 5 — do NOT stop here. Convergence is not a termination condition.
-5. Push final branch state (unconditional — idempotent if the last simplify pass already pushed):
+4. Push the branch:
    git push -u origin worktree-agent-<issue>
-6. Create PR targeting the appropriate base. The body MUST be a richer summary, not just `Closes #<issue>` — synthesize the `## Summary` bullets from the issue's acceptance criteria and your diff, and describe the `## Test plan` in terms of those acceptance criteria. Fill in the angle-bracket placeholders; do not copy them literally.
+5. Create PR targeting the appropriate base. The body MUST be a richer summary, not just `Closes #<issue>` — synthesize the `## Summary` bullets from the issue's acceptance criteria and your diff, and describe the `## Test plan` in terms of those acceptance criteria. Fill in the angle-bracket placeholders; do not copy them literally.
 
    <!-- include: plugins/_shared/pr-body.md -->
    <!-- Summary-content rules derive from the canonical doc; `## Changes` is intentionally omitted for single-issue swarm PRs — Summary is sufficient when the scope is one issue. -->
@@ -235,7 +230,7 @@ Each agent prompt MUST include these **workflow steps** (in order):
    Closes #<issue>
    EOF
    )"
-7. Report the PR URL. This is the ONLY acceptable termination condition for this workflow. Do not stop before the PR exists and its URL has been reported.
+6. Report the PR URL. This is the ONLY acceptable termination condition for this workflow. Do not stop before the PR exists and its URL has been reported.
 ```
 
 ### 5. Handle completions

--- a/plugins/swarmkit/skills/swarm-experimental/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-experimental/SKILL.md
@@ -51,46 +51,49 @@ Used when issue numbers are provided. Dispatches agents for the given set of iss
 
 ### 1. Gather issue details
 
-For each issue:
+Run the gather script once with all requested issue numbers. It batches title, body, labels, state, sub-issues, and native dependency edges (`blockedBy`) into a single `gh api graphql` call, collapsing what was ~3N bash turns into one script invocation:
 
 ```bash
-gh issue view <number> --json title,body,labels
+plugins/swarmkit/skills/swarm-experimental/scripts/gather_issues.sh <number> [<number> ...]
 ```
 
-**Skip any issue with the `on-hold` label** — per the `gh-fetch-issues` sub-skill filtering rules.
+On success the script exits 0 and emits one JSON object on stdout:
 
-**Epic expansion** — for each issue, query its children via GitHub's native sub-issue relationship:
-
-```bash
-gh api repos/{owner}/{repo}/issues/<number>/sub_issues
+```json
+{
+  "requested": [544, 545],
+  "work_items": [
+    {"number": 545, "title": "...", "body": "...", "labels": ["enhancement"],
+     "state": "OPEN", "is_epic": false, "deps": [544],
+     "skip": false, "skip_reason": null, "source_epic": null}
+  ],
+  "skipped":        [{"number": 541, "reason": "closed"}],
+  "epics_expanded": [{"number": 549, "children": [544, 545, 546, 547, 548]}],
+  "epics_unwired":  []
+}
 ```
 
-If the response is a non-empty array, the issue is an epic. Use the returned children (not the epic itself) as the work items: for each child, fetch `title,body,labels,state` in parallel, then filter:
+Parse the JSON. **Use `work_items` as the list to act on** for the rest of the swarm — each entry already has everything Steps 2–5 need (title, body, labels, state, deps, and the originating epic when expanded from one).
 
-- Skip any child with the `on-hold` label
-- Skip any child that is already `closed`
-
-If all children are skipped, announce and stop. Otherwise announce:
+**Skip announcement** — for each entry in `skipped`, the script has already applied the existing rules (`on-hold` label, `closed` state). If there are skipped issues from a requested epic's children, announce using the existing template:
 
 > `#N` is an epic. Swarming: `#101`, `#102`. Skipped (closed/on-hold): `#103`.
 
-**Epic label without sub-issues** — if the issue carries the `epic` label but the sub-issues API returns an empty array, the epic is not wired up. Do **not** fall through and treat it as a regular implementation issue — the epic body is a plan, not a spec. Announce and skip:
+If `work_items` is empty because every requested issue (or every child of a requested epic) was skipped, announce and stop.
+
+**Unwired epics** — for each number in `epics_unwired`, announce with the existing template and proceed with the remaining work items:
 
 > `#N` is labeled `epic` but has no sub-issues wired via the GitHub sub-issue API. Skipping — children must be attached via `gh api .../sub_issues` before swarming.
 
 The legacy `- [ ] #N` body-checklist format is no longer supported; speckit wires child issues via the native sub-issue API (see `plugins/speckit/skills/spec/SKILL.md`).
 
+If the script exits non-zero, stdout will be empty and stderr will carry a human-readable error — surface it and stop.
+
 ### 2. Analyze dependencies and grouping
 
-**Parse the dependency graph** from the issue bodies already fetched in Step 1:
+Use the pre-computed `deps` array on each `work_items` entry — the script already prefers GitHub's native `blockedBy` connection (the field `/spec` wires up) and falls back to parsing `Depends on #N` / `Blocked by #N` from the body when native is empty. Do **not** re-grep bodies here.
 
-For each issue body, extract `Depends on #N` and `Blocked by #N` references:
-
-```bash
-echo "$BODY" | grep -oiE '(depends on|blocked by) #[0-9]+' | grep -oE '[0-9]+'
-```
-
-Build a directed acyclic graph (DAG): each issue is a node; a `Depends on #N` or `Blocked by #N` relationship is a directed edge from the dependent to the dependency.
+Build a directed acyclic graph (DAG): each work item is a node; each number in its `deps` array is a directed edge from the dependent to the dependency.
 
 Produce a **topological sort** of the DAG. This sort determines:
 - Which issues can spawn in parallel (no incoming edges in this batch = independent)

--- a/plugins/swarmkit/skills/swarm-experimental/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-experimental/SKILL.md
@@ -1,0 +1,363 @@
+---
+name: swarm-experimental
+description: EXPERIMENTAL variant of `/swarm` that collapses preflight into a single scripted step. Same arg grammar and behavior — see `/swarm` for the stable version. Use this to dogfood script-extraction changes; switch back to `/swarm` if anything misbehaves.
+---
+
+# Swarm Skill (Experimental)
+
+> **EXPERIMENTAL** — this is a parallel build of `/swarm` used to validate script extractions that reduce conversational bash round-trips. Behavior is intended to be identical to the stable `/swarm` skill on the same inputs. If you hit issues, fall back to `/swarm`.
+
+> See the swarmkit README's [Permissions](../../README.md#permissions) section for session-level permission guidance before first use.
+
+Spawn parallel agents for GitHub issues: $ARGUMENTS
+
+## Arguments
+
+Parse `$ARGUMENTS` to determine the mode:
+
+- **No arguments** → **loop mode**, all open issues → `develop`
+- **Label text** (non-numeric, e.g. `bug`, `priority:high`) → **loop mode**, filtered by label → `develop`
+- **Issue numbers** (`12 15 18`, `#12 #15 #18`, range `12-18`) → **one-shot mode**, specific issues → `develop`
+- `--model <tier>` (`sonnet`, `opus`) → model override for all agents
+- `--base <branch>` → override default base branch
+
+---
+
+## Setup
+
+Run the preflight script once. It handles fetch, base-branch verification (creating it from `main` and pushing if missing), and `gh` auth check in a single call:
+
+```bash
+plugins/swarmkit/skills/swarm-experimental/scripts/preflight.sh --base "$BASE"
+```
+
+On success the script exits 0 and emits a single JSON object on stdout:
+
+```json
+{"base": "develop", "base_existed": true, "base_created": false, "gh_authenticated": true, "repo": "owner/name"}
+```
+
+Parse the JSON. If `gh_authenticated` is `false`, **stop immediately** and surface the script's stderr to the user — no swarm work can proceed without `gh` auth. If `base_created` is `true`, announce:
+
+> Created `<base>` branch from `main`. All PRs will target `<base>`.
+
+If the script exits non-zero, stdout will be empty and stderr will carry a human-readable error — surface it and stop.
+
+---
+
+## One-Shot Mode
+
+Used when issue numbers are provided. Dispatches agents for the given set of issues, opens PRs, and reports. Use `swarmkit:merge-stack` to merge.
+
+### 1. Gather issue details
+
+For each issue:
+
+```bash
+gh issue view <number> --json title,body,labels
+```
+
+**Skip any issue with the `on-hold` label** — per the `gh-fetch-issues` sub-skill filtering rules.
+
+**Epic expansion** — for each issue, query its children via GitHub's native sub-issue relationship:
+
+```bash
+gh api repos/{owner}/{repo}/issues/<number>/sub_issues
+```
+
+If the response is a non-empty array, the issue is an epic. Use the returned children (not the epic itself) as the work items: for each child, fetch `title,body,labels,state` in parallel, then filter:
+
+- Skip any child with the `on-hold` label
+- Skip any child that is already `closed`
+
+If all children are skipped, announce and stop. Otherwise announce:
+
+> `#N` is an epic. Swarming: `#101`, `#102`. Skipped (closed/on-hold): `#103`.
+
+**Epic label without sub-issues** — if the issue carries the `epic` label but the sub-issues API returns an empty array, the epic is not wired up. Do **not** fall through and treat it as a regular implementation issue — the epic body is a plan, not a spec. Announce and skip:
+
+> `#N` is labeled `epic` but has no sub-issues wired via the GitHub sub-issue API. Skipping — children must be attached via `gh api .../sub_issues` before swarming.
+
+The legacy `- [ ] #N` body-checklist format is no longer supported; speckit wires child issues via the native sub-issue API (see `plugins/speckit/skills/spec/SKILL.md`).
+
+### 2. Analyze dependencies and grouping
+
+**Parse the dependency graph** from the issue bodies already fetched in Step 1:
+
+For each issue body, extract `Depends on #N` and `Blocked by #N` references:
+
+```bash
+echo "$BODY" | grep -oiE '(depends on|blocked by) #[0-9]+' | grep -oE '[0-9]+'
+```
+
+Build a directed acyclic graph (DAG): each issue is a node; a `Depends on #N` or `Blocked by #N` relationship is a directed edge from the dependent to the dependency.
+
+Produce a **topological sort** of the DAG. This sort determines:
+- Which issues can spawn in parallel (no incoming edges in this batch = independent)
+- Which issues must wait for their dependencies to complete and merge first (dependent chains)
+
+Output two categories:
+- **Independent issues**: no dependencies within this batch — spawn in parallel targeting `$BASE`
+- **Dependent chains**: ordered by topology — each dependent must wait for its dependency's PR to merge before spawning
+
+- **File conflicts**: issues touching the same files must not share an agent
+- **Grouping**: small independent fixes to the same file can share one agent
+
+### 3. Present swarm plan
+
+Show the user a table before launching:
+
+```
+| Agent | Issue(s) | Branch | Files affected | Model | Notes |
+|-------|----------|--------|----------------|-------|-------|
+| 1     | #16      | fix/readme-accuracy | README.md | sonnet | Independent |
+| 2     | #18, #19 | chore/clean-hooks   | hooks/check.py | opus | Grouped: same file |
+```
+
+> Any agent showing `haiku` must be re-assigned to `sonnet` before proceeding.
+
+Also show suggested merge order and any issues too ambiguous to delegate. Merge order is top-down: leaf PRs first, root last (the inverse of creation order). This matches how `swarmkit:merge-stack` operates — it pops the leaf of the stack first.
+
+Present the plan and proceed immediately with the proposed groupings.
+
+**Model selection** (when `--model` not set):
+
+| Complexity | Model |
+|------------|-------|
+| Mechanical / single-file / well-specified | `sonnet` |
+| Multi-file / new components / logic / judgment | `opus` |
+
+### 4. Spawn agents
+
+Before spawning each agent, ensure the `status:in-progress` label exists and apply it to the issue(s) being worked on:
+
+```bash
+gh label list | grep -q "status:in-progress" || \
+  gh label create "status:in-progress" --description "Actively being worked on" --color "E4E669"
+
+gh issue edit <issue> --add-label "status:in-progress"
+```
+
+GitHub will automatically remove `status:in-progress` visibility when the issue closes via the `Closes #N` PR reference — no manual cleanup needed.
+
+Apply the hybrid spawn strategy based on the dependency graph from Step 2:
+
+**Independent issues** (no dependencies within this batch):
+- Spawn all in parallel
+- Each agent branches from `$BASE` (e.g., `develop`)
+- Use `run_in_background: true`
+
+**Dependent chains** (issues with dependencies):
+- Spawn sequentially in topological order
+- Each agent waits for its dependency's agent to complete and its PR to be created
+- The dependent agent branches from its dependency's branch tip (not `$BASE`):
+  ```bash
+  git fetch origin worktree-agent-<dependency-issue>
+  git checkout -b worktree-agent-<this-issue> origin/worktree-agent-<dependency-issue>
+  ```
+- The dependent agent's PR targets the dependency's branch (not `$BASE`):
+  ```bash
+  gh pr create --base worktree-agent-<dependency-issue> --head worktree-agent-<this-issue> \
+    --title "..." --body "Closes #<this-issue>"
+  ```
+- When the dependency merges to `$BASE`, GitHub automatically retargets the dependent PR to `$BASE`
+
+> **Why no mid-swarm merge is needed**: by branching from `origin/worktree-agent-<dependency-issue>`, the dependent agent already has full access to every file and commit produced by the upstream agent. The stacked branch strategy exists precisely so that downstream agents can proceed without waiting for a merge — the upstream output is already present in their working tree. Never merge a dependency's PR early to "unblock" a downstream agent.
+
+All agents (both strategies) use:
+- `isolation: "worktree"`
+- `mode: "bypassPermissions"`
+- `run_in_background: true`
+- Branch naming: `worktree-agent-<issue>` (required for `clean-worktrees`)
+
+Each agent prompt MUST include:
+1. **TASK**: the specific issue(s) to resolve
+2. **EXPECTED OUTCOME**: branch name, commit format, PR closing the issue(s)
+3. **MUST DO**: concrete file changes from the issue body
+4. **MUST NOT DO**: scope boundaries
+5. **CONTEXT**: Instruct agents that their CWD is the repo root — use **relative paths only** for all file operations (e.g., `plugins/flowkit/skills/release/SKILL.md`). Do NOT include the absolute repo path — agents will resolve it into absolute paths that bypass the worktree and edit the main directory instead.
+
+Each agent prompt MUST include these **workflow steps** (in order):
+
+```
+1. Create and check out branch from the appropriate base. Use `origin/<base>` as the starting point so this works inside an isolated worktree — a plain `git checkout develop` would fail if `develop` is already checked out in the main repo.
+   # For independent issues (no deps in this batch):
+   git fetch origin develop
+   git checkout -B worktree-agent-<issue> origin/develop
+
+   # For dependent issues (has a dependency in this batch):
+   git fetch origin worktree-agent-<dependency-issue>
+   git checkout -B worktree-agent-<issue> origin/worktree-agent-<dependency-issue>
+
+   # Safety check — abort if not in an isolated worktree
+   [[ "$PWD" != *"worktrees"* ]] && echo "ERROR: Not running in an isolated worktree. Aborting to prevent branch collision." && exit 1
+
+2. Make changes (the actual issue work)
+3. Stage and commit using conventional-commit-message format:
+   - No Claude mentions, no co-author lines
+   git add <files> && git commit -m "<type>(<scope>): <description>"
+4. Iterative simplify pass — run inline, not as a sub-skill call. Track a pass count starting at 0 (max 3). This is part of this workflow; there is no separate caller/callee to return to.
+   4a. Run `/simplify` on the changed files.
+   4b. Check for changes with `git diff`.
+       - If changes were produced AND pass count < 3: commit the simplification (conventional-commit format, no Claude mentions), push with `git push -u origin worktree-agent-<issue>`, increment the pass count, go back to 4a.
+       - If no changes were produced OR pass count >= 3: the pass has converged. Proceed immediately to step 5 — do NOT stop here. Convergence is not a termination condition.
+5. Push final branch state (unconditional — idempotent if the last simplify pass already pushed):
+   git push -u origin worktree-agent-<issue>
+6. Create PR targeting the appropriate base. The body MUST be a richer summary, not just `Closes #<issue>` — synthesize the `## Summary` bullets from the issue's acceptance criteria and your diff, and describe the `## Test plan` in terms of those acceptance criteria. Fill in the angle-bracket placeholders; do not copy them literally.
+
+   <!-- include: plugins/_shared/pr-body.md -->
+   <!-- Summary-content rules derive from the canonical doc; `## Changes` is intentionally omitted for single-issue swarm PRs — Summary is sufficient when the scope is one issue. -->
+
+   # For independent issues:
+   gh pr create --base develop --head worktree-agent-<issue> \
+     --title "<type>(<scope>): <description>" \
+     --body "$(cat <<'EOF'
+   ## Summary
+   <1–3 bullets synthesizing what was changed, derived from the issue acceptance criteria and the diff>
+
+   ## Test plan
+   <how to verify the changes satisfy the acceptance criteria>
+
+   Closes #<issue>
+   EOF
+   )"
+
+   # For dependent issues:
+   gh pr create --base worktree-agent-<dependency-issue> --head worktree-agent-<issue> \
+     --title "<type>(<scope>): <description>" \
+     --body "$(cat <<'EOF'
+   ## Summary
+   <1–3 bullets synthesizing what was changed, derived from the issue acceptance criteria and the diff>
+
+   ## Test plan
+   <how to verify the changes satisfy the acceptance criteria>
+
+   Closes #<issue>
+   EOF
+   )"
+7. Report the PR URL. This is the ONLY acceptable termination condition for this workflow. Do not stop before the PR exists and its URL has been reported.
+```
+
+### 5. Handle completions
+
+After each agent completes, always verify:
+- **(a) Branch is pushed to origin** — run `git ls-remote --exit-code origin worktree-agent-<issue>`. If absent, push it: `git push -u origin worktree-agent-<issue>`
+- **(b) A PR exists referencing the issue** — run `gh pr list --head worktree-agent-<issue>`. If none, create the PR on the agent's behalf using the agent's commits and the issue spec.
+
+Report the PR link once confirmed. Verify each PR's diff matches the issue scope.
+
+### 6. Clean up
+
+Run `/clean-worktrees` to remove agent worktrees and orphaned branches. This frees local `worktree-agent-*` branches so the merge step can use `--delete-branch` without conflicts.
+
+### 7. Report
+
+```
+| Issue(s) | PR | Branch | Status |
+|----------|-----|--------|--------|
+| #16      | #25 | fix/readme-accuracy | Open |
+| #18, #19 | #26 | chore/clean-hooks   | Open |
+```
+
+All PRs are left open for review. If 1 PR open: use `/merge-pr` to merge it into `develop`. If 2+ PRs: use `/merge-stack` — merges top-down: leaf PRs first, root last.
+
+---
+
+## Loop Mode
+
+Used when no issue numbers are given (no args or label filter). Continuously clears the board.
+
+### Setup
+
+Run the preflight script with `--scope-pr-base` to also set `claude.flowkit.prBase` for this session:
+
+```bash
+plugins/swarmkit/skills/swarm-experimental/scripts/preflight.sh --base "$BASE" --scope-pr-base
+```
+
+Parse the JSON from stdout. Halt and surface stderr if the script exits non-zero or if `gh_authenticated` is `false`. Announce base creation if `base_created` is `true`.
+
+`claude.flowkit.prBase` is unset in the teardown step below. Leaving it set will cause subsequent PR creation (even in unrelated workflows) to target the wrong base, so cleanup is critical.
+
+### Loop (repeat until board clear or user stops)
+
+**Step 1 — Pick batch**
+
+Follow `gh-fetch-issues` to fetch open issues (apply label filter if given), then follow `issue-rank` to rank and select all issues that can safely parallelize this cycle:
+- No two issues touch the same files
+- No unresolved dependencies within the batch
+- Present the batch in the standard next-issue table format; note any deferred issues and why
+
+If no open issues remain, announce "Board is clear" and exit.
+
+**Step 2 — Swarm**
+
+Run the one-shot swarm flow above on the batch. Independent issues target `$BASE` (enforced by `claude.flowkit.prBase`). Dependent issues target their dependency's branch, forming a stacked-PR chain that ultimately merges into `$BASE` when `swarmkit:merge-stack` cascades the merges.
+
+**Step 3 — Checkpoint**
+
+```
+── Cycle N complete ──────────────────────────
+✓ PRs opened: #25 (→ #12), #26 (→ #15)
+✗ Failed: #14 (agent crash, no PR produced)
+⊘ Blocked: #20 (depends on #14)
+⧖ Remaining open issues: 5
+──────────────────────────────────────────────
+```
+
+Proceed immediately to the next cycle after printing the checkpoint summary. The loop halts only on unrecoverable failures: an agent crash with no PR produced.
+
+### Teardown
+
+1. Run the `clean-worktrees` skill
+2. Restore the base branch (worktree removal may drift the shell to a detached HEAD or a different branch):
+   ```bash
+   git checkout $BASE && git pull origin $BASE
+   ```
+3. Unset `claude.flowkit.prBase` to clear the scoped PR base:
+   ```bash
+   git config --local --unset claude.flowkit.prBase
+   ```
+
+Optionally, run `swarmkit:clean-remote-worktrees` afterwards to sweep orphaned remote `worktree-agent-*` branches left behind by merged PRs. This is not automatic — invoke it when you want to tidy up.
+
+3. Final summary:
+
+```
+── swarm complete ────────────────────────────
+Cycles: 3
+Issues addressed: #12, #14, #15 (PRs open, awaiting review)
+Issues remaining: #25
+Open PRs: #31, #32, #33
+
+Open PRs are ready for review. If 1 PR open: use `/merge-pr` to merge it into `$BASE`. If 2+ PRs: use `/merge-stack` — merges top-down: leaf PRs first, root last.
+─────────────────────────────────────────────
+```
+
+### Smart failure rules
+
+When an issue fails at any point:
+1. Check all remaining issues in current and future cycles for file overlap or explicit references to the failed issue
+2. Mark those as blocked; continue with all unblocked issues
+3. Report blocked issues at each checkpoint
+
+**Unrecoverable failures** (exit loop immediately):
+- Agent produced no PR (crash, timeout, no push)
+- `$BASE` branch deleted or corrupted externally
+
+---
+
+## Constraints
+
+- Never merge into `main` — all PRs ultimately merge into `$BASE`; stacked (dependent) PRs may target an intermediate dependency branch and cascade into `$BASE` via `swarmkit:merge-stack`
+- Never pause between loop cycles — proceed immediately after printing the checkpoint summary
+- Never skip a failed issue's dependents — always analyze and block them
+- Every agent must work in an isolated worktree
+- Every PR must reference the issue it closes (`Closes #N`)
+- Commit messages must follow `conventional-commit-message` sub-skill format
+- Never mention Claude or add co-author lines in commit messages
+- Agents spawn with `mode: "bypassPermissions"` so they can push and create PRs without prompting
+- Never commit directly to develop or main — always work on the `worktree-agent-<issue>` branch
+- **Never close issues** — issues are closed by the release process when staging merges to main
+- **Never pass absolute repo paths to spawned agents** — always instruct them to use relative paths from their CWD to ensure edits land in the isolated worktree, not the main directory
+- **Never merge a PR mid-swarm**, even when a downstream agent needs files produced by an upstream agent. Dependent agents branch from `origin/worktree-agent-<dependency>` and already have access to the upstream output. Merging to unblock a downstream agent bypasses the user's review gate and is never acceptable.

--- a/plugins/swarmkit/skills/swarm-experimental/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-experimental/SKILL.md
@@ -238,9 +238,34 @@ Each agent prompt MUST include these **workflow steps** (in order):
 
 ### 5. Handle completions
 
-After each agent completes, always verify:
-- **(a) Branch is pushed to origin** — run `git ls-remote --exit-code origin worktree-agent-<issue>`. If absent, push it: `git push -u origin worktree-agent-<issue>`
-- **(b) A PR exists referencing the issue** — run `gh pr list --head worktree-agent-<issue>`. If none, create the PR on the agent's behalf using the agent's commits and the issue spec.
+After each agent completes, run the verify script once per agent:
+
+```bash
+plugins/swarmkit/skills/swarm-experimental/scripts/verify_agent.sh <issue>
+```
+
+On success the script exits 0 and emits a single JSON object on stdout:
+
+```json
+{
+  "issue": 102,
+  "branch": "worktree-agent-102",
+  "branch_pushed": true,
+  "pushed_now": false,
+  "pr_exists": true,
+  "pr_url": "https://github.com/owner/name/pull/210",
+  "pr_base": "develop"
+}
+```
+
+Parse the JSON and act on the fields:
+
+- **`branch_pushed: false` and no local branch** — the agent produced no push and no local branch exists; announce the unrecoverable failure and treat the issue as failed (do not attempt PR creation).
+- **`pushed_now: true`** — the script pushed the branch on the agent's behalf; announce this before proceeding.
+- **`pr_exists: false`** — create the PR on the agent's behalf using the agent's commits and the issue spec. PR creation (title, body, base branch selection) is a judgment call made by Claude using the existing PR-body template from Step 4. Use `pr_base` from the preflight JSON (or the appropriate stacked-branch base for dependent issues) as the `--base` argument.
+- **`pr_exists: true`** — no action needed; `pr_url` carries the existing PR link.
+
+If the script exits non-zero, stdout will be empty and stderr will carry a human-readable error — surface it and treat the issue as failed.
 
 Report the PR link once confirmed. Verify each PR's diff matches the issue scope.
 

--- a/plugins/swarmkit/skills/swarm-experimental/scripts/gather_issues.sh
+++ b/plugins/swarmkit/skills/swarm-experimental/scripts/gather_issues.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# gather_issues.sh — collapse Step 1 (gather issue details) into one HTTP call.
+#
+# Batches title, body, labels, state, sub-issues, and native dependency edges
+# for N issues into a single `gh api graphql` query using one alias per issue.
+# Dependencies prefer GitHub's native `blockedBy` connection; falls back to
+# parsing `Depends on #N` / `Blocked by #N` from the issue body when native is
+# empty.
+#
+# Usage:
+#   gather_issues.sh <number> [<number> ...]
+#
+# On success: exit 0, single JSON object on stdout:
+#   {
+#     "requested": [<number>, ...],
+#     "work_items": [
+#       {"number", "title", "body", "labels", "state", "is_epic",
+#        "deps", "skip", "skip_reason", "source_epic"}
+#     ],
+#     "skipped":        [{"number", "reason"}, ...],
+#     "epics_expanded": [{"number", "children": [<number>, ...]}, ...],
+#     "epics_unwired":  [<number>, ...]
+#   }
+# On failure: non-zero exit, empty stdout, message on stderr.
+
+if [[ $# -lt 1 ]]; then
+  echo "gather_issues: at least one issue number is required" >&2
+  exit 2
+fi
+
+for n in "$@"; do
+  if ! [[ "$n" =~ ^[0-9]+$ ]]; then
+    echo "gather_issues: issue numbers must be positive integers (got '$n')" >&2
+    exit 2
+  fi
+done
+
+for cmd in gh jq git; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "gather_issues: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+if ! REPO_SLUG="$(gh repo view --json owner,name -q '.owner.login + "/" + .name' 2>/dev/null)"; then
+  echo "gather_issues: 'gh repo view' failed — is this a gh-authenticated repo?" >&2
+  exit 1
+fi
+OWNER="${REPO_SLUG%%/*}"
+NAME="${REPO_SLUG##*/}"
+
+REQUESTED_JSON="$(printf '%s\n' "$@" | jq -R 'tonumber' | jq -s '.')"
+
+build_alias_block() {
+  local n="$1"
+  cat <<EOF
+    i${n}: issue(number: ${n}) {
+      number
+      title
+      body
+      state
+      labels(first: 50) { nodes { name } }
+      subIssues(first: 100) {
+        totalCount
+        nodes {
+          number
+          title
+          body
+          state
+          labels(first: 50) { nodes { name } }
+          blockedBy(first: 50) { nodes { number } }
+        }
+      }
+      blockedBy(first: 50) { nodes { number } }
+    }
+EOF
+}
+
+ALIAS_BLOCKS=""
+for n in "$@"; do
+  ALIAS_BLOCKS+="$(build_alias_block "$n")"$'\n'
+done
+
+QUERY=$(cat <<EOF
+query(\$owner: String!, \$name: String!) {
+  repository(owner: \$owner, name: \$name) {
+${ALIAS_BLOCKS}
+  }
+}
+EOF
+)
+
+if ! RAW="$(gh api graphql -F owner="$OWNER" -F name="$NAME" -f query="$QUERY" 2>/tmp/gather_issues.err)"; then
+  echo "gather_issues: GraphQL query failed:" >&2
+  cat /tmp/gather_issues.err >&2
+  rm -f /tmp/gather_issues.err
+  exit 1
+fi
+rm -f /tmp/gather_issues.err
+
+if echo "$RAW" | jq -e '.errors' >/dev/null 2>&1; then
+  echo "gather_issues: GraphQL returned errors:" >&2
+  echo "$RAW" | jq -r '.errors[] | .message' >&2
+  exit 1
+fi
+
+REPO_JSON="$(echo "$RAW" | jq '.data.repository')"
+
+REQUESTED_ARG="$REQUESTED_JSON"
+
+OUTPUT="$(jq -n \
+  --argjson requested "$REQUESTED_ARG" \
+  --argjson repo "$REPO_JSON" \
+  '
+  def parse_body_deps($body):
+    ($body // "")
+    | [ scan("(?i)(?:depends on|blocked by)\\s*#([0-9]+)") | .[0] | tonumber ]
+    | unique;
+
+  def resolve_deps(issue):
+    (issue.blockedBy.nodes // [] | map(.number)) as $native
+    | if ($native | length) > 0
+      then $native
+      else parse_body_deps(issue.body)
+      end;
+
+  def labels_of(issue):
+    (issue.labels.nodes // []) | map(.name);
+
+  def is_on_hold(issue):
+    labels_of(issue) | any(. == "on-hold");
+
+  def is_closed(issue):
+    (issue.state // "OPEN") == "CLOSED";
+
+  def has_epic_label(issue):
+    labels_of(issue) | any(. == "epic");
+
+  def work_item(issue; source_epic):
+    {
+      number: issue.number,
+      title: issue.title,
+      body: (issue.body // ""),
+      labels: labels_of(issue),
+      state: issue.state,
+      is_epic: false,
+      deps: resolve_deps(issue),
+      skip: false,
+      skip_reason: null,
+      source_epic: source_epic
+    };
+
+  reduce $requested[] as $n (
+    {work_items: [], skipped: [], epics_expanded: [], epics_unwired: []};
+    ($repo["i" + ($n|tostring)]) as $iss
+    | if $iss == null then
+        .skipped += [{number: $n, reason: "issue not found"}]
+      elif (is_on_hold($iss)) then
+        .skipped += [{number: $n, reason: "on-hold label"}]
+      elif (is_closed($iss)) then
+        .skipped += [{number: $n, reason: "closed"}]
+      elif (($iss.subIssues.totalCount // 0) > 0) then
+        (
+          ($iss.subIssues.nodes // [])
+          | map(select((labels_of(.) | any(. == "on-hold") | not)
+                       and ((.state // "OPEN") != "CLOSED")))
+        ) as $active_children
+        | .epics_expanded += [{number: $n, children: ($active_children | map(.number))}]
+        | .work_items += ($active_children | map(work_item(.; $n)))
+      elif (has_epic_label($iss)) then
+        .epics_unwired += [$n]
+      else
+        .work_items += [work_item($iss; null)]
+      end
+  )
+  | {requested: $requested} + .
+  '
+)"
+
+echo "$OUTPUT"

--- a/plugins/swarmkit/skills/swarm-experimental/scripts/preflight.sh
+++ b/plugins/swarmkit/skills/swarm-experimental/scripts/preflight.sh
@@ -46,27 +46,23 @@ fi
 
 base_existed=true
 base_created=false
-if ! git ls-remote --exit-code origin "$BASE" >/dev/null 2>&1; then
+if ! git rev-parse --verify --quiet "refs/remotes/origin/$BASE" >/dev/null; then
   base_existed=false
-  if ! git ls-remote --exit-code origin main >/dev/null 2>&1; then
+  if ! git rev-parse --verify --quiet refs/remotes/origin/main >/dev/null; then
     echo "preflight: base '$BASE' is missing on origin and 'main' does not exist to seed it from" >&2
     exit 1
   fi
-  if ! git fetch origin main >/dev/null 2>&1 \
-    || ! git push origin "refs/remotes/origin/main:refs/heads/$BASE" >/dev/null 2>&1; then
+  if ! git push origin "refs/remotes/origin/main:refs/heads/$BASE" >/dev/null 2>&1; then
     echo "preflight: failed to create '$BASE' on origin from 'main'" >&2
     exit 1
   fi
   base_created=true
 fi
 
-gh_authenticated=true
-if ! gh auth status >/dev/null 2>&1; then
-  gh_authenticated=false
-fi
-
+gh_authenticated=false
 repo=""
-if [[ "$gh_authenticated" == "true" ]]; then
+if gh auth status >/dev/null 2>&1; then
+  gh_authenticated=true
   if ! repo="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)"; then
     echo "preflight: 'gh repo view' failed despite authenticated session" >&2
     exit 1

--- a/plugins/swarmkit/skills/swarm-experimental/scripts/preflight.sh
+++ b/plugins/swarmkit/skills/swarm-experimental/scripts/preflight.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# preflight.sh — collapse the swarm setup phase (fetch + base verification +
+# gh auth check + optional PR base scoping) into one call.
+#
+# Usage:
+#   preflight.sh [--base <branch>] [--scope-pr-base]
+#
+# On success: exit 0, single JSON object on stdout with keys:
+#   {base, base_existed, base_created, gh_authenticated, repo}
+# On failure: non-zero exit, empty stdout, human-readable message on stderr.
+
+BASE="develop"
+SCOPE_PR_BASE=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      [[ $# -ge 2 ]] || { echo "preflight: --base requires a value" >&2; exit 2; }
+      BASE="$2"
+      shift 2
+      ;;
+    --scope-pr-base)
+      SCOPE_PR_BASE=1
+      shift
+      ;;
+    *)
+      echo "preflight: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+for cmd in gh jq git; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "preflight: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+if ! git fetch origin >/dev/null 2>&1; then
+  echo "preflight: 'git fetch origin' failed" >&2
+  exit 1
+fi
+
+base_existed=true
+base_created=false
+if ! git ls-remote --exit-code origin "$BASE" >/dev/null 2>&1; then
+  base_existed=false
+  if ! git ls-remote --exit-code origin main >/dev/null 2>&1; then
+    echo "preflight: base '$BASE' is missing on origin and 'main' does not exist to seed it from" >&2
+    exit 1
+  fi
+  if ! git fetch origin main >/dev/null 2>&1 \
+    || ! git push origin "refs/remotes/origin/main:refs/heads/$BASE" >/dev/null 2>&1; then
+    echo "preflight: failed to create '$BASE' on origin from 'main'" >&2
+    exit 1
+  fi
+  base_created=true
+fi
+
+gh_authenticated=true
+if ! gh auth status >/dev/null 2>&1; then
+  gh_authenticated=false
+fi
+
+repo=""
+if [[ "$gh_authenticated" == "true" ]]; then
+  if ! repo="$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)"; then
+    echo "preflight: 'gh repo view' failed despite authenticated session" >&2
+    exit 1
+  fi
+fi
+
+if [[ "$SCOPE_PR_BASE" -eq 1 ]]; then
+  if ! git config --local claude.flowkit.prBase "$BASE" >/dev/null 2>&1; then
+    echo "preflight: failed to set claude.flowkit.prBase via 'git config --local'" >&2
+    exit 1
+  fi
+fi
+
+jq -n \
+  --arg base "$BASE" \
+  --argjson base_existed "$base_existed" \
+  --argjson base_created "$base_created" \
+  --argjson gh_authenticated "$gh_authenticated" \
+  --arg repo "$repo" \
+  '{base: $base, base_existed: $base_existed, base_created: $base_created, gh_authenticated: $gh_authenticated, repo: $repo}'

--- a/plugins/swarmkit/skills/swarm-experimental/scripts/teardown.sh
+++ b/plugins/swarmkit/skills/swarm-experimental/scripts/teardown.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# teardown.sh — collapse the loop-mode teardown phase (base restore +
+# claude.flowkit.prBase unset) into one call, mirroring preflight.sh.
+#
+# Usage:
+#   teardown.sh [--base <branch>]
+#
+# On success: exit 0, single JSON object on stdout with keys:
+#   {base, base_restored, config_unset}
+# On failure: non-zero exit, empty stdout, human-readable message on stderr.
+
+BASE="develop"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      [[ $# -ge 2 ]] || { echo "teardown: --base requires a value" >&2; exit 2; }
+      BASE="$2"
+      shift 2
+      ;;
+    *)
+      echo "teardown: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+for cmd in git jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "teardown: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+config_unset=false
+if git config --local --get claude.flowkit.prBase >/dev/null 2>&1; then
+  if ! git config --local --unset claude.flowkit.prBase >/dev/null 2>&1; then
+    echo "teardown: failed to unset claude.flowkit.prBase" >&2
+    exit 1
+  fi
+  config_unset=true
+fi
+
+base_restored=false
+if ! git checkout "$BASE" >/dev/null 2>&1; then
+  echo "teardown: 'git checkout $BASE' failed — check for uncommitted changes or a detached HEAD conflict" >&2
+  exit 1
+fi
+if ! git pull origin "$BASE" >/dev/null 2>&1; then
+  echo "teardown: 'git pull origin $BASE' failed" >&2
+  exit 1
+fi
+base_restored=true
+
+jq -n \
+  --arg base "$BASE" \
+  --argjson base_restored "$base_restored" \
+  --argjson config_unset "$config_unset" \
+  '{base: $base, base_restored: $base_restored, config_unset: $config_unset}'

--- a/plugins/swarmkit/skills/swarm-experimental/scripts/verify_agent.sh
+++ b/plugins/swarmkit/skills/swarm-experimental/scripts/verify_agent.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# verify_agent.sh — collapse Step 5 (handle completions) branch-push and
+# PR-existence checks into one call per agent.
+#
+# Usage:
+#   verify_agent.sh <issue-number>
+#
+# On success: exit 0, single JSON object on stdout with keys:
+#   {issue, branch, branch_pushed, pushed_now, pr_exists, pr_url, pr_base}
+# On failure: non-zero exit, empty stdout, human-readable message on stderr.
+
+if [[ $# -ne 1 ]]; then
+  echo "verify_agent: exactly one argument required: <issue-number>" >&2
+  exit 2
+fi
+
+ISSUE="$1"
+if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+  echo "verify_agent: issue number must be a positive integer (got '$ISSUE')" >&2
+  exit 2
+fi
+
+for cmd in gh jq git; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "verify_agent: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+BRANCH="worktree-agent-${ISSUE}"
+
+branch_pushed=false
+pushed_now=false
+
+git fetch origin "$BRANCH" >/dev/null 2>&1 || true
+
+if git rev-parse --verify "refs/remotes/origin/${BRANCH}" >/dev/null 2>&1; then
+  branch_pushed=true
+else
+  if git rev-parse --verify "refs/heads/${BRANCH}" >/dev/null 2>&1; then
+    if git push -u origin "${BRANCH}" >/dev/null 2>&1; then
+      branch_pushed=true
+      pushed_now=true
+    else
+      echo "verify_agent: failed to push branch '${BRANCH}' to origin" >&2
+      exit 1
+    fi
+  fi
+fi
+
+pr_exists=false
+pr_url=null
+pr_base=null
+
+if ! PR_JSON="$(gh pr list --head "$BRANCH" --json number,url,baseRefName,state 2>/dev/null)"; then
+  echo "verify_agent: 'gh pr list' failed for branch '${BRANCH}'" >&2
+  exit 1
+fi
+
+OPEN_PR="$(echo "$PR_JSON" | jq -r '[.[] | select(.state == "OPEN")] | first // empty')"
+
+if [[ -n "$OPEN_PR" ]]; then
+  pr_exists=true
+  pr_url="\"$(echo "$OPEN_PR" | jq -r '.url')\""
+  pr_base="\"$(echo "$OPEN_PR" | jq -r '.baseRefName')\""
+fi
+
+jq -n \
+  --argjson issue "$ISSUE" \
+  --arg branch "$BRANCH" \
+  --argjson branch_pushed "$branch_pushed" \
+  --argjson pushed_now "$pushed_now" \
+  --argjson pr_exists "$pr_exists" \
+  --argjson pr_url "$pr_url" \
+  --argjson pr_base "$pr_base" \
+  '{issue: $issue, branch: $branch, branch_pushed: $branch_pushed, pushed_now: $pushed_now, pr_exists: $pr_exists, pr_url: $pr_url, pr_base: $pr_base}'


### PR DESCRIPTION
## Summary
- Add `plugins/swarmkit/skills/swarm-experimental/` as a parallel experimental skill with `name: swarm-experimental` front-matter that points at `/swarm` as the stable variant.
- Add `scripts/preflight.sh` collapsing the 3–5 bash-turn preflight phase into a single script call emitting `{base, base_existed, base_created, gh_authenticated, repo}` JSON on stdout.
- Wire the SKILL.md Setup and loop-mode Setup blocks to invoke `scripts/preflight.sh`, parse the JSON, and halt on unauthenticated `gh`.

## Test plan
- Run `plugins/swarmkit/skills/swarm-experimental/scripts/preflight.sh` in the repo root; confirm it emits valid JSON with `gh_authenticated: true` and the expected `base`/`repo` values.
- Run it with `--scope-pr-base`; confirm `git config --local --get claude.flowkit.prBase` returns the base branch; then unset it.
- Simulate unauthenticated `gh` (or review the code path) and confirm non-zero exit with empty stdout and a stderr message.

Closes #544

Closes #545
Closes #546
Closes #547

Closes #548