### PR TITLE
feat(swarmkit): add teardown.sh for loop-mode cleanup

### DIFF
--- a/plugins/swarmkit/skills/swarm-experimental/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-experimental/SKILL.md
@@ -333,14 +333,7 @@ Proceed immediately to the next cycle after printing the checkpoint summary. The
 ### Teardown
 
 1. Run the `clean-worktrees` skill
-2. Restore the base branch (worktree removal may drift the shell to a detached HEAD or a different branch):
-   ```bash
-   git checkout $BASE && git pull origin $BASE
-   ```
-3. Unset `claude.flowkit.prBase` to clear the scoped PR base:
-   ```bash
-   git config --local --unset claude.flowkit.prBase
-   ```
+2. Run `scripts/teardown.sh` (optionally `--base <branch>` to override the default `develop`). Parse the returned JSON and confirm `base_restored: true`. If `config_unset: false`, log that `claude.flowkit.prBase` was already clear — this is not a failure.
 
 Optionally, run `swarmkit:clean-remote-worktrees` afterwards to sweep orphaned remote `worktree-agent-*` branches left behind by merged PRs. This is not automatic — invoke it when you want to tidy up.
 

--- a/plugins/swarmkit/skills/swarm-experimental/scripts/teardown.sh
+++ b/plugins/swarmkit/skills/swarm-experimental/scripts/teardown.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# teardown.sh — collapse the loop-mode teardown phase (base restore +
+# claude.flowkit.prBase unset) into one call, mirroring preflight.sh.
+#
+# Usage:
+#   teardown.sh [--base <branch>]
+#
+# On success: exit 0, single JSON object on stdout with keys:
+#   {base, base_restored, config_unset}
+# On failure: non-zero exit, empty stdout, human-readable message on stderr.
+
+BASE="develop"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)
+      [[ $# -ge 2 ]] || { echo "teardown: --base requires a value" >&2; exit 2; }
+      BASE="$2"
+      shift 2
+      ;;
+    *)
+      echo "teardown: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+for cmd in git jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "teardown: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+config_unset=false
+if git config --local --get claude.flowkit.prBase >/dev/null 2>&1; then
+  if ! git config --local --unset claude.flowkit.prBase >/dev/null 2>&1; then
+    echo "teardown: failed to unset claude.flowkit.prBase" >&2
+    exit 1
+  fi
+  config_unset=true
+fi
+
+base_restored=false
+if ! git checkout "$BASE" >/dev/null 2>&1; then
+  echo "teardown: 'git checkout $BASE' failed — check for uncommitted changes or a detached HEAD conflict" >&2
+  exit 1
+fi
+if ! git pull origin "$BASE" >/dev/null 2>&1; then
+  echo "teardown: 'git pull origin $BASE' failed" >&2
+  exit 1
+fi
+base_restored=true
+
+jq -n \
+  --arg base "$BASE" \
+  --argjson base_restored "$base_restored" \
+  --argjson config_unset "$config_unset" \
+  '{base: $base, base_restored: $base_restored, config_unset: $config_unset}'


### PR DESCRIPTION
## Summary

Add `scripts/teardown.sh` to collapse the loop-mode base-restore and `claude.flowkit.prBase` unset into a single script call, matching the symmetry with `preflight.sh --scope-pr-base` from setup. `clean-worktrees` stays inline as a skill invocation — absorbing it into a shell script would cross a skill-boundary abstraction.

## Changes

- Add `plugins/swarmkit/skills/swarm-experimental/scripts/teardown.sh` — handles config unset (gracefully skips if already clear) and `git checkout $BASE && git pull origin $BASE`, emitting `{base, base_restored, config_unset}` JSON on success.
- Update `plugins/swarmkit/skills/swarm-experimental/SKILL.md` loop-mode Teardown section to replace the two inline bash steps (base restore + config unset) with a single `scripts/teardown.sh` invocation; `clean-worktrees` skill call and optional `clean-remote-worktrees` note remain unchanged.

## Test plan

- [ ] Set `git config --local claude.flowkit.prBase something` and run `scripts/teardown.sh` — confirm JSON reports `config_unset: true`, `base_restored: true`, and a subsequent `git config --local --get claude.flowkit.prBase` returns empty.
- [ ] Run `scripts/teardown.sh` a second time with no prior config set — confirm it returns `config_unset: false` without failing.
- [ ] Run with `--base <some-existing-branch>` and confirm the base override flows through the checkout + pull.
- [ ] Confirm `clean-worktrees` skill invocation is still inline in SKILL.md Teardown step 1.
- [ ] Confirm the optional `swarmkit:clean-remote-worktrees` note is intact.

Closes #547