### PR TITLE
feat(sessionkit): persist team state across handoff/pickup

### DIFF
--- a/plugins/sessionkit/README.md
+++ b/plugins/sessionkit/README.md
@@ -27,8 +27,8 @@ claude --plugin-dir /path/to/sessionkit
 
 | Skill | Invoke | What it does |
 |-------|--------|--------------|
-| **handoff** | `/handoff` | Captures session goal, progress, git state, remaining work, and active tasks into `.sessionkit/HANDOFF.md`. Use when context is running low or when switching agents. |
-| **pickup** | `/pickup` | Loads `.sessionkit/HANDOFF.md` at the start of a new session, orients the agent, and hydrates pending/in-progress tasks back into the task system. |
+| **handoff** | `/handoff` | Captures session goal, progress, git state, remaining work, active tasks, and (when present) multi-agent team state into `.sessionkit/HANDOFF.md`. Use when context is running low or when switching agents. |
+| **pickup** | `/pickup` | Loads `.sessionkit/HANDOFF.md` at the start of a new session, orients the agent, hydrates pending/in-progress tasks back into the task system, and auto-restores team role context when a `## Team State` block is present. |
 | **skillit** | `/skillit` | Reflects on the current session to identify patterns worth encoding as reusable skills. Checks for existing overlap before proposing anything new. |
 | **suggest-permissions** | `/suggest-permissions` | Scans recent session history for repeatedly approved permissions and proposes additions to `.claude/settings.json` to reduce future prompts. |
 
@@ -36,7 +36,7 @@ claude --plugin-dir /path/to/sessionkit
 
 | Skill | Used by | Purpose |
 |-------|---------|---------|
-| **get-session-id** | suggest-permissions | Resolves the current Claude Code session UUID from `~/.claude/projects/`. |
+| **get-session-id** | suggest-permissions, handoff, pickup | Resolves the current Claude Code session UUID from `~/.claude/projects/`. |
 
 ## Typical Workflows
 
@@ -90,6 +90,27 @@ The two skills are intentionally separate: handoff writes, pickup reads. The han
 
 **Back-compat**: legacy `HANDOFF.md` files that were written before task-list support was added (i.e. no `## Task List` section) are fully valid. `/pickup` emits one warning line — `No task list snapshot — skipping hydration` — and continues with the orientation summary.
 
+### Team State Round-Trip
+
+When the current session is part of a multi-agent team — i.e. a config file under `~/.claude/teams/<team>/config.json` matches by `leadSessionId` or member `cwd` — `/handoff` emits a `## Team State` fenced JSON block capturing the team identity and member roster:
+
+```json
+{
+  "teamName": "...",
+  "leadAgentId": "...",
+  "leadSessionId": "...",
+  "members": [
+    {"name": "team-lead", "agentType": "lead", "agentFile": "...", "cwd": "..."}
+  ]
+}
+```
+
+`/pickup` parses the block, identifies which member corresponds to the resuming session (by `cwd` match, or by lead-session-id match for the lead role), reads the member's `agentFile` if present, and surfaces one orientation line:
+
+> Active team `<name>` detected (role: <agentType>). Loaded role context from `<agentFile>`.
+
+When no team is active, the section is omitted entirely. Handoffs without a `## Team State` section are valid — `/pickup` simply skips the team-restore step.
+
 ## Handoff Document Structure
 
 `.sessionkit/HANDOFF.md` is a structured Markdown file with these sections, in order:
@@ -101,6 +122,7 @@ The two skills are intentionally separate: handoff writes, pickup reads. The han
 | **Git State** | Current branch, staged/unstaged files, recent commits |
 | **Remaining Work** | Prioritized list of what still needs to be done |
 | **Task List** | Fenced JSON array of task objects (see Task Round-Trip above) |
+| **Team State** | *(optional)* Fenced JSON object capturing active team identity and members (see Team State Round-Trip above). Omitted when no team is active. |
 | **Context** | Gotchas, constraints, or non-obvious state the next agent must know |
 
 You can manually edit `.sessionkit/HANDOFF.md` between sessions — `/pickup` reads whatever is there.

--- a/plugins/sessionkit/skills/handoff/SKILL.md
+++ b/plugins/sessionkit/skills/handoff/SKILL.md
@@ -7,7 +7,7 @@ triggers:
   - "create handoff"
   - "save handoff"
   - "context is running low"
-allowed-tools: Bash, Read, Write, TaskList, TaskGet
+allowed-tools: Bash, Read, Write, TaskList, TaskGet, Skill
 ---
 
 # Handoff
@@ -36,6 +36,27 @@ git diff --cached
 ```
 
 Also invoke `TaskList` to get all task IDs, then call `TaskGet` once per task ID to fetch full details. Collect every task that is **not** deleted (i.e. `status !== "deleted"`). This runs in parallel with the bash commands above.
+
+### 1b. Detect active team
+
+Check `~/.claude/teams/*/config.json` for a team config that matches the current session. A team matches if either:
+
+1. Its `leadSessionId` equals the current session ID (resolved via `sessionkit:get-session-id`), OR
+2. Any member's `cwd` equals `$PWD`.
+
+```bash
+CURRENT_SID="$(PROJECT_PATH=$(echo "$PWD" | sed 's|/|-|g'); ls -t ~/.claude/projects/${PROJECT_PATH}/*.jsonl 2>/dev/null | head -1 | xargs -r basename -s .jsonl)"
+ls ~/.claude/teams/*/config.json 2>/dev/null | while read CFG; do
+  jq -r --arg sid "$CURRENT_SID" --arg cwd "$PWD" '
+    if (.leadSessionId == $sid) or (any(.members[]?; .cwd == $cwd))
+    then "MATCH:" + input_filename
+    else empty
+    end
+  ' "$CFG"
+done
+```
+
+If a team matches, read its `config.json` and extract: `name`, `leadAgentId`, `leadSessionId`, and the `members` array. Drop runtime-only fields from each member (keep only `name`, `agentType`, `agentFile`, `cwd`). If `agentFile` is absent on a member, omit the field. If no team matches, skip the Team State section entirely in step 2.
 
 ### 2. Draft the document
 
@@ -78,6 +99,18 @@ Outstanding todos and next steps in priority order.
 ]
 ```
 
+## Team State
+```json
+{
+  "teamName": "<name>",
+  "leadAgentId": "<leadAgentId>",
+  "leadSessionId": "<leadSessionId>",
+  "members": [
+    {"name": "<name>", "agentType": "<type>", "agentFile": "<path>", "cwd": "<path>"}
+  ]
+}
+```
+
 ## Context
 Key decisions made, gotchas encountered, important notes the next agent must know.
 ```
@@ -87,6 +120,7 @@ Inference rules:
 - **Progress** — what's been completed, decided, or abandoned this session.
 - **Remaining Work** — pull from the todo file and from any unfinished threads in the conversation; order by priority.
 - **Task List** — serialize the tasks collected in step 1 as a single fenced `json` code block. The JSON is an array of task objects. Include only these fields: `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, `blocks`. Exclude `owner`, `metadata`, and any deleted tasks. If no tasks exist, write an empty array `[]`. The `id` field preserves the original task ID so `/pickup` can wire `blockedBy` relationships in a follow-up pass.
+- **Team State** — emit this section **only** when step 1b matched a team. Serialize the matched team as a single fenced `json` code block with these fields: `teamName`, `leadAgentId`, `leadSessionId`, and `members` (array of `{name, agentType, agentFile, cwd}` — `agentFile` optional). Omit the section entirely if no team matched.
 - **Context** — decisions, gotchas, dead ends, external references. Keep it to what the next agent genuinely needs.
 
 If `$ARGUMENTS` is provided, weave its guidance into the relevant sections (often Goal or Context).
@@ -128,6 +162,7 @@ Report the absolute path of the file written and suggest:
 - After presenting the draft, write it immediately — do not pause for approval
 - Keep the document concise — it's a recall aid, not full documentation
 - `.sessionkit/HANDOFF.md` in the working directory is the canonical location — never write elsewhere
-- Section order in HANDOFF.md is fixed: Goal → Progress → Git State → Remaining Work → Task List → Context
-- Legacy HANDOFFs that lack a `## Task List` section remain valid inputs to `/pickup` — its absence is not an error
+- Section order in HANDOFF.md is fixed: Goal → Progress → Git State → Remaining Work → Task List → Team State (optional) → Context
+- Legacy HANDOFFs that lack a `## Task List` or `## Team State` section remain valid inputs to `/pickup` — their absence is not an error
+- The `## Team State` section is omitted when no team config in `~/.claude/teams/` matches the current session by `leadSessionId` or member `cwd`
 - Always Read `.sessionkit/HANDOFF.md` before overwriting it with Write — the Write tool refuses to overwrite paths it hasn't read in the current conversation

--- a/plugins/sessionkit/skills/pickup/SKILL.md
+++ b/plugins/sessionkit/skills/pickup/SKILL.md
@@ -7,7 +7,7 @@ triggers:
   - "load handoff"
   - "resume from handoff"
   - "continue previous session"
-allowed-tools: Bash, Read, TaskCreate, TaskUpdate, TaskList
+allowed-tools: Bash, Read, TaskCreate, TaskUpdate, TaskList, Skill
 ---
 
 # Pickup
@@ -32,7 +32,7 @@ Then stop — do not proceed with the remaining steps.
 
 ### 2. Read and parse
 
-Read the full content of `.sessionkit/HANDOFF.md`. Parse the standard sections: **Project**, **Date**, **Branch**, **Goal**, **Progress**, **Git State**, **Remaining Work**, **Context**.
+Read the full content of `.sessionkit/HANDOFF.md`. Parse the standard sections: **Project**, **Date**, **Branch**, **Goal**, **Progress**, **Git State**, **Remaining Work**, **Context**. The optional **Team State** section is parsed in step 4b.
 
 ### 3. Present orientation summary
 
@@ -71,6 +71,31 @@ After all `TaskCreate` calls complete, iterate the same set of created tasks. Fo
 - Call `TaskUpdate` with `addBlockedBy` for the new task ID.
 
 Do not wire `blocks` — the inverse relationship is implicit and wiring both directions would double-write the graph.
+
+### 4b. Restore team state (if present)
+
+Parse the `## Team State` section from `.sessionkit/HANDOFF.md`:
+
+1. Locate the fenced ` ```json ` block immediately following the `## Team State` heading.
+2. If no `## Team State` section exists, or the JSON block is absent or unparseable, skip this step silently — back-compat with handoffs that pre-date team-state support.
+
+If a valid block is parsed, identify the **current role** by matching against the new session:
+
+- Resolve the current session ID via `sessionkit:get-session-id`.
+- A member matches if either its `cwd` equals `$PWD`, or the team's `leadSessionId` equals the current session ID and the member's `agentType` is the lead role (`lead` or `team-lead`).
+- If multiple members match, prefer the `cwd` match.
+
+When a member matches:
+
+- If `agentFile` is set and the file exists, Read it and fold the role's operating rules into the orientation summary (do not dump the file verbatim — surface the role's responsibilities concisely).
+- Emit exactly one orientation line:
+  > `Active team `<teamName>` detected (role: <agentType>). Loaded role context from <agentFile>.`
+- If `agentFile` is missing or unreadable, emit instead:
+  > `Active team `<teamName>` detected (role: <agentType>). No role file available.`
+
+When no member matches the current session, surface the team metadata as informational only:
+
+> `Team `<teamName>` referenced in handoff but no member matches this session.`
 
 ### 5. Restore git state (if needed)
 


### PR DESCRIPTION
## Summary

Extend the sessionkit handoff/pickup format to capture and restore multi-agent team state, so resuming a session that participates in an active team is a single-step recovery. Mirrors the existing `## Task List` JSON-block convention rather than introducing a new transport.

## Changes

- `plugins/sessionkit/skills/handoff/SKILL.md`: add a step that detects an active team by scanning `~/.claude/teams/*/config.json` for a match on `leadSessionId` (resolved via `sessionkit:get-session-id`) or member `cwd`, and emits a fenced `## Team State` JSON block with `teamName`, `leadAgentId`, `leadSessionId`, and trimmed `members`. Section is omitted when no team matches.
- `plugins/sessionkit/skills/pickup/SKILL.md`: add a parsing step that reads `## Team State`, identifies the current role by `cwd` (or by `leadSessionId` for the lead role), reads the member's `agentFile` when present, and surfaces a one-line orientation note. Skips silently when the section is absent (back-compat).
- `plugins/sessionkit/README.md`: document the Team State round-trip alongside the existing Task Round-Trip, and add `Team State` to the canonical section table.

## Test plan

- [ ] In a session attached to a `~/.claude/teams/<name>/config.json` that matches by `leadSessionId` or `cwd`, run `/handoff` and confirm the document contains a `## Team State` fenced JSON block with `teamName`, `leadAgentId`, `leadSessionId`, and `members`.
- [ ] In a session not attached to any team config, run `/handoff` and confirm the document contains no `## Team State` section.
- [ ] Run `/pickup` against a handoff that contains `## Team State`; confirm it surfaces the line `Active team <name> detected (role: <agentType>). Loaded role context from <agentFile>.`.
- [ ] Run `/pickup` against a legacy handoff with no `## Team State` and confirm orientation completes without errors and without mentioning team state.
- [ ] Confirm `## Task List` hydration still works unchanged when both sections are present.

Closes #594