### PR TITLE
feat(swarmkit:squad): successor spawn with -hN naming and worktree reuse

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Run it before staging and committing the release.
 
 ## Plugins
 
-`swarmkit` includes an experimental `squad` skill gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`. See `plugins/swarmkit/README.md` for details.
+`swarmkit` includes an experimental `squad` skill gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`. Squad supports preemptive handoff: builders near their context limit are rotated to a `-hN` successor before crashing. See `plugins/swarmkit/README.md` for details.
 
 ## Skill Authoring Conventions
 

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -189,3 +189,32 @@ Once enabled, invoke it the same way as `/swarm`:
 - **Reviewer is pre-push only** — the reviewer teammate provides feedback before PRs are opened. It does not perform GitHub-side code review after the PR is created.
 - **In-process backend ignores `isolation: "worktree"`** — today's default Agent Teams backend silently drops the flag, leaving builders in the orchestrator's cwd. The squad builder contract includes a temporary manual-worktree fallback that creates the worktree itself when this happens. See [#362](https://github.com/smallorbit/smallorbit-plugins/issues/362) — the fallback will be removed once the backend honors the flag.
 - **Experimental** — API and behavior may change without notice as the Agent Teams feature evolves.
+
+### Preemptive handoff
+
+Builder teammates have a finite context window. Without intervention, a builder whose transcript grows too large will crash mid-task — producing a partial result and triggering Halt-and-Report for the whole team.
+
+Preemptive handoff is the mechanism that rotates a builder out before that happens.
+
+**The signal.** Squad monitors each builder's transcript size. When the transcript crosses a configured threshold, the lead treats that builder as context-exhausted and initiates a handoff. The threshold was chosen empirically — see [#452](https://github.com/smallorbit/smallorbit-plugins/issues/452) for the probe that established it. There is no timer and no self-rotation: the signal is the transcript size, nothing else.
+
+**Successor naming.** When a builder is rotated, its successor takes the same base name with an `-hN` suffix counting up from 1:
+
+```
+builder-42          # original
+builder-42-h1       # first successor
+builder-42-h2       # second successor
+```
+
+The suffix is purely informational. If you see `builder-42-h2` in a log or worktree listing, the original builder completed two handoff cycles — it is not a sign of failure.
+
+**Worktree continuity.** Successors reuse the same isolated worktree as their predecessor. Partial work, staged files, and in-progress commits carry over. The successor picks up where the prior builder left off.
+
+**Teardown.** When a run completes, squad's teardown phase automatically removes stale teammate entries — including any `-hN` members that are no longer active. You do not need to clean them up manually.
+
+**What falls through to Halt-and-Report.** Preemptive handoff only covers the transcript-size signal. The following are out of scope and still halt the team:
+
+- A builder crashes for a reason unrelated to context size (process error, unhandled exception, etc.)
+- The lead itself exhausts its context — lead self-exhaustion has no rotation mechanism.
+
+Schema details and the full handoff protocol live in [`skills/squad/SKILL.md`](./skills/squad/SKILL.md).

--- a/plugins/swarmkit/skills/squad/SKILL.md
+++ b/plugins/swarmkit/skills/squad/SKILL.md
@@ -1029,22 +1029,34 @@ Runs **regardless of success or halt**. Every step must be idempotent — runnin
 
    If a teammate is already gone (crashed or already exited), the send is a no-op.
 
-2. **Force-clear stuck `isActive` members, then delete the team** — wait a reasonable timeout (e.g. 10 seconds) for each teammate to acknowledge the shutdown. Any member whose mailbox never responds within the timeout is considered dead-on-arrival: forcibly patch `~/.claude/teams/<team>/config.json` to set its `isActive` flag to `false` so that `TeamDelete` is not blocked:
+2. **Force-clear stuck `isActive` members, then delete the team** — three independent code paths feed the same jq patch against `~/.claude/teams/<team>/config.json`. They are additive: predecessor cleanup runs **in addition to**, not instead of, the other two.
+
+   **Path A — shutdown-ack timeout (10s).** Wait a reasonable timeout (e.g. 10 seconds) for each teammate to acknowledge the `shutdown_request` sent in step 1. Any member whose mailbox never responds within the timeout is considered dead-on-arrival and gets its `isActive` force-cleared via the patch below.
+
+   **Path B — `TeamDelete` active-member error.** If `TeamDelete` returns an active-member error for a name that never surfaced in path A, force-clear that name with the same patch and retry `TeamDelete`.
+
+   **Path C — predecessor cleanup (handoff chain).** For every teammate that completed a successful `handoff_ready` → successor-spawn sequence (see #514–#516), the predecessor exits without participating in the shutdown-ack handshake and without triggering the `TeamDelete` error — so paths A and B both miss it, and its `isActive` stays `true`, blocking future `TeamDelete` calls. Run the patch below on every such predecessor name recorded during the run.
+
+   The patch (used by all three paths):
 
    ```bash
-   # For each non-responding member <name>:
+   # For each name to force-clear <name>:
    jq '(.members[] | select(.name == "<name>")).isActive = false' \
      ~/.claude/teams/<team>/config.json > /tmp/team-config.json \
      && mv /tmp/team-config.json ~/.claude/teams/<team>/config.json
    ```
 
-   After all stuck members are cleared, delete the team:
+   The jq expression is idempotent: if `<name>` is already `isActive: false` (or the member is absent), the assignment is a no-op and the command exits cleanly. Running teardown twice on the same state must not error.
+
+   After all stuck members are cleared (via any of the three paths), delete the team:
 
    ```
    TeamDelete({name: "<team-name>"})
    ```
 
    This step must be idempotent — if the team was already deleted (e.g. teardown is running a second time), the `TeamDelete` call should be treated as a no-op.
+
+   **Test note:** verify by running a short squad that triggers at least one handoff, then re-running teardown and asserting no-op (no error, no config-file change, `TeamDelete` reports the team is already gone).
 
 3. **Invoke `clean-worktrees` sub-skill** — reuses existing logic to remove all `worktree-agent-*` worktrees, delete orphan local branches, and restore the caller's branch:
 

--- a/plugins/swarmkit/skills/squad/SKILL.md
+++ b/plugins/swarmkit/skills/squad/SKILL.md
@@ -435,6 +435,60 @@ For each roundtrip with teammate `<name>`, run these three steps **in order**:
 
 Do not re-emit `request_handoff` to the same teammate while an earlier one for that teammate is still outstanding — one handoff request per teammate at a time.
 
+#### 3b. Successor spawn on `handoff_ready` receipt
+
+When the lead receives a `handoff_ready` message (schema in the Preemptive Handoff Messages section) from a retiring teammate, it spawns a fresh successor that resumes the predecessor's in-flight work. This is the step that keeps headcount stable — without it, every preemptive handoff permanently reduces the pool by one and the squad eventually starves.
+
+On receipt of `handoff_ready` from predecessor `<predecessor>` carrying `current_task_id` and a role-specific `state` blob, the lead spawns the successor immediately — before clearing the outstanding `request_handoff` entry for `<predecessor>`.
+
+##### Successor name: `<role>-h<N>` lineage counter
+
+The successor's `Agent({name: ...})` is derived by appending (or incrementing) a `-h<N>` suffix on the predecessor's name:
+
+| Predecessor name | Successor name |
+|---|---|
+| `reviewer` | `reviewer-h1` |
+| `reviewer-h1` | `reviewer-h2` |
+| `builder-42` | `builder-42-h1` |
+| `builder-42-c2` | `builder-42-c2-h1` |
+| `builder-42-h1` | `builder-42-h2` |
+| `builder-42-h2` | `builder-42-h3` |
+
+**Counter rules:**
+
+- The counter `N` is **per-lineage**, not per-cycle: every successor in the same chain increments from the last `-h<N>` on the predecessor's name. A chain may grow arbitrarily long (`builder-42` → `-h1` → `-h2` → `-h3` → ...) within a single run.
+- **The counter spans chains** — it is not reset by loop-mode cycle boundaries, by reviewer handoffs, or by unrelated builder handoffs. As long as a teammate is the handoff descendant of another, the counter continues climbing on that lineage.
+- The counter is derived mechanically from the predecessor's name — parse the trailing `-h<digits>` if present, increment it; otherwise append `-h1`. The lead does not maintain a separate counter store; the name itself is the source of truth.
+- Names from other axes (`-c<cycle>` loop suffix, issue numbers) are preserved verbatim; only the `-h<N>` segment moves.
+
+##### Spawn options: no `isolation: "worktree"`
+
+The successor is spawned via `Agent({...})` with the **same** `team_name`, `subagent_type`, and general spawn shape as the predecessor, with one critical exception:
+
+> **Do not pass `isolation: "worktree"` on the successor spawn.** The predecessor's `handoff_ready` payload carries the `worktree_path` (builder variant) where the in-flight work — including any `stash_ref` — lives. A fresh isolated worktree would orphan the stash: the successor would land in a brand-new empty working tree with no path back to the predecessor's stashed edits or branch. Reusing the predecessor's worktree is what makes the stash-pop and branch continuity possible.
+
+For reviewers the flag is already omitted (reviewers never spawn with `isolation: "worktree"` in the first place), so the rule is a no-op on that side; it is stated here for consistency so the spawn shape matches across roles.
+
+##### Spawn prompt
+
+The successor's prompt is the same role contract (Builder Teammate Contract or Reviewer Teammate Contract) as the predecessor, **prefixed** with a handoff-resume preamble derived from the `handoff_ready` payload:
+
+1. **`cd` into the predecessor's worktree.** For the builder variant, use `state.worktree_path` verbatim. For the reviewer variant, the `state` blob is empty and no `cd` is needed — the reviewer is stateless on the filesystem.
+
+   ```bash
+   cd <state.worktree_path>        # builder only
+   ```
+
+2. **`git stash pop <stash_ref>` — builders only, and only if `state.stash_ref` is non-null.** The reviewer has no stash (its `state` is empty), so no pop is performed. If the builder's predecessor committed everything before quiescing and `state.stash_ref` is null, skip the pop.
+
+   ```bash
+   git stash pop <state.stash_ref>   # builder only, only when stash_ref != null
+   ```
+
+3. **Re-claim the task.** The preamble includes `current_task_id` from the payload so the successor can atomically re-claim it on the shared task list (the predecessor released the claim as part of its quiesce sequence — see Builder Teammate Contract step 10 and Reviewer Teammate Contract step 8). The successor then resumes the role's normal workflow from the appropriate step (builder: implementation; reviewer: audit loop).
+
+After spawning, the lead clears the outstanding-handoff tracking entry for `<predecessor>` so a future transcript-size breach against the successor can issue its own `request_handoff`. Predecessor teardown (removing the stale name from the team config, verifying it has exited) is out of scope here and handled separately.
+
 ### 4. Mode-specific termination
 
 - **One-shot mode** — exits as soon as every issue in the initial target set has a PR. No re-fetching.


### PR DESCRIPTION
## Summary
- Document lead-side `handoff_ready` receipt: spawn a successor via Agent with name `<role>-h<N>`, no isolation (reuse predecessor's worktree), and a stash-pop step for builders.
- Establish the per-lineage `-hN` counter so successor chains are unambiguous (`builder-42` → `builder-42-h1` → `-h2` → ...).
- Justify skipping `isolation: "worktree"` inline: isolation would orphan the predecessor's stash.

## Test plan
- Verify the naming scheme and per-lineage counter rules are documented.
- Confirm the spawn prompt template specifies `cd` to predecessor worktree, `git stash pop <ref>` for builders only, and task-ID re-claim.
- Confirm the no-isolation rationale (stash continuity) is stated inline.

Closes #516

Closes #517
Closes #518