### PR TITLE
perf(sessionkit): delegate handoff synthesis to haiku sub-agent

### DIFF
--- a/plugins/sessionkit/skills/handoff/SKILL.md
+++ b/plugins/sessionkit/skills/handoff/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: handoff
-description: Capture session context to a handoff document so another agent can take over seamlessly. Use when context is running low.
+description: Capture session context to a handoff document so another agent can take over seamlessly. Fast enough to run after every meaningful state change (PR opened, task completed, decision made) — not just when context is running low.
 triggers:
   - "/handoff"
   - "write a handoff"
   - "create handoff"
   - "save handoff"
   - "context is running low"
-allowed-tools: Bash, Read, Write, TaskList, TaskGet, Skill
+allowed-tools: Bash, Read, Write, TaskList, TaskGet, Skill, Agent
 ---
 
 # Handoff
 
 Capture the current session's goal, progress, git state, remaining work, and key context into `<working-dir>/.sessionkit/HANDOFF.md` so another agent can pick up without losing momentum.
 
-Use when context is running low, when switching machines or sessions, or whenever you want a clean baton-pass to a fresh agent.
+This skill is optimized for **frequent invocation**. Run it after every meaningful state change — a PR opens, a task flips to `completed`, a key decision lands — not only when context is running low. The synthesis step is delegated to a Haiku sub-agent and skips sections whose inputs haven't changed since the last run, so the cost is small.
 
 ## Input
 
@@ -28,6 +28,7 @@ Run these commands in parallel to collect raw data. Tolerate missing files — t
 
 ```bash
 cat .claude/TODO 2>/dev/null || cat .claude/todos.md 2>/dev/null || echo "No todo file"
+git rev-parse HEAD 2>/dev/null || echo "no-head"
 git branch --show-current
 git diff --cached --name-only
 git diff --name-only
@@ -36,6 +37,15 @@ git diff --cached
 ```
 
 Also invoke `TaskList` to get all task IDs, then call `TaskGet` once per task ID to fetch full details. Collect every task that is **not** deleted (i.e. `status !== "deleted"`). This runs in parallel with the bash commands above.
+
+### 1a. Compute change fingerprints
+
+Build two short fingerprints used in step 1c to decide which sections to regenerate:
+
+- `gitFingerprint` — `<HEAD-sha>:<sorted-staged-files-hash>:<sorted-unstaged-files-hash>`. A change in HEAD or in the working-tree file lists invalidates the Git State + Progress sections.
+- `taskFingerprint` — SHA-1 of the canonicalized (sorted by `id`, fields stripped to `id,subject,status,blockedBy`) Task List JSON. Any change invalidates the Task List + Remaining Work sections.
+
+Compute both in shell (e.g. `git rev-parse HEAD`, `printf %s "$json" | shasum -a 1 | cut -d' ' -f1`).
 
 ### 1b. Detect active team
 
@@ -58,11 +68,53 @@ done
 
 If a team matches, read its `config.json` and extract: `name`, `leadAgentId`, `leadSessionId`, and the `members` array. Drop runtime-only fields from each member (keep only `name`, `agentType`, `agentFile`, `cwd`). If `agentFile` is absent on a member, omit the field. If no team matches, skip the Team State section entirely in step 2.
 
-### 2. Draft the document
+### 1c. Skip-unchanged check
 
-Synthesize the collected data plus conversation history into this exact structure:
+If `.sessionkit/HANDOFF.md` already exists, Read it and look for an HTML comment header of the form:
+
+```
+<!-- handoff-meta gitFingerprint=<sha> taskFingerprint=<sha> -->
+```
+
+Compare against the fingerprints from step 1a:
+
+- If **both** match: nothing material has changed. Reuse the existing file's `## Git State`, `## Progress`, `## Task List`, and `## Remaining Work` sections verbatim — only refresh the `**Date**` field, `## Goal` (if `$ARGUMENTS` was passed), `## Context`, and `## Team State`. Skip the sub-agent call entirely; rewrite the file in-line. Report `(skip-unchanged: reused N sections)` in the confirmation.
+- If only `gitFingerprint` matches: reuse `## Git State` and `## Progress`. Regenerate the rest.
+- If only `taskFingerprint` matches: reuse `## Task List` and `## Remaining Work`. Regenerate the rest.
+- If neither matches, or no prior file exists, or the meta header is absent: regenerate all sections.
+
+### 2. Synthesize via Haiku sub-agent
+
+Delegate markdown synthesis to a sub-agent running on Haiku. The handoff document is structured output and does not need the main model.
+
+Invoke the `Agent` tool with:
+
+- `subagent_type`: `"general-purpose"`
+- `model`: `"claude-haiku-4-5"`
+- `prompt`: a single message containing
+  1. The fixed template from step 2a below.
+  2. The conversation context summary (recent goal, decisions, gotchas — bullet form, no prose).
+  3. The raw outputs from step 1 (git fingerprints, file lists, recent commits, todo file contents).
+  4. The Task List JSON from step 1.
+  5. The Team State JSON from step 1b (or `null`).
+  6. Any sections from step 1c marked "reuse verbatim" with their existing content.
+  7. `$ARGUMENTS` if present.
+  8. Explicit instructions: "Emit ONLY the markdown document. No commentary, no fences around the whole thing. Use bullets, not paragraphs, for Progress / Remaining Work / Context. Preserve the JSON code blocks for Task List and Team State exactly as given."
+
+**Timeout / failure handling**: if the Agent call fails, returns empty output, or produces output that does not contain the required `## Task List` heading, fall back to in-line synthesis. Prepend a single comment line to the document:
+
+```
+<!-- handoff-warning: haiku sub-agent unavailable, synthesized in-line -->
+```
+
+…and synthesize the document yourself using the same template.
+
+### 2a. Strict template
+
+The sub-agent (or in-line fallback) must emit exactly this structure. **Bullets only** in Progress / Remaining Work / Context — no narrative paragraphs. The meta header on line 1 is mandatory and is what step 1c reads on the next run.
 
 ```markdown
+<!-- handoff-meta gitFingerprint=<sha> taskFingerprint=<sha> -->
 # Handoff
 
 **Project**: <working directory>
@@ -70,19 +122,23 @@ Synthesize the collected data plus conversation history into this exact structur
 **Branch**: <current git branch>
 
 ## Goal
-What we were trying to accomplish this session.
+- <one bullet, one sentence>
 
 ## Progress
-How far we got — what's been completed, what's been decided.
+- <completed item>
+- <decision made>
+- <thread abandoned>
 
 ## Git State
 - Branch: <branch>
 - Staged: <list of staged files or "none">
 - Unstaged: <list of unstaged files or "none">
-- Recent commits (last 5): <list>
+- Recent commits (last 5):
+  - <sha> <subject>
 
 ## Remaining Work
-Outstanding todos and next steps in priority order.
+- <next step in priority order>
+- <next step>
 
 ## Task List
 ```json
@@ -112,24 +168,23 @@ Outstanding todos and next steps in priority order.
 ```
 
 ## Context
-Key decisions made, gotchas encountered, important notes the next agent must know.
+- <key decision>
+- <gotcha>
+- <external reference>
 ```
 
-Inference rules:
-- **Goal** — derive from branch name, recent commits, and the arc of the conversation.
-- **Progress** — what's been completed, decided, or abandoned this session.
-- **Remaining Work** — pull from the todo file and from any unfinished threads in the conversation; order by priority.
-- **Task List** — serialize the tasks collected in step 1 as a single fenced `json` code block. The JSON is an array of task objects. Include only these fields: `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, `blocks`. Exclude `owner`, `metadata`, and any deleted tasks. If no tasks exist, write an empty array `[]`. The `id` field preserves the original task ID so `/pickup` can wire `blockedBy` relationships in a follow-up pass.
-- **Team State** — emit this section **only** when step 1b matched a team. Serialize the matched team as a single fenced `json` code block with these fields: `teamName`, `leadAgentId`, `leadSessionId`, and `members` (array of `{name, agentType, agentFile, cwd}` — `agentFile` optional). Omit the section entirely if no team matched.
-- **Context** — decisions, gotchas, dead ends, external references. Keep it to what the next agent genuinely needs.
+Inference rules (applied by the sub-agent):
 
-If `$ARGUMENTS` is provided, weave its guidance into the relevant sections (often Goal or Context).
+- **Goal** — one bullet derived from branch name, recent commits, and conversation arc.
+- **Progress** — bullets only: what's been completed, decided, or abandoned this session.
+- **Remaining Work** — bullets in priority order, drawn from the todo file and unfinished conversation threads.
+- **Task List** — serialize the tasks from step 1 as a single fenced `json` code block. Array of task objects. Include only `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, `blocks`. Exclude `owner`, `metadata`, and deleted tasks. Empty array `[]` if none. Preserve original task `id` so `/pickup` can wire `blockedBy` relationships.
+- **Team State** — emit **only** when step 1b matched a team. Single fenced `json` block with `teamName`, `leadAgentId`, `leadSessionId`, `members` (`{name, agentType, agentFile, cwd}` — `agentFile` optional). Omit the section entirely otherwise.
+- **Context** — bullets only: decisions, gotchas, dead ends, external references. Keep to what the next agent genuinely needs.
 
-### 3. Present the draft
+If `$ARGUMENTS` is provided, weave its guidance into Goal or Context.
 
-Show the drafted document inline in the conversation so the user can see what will be written. Then proceed immediately to step 4 — no approval needed.
-
-### 4. Write to disk
+### 3. Write to disk
 
 Check `.gitignore` coverage first:
 
@@ -141,7 +196,7 @@ test -f .gitignore && grep -qE '^\.sessionkit/?$' .gitignore && echo "covered" |
 - **`.gitignore` present but not covered**: ask "`.gitignore` doesn't cover `.sessionkit/`. Append it? (yes/no)". On yes, append `.sessionkit/` to `.gitignore`. On no, proceed.
 - **Already covered**: proceed silently.
 
-If `.sessionkit/HANDOFF.md` already exists, Read it first (the Write tool requires a prior Read of the target path). If the file doesn't exist yet, skip this step.
+If `.sessionkit/HANDOFF.md` already exists, Read it first (the Write tool requires a prior Read of the target path). Step 1c already did this when a prior file exists.
 
 Then create the directory and write the file:
 
@@ -149,20 +204,22 @@ Then create the directory and write the file:
 mkdir -p .sessionkit
 ```
 
-Write the document to `.sessionkit/HANDOFF.md` using the Write tool, silently overwriting any existing file.
+Write the synthesized document to `.sessionkit/HANDOFF.md` using the Write tool, silently overwriting any existing file.
 
-### 5. Confirm
+### 4. Confirm
 
-Report the absolute path of the file written and suggest:
+Report the absolute path of the file written, the skip-unchanged status (e.g. `regenerated all sections` / `reused 4 sections, regenerated 2`), and suggest:
 
 > Start a new session and run `/pickup` to resume.
 
 ## Constraints
 
-- After presenting the draft, write it immediately — do not pause for approval
-- Keep the document concise — it's a recall aid, not full documentation
+- Run as soon as a meaningful state change happens — frequent handoffs are cheap by design (skip-unchanged + Haiku sub-agent)
+- Bullets only in Progress, Remaining Work, and Context — no prose paragraphs
+- The `<!-- handoff-meta ... -->` header on line 1 is mandatory; step 1c reads it on the next run to decide what to skip
 - `.sessionkit/HANDOFF.md` in the working directory is the canonical location — never write elsewhere
 - Section order in HANDOFF.md is fixed: Goal → Progress → Git State → Remaining Work → Task List → Team State (optional) → Context
-- Legacy HANDOFFs that lack a `## Task List` or `## Team State` section remain valid inputs to `/pickup` — their absence is not an error
+- Legacy HANDOFFs that lack a `## Task List`, `## Team State`, or meta header remain valid inputs to `/pickup` — their absence is not an error (the next run will simply regenerate everything)
 - The `## Team State` section is omitted when no team config in `~/.claude/teams/` matches the current session by `leadSessionId` or member `cwd`
 - Always Read `.sessionkit/HANDOFF.md` before overwriting it with Write — the Write tool refuses to overwrite paths it hasn't read in the current conversation
+- If the Haiku sub-agent fails, fall back to in-line synthesis and prepend a `<!-- handoff-warning: ... -->` line so the user knows the slow path was taken


### PR DESCRIPTION
## Summary

Speed up `/sessionkit:handoff` so it can be run after every meaningful state change without taxing the main session. Synthesis is delegated to a Haiku sub-agent, the template is bullets-only (no prose), and unchanged sections are reused from the prior `HANDOFF.md` via fingerprint comparison.

## Changes

- Delegate markdown synthesis to a Haiku sub-agent (`Agent` tool, `model: claude-haiku-4-5`) in `plugins/sessionkit/skills/handoff/SKILL.md`; the main session only assembles inputs and writes the file.
- Replace prose Progress / Remaining Work / Context paragraphs with a strict bullets-only template, dropping ~50% of output tokens while preserving section headings.
- Add skip-unchanged logic that reads a `<!-- handoff-meta gitFingerprint=... taskFingerprint=... -->` header on line 1 of the prior file, compares against current HEAD + Task List hashes, and reuses matching sections verbatim.
- Add a fallback path that synthesizes in-line and prepends a `<!-- handoff-warning: ... -->` comment if the Haiku sub-agent fails, times out, or returns malformed output.
- Update the skill's frontmatter description to recommend running it after every meaningful state change (PR opened, task completed, decision made), not only when context is running low.
- Preserve #594's `## Team State` JSON block, section ordering, and Task List shape so `/pickup` continues to parse the document unchanged.

## Test plan

- [ ] Run `/handoff` on a fresh session; confirm a Haiku sub-agent is dispatched and `.sessionkit/HANDOFF.md` is written with bullets (no prose) under Progress / Remaining Work / Context.
- [ ] Confirm line 1 of the output is `<!-- handoff-meta gitFingerprint=... taskFingerprint=... -->`.
- [ ] Run `/handoff` a second time with no git or task changes; confirm the confirmation message reports reused sections and the Goal / Context still update.
- [ ] Make a commit, then run `/handoff`; confirm Git State + Progress regenerate while Task List + Remaining Work are reused.
- [ ] Force the sub-agent path to fail (e.g. by simulating an empty return); confirm the in-line fallback runs and the file begins with `<!-- handoff-warning: ... -->`.
- [ ] Run `/pickup` against the new format; confirm it parses Goal, Progress, Git State, Remaining Work, Task List, Team State, and Context without errors.
- [ ] Run `/pickup` against a legacy HANDOFF.md (no meta header, prose paragraphs); confirm it still parses cleanly.

Closes #595
Refs #594