### PR TITLE
release: 2026-04-26

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship — with runtime staging detection and a one-command hotfix flow.",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -33,6 +33,7 @@ claude --plugin-dir /path/to/flowkit
 |-------|--------|--------------|
 | **commit** | `/commit` | Stage and commit changes with conventional commit format. Infers logical groupings and writes `type(scope): description` messages. |
 | **create-branch** | `/create-branch` | Create a new git branch off `develop` with an inferred or provided name. |
+| **cut-epic** | `/cut-epic` | Cut a long-lived `feature/<slug>-<issue>` branch from `develop`, push it, and pin `claude.flowkit.prBase` so subsequent PRs target it. |
 | **open-pr** | `/open-pr` | Push current branch and open a GitHub PR. Respects `claude.flowkit.prBase` for branch targeting. |
 | **pr** | `/pr` | Combined: `create-branch` → `commit` → `open-pr` in one step. |
 | **merge-pr** | `/merge-pr` | Squash-merge the open PR for the current branch; labels referenced issues with `merged-to-develop` (skipping any labeled `on-hold`). |
@@ -81,6 +82,24 @@ These are called by the skills above — you don't invoke them directly.
 /hotfix fix login redirect       # branch off main, apply fix, ship, back-merge
 ```
 
+### Epic flow (long-lived feature branch)
+
+When a feature spans multiple PRs and needs to stay isolated from `develop` until ready to ship, cut an epic branch and let sub-PRs target it instead of `develop`.
+
+```
+/cut-epic 1264                   # creates feature/<slug>-1264 from develop, pins claude.flowkit.prBase
+# ... loop ...
+/pr add CSV exporter             # sub-PR opened against feature/<slug>-1264 (not develop)
+/pr wire exporter into UI        # next sub-PR, also targets the epic branch
+# When ready to ship:
+gh pr create --base develop --head feature/<slug>-1264
+git config --unset claude.flowkit.prBase
+```
+
+The epic branch composes with `swarmkit:swarm`: any agents spawned while `claude.flowkit.prBase` is set will open their PRs against the epic branch automatically. Use `swarmkit:merge-stack` to fan the child PRs into the epic, then open the final epic-to-`develop` PR for review.
+
+> Do not run `/ship` while an epic is in flight unless you intend to ship the epic. `/ship` will rescope `claude.flowkit.prBase` to `develop` for its own flow.
+
 ### Feature flow
 
 ```
@@ -119,7 +138,7 @@ Flowkit reads one repo-local git config key:
 
 | Key | Purpose | Default |
 |-----|---------|---------|
-| `claude.flowkit.prBase` | Target base branch for `/open-pr` when no override is passed. Set automatically by `/ship` and `/swarm` loop mode; unset on teardown. | `develop` |
+| `claude.flowkit.prBase` | Target base branch for `/open-pr` when no override is passed. Set automatically by `/ship`, `/swarm` loop mode, and `/cut-epic`; unset on teardown. | `develop` |
 
 Inspect or set manually:
 

--- a/plugins/flowkit/skills/cut-epic/SKILL.md
+++ b/plugins/flowkit/skills/cut-epic/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: cut-epic
+description: Cut a long-lived `feature/<slug>-<issue>` branch from origin/develop, push it to origin, and pin `claude.flowkit.prBase` so subsequent PRs target it. Use when starting a multi-PR epic that should stay isolated from develop until ready to ship.
+triggers:
+  - "/cut-epic"
+  - "start an epic"
+  - "cut an epic branch"
+  - "create epic branch"
+  - "feature branch for epic"
+allowed-tools: Bash
+---
+
+# Cut Epic
+
+Create a long-lived feature branch for a multi-PR epic, push it to origin, and scope `claude.flowkit.prBase` to it so every subsequent `/open-pr` and `/pr` (and every `swarmkit:swarm` agent in the session) targets the epic branch instead of `develop`.
+
+The epic branch lives until the epic ships. When it's ready, open a single PR from the epic branch to `develop`, then run the teardown (see below) to clear the scope.
+
+## Input
+
+`$ARGUMENTS` — required. Either:
+
+1. An issue number (e.g. `1264`) — slug is inferred from the issue title via `gh issue view`.
+2. An issue number plus a slug (e.g. `1264 onboarding-v2` or `onboarding-v2 1264`) — slug is used verbatim.
+3. A full branch name already prefixed with `feature/` — used as-is after validation.
+
+If no arguments are provided, stop and ask for an issue number.
+
+## Process
+
+### 1. Resolve the epic branch name
+
+Determine `<issue>` and `<slug>`:
+
+- If `$ARGUMENTS` is a single number, treat it as the issue number and infer the slug:
+  ```bash
+  TITLE=$(gh issue view "$ISSUE" --json title --jq .title)
+  SLUG=$(echo "$TITLE" | tr '[:upper:]' '[:lower:]' \
+    | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' \
+    | cut -c1-40 | sed -E 's/-+$//')
+  ```
+- If `$ARGUMENTS` contains both a number and a kebab-case word, use them as `<issue>` and `<slug>` regardless of order.
+- If `$ARGUMENTS` is already a `feature/...` branch name, skip slug inference and use it directly.
+
+Assemble the branch name:
+
+```
+feature/<slug>-<issue>
+```
+
+Examples:
+- Issue 1264 titled "Onboarding v2" → `feature/onboarding-v2-1264`
+- `$ARGUMENTS = "1264 onboarding-v2"` → `feature/onboarding-v2-1264`
+- `$ARGUMENTS = "feature/onboarding-v2-1264"` → used as-is
+
+### 2. Validate
+
+Reject the following outright — do not create them:
+- `main`, `master`, `develop`, `staging`
+- Any name without the `feature/` prefix (after auto-prefixing in step 1)
+
+The full branch name must be 60 characters or fewer. If the slug pushes it over, truncate the slug, not the issue number.
+
+### 3. Fetch latest remote state
+
+```bash
+git fetch origin
+```
+
+### 4. Create the epic branch from origin/develop
+
+If the branch already exists locally or on origin, do not recreate it — check it out and reuse it. This keeps the skill idempotent for resumed sessions.
+
+```bash
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  git checkout "$BRANCH"
+elif git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+  git checkout -b "$BRANCH" "origin/$BRANCH"
+else
+  git checkout -b "$BRANCH" origin/develop
+fi
+```
+
+### 5. Push to origin
+
+```bash
+git push -u origin "$BRANCH"
+```
+
+If the branch already tracks origin, this is a no-op.
+
+### 6. Scope `claude.flowkit.prBase` to the epic branch
+
+Delegate to the `pr-base-scope` sub-skill — do not duplicate its config-write logic:
+
+```bash
+git config claude.flowkit.prBase "$BRANCH"
+```
+
+This is the same operation `pr-base-scope` performs in its **Set** mode. From now on, every `flowkit:open-pr` and `flowkit:pr` invocation in this repo (and every `swarmkit:swarm` agent that inherits the repo config) will target `$BRANCH` as the PR base.
+
+### 7. Report
+
+Print a confirmation including the branch name, the upstream, and the scoped config. Suggest the next step:
+
+> Epic branch `feature/onboarding-v2-1264` created from `origin/develop` and pushed.
+> `claude.flowkit.prBase` is now scoped to this branch.
+> Sub-PRs opened in this repo will target `feature/onboarding-v2-1264` until you tear down the scope.
+
+## Composition
+
+| Caller | Behavior |
+|--------|----------|
+| `flowkit:open-pr` | Reads `claude.flowkit.prBase` and targets the epic branch automatically. |
+| `flowkit:pr` | Same — branches off `origin/develop` for sub-work, but PRs target the epic branch. |
+| `swarmkit:swarm` | Loop-mode agents inherit the scoped base; each spawned PR targets the epic branch. Combine with `swarmkit:merge-stack` to fan child PRs into the epic branch. |
+| `flowkit:ship` | Will override `claude.flowkit.prBase` to `develop` for its own flow, then unset. **Do not run `/ship` while an epic is in flight** unless you intend to ship the epic itself. |
+
+## Teardown
+
+When the epic is ready to ship:
+
+1. Open a final PR from the epic branch into `develop`. The simplest path is to manually invoke `flowkit:open-pr` after temporarily clearing the scope, or run `gh pr create --base develop --head <epic-branch>` directly.
+2. Clear the scope so future PRs default back to `develop`:
+
+```bash
+git config --unset claude.flowkit.prBase
+```
+
+This is the **Unset** operation defined by `pr-base-scope`. Once cleared, `flowkit:open-pr` falls through to its default (`develop`).
+
+3. (Optional) Delete the epic branch after the merge:
+
+```bash
+git push origin --delete feature/<slug>-<issue>
+git branch -D feature/<slug>-<issue>
+```
+
+## Constraints
+
+- Always branch from `origin/develop`, never from a local `develop` (which may be behind).
+- Never write a non-`feature/` prefix — this skill is purposely narrow.
+- Never modify `claude.prBase` (the legacy key) — only `claude.flowkit.prBase`. See `pr-base-scope` for the rationale.
+- Idempotent: re-running with the same arguments must not error if the branch already exists.
+- This skill does not open a PR. It only sets up the branch and scope. Use `flowkit:pr` / `flowkit:open-pr` for sub-work.

--- a/plugins/flowkit/skills/pr-base-scope/SKILL.md
+++ b/plugins/flowkit/skills/pr-base-scope/SKILL.md
@@ -62,6 +62,7 @@ fi
 |--------|--------|
 | `/ship` | Sets `claude.flowkit.prBase develop` before opening PRs, then unsets after the flow completes |
 | `/swarm` loop mode | Sets `claude.flowkit.prBase` to the appropriate integration branch for the loop session |
+| `/cut-epic` | Sets `claude.flowkit.prBase` to the long-lived epic branch so sub-PRs target it; user runs **Unset** when the epic ships |
 | `/open-pr` | Reads the resolved base (new key → legacy key → `develop`) before creating the PR |
 
 ## Constraints

--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sessionkit",
   "description": "Session continuity and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, plan through structured interviews, discover reusable skills, and reduce permission noise.",
-  "version": "1.4.1",
+  "version": "1.5.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/sessionkit/README.md
+++ b/plugins/sessionkit/README.md
@@ -27,8 +27,8 @@ claude --plugin-dir /path/to/sessionkit
 
 | Skill | Invoke | What it does |
 |-------|--------|--------------|
-| **handoff** | `/handoff` | Captures session goal, progress, git state, remaining work, and active tasks into `.sessionkit/HANDOFF.md`. Use when context is running low or when switching agents. |
-| **pickup** | `/pickup` | Loads `.sessionkit/HANDOFF.md` at the start of a new session, orients the agent, and hydrates pending/in-progress tasks back into the task system. |
+| **handoff** | `/handoff` | Captures session goal, progress, git state, remaining work, active tasks, and (when present) multi-agent team state into `.sessionkit/HANDOFF.md`. Use when context is running low or when switching agents. |
+| **pickup** | `/pickup` | Loads `.sessionkit/HANDOFF.md` at the start of a new session, orients the agent, hydrates pending/in-progress tasks back into the task system, and auto-restores team role context when a `## Team State` block is present. |
 | **skillit** | `/skillit` | Reflects on the current session to identify patterns worth encoding as reusable skills. Checks for existing overlap before proposing anything new. |
 | **suggest-permissions** | `/suggest-permissions` | Scans recent session history for repeatedly approved permissions and proposes additions to `.claude/settings.json` to reduce future prompts. |
 
@@ -36,7 +36,7 @@ claude --plugin-dir /path/to/sessionkit
 
 | Skill | Used by | Purpose |
 |-------|---------|---------|
-| **get-session-id** | suggest-permissions | Resolves the current Claude Code session UUID from `~/.claude/projects/`. |
+| **get-session-id** | suggest-permissions, handoff, pickup | Resolves the current Claude Code session UUID from `~/.claude/projects/`. |
 
 ## Typical Workflows
 
@@ -90,6 +90,27 @@ The two skills are intentionally separate: handoff writes, pickup reads. The han
 
 **Back-compat**: legacy `HANDOFF.md` files that were written before task-list support was added (i.e. no `## Task List` section) are fully valid. `/pickup` emits one warning line — `No task list snapshot — skipping hydration` — and continues with the orientation summary.
 
+### Team State Round-Trip
+
+When the current session is part of a multi-agent team — i.e. a config file under `~/.claude/teams/<team>/config.json` matches by `leadSessionId` or member `cwd` — `/handoff` emits a `## Team State` fenced JSON block capturing the team identity and member roster:
+
+```json
+{
+  "teamName": "...",
+  "leadAgentId": "...",
+  "leadSessionId": "...",
+  "members": [
+    {"name": "team-lead", "agentType": "lead", "agentFile": "...", "cwd": "..."}
+  ]
+}
+```
+
+`/pickup` parses the block, identifies which member corresponds to the resuming session (by `cwd` match, or by lead-session-id match for the lead role), reads the member's `agentFile` if present, and surfaces one orientation line:
+
+> Active team `<name>` detected (role: <agentType>). Loaded role context from `<agentFile>`.
+
+When no team is active, the section is omitted entirely. Handoffs without a `## Team State` section are valid — `/pickup` simply skips the team-restore step.
+
 ## Handoff Document Structure
 
 `.sessionkit/HANDOFF.md` is a structured Markdown file with these sections, in order:
@@ -101,6 +122,7 @@ The two skills are intentionally separate: handoff writes, pickup reads. The han
 | **Git State** | Current branch, staged/unstaged files, recent commits |
 | **Remaining Work** | Prioritized list of what still needs to be done |
 | **Task List** | Fenced JSON array of task objects (see Task Round-Trip above) |
+| **Team State** | *(optional)* Fenced JSON object capturing active team identity and members (see Team State Round-Trip above). Omitted when no team is active. |
 | **Context** | Gotchas, constraints, or non-obvious state the next agent must know |
 
 You can manually edit `.sessionkit/HANDOFF.md` between sessions — `/pickup` reads whatever is there.

--- a/plugins/sessionkit/skills/handoff/SKILL.md
+++ b/plugins/sessionkit/skills/handoff/SKILL.md
@@ -1,20 +1,20 @@
 ---
 name: handoff
-description: Capture session context to a handoff document so another agent can take over seamlessly. Use when context is running low.
+description: Capture session context to a handoff document so another agent can take over seamlessly. Fast enough to run after every meaningful state change (PR opened, task completed, decision made) — not just when context is running low.
 triggers:
   - "/handoff"
   - "write a handoff"
   - "create handoff"
   - "save handoff"
   - "context is running low"
-allowed-tools: Bash, Read, Write, TaskList, TaskGet, Skill
+allowed-tools: Bash, Read, Write, TaskList, TaskGet, Skill, Agent
 ---
 
 # Handoff
 
 Capture the current session's goal, progress, git state, remaining work, and key context into `<working-dir>/.sessionkit/HANDOFF.md` so another agent can pick up without losing momentum.
 
-Use when context is running low, when switching machines or sessions, or whenever you want a clean baton-pass to a fresh agent.
+This skill is optimized for **frequent invocation**. Run it after every meaningful state change — a PR opens, a task flips to `completed`, a key decision lands — not only when context is running low. The synthesis step is delegated to a Haiku sub-agent and skips sections whose inputs haven't changed since the last run, so the cost is small.
 
 ## Input
 
@@ -28,6 +28,7 @@ Run these commands in parallel to collect raw data. Tolerate missing files — t
 
 ```bash
 cat .claude/TODO 2>/dev/null || cat .claude/todos.md 2>/dev/null || echo "No todo file"
+git rev-parse HEAD 2>/dev/null || echo "no-head"
 git branch --show-current
 git diff --cached --name-only
 git diff --name-only
@@ -36,6 +37,15 @@ git diff --cached
 ```
 
 Also invoke `TaskList` to get all task IDs, then call `TaskGet` once per task ID to fetch full details. Collect every task that is **not** deleted (i.e. `status !== "deleted"`). This runs in parallel with the bash commands above.
+
+### 1a. Compute change fingerprints
+
+Build two short fingerprints used in step 1c to decide which sections to regenerate:
+
+- `gitFingerprint` — `<HEAD-sha>:<sorted-staged-files-hash>:<sorted-unstaged-files-hash>`. A change in HEAD or in the working-tree file lists invalidates the Git State + Progress sections.
+- `taskFingerprint` — SHA-1 of the canonicalized (sorted by `id`, fields stripped to `id,subject,status,blockedBy`) Task List JSON. Any change invalidates the Task List + Remaining Work sections.
+
+Compute both in shell (e.g. `git rev-parse HEAD`, `printf %s "$json" | shasum -a 1 | cut -d' ' -f1`).
 
 ### 1b. Detect active team
 
@@ -58,11 +68,53 @@ done
 
 If a team matches, read its `config.json` and extract: `name`, `leadAgentId`, `leadSessionId`, and the `members` array. Drop runtime-only fields from each member (keep only `name`, `agentType`, `agentFile`, `cwd`). If `agentFile` is absent on a member, omit the field. If no team matches, skip the Team State section entirely in step 2.
 
-### 2. Draft the document
+### 1c. Skip-unchanged check
 
-Synthesize the collected data plus conversation history into this exact structure:
+If `.sessionkit/HANDOFF.md` already exists, Read it and look for an HTML comment header of the form:
+
+```
+<!-- handoff-meta gitFingerprint=<sha> taskFingerprint=<sha> -->
+```
+
+Compare against the fingerprints from step 1a:
+
+- If **both** match: nothing material has changed. Reuse the existing file's `## Git State`, `## Progress`, `## Task List`, and `## Remaining Work` sections verbatim — only refresh the `**Date**` field, `## Goal` (if `$ARGUMENTS` was passed), `## Context`, and `## Team State`. Skip the sub-agent call entirely; rewrite the file in-line. Report `(skip-unchanged: reused N sections)` in the confirmation.
+- If only `gitFingerprint` matches: reuse `## Git State` and `## Progress`. Regenerate the rest.
+- If only `taskFingerprint` matches: reuse `## Task List` and `## Remaining Work`. Regenerate the rest.
+- If neither matches, or no prior file exists, or the meta header is absent: regenerate all sections.
+
+### 2. Synthesize via Haiku sub-agent
+
+Delegate markdown synthesis to a sub-agent running on Haiku. The handoff document is structured output and does not need the main model.
+
+Invoke the `Agent` tool with:
+
+- `subagent_type`: `"general-purpose"`
+- `model`: `"claude-haiku-4-5"`
+- `prompt`: a single message containing
+  1. The fixed template from step 2a below.
+  2. The conversation context summary (recent goal, decisions, gotchas — bullet form, no prose).
+  3. The raw outputs from step 1 (git fingerprints, file lists, recent commits, todo file contents).
+  4. The Task List JSON from step 1.
+  5. The Team State JSON from step 1b (or `null`).
+  6. Any sections from step 1c marked "reuse verbatim" with their existing content.
+  7. `$ARGUMENTS` if present.
+  8. Explicit instructions: "Emit ONLY the markdown document. No commentary, no fences around the whole thing. Use bullets, not paragraphs, for Progress / Remaining Work / Context. Preserve the JSON code blocks for Task List and Team State exactly as given."
+
+**Timeout / failure handling**: if the Agent call fails, returns empty output, or produces output that does not contain the required `## Task List` heading, fall back to in-line synthesis. Prepend a single comment line to the document:
+
+```
+<!-- handoff-warning: haiku sub-agent unavailable, synthesized in-line -->
+```
+
+…and synthesize the document yourself using the same template.
+
+### 2a. Strict template
+
+The sub-agent (or in-line fallback) must emit exactly this structure. **Bullets only** in Progress / Remaining Work / Context — no narrative paragraphs. The meta header on line 1 is mandatory and is what step 1c reads on the next run.
 
 ```markdown
+<!-- handoff-meta gitFingerprint=<sha> taskFingerprint=<sha> -->
 # Handoff
 
 **Project**: <working directory>
@@ -70,19 +122,23 @@ Synthesize the collected data plus conversation history into this exact structur
 **Branch**: <current git branch>
 
 ## Goal
-What we were trying to accomplish this session.
+- <one bullet, one sentence>
 
 ## Progress
-How far we got — what's been completed, what's been decided.
+- <completed item>
+- <decision made>
+- <thread abandoned>
 
 ## Git State
 - Branch: <branch>
 - Staged: <list of staged files or "none">
 - Unstaged: <list of unstaged files or "none">
-- Recent commits (last 5): <list>
+- Recent commits (last 5):
+  - <sha> <subject>
 
 ## Remaining Work
-Outstanding todos and next steps in priority order.
+- <next step in priority order>
+- <next step>
 
 ## Task List
 ```json
@@ -112,24 +168,23 @@ Outstanding todos and next steps in priority order.
 ```
 
 ## Context
-Key decisions made, gotchas encountered, important notes the next agent must know.
+- <key decision>
+- <gotcha>
+- <external reference>
 ```
 
-Inference rules:
-- **Goal** — derive from branch name, recent commits, and the arc of the conversation.
-- **Progress** — what's been completed, decided, or abandoned this session.
-- **Remaining Work** — pull from the todo file and from any unfinished threads in the conversation; order by priority.
-- **Task List** — serialize the tasks collected in step 1 as a single fenced `json` code block. The JSON is an array of task objects. Include only these fields: `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, `blocks`. Exclude `owner`, `metadata`, and any deleted tasks. If no tasks exist, write an empty array `[]`. The `id` field preserves the original task ID so `/pickup` can wire `blockedBy` relationships in a follow-up pass.
-- **Team State** — emit this section **only** when step 1b matched a team. Serialize the matched team as a single fenced `json` code block with these fields: `teamName`, `leadAgentId`, `leadSessionId`, and `members` (array of `{name, agentType, agentFile, cwd}` — `agentFile` optional). Omit the section entirely if no team matched.
-- **Context** — decisions, gotchas, dead ends, external references. Keep it to what the next agent genuinely needs.
+Inference rules (applied by the sub-agent):
 
-If `$ARGUMENTS` is provided, weave its guidance into the relevant sections (often Goal or Context).
+- **Goal** — one bullet derived from branch name, recent commits, and conversation arc.
+- **Progress** — bullets only: what's been completed, decided, or abandoned this session.
+- **Remaining Work** — bullets in priority order, drawn from the todo file and unfinished conversation threads.
+- **Task List** — serialize the tasks from step 1 as a single fenced `json` code block. Array of task objects. Include only `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, `blocks`. Exclude `owner`, `metadata`, and deleted tasks. Empty array `[]` if none. Preserve original task `id` so `/pickup` can wire `blockedBy` relationships.
+- **Team State** — emit **only** when step 1b matched a team. Single fenced `json` block with `teamName`, `leadAgentId`, `leadSessionId`, `members` (`{name, agentType, agentFile, cwd}` — `agentFile` optional). Omit the section entirely otherwise.
+- **Context** — bullets only: decisions, gotchas, dead ends, external references. Keep to what the next agent genuinely needs.
 
-### 3. Present the draft
+If `$ARGUMENTS` is provided, weave its guidance into Goal or Context.
 
-Show the drafted document inline in the conversation so the user can see what will be written. Then proceed immediately to step 4 — no approval needed.
-
-### 4. Write to disk
+### 3. Write to disk
 
 Check `.gitignore` coverage first:
 
@@ -141,7 +196,7 @@ test -f .gitignore && grep -qE '^\.sessionkit/?$' .gitignore && echo "covered" |
 - **`.gitignore` present but not covered**: ask "`.gitignore` doesn't cover `.sessionkit/`. Append it? (yes/no)". On yes, append `.sessionkit/` to `.gitignore`. On no, proceed.
 - **Already covered**: proceed silently.
 
-If `.sessionkit/HANDOFF.md` already exists, Read it first (the Write tool requires a prior Read of the target path). If the file doesn't exist yet, skip this step.
+If `.sessionkit/HANDOFF.md` already exists, Read it first (the Write tool requires a prior Read of the target path). Step 1c already did this when a prior file exists.
 
 Then create the directory and write the file:
 
@@ -149,20 +204,22 @@ Then create the directory and write the file:
 mkdir -p .sessionkit
 ```
 
-Write the document to `.sessionkit/HANDOFF.md` using the Write tool, silently overwriting any existing file.
+Write the synthesized document to `.sessionkit/HANDOFF.md` using the Write tool, silently overwriting any existing file.
 
-### 5. Confirm
+### 4. Confirm
 
-Report the absolute path of the file written and suggest:
+Report the absolute path of the file written, the skip-unchanged status (e.g. `regenerated all sections` / `reused 4 sections, regenerated 2`), and suggest:
 
 > Start a new session and run `/pickup` to resume.
 
 ## Constraints
 
-- After presenting the draft, write it immediately — do not pause for approval
-- Keep the document concise — it's a recall aid, not full documentation
+- Run as soon as a meaningful state change happens — frequent handoffs are cheap by design (skip-unchanged + Haiku sub-agent)
+- Bullets only in Progress, Remaining Work, and Context — no prose paragraphs
+- The `<!-- handoff-meta ... -->` header on line 1 is mandatory; step 1c reads it on the next run to decide what to skip
 - `.sessionkit/HANDOFF.md` in the working directory is the canonical location — never write elsewhere
 - Section order in HANDOFF.md is fixed: Goal → Progress → Git State → Remaining Work → Task List → Team State (optional) → Context
-- Legacy HANDOFFs that lack a `## Task List` or `## Team State` section remain valid inputs to `/pickup` — their absence is not an error
+- Legacy HANDOFFs that lack a `## Task List`, `## Team State`, or meta header remain valid inputs to `/pickup` — their absence is not an error (the next run will simply regenerate everything)
 - The `## Team State` section is omitted when no team config in `~/.claude/teams/` matches the current session by `leadSessionId` or member `cwd`
 - Always Read `.sessionkit/HANDOFF.md` before overwriting it with Write — the Write tool refuses to overwrite paths it hasn't read in the current conversation
+- If the Haiku sub-agent fails, fall back to in-line synthesis and prepend a `<!-- handoff-warning: ... -->` line so the user knows the slow path was taken

--- a/plugins/sessionkit/skills/handoff/SKILL.md
+++ b/plugins/sessionkit/skills/handoff/SKILL.md
@@ -7,7 +7,7 @@ triggers:
   - "create handoff"
   - "save handoff"
   - "context is running low"
-allowed-tools: Bash, Read, Write, TaskList, TaskGet
+allowed-tools: Bash, Read, Write, TaskList, TaskGet, Skill
 ---
 
 # Handoff
@@ -36,6 +36,27 @@ git diff --cached
 ```
 
 Also invoke `TaskList` to get all task IDs, then call `TaskGet` once per task ID to fetch full details. Collect every task that is **not** deleted (i.e. `status !== "deleted"`). This runs in parallel with the bash commands above.
+
+### 1b. Detect active team
+
+Check `~/.claude/teams/*/config.json` for a team config that matches the current session. A team matches if either:
+
+1. Its `leadSessionId` equals the current session ID (resolved via `sessionkit:get-session-id`), OR
+2. Any member's `cwd` equals `$PWD`.
+
+```bash
+CURRENT_SID="$(PROJECT_PATH=$(echo "$PWD" | sed 's|/|-|g'); ls -t ~/.claude/projects/${PROJECT_PATH}/*.jsonl 2>/dev/null | head -1 | xargs -r basename -s .jsonl)"
+ls ~/.claude/teams/*/config.json 2>/dev/null | while read CFG; do
+  jq -r --arg sid "$CURRENT_SID" --arg cwd "$PWD" '
+    if (.leadSessionId == $sid) or (any(.members[]?; .cwd == $cwd))
+    then "MATCH:" + input_filename
+    else empty
+    end
+  ' "$CFG"
+done
+```
+
+If a team matches, read its `config.json` and extract: `name`, `leadAgentId`, `leadSessionId`, and the `members` array. Drop runtime-only fields from each member (keep only `name`, `agentType`, `agentFile`, `cwd`). If `agentFile` is absent on a member, omit the field. If no team matches, skip the Team State section entirely in step 2.
 
 ### 2. Draft the document
 
@@ -78,6 +99,18 @@ Outstanding todos and next steps in priority order.
 ]
 ```
 
+## Team State
+```json
+{
+  "teamName": "<name>",
+  "leadAgentId": "<leadAgentId>",
+  "leadSessionId": "<leadSessionId>",
+  "members": [
+    {"name": "<name>", "agentType": "<type>", "agentFile": "<path>", "cwd": "<path>"}
+  ]
+}
+```
+
 ## Context
 Key decisions made, gotchas encountered, important notes the next agent must know.
 ```
@@ -87,6 +120,7 @@ Inference rules:
 - **Progress** — what's been completed, decided, or abandoned this session.
 - **Remaining Work** — pull from the todo file and from any unfinished threads in the conversation; order by priority.
 - **Task List** — serialize the tasks collected in step 1 as a single fenced `json` code block. The JSON is an array of task objects. Include only these fields: `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, `blocks`. Exclude `owner`, `metadata`, and any deleted tasks. If no tasks exist, write an empty array `[]`. The `id` field preserves the original task ID so `/pickup` can wire `blockedBy` relationships in a follow-up pass.
+- **Team State** — emit this section **only** when step 1b matched a team. Serialize the matched team as a single fenced `json` code block with these fields: `teamName`, `leadAgentId`, `leadSessionId`, and `members` (array of `{name, agentType, agentFile, cwd}` — `agentFile` optional). Omit the section entirely if no team matched.
 - **Context** — decisions, gotchas, dead ends, external references. Keep it to what the next agent genuinely needs.
 
 If `$ARGUMENTS` is provided, weave its guidance into the relevant sections (often Goal or Context).
@@ -128,6 +162,7 @@ Report the absolute path of the file written and suggest:
 - After presenting the draft, write it immediately — do not pause for approval
 - Keep the document concise — it's a recall aid, not full documentation
 - `.sessionkit/HANDOFF.md` in the working directory is the canonical location — never write elsewhere
-- Section order in HANDOFF.md is fixed: Goal → Progress → Git State → Remaining Work → Task List → Context
-- Legacy HANDOFFs that lack a `## Task List` section remain valid inputs to `/pickup` — its absence is not an error
+- Section order in HANDOFF.md is fixed: Goal → Progress → Git State → Remaining Work → Task List → Team State (optional) → Context
+- Legacy HANDOFFs that lack a `## Task List` or `## Team State` section remain valid inputs to `/pickup` — their absence is not an error
+- The `## Team State` section is omitted when no team config in `~/.claude/teams/` matches the current session by `leadSessionId` or member `cwd`
 - Always Read `.sessionkit/HANDOFF.md` before overwriting it with Write — the Write tool refuses to overwrite paths it hasn't read in the current conversation

--- a/plugins/sessionkit/skills/pickup/SKILL.md
+++ b/plugins/sessionkit/skills/pickup/SKILL.md
@@ -7,7 +7,7 @@ triggers:
   - "load handoff"
   - "resume from handoff"
   - "continue previous session"
-allowed-tools: Bash, Read, TaskCreate, TaskUpdate, TaskList
+allowed-tools: Bash, Read, TaskCreate, TaskUpdate, TaskList, Skill
 ---
 
 # Pickup
@@ -32,7 +32,7 @@ Then stop — do not proceed with the remaining steps.
 
 ### 2. Read and parse
 
-Read the full content of `.sessionkit/HANDOFF.md`. Parse the standard sections: **Project**, **Date**, **Branch**, **Goal**, **Progress**, **Git State**, **Remaining Work**, **Context**.
+Read the full content of `.sessionkit/HANDOFF.md`. Parse the standard sections: **Project**, **Date**, **Branch**, **Goal**, **Progress**, **Git State**, **Remaining Work**, **Context**. The optional **Team State** section is parsed in step 4b.
 
 ### 3. Present orientation summary
 
@@ -71,6 +71,31 @@ After all `TaskCreate` calls complete, iterate the same set of created tasks. Fo
 - Call `TaskUpdate` with `addBlockedBy` for the new task ID.
 
 Do not wire `blocks` — the inverse relationship is implicit and wiring both directions would double-write the graph.
+
+### 4b. Restore team state (if present)
+
+Parse the `## Team State` section from `.sessionkit/HANDOFF.md`:
+
+1. Locate the fenced ` ```json ` block immediately following the `## Team State` heading.
+2. If no `## Team State` section exists, or the JSON block is absent or unparseable, skip this step silently — back-compat with handoffs that pre-date team-state support.
+
+If a valid block is parsed, identify the **current role** by matching against the new session:
+
+- Resolve the current session ID via `sessionkit:get-session-id`.
+- A member matches if either its `cwd` equals `$PWD`, or the team's `leadSessionId` equals the current session ID and the member's `agentType` is the lead role (`lead` or `team-lead`).
+- If multiple members match, prefer the `cwd` match.
+
+When a member matches:
+
+- If `agentFile` is set and the file exists, Read it and fold the role's operating rules into the orientation summary (do not dump the file verbatim — surface the role's responsibilities concisely).
+- Emit exactly one orientation line:
+  > `Active team `<teamName>` detected (role: <agentType>). Loaded role context from <agentFile>.`
+- If `agentFile` is missing or unreadable, emit instead:
+  > `Active team `<teamName>` detected (role: <agentType>). No role file available.`
+
+When no member matches the current session, surface the team metadata as informational only:
+
+> `Team `<teamName>` referenced in handoff but no member matches this session.`
 
 ### 5. Restore git state (if needed)
 

--- a/plugins/speckit/.claude-plugin/plugin.json
+++ b/plugins/speckit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "speckit",
   "description": "Define and capture work as GitHub issues. Interview a feature into existence with /spec, bulk-convert findings with /catalog, or quickly file a single issue with /issue.",
-  "version": "1.4.3",
+  "version": "1.5.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/speckit/README.md
+++ b/plugins/speckit/README.md
@@ -87,6 +87,32 @@ When `/spec` runs the full interview path, the interview skill applies a silent 
 3. **Soft cap on epic size** — if the task count is still greater than 4 after signals 1 and 2, a second merge pass re-examines under looser interpretations of 1 and 2. The cap is a prompt to re-examine, not a hard limit — genuinely independent tasks are never forced together.
 4. **Docs-only tail merge** — if the auto-appended documentation task is the only non-implementation task remaining and the impl task(s) cover the same surface, docs fold into impl.
 
+### Team-readiness assessment
+
+After the epic and child issues are filed, `/spec` (full path only) assesses
+whether the work is well-suited for a parallel agent team. The signals it
+scores against:
+
+1. **Multiple independent modules** — work spans ≥2 modules / skills / packages.
+2. **Clear interface boundaries** — at least one task can be expressed as a contract.
+3. **Separable phases** — work splits into contract → implementation → integration waves.
+4. **Non-trivial implementation surface** — ≥3 tasks, with multiple non-trivial edits.
+
+If at least three signals hold, `/spec` re-decomposes the filed issues for
+agent execution: it provisions `phase:1`, `phase:2`, `phase:3` labels (creating
+them if missing, matching the catalog skill's label-provisioning pattern),
+assigns each child issue to a phase, extracts interface contracts as their own
+issue when bundled inside an implementation task, identifies the issue whose
+branch should become the epic's feature-branch base (see
+[#592](https://github.com/smallorbit/smallorbit-plugins/issues/592) for the
+matching flowkit work), and posts a team dispatch summary as a comment on the
+epic issue describing recommended spawn config (builder count, model, feature
+branch, initial dispatch order).
+
+If fewer than three signals hold, `/spec` prints
+`Team decomposition skipped — <reason>` and proceeds to the final report. The
+simple path always skips this step — single-issue plans are never team-suitable.
+
 ## How Catalog Works
 
 `/catalog` accepts findings from three sources (checked in order): explicit input in `$ARGUMENTS`, findings from earlier in the conversation, or a file path. It parses them into discrete issues, checks for existing duplicates and labels, shows a summary table for approval, then creates all issues in priority order (high first).

--- a/plugins/speckit/skills/catalog/SKILL.md
+++ b/plugins/speckit/skills/catalog/SKILL.md
@@ -168,6 +168,8 @@ Output the created issues as a table with links:
 | 1 | [#N](url) title | high | ... |
 ```
 
+**Sub-skill output contract**: When `--epic <slug>` is present (i.e. catalog was invoked from `/spec`), the results table above is the FINAL output. Stop immediately after the table — zero trailing prose, no hand-off sentence, no "returning to /spec" message, no transition language of any kind. The orchestrator resumes automatically; any trailing text will stall it.
+
 ## Constraints
 
 - Never create issues without showing the user the catalog first (unless `--auto` was passed)

--- a/plugins/speckit/skills/spec/SKILL.md
+++ b/plugins/speckit/skills/spec/SKILL.md
@@ -280,6 +280,8 @@ Pass the full task list from the plan to `/catalog` in a single call, prefixing 
 
 Do not instruct `/catalog` to embed `Depends on #N` lines (or any other `#<number>` task-reference) in issue bodies. GitHub auto-links `#N` tokens, so a body that says "Depends on task #3" will link to unrelated issue 3 in the repo. Task-to-task dependencies are wired in step 5 via the native GitHub blocked-by API — keep them out of the issue body.
 
+**After `/catalog` returns, do not pause and do not wait for user input. Proceed immediately to step 5.** The catalog sub-skill's final output is the results table; any trailing prose it may emit is noise and must be ignored. The orchestrator owns the transition and must advance autonomously.
+
 ### 5. Create the epic tracking issue
 
 Before creating, check for an existing epic: `gh issue list --search "epic: <title>" --state open`. Skip creation and report the existing issue number if found.

--- a/plugins/speckit/skills/spec/SKILL.md
+++ b/plugins/speckit/skills/spec/SKILL.md
@@ -121,7 +121,8 @@ ambiguous prompt) — short-circuit the rest of this skill:
 4. On approval, hand the single task to `/catalog` with **no `--epic` flag**.
    Catalog files one standalone issue. Skip step 2.5, step 5 (no epic tracking
    issue), and the sub-issue / blocked-by wiring.
-5. Jump to step 6 to report the filed issue, then stop.
+5. Jump to step 7 to report the filed issue, then stop. Skip step 6 — the
+   team-readiness assessment is full-path only.
 
 **On Full interview** (clearly-full narration, or `Full interview` picked in
 the ambiguous prompt): fall through to step 2 (invoke `/speckit:interview`)
@@ -345,18 +346,113 @@ After creating the epic, wire up relationships:
    ```
    Use `-F` (not `-f`) to pass integers. Map task numbers to issue IDs from the created issues.
 
-### 6. Report
+### 6. Team-readiness assessment
+
+Only run this step on the full-path flow (epic with 2+ child issues). Skip
+entirely on the simple path — single-issue plans are never team-suitable.
+
+Assess whether the spec is well-suited for a parallel agent team. The default
+`/catalog` decomposition is written for human developers and is rarely shaped
+for agent-team execution; this step re-evaluates the work and, when warranted,
+re-decomposes the freshly filed issues so multiple builders can run in parallel.
+
+**Suitability signals** — score the spec against all four. The work is
+team-suitable only when **at least three** hold:
+
+1. **Multiple independent modules** — child issues touch ≥2 distinct
+   modules / skills / packages with no shared mutable state.
+2. **Clear interface boundaries** — at least one task can be expressed as a
+   contract (function signature, schema, protocol) that downstream tasks
+   consume.
+3. **Separable phases** — work naturally splits into a contract / interface
+   wave, an implementation wave, and an integration wave.
+4. **Non-trivial implementation surface** — total task count ≥3 after
+   consolidation, with at least two tasks expected to take more than a
+   trivial single-file edit.
+
+If fewer than three signals hold, print a single line and stop:
+
+```
+Team decomposition skipped — <one-line reason, e.g. "tightly sequential, single module">.
+```
+
+Then proceed to step 7 (Report).
+
+**If team-suitable**, re-decompose the filed issues:
+
+1. **Provision phase labels.** For each phase you intend to use (typically
+   `phase:1`, `phase:2`, `phase:3`), check existence and create if missing.
+   Match the catalog skill's label-provisioning pattern:
+   ```bash
+   gh label list --search "phase:" --json name --jq '.[].name'
+   gh label create "phase:<N>" \
+     --color fbca04 \
+     --description "Agent-team execution wave <N>"
+   ```
+   Use the shared color `#fbca04` (yellow family) so phase labels are visually
+   grouped in the GitHub UI.
+
+2. **Assign each child issue to a phase** using `gh issue edit <N>
+   --add-label "phase:<K>"`. Conventional waves:
+   - `phase:1` — interface contracts, schemas, scaffolding (parallel-safe,
+     unblocks downstream)
+   - `phase:2` — implementation tasks that depend on phase:1 contracts
+   - `phase:3` — integration, end-to-end tests, documentation
+
+3. **Extract interface contracts as their own issue** when an implementation
+   task implicitly bundles a contract. Use `/speckit:issue` (or `gh issue
+   create` directly) to file the new contract issue, then add it as a sub-issue
+   of the epic and wire the original implementation issue's blocked-by to
+   point at the contract issue. This lets the tester / consumer agents start
+   in parallel against the contract while the implementer is still working.
+
+4. **Identify the base-branch issue.** One phase:1 issue should be marked as
+   the epic's feature branch base — its branch becomes the integration target
+   for all sibling builders. Note this in the dispatch summary below. (See
+   #592 — flowkit's epic-branch work tracks the matching swarm/flowkit
+   support; this step is informational until that ships.)
+
+5. **Post the team dispatch summary as a comment on the epic issue.** Use
+   `gh issue comment <epic_number> --body` (a comment, NOT a separate issue)
+   with this shape:
+
+   ```markdown
+   ## Team dispatch summary
+
+   This epic has been assessed as suitable for parallel agent-team execution.
+
+   **Recommended spawn config**
+   - Builders: <N> (one per phase:1 issue + one per independent phase:2 stream)
+   - Model: <opus | sonnet — opus for novel design, sonnet for mechanical impl>
+   - Feature branch base: #<base_issue_number> (see #592)
+
+   **Dispatch order**
+   1. Phase 1 (parallel): #A, #B — interface contracts, base branch
+   2. Phase 2 (parallel after phase 1): #C, #D — implementation
+   3. Phase 3 (after phase 2): #E — integration, docs
+
+   **Notes**
+   - <any cross-cutting risks or coordination notes>
+   ```
+
+   Replace placeholders with the actual issue numbers from step 4. Reference
+   #592 verbatim so the link resolves.
+
+### 7. Report
 
 Output a summary table:
 
 ```
 Epic:  #N  epic: <title>
 
-| # | Issue | Category | Priority |
-|---|-------|----------|----------|
-| 1 | #N title | bug | high |
-| 2 | #N title | test | medium |
+| # | Issue | Category | Priority | Phase |
+|---|-------|----------|----------|-------|
+| 1 | #N title | bug | high | phase:1 |
+| 2 | #N title | test | medium | phase:2 |
 ```
+
+Include the `Phase` column only when step 6 ran the team decomposition. If the
+team-readiness assessment skipped, omit the column.
 
 ## Constraints
 


### PR DESCRIPTION
## Summary

Three plugins ship coordinated multi-agent workflow improvements: speckit auto-assesses agent-team suitability and stops stalling on `/spec`, sessionkit persists team state across `/handoff` ↔ `/pickup` and delegates synthesis to a Haiku sub-agent for ~3-5× faster runs, and flowkit gains an epic/feature-branch workflow for stacking long-lived feature PRs. Together they reduce the manual orchestration overhead when running multi-agent epics.

## Release summary

**Built from**: `rc/2026-04-26.1`

### Version bumps
- chore(plugins): bump flowkit@3.2.0, sessionkit@1.5.0, speckit@1.5.0

### Changes

**flowkit**
- feat(flowkit): add epic/feature-branch workflow (#597)

**speckit**
- feat(speckit): add team-readiness assessment phase (#599)
- fix(speckit): prevent /spec from stalling after catalog sub-skill (#596)

**sessionkit**
- perf(sessionkit): delegate handoff synthesis to haiku sub-agent (#600)
- feat(sessionkit): persist team state across handoff/pickup (#598)

Closes #591
Closes #592
Closes #593
Closes #594
Closes #595
Closes #256
