### PR TITLE
feat(swarmkit): add verify_agent.sh for post-agent verification

### DIFF
--- a/plugins/swarmkit/skills/swarm-experimental/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-experimental/SKILL.md
@@ -333,14 +333,7 @@ Proceed immediately to the next cycle after printing the checkpoint summary. The
 ### Teardown
 
 1. Run the `clean-worktrees` skill
-2. Restore the base branch (worktree removal may drift the shell to a detached HEAD or a different branch):
-   ```bash
-   git checkout $BASE && git pull origin $BASE
-   ```
-3. Unset `claude.flowkit.prBase` to clear the scoped PR base:
-   ```bash
-   git config --local --unset claude.flowkit.prBase
-   ```
+2. Run `scripts/teardown.sh` (optionally `--base <branch>` to override the default `develop`). Parse the returned JSON and confirm `base_restored: true`. If `config_unset: false`, log that `claude.flowkit.prBase` was already clear — this is not a failure.
 
 Optionally, run `swarmkit:clean-remote-worktrees` afterwards to sweep orphaned remote `worktree-agent-*` branches left behind by merged PRs. This is not automatic — invoke it when you want to tidy up.
 

--- a/plugins/swarmkit/skills/swarm-experimental/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-experimental/SKILL.md
@@ -238,9 +238,34 @@ Each agent prompt MUST include these **workflow steps** (in order):
 
 ### 5. Handle completions
 
-After each agent completes, always verify:
-- **(a) Branch is pushed to origin** — run `git ls-remote --exit-code origin worktree-agent-<issue>`. If absent, push it: `git push -u origin worktree-agent-<issue>`
-- **(b) A PR exists referencing the issue** — run `gh pr list --head worktree-agent-<issue>`. If none, create the PR on the agent's behalf using the agent's commits and the issue spec.
+After each agent completes, run the verify script once per agent:
+
+```bash
+plugins/swarmkit/skills/swarm-experimental/scripts/verify_agent.sh <issue>
+```
+
+On success the script exits 0 and emits a single JSON object on stdout:
+
+```json
+{
+  "issue": 102,
+  "branch": "worktree-agent-102",
+  "branch_pushed": true,
+  "pushed_now": false,
+  "pr_exists": true,
+  "pr_url": "https://github.com/owner/name/pull/210",
+  "pr_base": "develop"
+}
+```
+
+Parse the JSON and act on the fields:
+
+- **`branch_pushed: false` and no local branch** — the agent produced no push and no local branch exists; announce the unrecoverable failure and treat the issue as failed (do not attempt PR creation).
+- **`pushed_now: true`** — the script pushed the branch on the agent's behalf; announce this before proceeding.
+- **`pr_exists: false`** — create the PR on the agent's behalf using the agent's commits and the issue spec. PR creation (title, body, base branch selection) is a judgment call made by Claude using the existing PR-body template from Step 4. Use `pr_base` from the preflight JSON (or the appropriate stacked-branch base for dependent issues) as the `--base` argument.
+- **`pr_exists: true`** — no action needed; `pr_url` carries the existing PR link.
+
+If the script exits non-zero, stdout will be empty and stderr will carry a human-readable error — surface it and treat the issue as failed.
 
 Report the PR link once confirmed. Verify each PR's diff matches the issue scope.
 

--- a/plugins/swarmkit/skills/swarm-experimental/scripts/teardown.sh
+++ b/plugins/swarmkit/skills/swarm-experimental/scripts/teardown.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# teardown.sh — collapse the loop-mode teardown phase (base restore +
+# claude.flowkit.prBase unset) into one call, mirroring preflight.sh.
+#
+# Usage:
+#   teardown.sh [--base <branch>]
+#
+# On success: exit 0, single JSON object on stdout with keys:
+#   {base, base_restored, config_unset}
+# On failure: non-zero exit, empty stdout, human-readable message on stderr.
+
+BASE="develop"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      [[ $# -ge 2 ]] || { echo "teardown: --base requires a value" >&2; exit 2; }
+      BASE="$2"
+      shift 2
+      ;;
+    *)
+      echo "teardown: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+for cmd in git jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "teardown: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+config_unset=false
+if git config --local --get claude.flowkit.prBase >/dev/null 2>&1; then
+  if ! git config --local --unset claude.flowkit.prBase >/dev/null 2>&1; then
+    echo "teardown: failed to unset claude.flowkit.prBase" >&2
+    exit 1
+  fi
+  config_unset=true
+fi
+
+base_restored=false
+if ! git checkout "$BASE" >/dev/null 2>&1; then
+  echo "teardown: 'git checkout $BASE' failed — check for uncommitted changes or a detached HEAD conflict" >&2
+  exit 1
+fi
+if ! git pull origin "$BASE" >/dev/null 2>&1; then
+  echo "teardown: 'git pull origin $BASE' failed" >&2
+  exit 1
+fi
+base_restored=true
+
+jq -n \
+  --arg base "$BASE" \
+  --argjson base_restored "$base_restored" \
+  --argjson config_unset "$config_unset" \
+  '{base: $base, base_restored: $base_restored, config_unset: $config_unset}'

--- a/plugins/swarmkit/skills/swarm-experimental/scripts/verify_agent.sh
+++ b/plugins/swarmkit/skills/swarm-experimental/scripts/verify_agent.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# verify_agent.sh — collapse Step 5 (handle completions) branch-push and
+# PR-existence checks into one call per agent.
+#
+# Usage:
+#   verify_agent.sh <issue-number>
+#
+# On success: exit 0, single JSON object on stdout with keys:
+#   {issue, branch, branch_pushed, pushed_now, pr_exists, pr_url, pr_base}
+# On failure: non-zero exit, empty stdout, human-readable message on stderr.
+
+if [[ $# -ne 1 ]]; then
+  echo "verify_agent: exactly one argument required: <issue-number>" >&2
+  exit 2
+fi
+
+ISSUE="$1"
+if ! [[ "$ISSUE" =~ ^[0-9]+$ ]]; then
+  echo "verify_agent: issue number must be a positive integer (got '$ISSUE')" >&2
+  exit 2
+fi
+
+for cmd in gh jq git; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "verify_agent: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+BRANCH="worktree-agent-${ISSUE}"
+
+branch_pushed=false
+pushed_now=false
+
+git fetch origin "$BRANCH" >/dev/null 2>&1 || true
+
+if git rev-parse --verify "refs/remotes/origin/${BRANCH}" >/dev/null 2>&1; then
+  branch_pushed=true
+else
+  if git rev-parse --verify "refs/heads/${BRANCH}" >/dev/null 2>&1; then
+    if git push -u origin "${BRANCH}" >/dev/null 2>&1; then
+      branch_pushed=true
+      pushed_now=true
+    else
+      echo "verify_agent: failed to push branch '${BRANCH}' to origin" >&2
+      exit 1
+    fi
+  fi
+fi
+
+pr_exists=false
+pr_url=null
+pr_base=null
+
+if ! PR_JSON="$(gh pr list --head "$BRANCH" --json number,url,baseRefName,state 2>/dev/null)"; then
+  echo "verify_agent: 'gh pr list' failed for branch '${BRANCH}'" >&2
+  exit 1
+fi
+
+OPEN_PR="$(echo "$PR_JSON" | jq -r '[.[] | select(.state == "OPEN")] | first // empty')"
+
+if [[ -n "$OPEN_PR" ]]; then
+  pr_exists=true
+  pr_url="\"$(echo "$OPEN_PR" | jq -r '.url')\""
+  pr_base="\"$(echo "$OPEN_PR" | jq -r '.baseRefName')\""
+fi
+
+jq -n \
+  --argjson issue "$ISSUE" \
+  --arg branch "$BRANCH" \
+  --argjson branch_pushed "$branch_pushed" \
+  --argjson pushed_now "$pushed_now" \
+  --argjson pr_exists "$pr_exists" \
+  --argjson pr_url "$pr_url" \
+  --argjson pr_base "$pr_base" \
+  '{issue: $issue, branch: $branch, branch_pushed: $branch_pushed, pushed_now: $pushed_now, pr_exists: $pr_exists, pr_url: $pr_url, pr_base: $pr_base}'


### PR DESCRIPTION
## Summary
- Add `scripts/verify_agent.sh` that takes a single issue number, ensures `worktree-agent-<issue>` is pushed to origin (pushing it if absent), and reports whether an open PR exists for that branch — collapsing 2N bash calls into N script calls for post-agent verification.
- Script reports state only; PR creation (title / body / base synthesis) stays in Claude per the issue's acceptance criteria.
- Wire SKILL.md Step 5 to invoke the script and parse the JSON, creating the PR only when `pr_exists` is false.

## Test plan
- Run `scripts/verify_agent.sh 544` (which has PR #550 open) and confirm `branch_pushed: true`, `pushed_now: false`, `pr_exists: true`, `pr_url` pointing at #550, `pr_base: develop`.
- Run the script for an issue whose branch exists only locally and confirm it pushes the branch and reports `pushed_now: true`.
- Run the script for a fake issue number and confirm it emits `branch_pushed: false, pr_exists: false` without erroring.
- Confirm the script never creates a PR — search git log / PR list for evidence.

Closes #546

Closes #547