### PR TITLE
docs(bump-versions): complete plugin locations table for issue #584

### DIFF
--- a/.claude/skills/bump-versions/SKILL.md
+++ b/.claude/skills/bump-versions/SKILL.md
@@ -13,12 +13,16 @@ Bumps `plugin.json` version fields for plugins that have changed since their las
 
 ## Plugin locations
 
+Every kit under `plugins/*` that ships a manifest at `.claude-plugin/plugin.json` participates in version bumps. The root [README `#available-plugins`](../../../README.md#available-plugins) is the canonical plugin catalog — keep this table in sync when adding or removing kits.
+
 | Plugin | plugin.json |
 |--------|-------------|
-| swarmkit | `plugins/swarmkit/.claude-plugin/plugin.json` |
 | flowkit | `plugins/flowkit/.claude-plugin/plugin.json` |
+| polishkit | `plugins/polishkit/.claude-plugin/plugin.json` |
 | sessionkit | `plugins/sessionkit/.claude-plugin/plugin.json` |
 | speckit | `plugins/speckit/.claude-plugin/plugin.json` |
+| swarmkit | `plugins/swarmkit/.claude-plugin/plugin.json` |
+| vaultkit | `plugins/vaultkit/.claude-plugin/plugin.json` |
 
 ## Git tag format
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The `/bump-versions` skill documented only four kits in its plugin locations table even though the monorepo ships six manifests under `plugins/*/.claude-plugin/plugin.json`. Agents following the skill could overlook **vaultkit** and **polishkit** when deciding what to bump and tag.

## Changes

- Extend `.claude/skills/bump-versions/SKILL.md` "Plugin locations" with **polishkit** and **vaultkit**, sorted alphabetically alongside the existing four kits.
- Add a short note that every kit with that manifest path participates in bumps and that the root README `#available-plugins` anchor is the canonical catalog to keep in sync when kits are added or removed (with a relative link to `README.md`).

## Test plan

- [ ] Open `.claude/skills/bump-versions/SKILL.md` and confirm the table lists all six directories that contain `plugins/<name>/.claude-plugin/plugin.json`.
- [ ] Click the README link from the skill (or resolve `../../../README.md#available-plugins`) and confirm the catalog matches the table.

Closes #584
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-df9c3283-a40c-441e-ae14-2b152e9e4b72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-df9c3283-a40c-441e-ae14-2b152e9e4b72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

