### PR TITLE
feat(speckit): add team-readiness assessment phase

### DIFF
--- a/plugins/speckit/README.md
+++ b/plugins/speckit/README.md
@@ -87,6 +87,32 @@ When `/spec` runs the full interview path, the interview skill applies a silent 
 3. **Soft cap on epic size** — if the task count is still greater than 4 after signals 1 and 2, a second merge pass re-examines under looser interpretations of 1 and 2. The cap is a prompt to re-examine, not a hard limit — genuinely independent tasks are never forced together.
 4. **Docs-only tail merge** — if the auto-appended documentation task is the only non-implementation task remaining and the impl task(s) cover the same surface, docs fold into impl.
 
+### Team-readiness assessment
+
+After the epic and child issues are filed, `/spec` (full path only) assesses
+whether the work is well-suited for a parallel agent team. The signals it
+scores against:
+
+1. **Multiple independent modules** — work spans ≥2 modules / skills / packages.
+2. **Clear interface boundaries** — at least one task can be expressed as a contract.
+3. **Separable phases** — work splits into contract → implementation → integration waves.
+4. **Non-trivial implementation surface** — ≥3 tasks, with multiple non-trivial edits.
+
+If at least three signals hold, `/spec` re-decomposes the filed issues for
+agent execution: it provisions `phase:1`, `phase:2`, `phase:3` labels (creating
+them if missing, matching the catalog skill's label-provisioning pattern),
+assigns each child issue to a phase, extracts interface contracts as their own
+issue when bundled inside an implementation task, identifies the issue whose
+branch should become the epic's feature-branch base (see
+[#592](https://github.com/smallorbit/smallorbit-plugins/issues/592) for the
+matching flowkit work), and posts a team dispatch summary as a comment on the
+epic issue describing recommended spawn config (builder count, model, feature
+branch, initial dispatch order).
+
+If fewer than three signals hold, `/spec` prints
+`Team decomposition skipped — <reason>` and proceeds to the final report. The
+simple path always skips this step — single-issue plans are never team-suitable.
+
 ## How Catalog Works
 
 `/catalog` accepts findings from three sources (checked in order): explicit input in `$ARGUMENTS`, findings from earlier in the conversation, or a file path. It parses them into discrete issues, checks for existing duplicates and labels, shows a summary table for approval, then creates all issues in priority order (high first).

--- a/plugins/speckit/skills/spec/SKILL.md
+++ b/plugins/speckit/skills/spec/SKILL.md
@@ -121,7 +121,8 @@ ambiguous prompt) — short-circuit the rest of this skill:
 4. On approval, hand the single task to `/catalog` with **no `--epic` flag**.
    Catalog files one standalone issue. Skip step 2.5, step 5 (no epic tracking
    issue), and the sub-issue / blocked-by wiring.
-5. Jump to step 6 to report the filed issue, then stop.
+5. Jump to step 7 to report the filed issue, then stop. Skip step 6 — the
+   team-readiness assessment is full-path only.
 
 **On Full interview** (clearly-full narration, or `Full interview` picked in
 the ambiguous prompt): fall through to step 2 (invoke `/speckit:interview`)
@@ -345,18 +346,113 @@ After creating the epic, wire up relationships:
    ```
    Use `-F` (not `-f`) to pass integers. Map task numbers to issue IDs from the created issues.
 
-### 6. Report
+### 6. Team-readiness assessment
+
+Only run this step on the full-path flow (epic with 2+ child issues). Skip
+entirely on the simple path — single-issue plans are never team-suitable.
+
+Assess whether the spec is well-suited for a parallel agent team. The default
+`/catalog` decomposition is written for human developers and is rarely shaped
+for agent-team execution; this step re-evaluates the work and, when warranted,
+re-decomposes the freshly filed issues so multiple builders can run in parallel.
+
+**Suitability signals** — score the spec against all four. The work is
+team-suitable only when **at least three** hold:
+
+1. **Multiple independent modules** — child issues touch ≥2 distinct
+   modules / skills / packages with no shared mutable state.
+2. **Clear interface boundaries** — at least one task can be expressed as a
+   contract (function signature, schema, protocol) that downstream tasks
+   consume.
+3. **Separable phases** — work naturally splits into a contract / interface
+   wave, an implementation wave, and an integration wave.
+4. **Non-trivial implementation surface** — total task count ≥3 after
+   consolidation, with at least two tasks expected to take more than a
+   trivial single-file edit.
+
+If fewer than three signals hold, print a single line and stop:
+
+```
+Team decomposition skipped — <one-line reason, e.g. "tightly sequential, single module">.
+```
+
+Then proceed to step 7 (Report).
+
+**If team-suitable**, re-decompose the filed issues:
+
+1. **Provision phase labels.** For each phase you intend to use (typically
+   `phase:1`, `phase:2`, `phase:3`), check existence and create if missing.
+   Match the catalog skill's label-provisioning pattern:
+   ```bash
+   gh label list --search "phase:" --json name --jq '.[].name'
+   gh label create "phase:<N>" \
+     --color fbca04 \
+     --description "Agent-team execution wave <N>"
+   ```
+   Use the shared color `#fbca04` (yellow family) so phase labels are visually
+   grouped in the GitHub UI.
+
+2. **Assign each child issue to a phase** using `gh issue edit <N>
+   --add-label "phase:<K>"`. Conventional waves:
+   - `phase:1` — interface contracts, schemas, scaffolding (parallel-safe,
+     unblocks downstream)
+   - `phase:2` — implementation tasks that depend on phase:1 contracts
+   - `phase:3` — integration, end-to-end tests, documentation
+
+3. **Extract interface contracts as their own issue** when an implementation
+   task implicitly bundles a contract. Use `/speckit:issue` (or `gh issue
+   create` directly) to file the new contract issue, then add it as a sub-issue
+   of the epic and wire the original implementation issue's blocked-by to
+   point at the contract issue. This lets the tester / consumer agents start
+   in parallel against the contract while the implementer is still working.
+
+4. **Identify the base-branch issue.** One phase:1 issue should be marked as
+   the epic's feature branch base — its branch becomes the integration target
+   for all sibling builders. Note this in the dispatch summary below. (See
+   #592 — flowkit's epic-branch work tracks the matching swarm/flowkit
+   support; this step is informational until that ships.)
+
+5. **Post the team dispatch summary as a comment on the epic issue.** Use
+   `gh issue comment <epic_number> --body` (a comment, NOT a separate issue)
+   with this shape:
+
+   ```markdown
+   ## Team dispatch summary
+
+   This epic has been assessed as suitable for parallel agent-team execution.
+
+   **Recommended spawn config**
+   - Builders: <N> (one per phase:1 issue + one per independent phase:2 stream)
+   - Model: <opus | sonnet — opus for novel design, sonnet for mechanical impl>
+   - Feature branch base: #<base_issue_number> (see #592)
+
+   **Dispatch order**
+   1. Phase 1 (parallel): #A, #B — interface contracts, base branch
+   2. Phase 2 (parallel after phase 1): #C, #D — implementation
+   3. Phase 3 (after phase 2): #E — integration, docs
+
+   **Notes**
+   - <any cross-cutting risks or coordination notes>
+   ```
+
+   Replace placeholders with the actual issue numbers from step 4. Reference
+   #592 verbatim so the link resolves.
+
+### 7. Report
 
 Output a summary table:
 
 ```
 Epic:  #N  epic: <title>
 
-| # | Issue | Category | Priority |
-|---|-------|----------|----------|
-| 1 | #N title | bug | high |
-| 2 | #N title | test | medium |
+| # | Issue | Category | Priority | Phase |
+|---|-------|----------|----------|-------|
+| 1 | #N title | bug | high | phase:1 |
+| 2 | #N title | test | medium | phase:2 |
 ```
+
+Include the `Phase` column only when step 6 ran the team decomposition. If the
+team-readiness assessment skipped, omit the column.
 
 ## Constraints
 


### PR DESCRIPTION
## Summary

Adds a team-readiness assessment phase to `/speckit:spec` so that, after issues are filed, the skill evaluates whether the work is well-suited for a parallel agent team and — if so — re-decomposes the issues with phase labels and a dispatch summary. Default catalog output is shaped for human developers, so leads previously had to re-decompose by hand before spawning a swarm.

## Changes

- `plugins/speckit/skills/spec/SKILL.md`: insert step 6 "Team-readiness assessment" between issue cataloging and the final report. Step assesses against four signals (multiple modules, interface boundaries, separable phases, non-trivial surface), creates `phase:1`/`phase:2`/`phase:3` labels via `gh label create` if missing (matching the catalog skill's label-provisioning pattern), assigns child issues via `gh issue edit`, extracts interface contracts as their own issues when bundled, identifies the feature-branch base issue, and posts a team dispatch summary as a comment on the epic via `gh issue comment` (not a separate issue). Renumbers final Report step to 7 and adds an optional Phase column. Cross-references #592 where the feature-branch base flag is mentioned. Simple path explicitly skips step 6.
- `plugins/speckit/README.md`: add a new "Team-readiness assessment" subsection under the spec docs describing the four signals, the phase labels, the dispatch comment, and the link to #592.

## Test plan

- [ ] Run `/speckit:spec` on a multi-module feature with 3+ tasks; confirm step 6 fires, `phase:N` labels are created if missing, and a dispatch comment appears on the epic.
- [ ] Run `/speckit:spec` on a tightly sequential single-module change; confirm step 6 prints `Team decomposition skipped — <reason>` and proceeds to step 7.
- [ ] Run a simple-path `/speckit:spec` and confirm it skips straight from step 4 to step 7 with no phase labels applied.
- [ ] Confirm the dispatch summary comment lives on the epic issue (not a new issue) and references #592 verbatim.

Closes #593
Refs #592