### PR TITLE
docs(swarmkit): document /swarm-experimental in plugin README

### DIFF
--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -51,6 +51,7 @@ Swarmkit is designed to run best when agents don't have to pause for per-command
 | Skill | Invoke | What it does |
 |-------|--------|--------------|
 | **swarm** | `/swarm` | Spawn parallel isolated-worktree agents to resolve GitHub issues. Supports one-shot mode (specific issues) and loop mode (clear the board). Auto-creates PRs targeting `develop`. |
+| **swarm-experimental** | `/swarm-experimental` | Experimental parallel variant of `/swarm`. Script-backed mechanical phases (preflight, teardown) reduce model round-trips. Same arg grammar and behavior as `/swarm` — prefer `/swarm` for stable workflows. |
 | **next-issue** | `/next-issue` | Fetches open issues, ranks them by priority, specificity, and architectural impact, and recommends what to work on next. |
 | **merge-stack** | `/merge-stack` | Merges all open swarm PRs top-down (leaf PRs first, root last). |
 | **clean-worktrees** | `/clean-worktrees` | Removes all agent worktrees and their orphaned `worktree-agent-*` branches. |
@@ -155,6 +156,18 @@ Swarmkit executes work; [speckit](../speckit) defines it. Use them together for 
 [Sessionkit](../sessionkit) complements swarmkit throughout: use `/handoff` to preserve state when context runs low mid-swarm, and `/skillit` after a swarm to capture reusable patterns that emerged.
 
 ## Experimental features
+
+### `swarm-experimental`
+
+A parallel, experimental variant of `/swarm`. It accepts the same arguments and produces the same outcomes, but collapses deterministic mechanical phases — preflight, issue gathering, post-agent verification, and loop-mode teardown — into shell scripts rather than conversational model steps. This reduces model round-trips for work that doesn't require judgment.
+
+**When to use it**: dogfooding script-extraction changes or benchmarking round-trip reduction. `/swarm` remains the stable entry point — if anything misbehaves, fall back to it.
+
+```
+/swarm-experimental 12 15 18
+```
+
+No special setup is required beyond what `/swarm` needs. See [Prerequisites](#prerequisites) and [Permissions](#permissions).
 
 ### `squad`
 


### PR DESCRIPTION
## Summary
- Add a `/swarm-experimental` entry to the swarmkit plugin README's skill list.
- Add a short paragraph explaining the experimental variant (script-backed mechanical phases to reduce model round-trips) and reaffirming `/swarm` as the stable entry point.

## Test plan
- Read the updated `plugins/swarmkit/README.md` and confirm `/swarm-experimental` is discoverable from the skill list and the accompanying note clarifies its purpose and stability status.
- Confirm root `README.md` and `CLAUDE.md` are untouched (the change is plugin-scoped).

Closes #548