### PR TITLE
chore(test): remove merge-stack test artifact from develop

### DIFF
--- a/docs/research/ms-test.md
+++ b/docs/research/ms-test.md
@@ -1,5 +1,0 @@
-# merge-stack bottom-up test
-
-line A
-line B
-line C


### PR DESCRIPTION
Removes the throwaway `docs/research/ms-test.md` left behind by the bottom-up merge-stack validation (#570/#571/#572). Test complete — see conversation for findings.