### PR TITLE
feat(flowkit): add epic/feature-branch workflow

### DIFF
--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -33,6 +33,7 @@ claude --plugin-dir /path/to/flowkit
 |-------|--------|--------------|
 | **commit** | `/commit` | Stage and commit changes with conventional commit format. Infers logical groupings and writes `type(scope): description` messages. |
 | **create-branch** | `/create-branch` | Create a new git branch off `develop` with an inferred or provided name. |
+| **cut-epic** | `/cut-epic` | Cut a long-lived `feature/<slug>-<issue>` branch from `develop`, push it, and pin `claude.flowkit.prBase` so subsequent PRs target it. |
 | **open-pr** | `/open-pr` | Push current branch and open a GitHub PR. Respects `claude.flowkit.prBase` for branch targeting. |
 | **pr** | `/pr` | Combined: `create-branch` → `commit` → `open-pr` in one step. |
 | **merge-pr** | `/merge-pr` | Squash-merge the open PR for the current branch; labels referenced issues with `merged-to-develop` (skipping any labeled `on-hold`). |
@@ -81,6 +82,24 @@ These are called by the skills above — you don't invoke them directly.
 /hotfix fix login redirect       # branch off main, apply fix, ship, back-merge
 ```
 
+### Epic flow (long-lived feature branch)
+
+When a feature spans multiple PRs and needs to stay isolated from `develop` until ready to ship, cut an epic branch and let sub-PRs target it instead of `develop`.
+
+```
+/cut-epic 1264                   # creates feature/<slug>-1264 from develop, pins claude.flowkit.prBase
+# ... loop ...
+/pr add CSV exporter             # sub-PR opened against feature/<slug>-1264 (not develop)
+/pr wire exporter into UI        # next sub-PR, also targets the epic branch
+# When ready to ship:
+gh pr create --base develop --head feature/<slug>-1264
+git config --unset claude.flowkit.prBase
+```
+
+The epic branch composes with `swarmkit:swarm`: any agents spawned while `claude.flowkit.prBase` is set will open their PRs against the epic branch automatically. Use `swarmkit:merge-stack` to fan the child PRs into the epic, then open the final epic-to-`develop` PR for review.
+
+> Do not run `/ship` while an epic is in flight unless you intend to ship the epic. `/ship` will rescope `claude.flowkit.prBase` to `develop` for its own flow.
+
 ### Feature flow
 
 ```
@@ -119,7 +138,7 @@ Flowkit reads one repo-local git config key:
 
 | Key | Purpose | Default |
 |-----|---------|---------|
-| `claude.flowkit.prBase` | Target base branch for `/open-pr` when no override is passed. Set automatically by `/ship` and `/swarm` loop mode; unset on teardown. | `develop` |
+| `claude.flowkit.prBase` | Target base branch for `/open-pr` when no override is passed. Set automatically by `/ship`, `/swarm` loop mode, and `/cut-epic`; unset on teardown. | `develop` |
 
 Inspect or set manually:
 

--- a/plugins/flowkit/skills/cut-epic/SKILL.md
+++ b/plugins/flowkit/skills/cut-epic/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: cut-epic
+description: Cut a long-lived `feature/<slug>-<issue>` branch from origin/develop, push it to origin, and pin `claude.flowkit.prBase` so subsequent PRs target it. Use when starting a multi-PR epic that should stay isolated from develop until ready to ship.
+triggers:
+  - "/cut-epic"
+  - "start an epic"
+  - "cut an epic branch"
+  - "create epic branch"
+  - "feature branch for epic"
+allowed-tools: Bash
+---
+
+# Cut Epic
+
+Create a long-lived feature branch for a multi-PR epic, push it to origin, and scope `claude.flowkit.prBase` to it so every subsequent `/open-pr` and `/pr` (and every `swarmkit:swarm` agent in the session) targets the epic branch instead of `develop`.
+
+The epic branch lives until the epic ships. When it's ready, open a single PR from the epic branch to `develop`, then run the teardown (see below) to clear the scope.
+
+## Input
+
+`$ARGUMENTS` — required. Either:
+
+1. An issue number (e.g. `1264`) — slug is inferred from the issue title via `gh issue view`.
+2. An issue number plus a slug (e.g. `1264 onboarding-v2` or `onboarding-v2 1264`) — slug is used verbatim.
+3. A full branch name already prefixed with `feature/` — used as-is after validation.
+
+If no arguments are provided, stop and ask for an issue number.
+
+## Process
+
+### 1. Resolve the epic branch name
+
+Determine `<issue>` and `<slug>`:
+
+- If `$ARGUMENTS` is a single number, treat it as the issue number and infer the slug:
+  ```bash
+  TITLE=$(gh issue view "$ISSUE" --json title --jq .title)
+  SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' \
+    | cut -c1-40 | sed -E 's/-+$//')
+  ```
+- If `$ARGUMENTS` contains both a number and a kebab-case word, use them as `<issue>` and `<slug>` regardless of order.
+- If `$ARGUMENTS` is already a `feature/...` branch name, skip slug inference and use it directly.
+
+Assemble the branch name:
+
+```
+feature/<slug>-<issue>
+```
+
+Examples:
+- Issue 1264 titled "Onboarding v2" → `feature/onboarding-v2-1264`
+- `$ARGUMENTS = "1264 onboarding-v2"` → `feature/onboarding-v2-1264`
+- `$ARGUMENTS = "feature/onboarding-v2-1264"` → used as-is
+
+### 2. Validate
+
+Reject the following outright — do not create them:
+- `main`, `master`, `develop`, `staging`
+- Any name without the `feature/` prefix (after auto-prefixing in step 1)
+
+The full branch name must be 60 characters or fewer. If the slug pushes it over, truncate the slug, not the issue number.
+
+### 3. Fetch latest remote state
+
+```bash
+git fetch origin
+```
+
+### 4. Create the epic branch from origin/develop
+
+If the branch already exists locally or on origin, do not recreate it — check it out and reuse it. This keeps the skill idempotent for resumed sessions.
+
+```bash
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  git checkout "$BRANCH"
+elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+  git checkout -b "$BRANCH" "origin/$BRANCH"
+else
+  git checkout -b "$BRANCH" origin/develop
+fi
+```
+
+### 5. Push to origin
+
+```bash
+git push -u origin "$BRANCH"
+```
+
+If the branch already tracks origin, this is a no-op.
+
+### 6. Scope `claude.flowkit.prBase` to the epic branch
+
+Delegate to the `pr-base-scope` sub-skill — do not duplicate its config-write logic:
+
+```bash
+git config claude.flowkit.prBase "$BRANCH"
+```
+
+This is the same operation `pr-base-scope` performs in its **Set** mode. From now on, every `flowkit:open-pr` and `flowkit:pr` invocation in this repo (and every `swarmkit:swarm` agent that inherits the repo config) will target `$BRANCH` as the PR base.
+
+### 7. Report
+
+Print a confirmation including the branch name, the upstream, and the scoped config. Suggest the next step:
+
+> Epic branch `feature/onboarding-v2-1264` created from `origin/develop` and pushed.
+> `claude.flowkit.prBase` is now scoped to this branch.
+> Sub-PRs opened in this repo will target `feature/onboarding-v2-1264` until you tear down the scope.
+
+## Composition
+
+| Caller | Behavior |
+|--------|----------|
+| `flowkit:open-pr` | Reads `claude.flowkit.prBase` and targets the epic branch automatically. |
+| `flowkit:pr` | Same — branches off `origin/develop` for sub-work, but PRs target the epic branch. |
+| `swarmkit:swarm` | Loop-mode agents inherit the scoped base; each spawned PR targets the epic branch. Combine with `swarmkit:merge-stack` to fan child PRs into the epic branch. |
+| `flowkit:ship` | Will override `claude.flowkit.prBase` to `develop` for its own flow, then unset. **Do not run `/ship` while an epic is in flight** unless you intend to ship the epic itself. |
+
+## Teardown
+
+When the epic is ready to ship:
+
+1. Open a final PR from the epic branch into `develop`. The simplest path is to manually invoke `flowkit:open-pr` after temporarily clearing the scope, or run `gh pr create --base develop --head <epic-branch>` directly.
+2. Clear the scope so future PRs default back to `develop`:
+
+```bash
+git config --unset claude.flowkit.prBase
+```
+
+This is the **Unset** operation defined by `pr-base-scope`. Once cleared, `flowkit:open-pr` falls through to its default (`develop`).
+
+3. (Optional) Delete the epic branch after the merge:
+
+```bash
+git push origin --delete feature/<slug>-<issue>
+git branch -D feature/<slug>-<issue>
+```
+
+## Constraints
+
+- Always branch from `origin/develop`, never from a local `develop` (which may be behind).
+- Never write a non-`feature/` prefix — this skill is purposely narrow.
+- Never modify `claude.prBase` (the legacy key) — only `claude.flowkit.prBase`. See `pr-base-scope` for the rationale.
+- Idempotent: re-running with the same arguments must not error if the branch already exists.
+- This skill does not open a PR. It only sets up the branch and scope. Use `flowkit:pr` / `flowkit:open-pr` for sub-work.

--- a/plugins/flowkit/skills/pr-base-scope/SKILL.md
+++ b/plugins/flowkit/skills/pr-base-scope/SKILL.md
@@ -62,6 +62,7 @@ fi
 |--------|--------|
 | `/ship` | Sets `claude.flowkit.prBase develop` before opening PRs, then unsets after the flow completes |
 | `/swarm` loop mode | Sets `claude.flowkit.prBase` to the appropriate integration branch for the loop session |
+| `/cut-epic` | Sets `claude.flowkit.prBase` to the long-lived epic branch so sub-PRs target it; user runs **Unset** when the epic ships |
 | `/open-pr` | Reads the resolved base (new key → legacy key → `develop`) before creating the PR |
 
 ## Constraints


### PR DESCRIPTION
## Summary

Adds a `cut-epic` skill to flowkit so multi-PR epics can stay isolated on a long-lived `feature/<slug>-<issue>` branch instead of landing piecemeal on `develop`. The skill composes with the existing `pr-base-scope` primitive — it pins `claude.flowkit.prBase` to the epic branch so every subsequent `/open-pr`, `/pr`, and `swarmkit:swarm` agent in the session targets the epic automatically.

## Changes

- Add `plugins/flowkit/skills/cut-epic/SKILL.md` — creates `feature/<slug>-<issue>` from `origin/develop`, pushes to origin, and sets `claude.flowkit.prBase`. Idempotent on re-run, supports issue-number-only input (slug inferred from `gh issue view`), explicit slug, or full branch name.
- Document the epic-branch pattern in `plugins/flowkit/README.md` (skills table, new "Epic flow" workflow section, updated `claude.flowkit.prBase` config row noting `/cut-epic` as a writer).
- Cross-reference `/cut-epic` from `plugins/flowkit/skills/pr-base-scope/SKILL.md` so the sub-skill's caller table stays accurate.

## Test plan

- [ ] Run `/cut-epic 1264` in a repo with issue 1264 open; confirm `feature/<slug>-1264` is created from `origin/develop`, pushed, and `git config claude.flowkit.prBase` returns the new branch.
- [ ] Run `/cut-epic 1264` a second time; confirm it reuses the branch without erroring (idempotent).
- [ ] With the scope set, run `flowkit:open-pr`; confirm the PR targets the epic branch, not `develop`.
- [ ] Run `git config --unset claude.flowkit.prBase`; confirm `flowkit:open-pr` falls back to `develop`.
- [ ] Spawn a `swarmkit:swarm` agent while the scope is set; confirm its PR targets the epic branch.

Closes #592