### PR TITLE
refactor(swarmkit:merge-stack): bottom-up merging with up-front retargeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Swarm complete — 4 PRs opened:
   #212 feat(notes): render tag chips on note cards            → worktree-agent-103
   #213 feat(notes): filter notes by tag from the sidebar      → worktree-agent-104
 
-Stack root: #210. Run /merge-stack to merge top-down.
+Stack root: #210. Run /merge-stack to merge bottom-up.
 ```
 
 ### 4. Ship it (optional — use your own process if you prefer)
@@ -117,7 +117,7 @@ Once the PRs look right, merge and release them however you normally would. If y
 Then merge everything in three commands:
 
 ```
-/merge-stack     # merge all swarm PRs top-down into develop
+/merge-stack     # merge all swarm PRs bottom-up into develop
 /cut             # create a release candidate from develop
 /release         # promote to main, tag the release, close referenced issues
 ```

--- a/plugins/swarmkit/METHODOLOGY.md
+++ b/plugins/swarmkit/METHODOLOGY.md
@@ -2,11 +2,11 @@
 
 ## Overview
 
-Swarmkit resolves a batch of GitHub issues by spawning one agent per issue, each working in its own isolated git worktree. When issues are independent, the agents run fully in parallel and open pull requests that target the base branch directly. When issues depend on one another, the dependent agent branches from its dependency's branch tip instead of from the base, and opens its pull request against that dependency's branch — forming a stack. A separate merge step then collapses the stack top-down, accumulating issue references as it goes, and merges the whole thing into the base branch with a single reviewable history.
+Swarmkit resolves a batch of GitHub issues by spawning one agent per issue, each working in its own isolated git worktree. When issues are independent, the agents run fully in parallel and open pull requests that target the base branch directly. When issues depend on one another, the dependent agent branches from its dependency's branch tip instead of from the base, and opens its pull request against that dependency's branch — forming a stack. A separate merge step then retargets every non-root PR to the base branch up front, then merges the stack bottom-up — root first, then each former child in turn — with a uniform squash, landing each PR's own closing references natively as it merges.
 
 This shape exists because large features rarely factor cleanly into one pull request. The traditional alternatives are both painful: either the author opens one huge PR that is slow to review and risky to merge, or they open a sequence of PRs manually and spend significant effort keeping branches rebased against one another. Stacked pull requests — pioneered in tools like Gerrit and Phabricator and popularized on GitHub by Graphite and Aviator — solve this by treating each change as a small, independently reviewable unit that is explicitly stacked on its predecessor. Swarmkit takes the same idea and combines it with agent parallelism: independent work happens concurrently, dependent work is stacked, and both categories share a single merge strategy.
 
-The four ideas that make this work together are worktree isolation (so agents cannot step on each other), the stacked branch strategy (so dependent work can start before its predecessor merges), top-down merging with reference accumulation (so GitHub does not auto-close dependent PRs and so issue references survive the collapse), and loop mode with failure handling (so a long queue of issues can be cleared without manual babysitting).
+The four ideas that make this work together are worktree isolation (so agents cannot step on each other), the stacked branch strategy (so dependent work can start before its predecessor merges), bottom-up merging with up-front retargeting (so GitHub does not auto-close dependent PRs and so each PR lands with the same diff that was reviewed), and loop mode with failure handling (so a long queue of issues can be cleared without manual babysitting).
 
 ## Quick Start
 
@@ -15,7 +15,7 @@ If you just want to run a swarm and merge the result, this is the full shape of 
 ```
 /next-issue          # see what is ready to work on
 /swarm 12 15 18      # spawn parallel agents for specific issues
-/merge-stack         # merge all open swarm PRs top-down (use /merge-pr for a single PR)
+/merge-stack         # merge all open swarm PRs bottom-up (use /merge-pr for a single PR)
 /clean-worktrees     # remove the worktree directories and orphaned branches
 ```
 
@@ -23,7 +23,7 @@ If you just want to run a swarm and merge the result, this is the full shape of 
 
 Each agent does the same thing: creates a branch named `worktree-agent-<issue>`, makes the changes described in the issue, commits in conventional-commit format, pushes, and opens a pull request whose body includes `Closes #<issue>`. The agent then stops. Nothing is merged automatically — swarm agents open PRs and leave them open for your review.
 
-When you are ready to merge the stack, run `/merge-stack`. It identifies every open pull request whose head branch starts with `worktree-agent-`, works out the stack graph from the head/base relationships, and merges top-down — leaf PRs first, root PRs last, with issue references accumulating into each surviving PR body as the stack collapses. The final PR into the base branch carries the full set of closing references for the entire chain.
+When you are ready to merge the stack, run `/merge-stack`. It identifies every open pull request whose head branch starts with `worktree-agent-`, works out the stack graph from the head/base relationships, retargets every non-root PR in each chain to the base branch, and then merges each chain bottom-up — root PR first, then its former children, up to the leaf — with a uniform `gh pr merge <N> --squash --delete-branch`. Each PR closes its own `Closes #N` references natively as it merges.
 
 ## How It Works
 
@@ -65,15 +65,15 @@ This is the stack. Each pull request in a chain has a head branch and a base bra
 
 The reason this works as a concurrency primitive is that the dependent agent already has access to everything the upstream agent produced — the upstream output is in the working tree from the moment the dependent branch is created. The dependent agent never needs to wait for the upstream pull request to merge. That is also why swarmkit forbids merging a dependency PR mid-swarm "to unblock" a downstream agent: the downstream agent is already unblocked by virtue of branching from the upstream tip, and an early merge would bypass your review gate for no gain.
 
-### Top-Down Merge with Ref Accumulation
+### Bottom-Up Merge with Up-Front Retargeting
 
-The naive way to merge a stack is bottom-up: merge the PR that targets `develop` first, then the one above it, then the one above that. This fails badly on GitHub. When the bottom PR merges and its branch is deleted, the PR immediately above it loses its base branch, and GitHub interprets the missing base as abandonment and auto-closes the dependent PR. You end up fighting the platform to re-open and re-target PRs that were perfectly healthy a minute earlier.
+The naive way to merge a stack bottom-up fails badly on GitHub: when the root PR merges and its branch is deleted, the PR immediately above it loses its base branch, and GitHub interprets the missing base as abandonment and auto-closes the dependent PR. You end up fighting the platform to re-open and re-target PRs that were perfectly healthy a minute earlier.
 
-`/merge-stack` merges top-down instead: leaf PRs first, then the PR below each leaf, cascading down until the root PR finally merges into the base branch. Intermediate merges deliberately omit `--delete-branch` so the base branch of the PR below survives for the next merge step. Only the final merge into the base branch deletes its branch.
+`/merge-stack` sidesteps this with an up-front retarget. Before any merge runs, every non-root PR in a multi-PR chain is retargeted to the base branch with `gh pr edit <N> --base $BASE`. Once a child's base is the base branch, deleting its predecessor's branch no longer looks like abandonment — the auto-close cascade never fires. This is the direction used by Graphite, git-spice, Sapling, and Phabricator, and it means the diff a reviewer approves is the diff that lands: no successive rebases into the root, no CI re-runs on a growing stack, no ref-juggling to preserve closing metadata.
 
-As each intermediate PR merges, its closing issue references are extracted from its body and appended to the body of the next PR down in the chain. By the time the root PR is merged, its body carries the complete set of `Closes #N` references for every issue in the chain. This matters for two reasons: the PR that merges into the base branch contains a full audit trail of what it resolved, and if the merge halts partway down (for example, because of a conflict), the lowest unmerged PR in the chain already contains every reference that successfully merged above it. Nothing is lost mid-collapse.
+With retargeting in place, every PR merges uniformly with `gh pr merge <N> --squash --delete-branch`. There is no per-role strategy matrix and no intermediate-branch sweep — `--delete-branch` handles cleanup inline. Each PR's own body closes its own `Closes #N` references natively as it merges. Chains merge from the root upward to the leaf; independent PRs (whose base is already `develop` and that have nothing stacked on them) may merge in any order.
 
-Independent PRs — those whose base is already `develop` and that no other PR sits on top of — may be merged in any order after the stacked chains resolve. They do not need the ref-accumulation dance because they are not part of a chain.
+If a merge halts partway up a chain (for example, because of a conflict), the remaining PRs above the halt point are marked blocked and reported at the end. Each PR above the halt still targets the base branch after the retarget, so the user can resolve the conflict and re-run `/merge-stack` without re-threading the stack.
 
 ### Loop Mode and Failure Handling
 
@@ -105,21 +105,20 @@ Agent 103 waits for #202 to exist, then spawns. It fetches `origin/worktree-agen
 
 At this point three PRs are open: #201 (→ `develop`), #202 (→ `worktree-agent-101`), #203 (→ `worktree-agent-102`). You review each one. None of them has merged yet.
 
-You run `/merge-stack`. It discovers the three PRs by scanning for open PRs with `worktree-agent-` head branches, builds the stack graph from the head/base fields, and prints a merge plan:
+You run `/merge-stack`. It discovers the three PRs by scanning for open PRs with `worktree-agent-` head branches, builds the stack graph from the head/base fields, retargets every non-root PR to `develop`, and prints a merge plan:
 
 ```
-Chain 1:  PR #203 → PR #202 → PR #201 → develop
+Chain 1:  develop ← PR #201 ← PR #202 ← PR #203
 
-  Step 1. Merge PR #203 into worktree-agent-102 (leaf of chain 1)
-  Step 2. Accumulate refs from #203 into PR #202 body
-  Step 3. Merge PR #202 into worktree-agent-101
-  Step 4. Accumulate refs from #202 into PR #201 body
-  Step 5. Merge PR #201 into develop
+  Retargeted 2 non-root PRs to develop: #202, #203
+  Step 1. Merge PR #201 into develop (squash, delete branch)
+  Step 2. Merge PR #202 into develop (squash, delete branch)
+  Step 3. Merge PR #203 into develop (squash, delete branch)
 ```
 
-Step 1 squash-merges #203 into `worktree-agent-102`. The `--delete-branch` flag is omitted because `worktree-agent-103` is not a base-branch target. In step 2, `Closes #103` is appended to the body of #202. Step 3 squash-merges #202 into `worktree-agent-101`, again without deleting the branch. Step 4 appends `Closes #102` and `Closes #103` to the body of #201. Step 5 squash-merges #201 into `develop` with `--delete-branch`, closing issues #101, #102, and #103 in a single merge. Finally `/clean-worktrees` removes the three worktree directories and the three local `worktree-agent-*` branches.
+Step 1 squash-merges #201 into `develop` and deletes `worktree-agent-101`. Because #202 was already retargeted to `develop`, GitHub does not auto-close it — #202's base is still `develop`. Step 2 squash-merges #202 into `develop` and deletes `worktree-agent-102`; step 3 does the same for #203. Each PR carries its own `Closes #10N` reference, so each issue closes natively on merge. Finally `/clean-worktrees` removes the three worktree directories and the three local `worktree-agent-*` branches.
 
-If anything had gone wrong on the way down — a merge conflict on #202, for example — the merge would have stopped there and reported the chain as halted at #202 with #201 as blocked downstream. PR #201's body would still carry the accumulated `Closes #103` reference from the successful #203 merge, so nothing from the completed work above is lost.
+If anything had gone wrong on the way up — a merge conflict on #202, for example — the merge would have stopped there and reported the chain as halted at #202 with #203 as blocked upstream. The retarget happened before the first merge, so #203 still targets `develop`; the user can resolve the conflict on #202 and re-run `/merge-stack` without re-threading the stack.
 
 ## Further Reading
 

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -4,7 +4,7 @@ A Claude Code plugin that resolves GitHub issues with parallel agents. Pick what
 
 > **New to smallorbit-plugins?** Start with the [Getting Started walkthrough](../../README.md#getting-started) — it covers install, `/spec`, and `/swarm` end to end.
 
-**Already here for swarmkit specifically?** Read [METHODOLOGY.md](./METHODOLOGY.md) for the full narrative on how the stacked agent/PR workflow fits together — worktree isolation, stacked branches, top-down merging with reference accumulation, and loop mode.
+**Already here for swarmkit specifically?** Read [METHODOLOGY.md](./METHODOLOGY.md) for the full narrative on how the stacked agent/PR workflow fits together — worktree isolation, stacked branches, bottom-up merging with up-front retargeting, and loop mode.
 
 ## Installation
 
@@ -53,7 +53,7 @@ Swarmkit is designed to run best when agents don't have to pause for per-command
 | **swarm** | `/swarm` | Spawn parallel isolated-worktree agents to resolve GitHub issues. Supports one-shot mode (specific issues) and loop mode (clear the board). Auto-creates PRs targeting `develop`. |
 | **swarm-experimental** | `/swarm-experimental` | Experimental parallel variant of `/swarm`. Script-backed mechanical phases (preflight, teardown) reduce model round-trips. Same arg grammar and behavior as `/swarm` — prefer `/swarm` for stable workflows. |
 | **next-issue** | `/next-issue` | Fetches open issues, ranks them by priority, specificity, and architectural impact, and recommends what to work on next. |
-| **merge-stack** | `/merge-stack` | Merges all open swarm PRs top-down (leaf PRs first, root last). |
+| **merge-stack** | `/merge-stack` | Merges all open swarm PRs bottom-up (root PRs first, leaves last) after retargeting non-root PRs to `$BASE`. |
 | **clean-worktrees** | `/clean-worktrees` | Removes all agent worktrees and their orphaned `worktree-agent-*` branches. |
 | **clean-remote-worktrees** | `/clean-remote-worktrees` | Sweeps orphaned remote `worktree-agent-*` branches from the remote. |
 | **squad** (experimental) | `/squad` | Agent Teams variant of `/swarm` — runs a structured lead/builder/reviewer team. See [Experimental features](#experimental-features). |
@@ -74,7 +74,7 @@ These are called by the skills above — you don't invoke them directly.
 /next-issue                          # See what's ready to work on
 /swarm 12 15 18                      # Resolve specific issues in parallel
 /merge-pr       # If one PR — merge it directly (flowkit skill)
-/merge-stack    # If two or more PRs — merges top-down: leaf PRs first, root last
+/merge-stack    # If two or more PRs — retargets non-root PRs to $BASE, merges bottom-up: root first, leaves last
 /swarm                               # Or clear the entire board in a loop
 /clean-worktrees                     # Tidy up after a swarm run
 ```
@@ -85,7 +85,7 @@ These are called by the skills above — you don't invoke them directly.
 2. Fetches issues, analyzes dependencies, and presents a swarm plan
 3. Spawns one agent per issue (or grouped set) in isolated git worktrees
 4. Each agent: creates branch, makes changes, commits, pushes, opens PR — then stops
-5. Use `/merge-pr` (1 PR, from [flowkit](../flowkit)) or `/merge-stack` (2+ PRs) to merge into `develop` — top-down: leaf PRs first, root last
+5. Use `/merge-pr` (1 PR, from [flowkit](../flowkit)) or `/merge-stack` (2+ PRs) to merge into `develop` — bottom-up: root PRs first, leaves last, after retargeting non-root PRs to `develop`
 6. Cleans up worktrees and orphaned branches
 
 **One-shot mode**: `/swarm 12 15 18` — resolve those issues and stop.

--- a/plugins/swarmkit/skills/merge-stack/SKILL.md
+++ b/plugins/swarmkit/skills/merge-stack/SKILL.md
@@ -109,11 +109,18 @@ For every still-open PR in the chain, from closest-to-root to leaf:
 ```bash
 git fetch origin <head-branch> $BASE
 git checkout <head-branch>
-git rebase origin/$BASE
+if ! git rebase origin/$BASE; then
+  git rebase --abort
+  # Real content conflict (e.g. add/add on a file two chains both created).
+  # Fall through to 5c: stop this chain, block its dependents, continue with
+  # other chains/independents. Do NOT force-push; leave the PR untouched so
+  # the user can resolve by hand.
+  continue  # or equivalent control flow in the skill's execution loop
+fi
 git push --force-with-lease origin <head-branch>
 ```
 
-`git rebase` will emit `warning: skipped previously applied commit <sha>` for each predecessor commit it drops via patch-id — that's the expected happy path, not an error. If rebase stops with a real merge conflict, follow 5c.
+`git rebase` will emit `warning: skipped previously applied commit <sha>` for each predecessor commit it drops via patch-id — that's the expected happy path, not an error. A non-zero exit from `git rebase` means a real merge conflict git could not auto-resolve; handle it per 5c. Always `git rebase --abort` before falling through so the branch returns to its pre-rebase state and no partial work is pushed.
 
 After the rebases, re-query `mergeStateStatus` for the next PR to merge and proceed to 5b. GitHub may report `UNKNOWN` briefly after a force-push; poll with `sleep 3` until it resolves to `CLEAN`, `BEHIND`, or `DIRTY`.
 

--- a/plugins/swarmkit/skills/merge-stack/SKILL.md
+++ b/plugins/swarmkit/skills/merge-stack/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: merge-stack
-description: Merge all open swarm PRs top-down, accumulating issue refs as the stack collapses into the base branch.
+description: Merge all open swarm PRs bottom-up after retargeting every non-root PR to the base branch, using a uniform squash-and-delete-branch strategy.
 ---
 
 # merge-stack
 
-Merges all open swarm PRs top-down — leaf PRs first, cascading down to the base branch. Each merge injects the absorbed PR's `Closes/Fixes/Resolves/Refs` tokens into the next PR's body so refs accumulate on the way down. The PR that finally merges into `$BASE` carries the complete ref set for the entire stack.
+Merges all open swarm PRs bottom-up — root PRs first, then their former children, up to the leaves. Before any merge happens, every non-root PR in a multi-PR chain is retargeted to `$BASE` so GitHub never fires its auto-close cascade. Every PR then merges uniformly with `gh pr merge <N> --squash --delete-branch`, and each PR closes its own `Closes/Fixes/Resolves/Refs` references on merge.
 
-This avoids the auto-close cascade caused by bottom-up merging: merging bottom-up deletes the base branch of the PR above it, which GitHub interprets as abandonment and auto-closes the dependent PR.
+This matches the merge direction used by Graphite, git-spice, Sapling, and Phabricator: reviewers see and land the same diff, CI runs once per PR instead of re-running on every rebase, and conflicts surface at the leaf instead of cascading down into the root.
 
 ## When to use
 
@@ -31,36 +31,45 @@ If no open swarm PRs are found, report "No open swarm PRs found" and stop.
 Model the PRs as a directed graph where an edge A → B means "A's head branch is B's base branch" (A sits on top of B). Build this from the `headRefName` / `baseRefName` fields — no issue-body parsing needed for ordering.
 
 Identify:
-- **Leaves**: PRs whose `headRefName` is not the `baseRefName` of any other open PR — these are the tops of chains and merge first.
-- **Root PRs**: PRs whose `baseRefName` is `$BASE` (e.g. `develop`) — these merge last.
-- **Independent PRs**: PRs whose `baseRefName` is already `$BASE` and that no other PR sits on top of — these have no stack relationship and can merge in any order after stacked chains resolve.
+- **Root PRs**: PRs whose `baseRefName` is `$BASE` (e.g. `develop`) and that have at least one other PR stacked on top — these merge first in their chain.
+- **Leaves**: PRs whose `headRefName` is not the `baseRefName` of any other open PR — these are the tops of chains and merge last.
+- **Independent PRs**: PRs whose `baseRefName` is already `$BASE` and that no other PR sits on top of — these have no stack relationship and can merge in any order.
 
-For each chain, the merge order is: leaf → … → root (top-down).
+For each chain, the merge order is: root → … → leaf (bottom-up).
 
-### 3. Present merge plan
+### 3. Retarget non-root PRs to `$BASE`
+
+For every multi-PR chain, retarget every non-root PR to `$BASE` before merging anything. This neutralizes GitHub's auto-close cascade: once a child's base is `$BASE`, deleting a predecessor's branch on merge no longer looks like abandonment.
+
+```bash
+gh pr edit <N> --base $BASE
+```
+
+Apply this to every PR in a multi-PR chain except the chain root. Independent PRs already target `$BASE` and need no retargeting. Track the retarget count for the plan preview and final report.
+
+### 4. Present merge plan
 
 Show the plan before proceeding:
 
 ```
-Merge order (top-down per chain):
-  Chain 1:  PR #105 → PR #104 → PR #103 → develop
-  Chain 2:  PR #108 → develop  (independent)
+Merge order (bottom-up per chain):
+  Chain 1:  develop ← PR #103 ← PR #104 ← PR #105
+  Chain 2:  develop ← PR #108  (independent)
 
-  Step 1. Merge PR #105 into worktree-agent-104 (head of chain 1)
-  Step 2. Accumulate refs from #105 into PR #104 body
-  Step 3. Merge PR #104 into worktree-agent-103
-  Step 4. Accumulate refs from #104 into PR #103 body
-  Step 5. Merge PR #103 into develop
-  Step 6. Merge PR #108 into develop
+  Retargeted 2 non-root PRs to develop: #104, #105
+  Step 1. Merge PR #103 into develop (squash, delete branch)
+  Step 2. Merge PR #104 into develop (squash, delete branch)
+  Step 3. Merge PR #105 into develop (squash, delete branch)
+  Step 4. Merge PR #108 into develop (squash, delete branch)
 ```
 
 Proceed immediately.
 
-### 4. Merge top-down with ref accumulation
+### 5. Merge bottom-up
 
-For each chain, work from the leaf down. For each PR in order:
+For each chain, work from the root up to the leaf. For each PR in order:
 
-#### 4a. Check mergeability
+#### 5a. Check mergeability
 
 ```bash
 gh pr view <N> --json mergeable,mergeStateStatus,baseRefName
@@ -73,86 +82,32 @@ gh pr update-branch <N>
 sleep 3
 ```
 
-#### 4b. Collect this PR's issue refs
+#### 5b. Merge
 
-Extract all `Closes/Fixes/Resolves/Refs #N` references from the PR body:
-
-```bash
-REFS=$(echo "$PR_BODY" | grep -oiE '(closes|fixes|resolves|refs) #[0-9]+' | sort -u)
-```
-
-#### 4c. Merge — strategy depends on the PR's role in the stack
-
-Three cases, each using a different strategy so that stacked PRs keep their individual commits on `$BASE` instead of being collapsed into a single squash commit:
+Every PR uses the same strategy — uniform squash with branch deletion:
 
 ```bash
-# Intermediate merge (base is a worktree-agent-* branch)
-# Rebase the leaf's commits onto its parent worktree-agent branch so each
-# per-PR commit is preserved as the chain collapses downward.
-# Omit --delete-branch so the base branch survives for the next merge step.
-gh pr merge <N> --rebase
-
-# Final merge into $BASE for the root of a multi-PR chain
-# Use --merge so the accumulated stack lands as a merge commit preserving
-# the per-PR commits underneath.
-gh pr merge <N> --merge --delete-branch
-
-# Final merge into $BASE for an independent (single-PR) chain
-# No stack to preserve — squash to match flowkit's one-PR-one-commit convention.
 gh pr merge <N> --squash --delete-branch
 ```
 
-A PR is the "root of a multi-PR chain" iff its `baseRefName` is `$BASE` **and** at least one other open PR has this PR's `headRefName` as its `baseRefName` (i.e. something sits on top of it). A PR is "independent" iff its `baseRefName` is `$BASE` and nothing sits on top. Both distinctions were captured when building the stack graph in step 2.
+Each PR's own body closes its own issues natively on merge. No ref injection, no body rewriting.
 
-#### 4d. Inject refs into the next PR down
-
-After a non-root merge, append this PR's refs into the body of the PR immediately below it in the chain (the PR whose `headRefName` equals the just-merged PR's `baseRefName`):
-
-```bash
-NEXT_PR=<number of the PR below in the chain>
-CURRENT_BODY=$(gh pr view $NEXT_PR --json body --jq '.body')
-NEW_BODY="$CURRENT_BODY
-
-$REFS"
-gh pr edit $NEXT_PR --body "$NEW_BODY"
-```
-
-This ensures that if the merge halts mid-stack (conflict, failure), the surviving lowest unmerged PR already contains all refs from everything above it that successfully merged.
-
-#### 4e. Conflict handling
+#### 5c. Conflict handling
 
 If a merge fails with `CONFLICTING`:
 - Stop the chain at this PR
 - Report the conflict with the PR number and branch names
-- Mark all PRs below it in the same chain as blocked
+- Mark all PRs above it in the same chain as blocked
 - Continue with any independent PRs or unrelated chains
 - At the end, list all stopped and blocked PRs so the user can resolve and re-run
 
-#### 4f. Pause between merges
+#### 5d. Pause between merges
 
 ```bash
 sleep 3
 ```
 
-#### 4g. Sweep intermediate remote branches
-
-After the chain's root PR merges into `$BASE`, delete every intermediate `worktree-agent-*` branch from the remote. Intermediate branches are every `headRefName` whose `baseRefName` was another `worktree-agent-*` branch — these were captured when building the stack graph in step 2.
-
-Run this sweep immediately after the root merge so partial runs still clean up the chains that did complete. Skip if there are no intermediate branches (single-PR chain or independent PR).
-
-When the full list is available up front, batch the deletes into one push call to minimize round-trips. Fall back to per-branch deletes if the batch call fails (e.g. mixed stale refs):
-
-```bash
-if [ -n "$INTERMEDIATE_BRANCHES" ]; then
-  echo "$INTERMEDIATE_BRANCHES" | while read branch; do
-    git push origin --delete "$branch" 2>/dev/null || true
-  done
-fi
-```
-
-The `|| true` on each delete keeps a stale-ref failure from aborting the rest of the sweep. Track the count of swept branches for the report.
-
-### 5. Sync base branch
+### 6. Sync base branch
 
 After all merges:
 
@@ -163,13 +118,12 @@ git pull origin $BASE
 
 Where `$BASE` is the base branch of the root PRs (typically `develop`).
 
-### 6. Report
+### 7. Report
 
 ```
 ── merge-stack complete ──────────────────────────────
-✓ Merged (chain 1): PR #105 → #104 → #103 → develop
-    Refs accumulated into PR #103: Closes #90, #91, #92, #93, #94
-    Swept 2 intermediate remote branches (worktree-agent-105, worktree-agent-104)
+✓ Retargeted 2 non-root PRs to develop
+✓ Merged (chain 1): PR #103 → PR #104 → PR #105 → develop
 ✓ Merged (independent): PR #108 → develop
 ✗ Conflicted: PR #107 — stopped mid-chain
 ⊘ Blocked: PR #106 — depends on #107
@@ -178,11 +132,9 @@ Where `$BASE` is the base branch of the root PRs (typically `develop`).
 
 ## Constraints
 
-- Always merge top-down (leaf PRs first, root last)
-- Use `--rebase` for intermediate merges, `--merge` for the root of a multi-PR chain, `--squash` for independent single-PR chains — never collapse a stack with a single squash
-- Never use `--delete-branch` on intermediate merges — only on the final merge into `$BASE`
-- Always accumulate refs downward after each intermediate merge
+- Always merge bottom-up (root PRs first, leaves last)
+- Always retarget every non-root PR in a multi-PR chain to `$BASE` before merging anything in that chain
+- Use `gh pr merge <N> --squash --delete-branch` for every PR — no per-role strategy matrix
 - Never merge into `main` directly — only into `$BASE` (e.g., `develop`)
 - Never skip a conflicted chain's dependents — block and report them
 - Independent PRs (targeting `$BASE` with nothing stacked on them) may merge in any order
-- After a chain's root PR merges, delete every intermediate `worktree-agent-*` branch from the remote — their only purpose was to host the stack, and they are redundant once the root is in `$BASE`

--- a/plugins/swarmkit/skills/merge-stack/SKILL.md
+++ b/plugins/swarmkit/skills/merge-stack/SKILL.md
@@ -7,6 +7,8 @@ description: Merge all open swarm PRs bottom-up after retargeting every non-root
 
 Merges all open swarm PRs bottom-up — root PRs first, then their former children, up to the leaves. Before any merge happens, every non-root PR in a multi-PR chain is retargeted to `$BASE` so GitHub never fires its auto-close cascade. Every PR then merges uniformly with `gh pr merge <N> --squash --delete-branch`, and each PR closes its own `Closes/Fixes/Resolves/Refs` references on merge.
 
+Between merges, each still-open downstream branch is locally rebased onto the freshly-updated `$BASE` and force-pushed. Git's patch-id matching drops the predecessor commits (which are already on `$BASE` in squashed form under a different SHA), leaving only the downstream PR's own new commits. Without this rebase, the next PR would flip to `CONFLICTING` the moment its predecessor merges, because the old predecessor commits in its history collide with the new squash commit on `$BASE`.
+
 This matches the merge direction used by Graphite, git-spice, Sapling, and Phabricator: reviewers see and land the same diff, CI runs once per PR instead of re-running on every rebase, and conflicts surface at the leaf instead of cascading down into the root.
 
 ## When to use
@@ -58,9 +60,11 @@ Merge order (bottom-up per chain):
 
   Retargeted 2 non-root PRs to develop: #104, #105
   Step 1. Merge PR #103 into develop (squash, delete branch)
-  Step 2. Merge PR #104 into develop (squash, delete branch)
-  Step 3. Merge PR #105 into develop (squash, delete branch)
-  Step 4. Merge PR #108 into develop (squash, delete branch)
+  Step 2. Rebase #104, #105 onto develop (drop #103's commits via patch-id)
+  Step 3. Merge PR #104 into develop (squash, delete branch)
+  Step 4. Rebase #105 onto develop (drop #104's commits via patch-id)
+  Step 5. Merge PR #105 into develop (squash, delete branch)
+  Step 6. Merge PR #108 into develop (squash, delete branch)
 ```
 
 Proceed immediately.
@@ -75,12 +79,7 @@ For each chain, work from the root up to the leaf. For each PR in order:
 gh pr view <N> --json mergeable,mergeStateStatus,baseRefName
 ```
 
-If `mergeStateStatus` is `BEHIND`: update the branch and re-check:
-
-```bash
-gh pr update-branch <N>
-sleep 3
-```
+If `mergeStateStatus` is `BEHIND` (or `UNKNOWN` — retry after a short sleep): run the local rebase step from 5d against this branch, then re-check.
 
 #### 5b. Merge
 
@@ -94,14 +93,33 @@ Each PR's own body closes its own issues natively on merge. No ref injection, no
 
 #### 5c. Conflict handling
 
-If a merge fails with `CONFLICTING`:
+If a merge fails with `CONFLICTING`, or if the rebase in 5d fails with a genuine content conflict (not a patch-id-matchable duplicate):
 - Stop the chain at this PR
 - Report the conflict with the PR number and branch names
 - Mark all PRs above it in the same chain as blocked
 - Continue with any independent PRs or unrelated chains
 - At the end, list all stopped and blocked PRs so the user can resolve and re-run
 
-#### 5d. Pause between merges
+#### 5d. Rebase downstream PRs before merging the next one
+
+After merging a non-leaf PR in a chain, every still-open downstream PR in that chain has its predecessor's commits in its history under the old (pre-squash) SHAs. `$BASE` now carries the same content under a new squash SHA, so GitHub will flag the next PR as `DIRTY`/`CONFLICTING` even though the content overlap is benign. `gh pr update-branch` cannot resolve this — it fails with `Cannot update PR branch due to conflicts`. A local rebase is required because only `git rebase`'s patch-id matching drops the already-applied commits.
+
+For every still-open PR in the chain, from closest-to-root to leaf:
+
+```bash
+git fetch origin <head-branch> $BASE
+git checkout <head-branch>
+git rebase origin/$BASE
+git push --force-with-lease origin <head-branch>
+```
+
+`git rebase` will emit `warning: skipped previously applied commit <sha>` for each predecessor commit it drops via patch-id — that's the expected happy path, not an error. If rebase stops with a real merge conflict, follow 5c.
+
+After the rebases, re-query `mergeStateStatus` for the next PR to merge and proceed to 5b. GitHub may report `UNKNOWN` briefly after a force-push; poll with `sleep 3` until it resolves to `CLEAN`, `BEHIND`, or `DIRTY`.
+
+For independent PRs (no chain), skip this step — they target `$BASE` directly and have no predecessor commits to drop.
+
+#### 5e. Pause between merges
 
 ```bash
 sleep 3
@@ -134,6 +152,7 @@ Where `$BASE` is the base branch of the root PRs (typically `develop`).
 
 - Always merge bottom-up (root PRs first, leaves last)
 - Always retarget every non-root PR in a multi-PR chain to `$BASE` before merging anything in that chain
+- After each non-leaf merge in a chain, always rebase every still-open downstream branch onto `$BASE` locally and force-push before merging the next one — `gh pr update-branch` cannot resolve the squash-history collision
 - Use `gh pr merge <N> --squash --delete-branch` for every PR — no per-role strategy matrix
 - Never merge into `main` directly — only into `$BASE` (e.g., `develop`)
 - Never skip a conflicted chain's dependents — block and report them

--- a/plugins/swarmkit/skills/squad/SKILL.md
+++ b/plugins/swarmkit/skills/squad/SKILL.md
@@ -149,7 +149,7 @@ Before spawning any teammates, print a summary table of builder assignments so t
 ```
 
 Include:
-- **Suggested merge order** — leaf PRs first (no dependents), root PRs last
+- **Suggested merge order** — root PRs first (targeting `$BASE`), leaves last; `swarmkit:merge-stack` retargets non-root PRs to `$BASE` up front and then merges each chain bottom-up
 - **Any issues too ambiguous to delegate** — list them with a brief reason; they are excluded from the dispatch but not from the target set
 
 After printing the table, continue immediately to the next step.

--- a/plugins/swarmkit/skills/swarm-experimental/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-experimental/SKILL.md
@@ -119,7 +119,7 @@ Show the user a table before launching:
 
 > Any agent showing `haiku` must be re-assigned to `sonnet` before proceeding.
 
-Also show suggested merge order and any issues too ambiguous to delegate. Merge order is top-down: leaf PRs first, root last (the inverse of creation order). This matches how `swarmkit:merge-stack` operates — it pops the leaf of the stack first.
+Also show suggested merge order and any issues too ambiguous to delegate. Merge order is bottom-up: root PRs first, leaves last (the same order as creation). This matches how `swarmkit:merge-stack` operates — it retargets every non-root PR to `$BASE` up front, then merges each chain from the root upward with a uniform squash.
 
 Present the plan and proceed immediately with the proposed groupings.
 
@@ -282,7 +282,7 @@ Run `/clean-worktrees` to remove agent worktrees and orphaned branches. This fre
 | #18, #19 | #26 | chore/clean-hooks   | Open |
 ```
 
-All PRs are left open for review. If 1 PR open: use `/merge-pr` to merge it into `develop`. If 2+ PRs: use `/merge-stack` — merges top-down: leaf PRs first, root last.
+All PRs are left open for review. If 1 PR open: use `/merge-pr` to merge it into `develop`. If 2+ PRs: use `/merge-stack` — retargets non-root PRs to `$BASE` and merges bottom-up: root PRs first, leaves last.
 
 ---
 
@@ -346,7 +346,7 @@ Issues addressed: #12, #14, #15 (PRs open, awaiting review)
 Issues remaining: #25
 Open PRs: #31, #32, #33
 
-Open PRs are ready for review. If 1 PR open: use `/merge-pr` to merge it into `$BASE`. If 2+ PRs: use `/merge-stack` — merges top-down: leaf PRs first, root last.
+Open PRs are ready for review. If 1 PR open: use `/merge-pr` to merge it into `$BASE`. If 2+ PRs: use `/merge-stack` — retargets non-root PRs to `$BASE` and merges bottom-up: root PRs first, leaves last.
 ─────────────────────────────────────────────
 ```
 

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -121,7 +121,7 @@ Show the user a table before launching:
 
 > Any agent showing `haiku` must be re-assigned to `sonnet` before proceeding.
 
-Also show suggested merge order and any issues too ambiguous to delegate. Merge order is top-down: leaf PRs first, root last (the inverse of creation order). This matches how `swarmkit:merge-stack` operates — it pops the leaf of the stack first.
+Also show suggested merge order and any issues too ambiguous to delegate. Merge order is bottom-up: root PRs first, leaves last (the same order as creation). This matches how `swarmkit:merge-stack` operates — it retargets every non-root PR to `$BASE` up front, then merges each chain from the root upward with a uniform squash.
 
 Present the plan and proceed immediately with the proposed groupings.
 
@@ -259,7 +259,7 @@ Run `/clean-worktrees` to remove agent worktrees and orphaned branches. This fre
 | #18, #19 | #26 | chore/clean-hooks   | Open |
 ```
 
-All PRs are left open for review. If 1 PR open: use `/merge-pr` to merge it into `develop`. If 2+ PRs: use `/merge-stack` — merges top-down: leaf PRs first, root last.
+All PRs are left open for review. If 1 PR open: use `/merge-pr` to merge it into `develop`. If 2+ PRs: use `/merge-stack` — retargets non-root PRs to `$BASE` and merges bottom-up: root PRs first, leaves last.
 
 ---
 
@@ -332,7 +332,7 @@ Issues addressed: #12, #14, #15 (PRs open, awaiting review)
 Issues remaining: #25
 Open PRs: #31, #32, #33
 
-Open PRs are ready for review. If 1 PR open: use `/merge-pr` to merge it into `$BASE`. If 2+ PRs: use `/merge-stack` — merges top-down: leaf PRs first, root last.
+Open PRs are ready for review. If 1 PR open: use `/merge-pr` to merge it into `$BASE`. If 2+ PRs: use `/merge-stack` — retargets non-root PRs to `$BASE` and merges bottom-up: root PRs first, leaves last.
 ─────────────────────────────────────────────
 ```
 


### PR DESCRIPTION
## Summary
- Rewrote swarmkit:merge-stack to merge stacked PRs bottom-up (root → leaves) after an up-front retarget of every non-root PR to `$BASE`, matching Graphite/git-spice conventions.
- Collapsed the three-strategy merge matrix to a uniform `gh pr merge --squash --delete-branch` and removed the fragile ref-accumulation step — each PR now closes its own refs natively.
- Updated cross-references in swarmkit:swarm, swarm-experimental, squad, flowkit:ship, the swarmkit README/METHODOLOGY, and the root README so merge-direction narration stays consistent.

## Test plan
- `grep -ri "top-down" plugins/` returns no matches.
- `grep -i "accumulate" plugins/swarmkit/skills/merge-stack/SKILL.md` returns no matches.
- Skill reads cleanly end-to-end: one merge strategy, no ref-accumulation, bottom-up throughout.
- Dry-read swarm/squad/ship skills: merge-direction guidance aligns with the rewritten merge-stack.

Closes #566