### PR TITLE
chore(test): remove merge-stack test run 2 artifact

### DIFF
--- a/docs/research/ms-test2.md
+++ b/docs/research/ms-test2.md
@@ -1,5 +1,0 @@
-# merge-stack bottom-up test (run 2)
-
-line A
-line B
-line C


### PR DESCRIPTION
Removes the throwaway `docs/research/ms-test2.md` from the second bottom-up merge-stack validation run (#574/#575/#576). Amended skill behaved correctly.