### PR TITLE
fix(speckit): prevent /spec from stalling after catalog sub-skill

### DIFF
--- a/plugins/speckit/skills/catalog/SKILL.md
+++ b/plugins/speckit/skills/catalog/SKILL.md
@@ -168,6 +168,8 @@ Output the created issues as a table with links:
 | 1 | [#N](url) title | high | ... |
 ```
 
+**Sub-skill output contract**: When `--epic <slug>` is present (i.e. catalog was invoked from `/spec`), the results table above is the FINAL output. Stop immediately after the table — zero trailing prose, no hand-off sentence, no "returning to /spec" message, no transition language of any kind. The orchestrator resumes automatically; any trailing text will stall it.
+
 ## Constraints
 
 - Never create issues without showing the user the catalog first (unless `--auto` was passed)

--- a/plugins/speckit/skills/spec/SKILL.md
+++ b/plugins/speckit/skills/spec/SKILL.md
@@ -280,6 +280,8 @@ Pass the full task list from the plan to `/catalog` in a single call, prefixing 
 
 Do not instruct `/catalog` to embed `Depends on #N` lines (or any other `#<number>` task-reference) in issue bodies. GitHub auto-links `#N` tokens, so a body that says "Depends on task #3" will link to unrelated issue 3 in the repo. Task-to-task dependencies are wired in step 5 via the native GitHub blocked-by API — keep them out of the issue body.
 
+**After `/catalog` returns, do not pause and do not wait for user input. Proceed immediately to step 5.** The catalog sub-skill's final output is the results table; any trailing prose it may emit is noise and must be ignored. The orchestrator owns the transition and must advance autonomously.
+
 ### 5. Create the epic tracking issue
 
 Before creating, check for an existing epic: `gh issue list --search "epic: <title>" --state open`. Skip creation and report the existing issue number if found.


### PR DESCRIPTION
## Summary

When `/speckit:spec` invokes `/speckit:catalog` as a sub-skill (step 4), trailing hand-off prose emitted by catalog caused the orchestrator model to treat the turn as complete and wait for user input instead of advancing to step 5. This adds an explicit no-trailing-prose contract to catalog's sub-skill output and a no-pause directive to spec's step 4 → step 5 transition.

## Test plan

- [ ] Run `/spec` on a multi-task request through to step 4; confirm the orchestrator advances to step 5 (epic tracking issue creation) without requiring user input after catalog returns.
- [ ] Confirm catalog's results table is still emitted normally when invoked as a sub-skill with `--epic <slug>`.
- [ ] Confirm catalog's interactive flow (approval prompt, adjustments) is unaffected when invoked standalone (no `--epic` flag).

Closes #591