### PR TITLE
release: 2026-04-24

### DIFF
--- a/.claude/skills/bump-versions/SKILL.md
+++ b/.claude/skills/bump-versions/SKILL.md
@@ -13,12 +13,16 @@ Bumps `plugin.json` version fields for plugins that have changed since their las
 
 ## Plugin locations
 
+Every kit under `plugins/*` that ships a manifest at `.claude-plugin/plugin.json` participates in version bumps. The root [README `#available-plugins`](../../../README.md#available-plugins) is the canonical plugin catalog — keep this table in sync when adding or removing kits.
+
 | Plugin | plugin.json |
 |--------|-------------|
-| swarmkit | `plugins/swarmkit/.claude-plugin/plugin.json` |
 | flowkit | `plugins/flowkit/.claude-plugin/plugin.json` |
+| polishkit | `plugins/polishkit/.claude-plugin/plugin.json` |
 | sessionkit | `plugins/sessionkit/.claude-plugin/plugin.json` |
 | speckit | `plugins/speckit/.claude-plugin/plugin.json` |
+| swarmkit | `plugins/swarmkit/.claude-plugin/plugin.json` |
+| vaultkit | `plugins/vaultkit/.claude-plugin/plugin.json` |
 
 ## Git tag format
 


### PR DESCRIPTION
## Summary

Documentation tidy-up for the `/bump-versions` skill: its plugin-locations table now lists all six kits in the monorepo, so agents won't overlook polishkit or vaultkit when bumping plugin versions.

## Release summary

**Built from**: `rc/2026-04-24.1`

### Version bumps
- Merge pull request #585 from smallorbit/cursor/bump-versions-skill-plugin-table-584-4b72
- docs(bump-versions): list all six plugins in locations table

Closes #584
Closes #256