### PR TITLE
docs(swarmkit): document preemptive handoff flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Run it before staging and committing the release.
 
 ## Plugins
 
-`swarmkit` includes an experimental `squad` skill gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`. See `plugins/swarmkit/README.md` for details.
+`swarmkit` includes an experimental `squad` skill gated behind `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS`. Squad supports preemptive handoff: builders near their context limit are rotated to a `-hN` successor before crashing. See `plugins/swarmkit/README.md` for details.
 
 ## Skill Authoring Conventions
 

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -189,3 +189,32 @@ Once enabled, invoke it the same way as `/swarm`:
 - **Reviewer is pre-push only** — the reviewer teammate provides feedback before PRs are opened. It does not perform GitHub-side code review after the PR is created.
 - **In-process backend ignores `isolation: "worktree"`** — today's default Agent Teams backend silently drops the flag, leaving builders in the orchestrator's cwd. The squad builder contract includes a temporary manual-worktree fallback that creates the worktree itself when this happens. See [#362](https://github.com/smallorbit/smallorbit-plugins/issues/362) — the fallback will be removed once the backend honors the flag.
 - **Experimental** — API and behavior may change without notice as the Agent Teams feature evolves.
+
+### Preemptive handoff
+
+Builder teammates have a finite context window. Without intervention, a builder whose transcript grows too large will crash mid-task — producing a partial result and triggering Halt-and-Report for the whole team.
+
+Preemptive handoff is the mechanism that rotates a builder out before that happens.
+
+**The signal.** Squad monitors each builder's transcript size. When the transcript crosses a configured threshold, the lead treats that builder as context-exhausted and initiates a handoff. The threshold was chosen empirically — see [#452](https://github.com/smallorbit/smallorbit-plugins/issues/452) for the probe that established it. There is no timer and no self-rotation: the signal is the transcript size, nothing else.
+
+**Successor naming.** When a builder is rotated, its successor takes the same base name with an `-hN` suffix counting up from 1:
+
+```
+builder-42          # original
+builder-42-h1       # first successor
+builder-42-h2       # second successor
+```
+
+The suffix is purely informational. If you see `builder-42-h2` in a log or worktree listing, the original builder completed two handoff cycles — it is not a sign of failure.
+
+**Worktree continuity.** Successors reuse the same isolated worktree as their predecessor. Partial work, staged files, and in-progress commits carry over. The successor picks up where the prior builder left off.
+
+**Teardown.** When a run completes, squad's teardown phase automatically removes stale teammate entries — including any `-hN` members that are no longer active. You do not need to clean them up manually.
+
+**What falls through to Halt-and-Report.** Preemptive handoff only covers the transcript-size signal. The following are out of scope and still halt the team:
+
+- A builder crashes for a reason unrelated to context size (process error, unhandled exception, etc.)
+- The lead itself exhausts its context — lead self-exhaustion has no rotation mechanism.
+
+Schema details and the full handoff protocol live in [`skills/squad/SKILL.md`](./skills/squad/SKILL.md).


### PR DESCRIPTION
## Summary
- Add a Preemptive handoff section to `plugins/swarmkit/README.md` covering the transcript-size signal (with pointer to #452), the `-hN` successor naming, the threshold-only trigger (no timer, no self-rotation), and what falls through to Halt-and-Report.
- Add a single-line summary of the handoff mechanism to the repo's root `CLAUDE.md`.

## Changes
- `plugins/swarmkit/README.md`: new **Preemptive handoff** subsection under `### squad`, covering all four required points operator-facing — no schema or implementation mechanics duplicated from SKILL.md.
- `CLAUDE.md`: one-line addition noting preemptive handoff and the `-hN` naming scheme alongside the existing squad mention.

## Test plan
- Verify the README section is operator-facing: no schema or implementation mechanics — those stay in SKILL.md.
- Confirm the four required points are covered: transcript-size signal + why (#452 reference), `-hN` naming scheme, threshold-only trigger (no timer, no lead self-rotation), and out-of-scope signal cases (non-context crashes, lead self-exhaustion).
- Confirm `SKILL.md` was not modified.
- Confirm no files outside this repo were touched.

Closes #518