### PR TITLE
feat(swarmkit): add gather_issues.sh with native-first dep detection

### DIFF
--- a/plugins/swarmkit/skills/swarm-experimental/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-experimental/SKILL.md
@@ -333,14 +333,7 @@ Proceed immediately to the next cycle after printing the checkpoint summary. The
 ### Teardown
 
 1. Run the `clean-worktrees` skill
-2. Restore the base branch (worktree removal may drift the shell to a detached HEAD or a different branch):
-   ```bash
-   git checkout $BASE && git pull origin $BASE
-   ```
-3. Unset `claude.flowkit.prBase` to clear the scoped PR base:
-   ```bash
-   git config --local --unset claude.flowkit.prBase
-   ```
+2. Run `scripts/teardown.sh` (optionally `--base <branch>` to override the default `develop`). Parse the returned JSON and confirm `base_restored: true`. If `config_unset: false`, log that `claude.flowkit.prBase` was already clear — this is not a failure.
 
 Optionally, run `swarmkit:clean-remote-worktrees` afterwards to sweep orphaned remote `worktree-agent-*` branches left behind by merged PRs. This is not automatic — invoke it when you want to tidy up.
 

--- a/plugins/swarmkit/skills/swarm-experimental/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-experimental/SKILL.md
@@ -51,46 +51,49 @@ Used when issue numbers are provided. Dispatches agents for the given set of iss
 
 ### 1. Gather issue details
 
-For each issue:
+Run the gather script once with all requested issue numbers. It batches title, body, labels, state, sub-issues, and native dependency edges (`blockedBy`) into a single `gh api graphql` call, collapsing what was ~3N bash turns into one script invocation:
 
 ```bash
-gh issue view <number> --json title,body,labels
+plugins/swarmkit/skills/swarm-experimental/scripts/gather_issues.sh <number> [<number> ...]
 ```
 
-**Skip any issue with the `on-hold` label** — per the `gh-fetch-issues` sub-skill filtering rules.
+On success the script exits 0 and emits one JSON object on stdout:
 
-**Epic expansion** — for each issue, query its children via GitHub's native sub-issue relationship:
-
-```bash
-gh api repos/{owner}/{repo}/issues/<number>/sub_issues
+```json
+{
+  "requested": [544, 545],
+  "work_items": [
+    {"number": 545, "title": "...", "body": "...", "labels": ["enhancement"],
+     "state": "OPEN", "is_epic": false, "deps": [544],
+     "skip": false, "skip_reason": null, "source_epic": null}
+  ],
+  "skipped":        [{"number": 541, "reason": "closed"}],
+  "epics_expanded": [{"number": 549, "children": [544, 545, 546, 547, 548]}],
+  "epics_unwired":  []
+}
 ```
 
-If the response is a non-empty array, the issue is an epic. Use the returned children (not the epic itself) as the work items: for each child, fetch `title,body,labels,state` in parallel, then filter:
+Parse the JSON. **Use `work_items` as the list to act on** for the rest of the swarm — each entry already has everything Steps 2–5 need (title, body, labels, state, deps, and the originating epic when expanded from one).
 
-- Skip any child with the `on-hold` label
-- Skip any child that is already `closed`
-
-If all children are skipped, announce and stop. Otherwise announce:
+**Skip announcement** — for each entry in `skipped`, the script has already applied the existing rules (`on-hold` label, `closed` state). If there are skipped issues from a requested epic's children, announce using the existing template:
 
 > `#N` is an epic. Swarming: `#101`, `#102`. Skipped (closed/on-hold): `#103`.
 
-**Epic label without sub-issues** — if the issue carries the `epic` label but the sub-issues API returns an empty array, the epic is not wired up. Do **not** fall through and treat it as a regular implementation issue — the epic body is a plan, not a spec. Announce and skip:
+If `work_items` is empty because every requested issue (or every child of a requested epic) was skipped, announce and stop.
+
+**Unwired epics** — for each number in `epics_unwired`, announce with the existing template and proceed with the remaining work items:
 
 > `#N` is labeled `epic` but has no sub-issues wired via the GitHub sub-issue API. Skipping — children must be attached via `gh api .../sub_issues` before swarming.
 
 The legacy `- [ ] #N` body-checklist format is no longer supported; speckit wires child issues via the native sub-issue API (see `plugins/speckit/skills/spec/SKILL.md`).
 
+If the script exits non-zero, stdout will be empty and stderr will carry a human-readable error — surface it and stop.
+
 ### 2. Analyze dependencies and grouping
 
-**Parse the dependency graph** from the issue bodies already fetched in Step 1:
+Use the pre-computed `deps` array on each `work_items` entry — the script already prefers GitHub's native `blockedBy` connection (the field `/spec` wires up) and falls back to parsing `Depends on #N` / `Blocked by #N` from the body when native is empty. Do **not** re-grep bodies here.
 
-For each issue body, extract `Depends on #N` and `Blocked by #N` references:
-
-```bash
-echo "$BODY" | grep -oiE '(depends on|blocked by) #[0-9]+' | grep -oE '[0-9]+'
-```
-
-Build a directed acyclic graph (DAG): each issue is a node; a `Depends on #N` or `Blocked by #N` relationship is a directed edge from the dependent to the dependency.
+Build a directed acyclic graph (DAG): each work item is a node; each number in its `deps` array is a directed edge from the dependent to the dependency.
 
 Produce a **topological sort** of the DAG. This sort determines:
 - Which issues can spawn in parallel (no incoming edges in this batch = independent)

--- a/plugins/swarmkit/skills/swarm-experimental/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-experimental/SKILL.md
@@ -238,9 +238,34 @@ Each agent prompt MUST include these **workflow steps** (in order):
 
 ### 5. Handle completions
 
-After each agent completes, always verify:
-- **(a) Branch is pushed to origin** — run `git ls-remote --exit-code origin worktree-agent-<issue>`. If absent, push it: `git push -u origin worktree-agent-<issue>`
-- **(b) A PR exists referencing the issue** — run `gh pr list --head worktree-agent-<issue>`. If none, create the PR on the agent's behalf using the agent's commits and the issue spec.
+After each agent completes, run the verify script once per agent:
+
+```bash
+plugins/swarmkit/skills/swarm-experimental/scripts/verify_agent.sh <issue>
+```
+
+On success the script exits 0 and emits a single JSON object on stdout:
+
+```json
+{
+  "issue": 102,
+  "branch": "worktree-agent-102",
+  "branch_pushed": true,
+  "pushed_now": false,
+  "pr_exists": true,
+  "pr_url": "https://github.com/owner/name/pull/210",
+  "pr_base": "develop"
+}
+```
+
+Parse the JSON and act on the fields:
+
+- **`branch_pushed: false` and no local branch** — the agent produced no push and no local branch exists; announce the unrecoverable failure and treat the issue as failed (do not attempt PR creation).
+- **`pushed_now: true`** — the script pushed the branch on the agent's behalf; announce this before proceeding.
+- **`pr_exists: false`** — create the PR on the agent's behalf using the agent's commits and the issue spec. PR creation (title, body, base branch selection) is a judgment call made by Claude using the existing PR-body template from Step 4. Use `pr_base` from the preflight JSON (or the appropriate stacked-branch base for dependent issues) as the `--base` argument.
+- **`pr_exists: true`** — no action needed; `pr_url` carries the existing PR link.
+
+If the script exits non-zero, stdout will be empty and stderr will carry a human-readable error — surface it and treat the issue as failed.
 
 Report the PR link once confirmed. Verify each PR's diff matches the issue scope.
 

--- a/plugins/swarmkit/skills/swarm-experimental/scripts/gather_issues.sh
+++ b/plugins/swarmkit/skills/swarm-experimental/scripts/gather_issues.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# gather_issues.sh — collapse Step 1 (gather issue details) into one HTTP call.
+#
+# Batches title, body, labels, state, sub-issues, and native dependency edges
+# for N issues into a single `gh api graphql` query using one alias per issue.
+# Dependencies prefer GitHub's native `blockedBy` connection; falls back to
+# parsing `Depends on #N` / `Blocked by #N` from the issue body when native is
+# empty.
+#
+# Usage:
+#   gather_issues.sh <number> [<number> ...]
+#
+# On success: exit 0, single JSON object on stdout:
+#   {
+#     "requested": [<number>, ...],
+#     "work_items": [
+#       {"number", "title", "body", "labels", "state", "is_epic",
+#        "deps", "skip", "skip_reason", "source_epic"}
+#     ],
+#     "skipped":        [{"number", "reason"}, ...],
+#     "epics_expanded": [{"number", "children": [<number>, ...]}, ...],
+#     "epics_unwired":  [<number>, ...]
+#   }
+# On failure: non-zero exit, empty stdout, message on stderr.
+
+if [[ $# -lt 1 ]]; then
+  echo "gather_issues: at least one issue number is required" >&2
+  exit 2
+fi
+
+for n in "$@"; do
+  if ! [[ "$n" =~ ^[0-9]+$ ]]; then
+    echo "gather_issues: issue numbers must be positive integers (got '$n')" >&2
+    exit 2
+  fi
+done
+
+for cmd in gh jq git; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "gather_issues: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+if ! REPO_SLUG="$(gh repo view --json owner,name -q '.owner.login + "/" + .name' 2>/dev/null)"; then
+  echo "gather_issues: 'gh repo view' failed — is this a gh-authenticated repo?" >&2
+  exit 1
+fi
+OWNER="${REPO_SLUG%%/*}"
+NAME="${REPO_SLUG##*/}"
+
+REQUESTED_JSON="$(printf '%s\n' "$@" | jq -R 'tonumber' | jq -s '.')"
+
+build_alias_block() {
+  local n="$1"
+  cat <<EOF
+    i${n}: issue(number: ${n}) {
+      number
+      title
+      body
+      state
+      labels(first: 50) { nodes { name } }
+      subIssues(first: 100) {
+        totalCount
+        nodes {
+          number
+          title
+          body
+          state
+          labels(first: 50) { nodes { name } }
+          blockedBy(first: 50) { nodes { number } }
+        }
+      }
+      blockedBy(first: 50) { nodes { number } }
+    }
+EOF
+}
+
+ALIAS_BLOCKS=""
+for n in "$@"; do
+  ALIAS_BLOCKS+="$(build_alias_block "$n")"$'\n'
+done
+
+QUERY=$(cat <<EOF
+query(\$owner: String!, \$name: String!) {
+  repository(owner: \$owner, name: \$name) {
+${ALIAS_BLOCKS}
+  }
+}
+EOF
+)
+
+if ! RAW="$(gh api graphql -F owner="$OWNER" -F name="$NAME" -f query="$QUERY" 2>/tmp/gather_issues.err)"; then
+  echo "gather_issues: GraphQL query failed:" >&2
+  cat /tmp/gather_issues.err >&2
+  rm -f /tmp/gather_issues.err
+  exit 1
+fi
+rm -f /tmp/gather_issues.err
+
+if echo "$RAW" | jq -e '.errors' >/dev/null 2>&1; then
+  echo "gather_issues: GraphQL returned errors:" >&2
+  echo "$RAW" | jq -r '.errors[] | .message' >&2
+  exit 1
+fi
+
+REPO_JSON="$(echo "$RAW" | jq '.data.repository')"
+
+REQUESTED_ARG="$REQUESTED_JSON"
+
+OUTPUT="$(jq -n \
+  --argjson requested "$REQUESTED_ARG" \
+  --argjson repo "$REPO_JSON" \
+  '
+  def parse_body_deps($body):
+    ($body // "")
+    | [ scan("(?i)(?:depends on|blocked by)\\s*#([0-9]+)") | .[0] | tonumber ]
+    | unique;
+
+  def resolve_deps(issue):
+    (issue.blockedBy.nodes // [] | map(.number)) as $native
+    | if ($native | length) > 0
+      then $native
+      else parse_body_deps(issue.body)
+      end;
+
+  def labels_of(issue):
+    (issue.labels.nodes // []) | map(.name);
+
+  def is_on_hold(issue):
+    labels_of(issue) | any(. == "on-hold");
+
+  def is_closed(issue):
+    (issue.state // "OPEN") == "CLOSED";
+
+  def has_epic_label(issue):
+    labels_of(issue) | any(. == "epic");
+
+  def work_item(issue; source_epic):
+    {
+      number: issue.number,
+      title: issue.title,
+      body: (issue.body // ""),
+      labels: labels_of(issue),
+      state: issue.state,
+      is_epic: false,
+      deps: resolve_deps(issue),
+      skip: false,
+      skip_reason: null,
+      source_epic: source_epic
+    };
+
+  reduce $requested[] as $n (
+    {work_items: [], skipped: [], epics_expanded: [], epics_unwired: []};
+    ($repo["i" + ($n|tostring)]) as $iss
+    | if $iss == null then
+        .skipped += [{number: $n, reason: "issue not found"}]
+      elif (is_on_hold($iss)) then
+        .skipped += [{number: $n, reason: "on-hold label"}]
+      elif (is_closed($iss)) then
+        .skipped += [{number: $n, reason: "closed"}]
+      elif (($iss.subIssues.totalCount // 0) > 0) then
+        (
+          ($iss.subIssues.nodes // [])
+          | map(select((labels_of(.) | any(. == "on-hold") | not)
+                       and ((.state // "OPEN") != "CLOSED")))
+        ) as $active_children
+        | .epics_expanded += [{number: $n, children: ($active_children | map(.number))}]
+        | .work_items += ($active_children | map(work_item(.; $n)))
+      elif (has_epic_label($iss)) then
+        .epics_unwired += [$n]
+      else
+        .work_items += [work_item($iss; null)]
+      end
+  )
+  | {requested: $requested} + .
+  '
+)"
+
+echo "$OUTPUT"

--- a/plugins/swarmkit/skills/swarm-experimental/scripts/teardown.sh
+++ b/plugins/swarmkit/skills/swarm-experimental/scripts/teardown.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# teardown.sh — collapse the loop-mode teardown phase (base restore +
+# claude.flowkit.prBase unset) into one call, mirroring preflight.sh.
+#
+# Usage:
+#   teardown.sh [--base <branch>]
+#
+# On success: exit 0, single JSON object on stdout with keys:
+#   {base, base_restored, config_unset}
+# On failure: non-zero exit, empty stdout, human-readable message on stderr.
+
+BASE="develop"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      [[ $# -ge 2 ]] || { echo "teardown: --base requires a value" >&2; exit 2; }
+      BASE="$2"
+      shift 2
+      ;;
+    *)
+      echo "teardown: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+for cmd in git jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "teardown: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+config_unset=false
+if git config --local --get claude.flowkit.prBase >/dev/null 2>&1; then
+  if ! git config --local --unset claude.flowkit.prBase >/dev/null 2>&1; then
+    echo "teardown: failed to unset claude.flowkit.prBase" >&2
+    exit 1
+  fi
+  config_unset=true
+fi
+
+base_restored=false
+if ! git checkout "$BASE" >/dev/null 2>&1; then
+  echo "teardown: 'git checkout $BASE' failed — check for uncommitted changes or a detached HEAD conflict" >&2
+  exit 1
+fi
+if ! git pull origin "$BASE" >/dev/null 2>&1; then
+  echo "teardown: 'git pull origin $BASE' failed" >&2
+  exit 1
+fi
+base_restored=true
+
+jq -n \
+  --arg base "$BASE" \
+  --argjson base_restored "$base_restored" \
+  --argjson config_unset "$config_unset" \
+  '{base: $base, base_restored: $base_restored, config_unset: $config_unset}'

--- a/plugins/swarmkit/skills/swarm-experimental/scripts/verify_agent.sh
+++ b/plugins/swarmkit/skills/swarm-experimental/scripts/verify_agent.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# verify_agent.sh — collapse Step 5 (handle completions) branch-push and
+# PR-existence checks into one call per agent.
+#
+# Usage:
+#   verify_agent.sh <issue-number>
+#
+# On success: exit 0, single JSON object on stdout with keys:
+#   {issue, branch, branch_pushed, pushed_now, pr_exists, pr_url, pr_base}
+# On failure: non-zero exit, empty stdout, human-readable message on stderr.
+
+if [[ $# -ne 1 ]]; then
+  echo "verify_agent: exactly one argument required: <issue-number>" >&2
+  exit 2
+fi
+
+ISSUE="$1"
+if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+  echo "verify_agent: issue number must be a positive integer (got '$ISSUE')" >&2
+  exit 2
+fi
+
+for cmd in gh jq git; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "verify_agent: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+BRANCH="worktree-agent-${ISSUE}"
+
+branch_pushed=false
+pushed_now=false
+
+git fetch origin "$BRANCH" >/dev/null 2>&1 || true
+
+if git rev-parse --verify "refs/remotes/origin/${BRANCH}" >/dev/null 2>&1; then
+  branch_pushed=true
+else
+  if git rev-parse --verify "refs/heads/${BRANCH}" >/dev/null 2>&1; then
+    if git push -u origin "${BRANCH}" >/dev/null 2>&1; then
+      branch_pushed=true
+      pushed_now=true
+    else
+      echo "verify_agent: failed to push branch '${BRANCH}' to origin" >&2
+      exit 1
+    fi
+  fi
+fi
+
+pr_exists=false
+pr_url=null
+pr_base=null
+
+if ! PR_JSON="$(gh pr list --head "$BRANCH" --json number,url,baseRefName,state 2>/dev/null)"; then
+  echo "verify_agent: 'gh pr list' failed for branch '${BRANCH}'" >&2
+  exit 1
+fi
+
+OPEN_PR="$(echo "$PR_JSON" | jq -r '[.[] | select(.state == "OPEN")] | first // empty')"
+
+if [[ -n "$OPEN_PR" ]]; then
+  pr_exists=true
+  pr_url="\"$(echo "$OPEN_PR" | jq -r '.url')\""
+  pr_base="\"$(echo "$OPEN_PR" | jq -r '.baseRefName')\""
+fi
+
+jq -n \
+  --argjson issue "$ISSUE" \
+  --arg branch "$BRANCH" \
+  --argjson branch_pushed "$branch_pushed" \
+  --argjson pushed_now "$pushed_now" \
+  --argjson pr_exists "$pr_exists" \
+  --argjson pr_url "$pr_url" \
+  --argjson pr_base "$pr_base" \
+  '{issue: $issue, branch: $branch, branch_pushed: $branch_pushed, pushed_now: $pushed_now, pr_exists: $pr_exists, pr_url: $pr_url, pr_base: $pr_base}'


### PR DESCRIPTION
## Summary
- Add `scripts/gather_issues.sh` batching issue metadata (title, body, labels, state, sub-issues, native dependencies) into a single `gh api graphql` call — collapsing 3N bash turns into 1 script call.
- Prefer GitHub's native issue-dependency API (`blockedBy`) over body-grep for `Depends on #N` / `Blocked by #N`, picking up relationships wired by `/spec` that the legacy path missed.
- Wire SKILL.md Step 1 and Step 2 to consume the script's `work_items` + `deps`, preserving existing skip and epic-expansion announcements.

## Changes
- New: `plugins/swarmkit/skills/swarm-experimental/scripts/gather_issues.sh` — positional `<number> [<number> ...]`, one GraphQL request with per-issue aliases, outputs `{requested, work_items, skipped, epics_expanded, epics_unwired}` via `jq -n`. Per-script dep check for `gh`/`jq`/`git`, `set -euo pipefail`, executable bit set. Native `blockedBy` preferred; body-grep fallback (case-insensitive) when native is empty.
- Updated: `plugins/swarmkit/skills/swarm-experimental/SKILL.md` Step 1 — replaced inline `gh issue view` + `gh api .../sub_issues` + body-grep loop with one script invocation; documented `work_items`, `skipped`, `epics_expanded`, `epics_unwired` handling and kept existing announcement templates.
- Updated: same SKILL.md Step 2 — consumes pre-computed `deps` from `work_items` instead of re-grepping bodies; topological sort semantics preserved.

## Test plan
- Run `scripts/gather_issues.sh 544 545` against this repo — confirms `#545.deps == [544]` (native `blockedBy` wired by `/spec`), both items appear in `work_items`, no skips.
- Run against wired epic `#549` — confirms all 5 children appear with `source_epic: 549` and `epics_expanded` lists them; native deps flow through onto each child.
- Run against closed issues (`#541`, `#526`) — confirms they land in `skipped` with `reason: "closed"`.
- Smoke-test argument validation: no args and non-numeric args exit 2 with stderr message; bad issue numbers propagate the GraphQL error cleanly to stderr with non-zero exit.
- Confirm body-grep fallback: jq `scan` regex `(?i)(?:depends on|blocked by)\s*#([0-9]+)` captures mixed-case and multi-occurrence references.

Closes #545

Closes #546
Closes #547