### PR TITLE
refactor(squadkit): own team-state restoration via SessionStart hook

### DIFF
--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sessionkit",
   "description": "Session continuity and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, plan through structured interviews, discover reusable skills, and reduce permission noise.",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/sessionkit/README.md
+++ b/plugins/sessionkit/README.md
@@ -27,8 +27,8 @@ claude --plugin-dir /path/to/sessionkit
 
 | Skill | Invoke | What it does |
 |-------|--------|--------------|
-| **handoff** | `/handoff` | Captures session goal, progress, git state, remaining work, active tasks, and (when present) multi-agent team state into `.sessionkit/HANDOFF.md`. Use when context is running low or when switching agents. |
-| **pickup** | `/pickup` | Loads `.sessionkit/HANDOFF.md` at the start of a new session, orients the agent, hydrates pending/in-progress tasks back into the task system, and auto-restores team role context when a `## Team State` block is present. |
+| **handoff** | `/handoff` | Captures session goal, progress, git state, remaining work, and active tasks into `.sessionkit/HANDOFF.md`. Use when context is running low or when switching agents. |
+| **pickup** | `/pickup` | Loads `.sessionkit/HANDOFF.md` at the start of a new session, orients the agent, and hydrates pending/in-progress tasks back into the task system. |
 | **skillit** | `/skillit` | Reflects on the current session to identify patterns worth encoding as reusable skills. Checks for existing overlap before proposing anything new. |
 | **suggest-permissions** | `/suggest-permissions` | Scans recent session history for repeatedly approved permissions and proposes additions to `.claude/settings.json` to reduce future prompts. |
 
@@ -90,26 +90,11 @@ The two skills are intentionally separate: handoff writes, pickup reads. The han
 
 **Back-compat**: legacy `HANDOFF.md` files that were written before task-list support was added (i.e. no `## Task List` section) are fully valid. `/pickup` emits one warning line — `No task list snapshot — skipping hydration` — and continues with the orientation summary.
 
-### Team State Round-Trip
+### Team Coordination
 
-When the current session is part of a multi-agent team — i.e. a config file under `~/.claude/teams/<team>/config.json` matches by `leadSessionId` or member `cwd` — `/handoff` emits a `## Team State` fenced JSON block capturing the team identity and member roster:
+Multi-agent team coordination is owned by [squadkit](../squadkit). Squadkit ships a `SessionStart` hook that reads `~/.claude/teams/*/config.json` directly and re-emits the active role contract whenever a session starts — including sessions resumed via `/pickup`. Sessionkit therefore stays orthogonal: it captures generic session state, and squadkit layers team-role context on top.
 
-```json
-{
-  "teamName": "...",
-  "leadAgentId": "...",
-  "leadSessionId": "...",
-  "members": [
-    {"name": "team-lead", "agentType": "lead", "agentFile": "...", "cwd": "..."}
-  ]
-}
-```
-
-`/pickup` parses the block, identifies which member corresponds to the resuming session (by `cwd` match, or by lead-session-id match for the lead role), reads the member's `agentFile` if present, and surfaces one orientation line:
-
-> Active team `<name>` detected (role: <agentType>). Loaded role context from `<agentFile>`.
-
-When no team is active, the section is omitted entirely. Handoffs without a `## Team State` section are valid — `/pickup` simply skips the team-restore step.
+Handoff files written by sessionkit ≤ 1.5.0 may contain a `## Team State` JSON block. `/pickup` ignores those sections silently — they're inert legacy artifacts, not parse errors.
 
 ## Handoff Document Structure
 
@@ -122,7 +107,6 @@ When no team is active, the section is omitted entirely. Handoffs without a `## 
 | **Git State** | Current branch, staged/unstaged files, recent commits |
 | **Remaining Work** | Prioritized list of what still needs to be done |
 | **Task List** | Fenced JSON array of task objects (see Task Round-Trip above) |
-| **Team State** | *(optional)* Fenced JSON object capturing active team identity and members (see Team State Round-Trip above). Omitted when no team is active. |
 | **Context** | Gotchas, constraints, or non-obvious state the next agent must know |
 
 You can manually edit `.sessionkit/HANDOFF.md` between sessions — `/pickup` reads whatever is there.

--- a/plugins/sessionkit/skills/handoff/SKILL.md
+++ b/plugins/sessionkit/skills/handoff/SKILL.md
@@ -47,27 +47,6 @@ Build two short fingerprints used in step 1c to decide which sections to regener
 
 Compute both in shell (e.g. `git rev-parse HEAD`, `printf %s "$json" | shasum -a 1 | cut -d' ' -f1`).
 
-### 1b. Detect active team
-
-Check `~/.claude/teams/*/config.json` for a team config that matches the current session. A team matches if either:
-
-1. Its `leadSessionId` equals the current session ID (resolved via `sessionkit:get-session-id`), OR
-2. Any member's `cwd` equals `$PWD`.
-
-```bash
-CURRENT_SID="$(PROJECT_PATH=$(echo "$PWD" | sed 's|/|-|g'); ls -t ~/.claude/projects/${PROJECT_PATH}/*.jsonl 2>/dev/null | head -1 | xargs -r basename -s .jsonl)"
-ls ~/.claude/teams/*/config.json 2>/dev/null | while read CFG; do
-  jq -r --arg sid "$CURRENT_SID" --arg cwd "$PWD" '
-    if (.leadSessionId == $sid) or (any(.members[]?; .cwd == $cwd))
-    then "MATCH:" + input_filename
-    else empty
-    end
-  ' "$CFG"
-done
-```
-
-If a team matches, read its `config.json` and extract: `name`, `leadAgentId`, `leadSessionId`, and the `members` array. Drop runtime-only fields from each member (keep only `name`, `agentType`, `agentFile`, `cwd`). If `agentFile` is absent on a member, omit the field. If no team matches, skip the Team State section entirely in step 2.
-
 ### 1c. Skip-unchanged check
 
 If `.sessionkit/HANDOFF.md` already exists, Read it and look for an HTML comment header of the form:
@@ -78,7 +57,7 @@ If `.sessionkit/HANDOFF.md` already exists, Read it and look for an HTML comment
 
 Compare against the fingerprints from step 1a:
 
-- If **both** match: nothing material has changed. Reuse the existing file's `## Git State`, `## Progress`, `## Task List`, and `## Remaining Work` sections verbatim — only refresh the `**Date**` field, `## Goal` (if `$ARGUMENTS` was passed), `## Context`, and `## Team State`. Skip the sub-agent call entirely; rewrite the file in-line. Report `(skip-unchanged: reused N sections)` in the confirmation.
+- If **both** match: nothing material has changed. Reuse the existing file's `## Git State`, `## Progress`, `## Task List`, and `## Remaining Work` sections verbatim — only refresh the `**Date**` field, `## Goal` (if `$ARGUMENTS` was passed), and `## Context`. Skip the sub-agent call entirely; rewrite the file in-line. Report `(skip-unchanged: reused N sections)` in the confirmation.
 - If only `gitFingerprint` matches: reuse `## Git State` and `## Progress`. Regenerate the rest.
 - If only `taskFingerprint` matches: reuse `## Task List` and `## Remaining Work`. Regenerate the rest.
 - If neither matches, or no prior file exists, or the meta header is absent: regenerate all sections.
@@ -96,10 +75,9 @@ Invoke the `Agent` tool with:
   2. The conversation context summary (recent goal, decisions, gotchas — bullet form, no prose).
   3. The raw outputs from step 1 (git fingerprints, file lists, recent commits, todo file contents).
   4. The Task List JSON from step 1.
-  5. The Team State JSON from step 1b (or `null`).
-  6. Any sections from step 1c marked "reuse verbatim" with their existing content.
-  7. `$ARGUMENTS` if present.
-  8. Explicit instructions: "Emit ONLY the markdown document. No commentary, no fences around the whole thing. Use bullets, not paragraphs, for Progress / Remaining Work / Context. Preserve the JSON code blocks for Task List and Team State exactly as given."
+  5. Any sections from step 1c marked "reuse verbatim" with their existing content.
+  6. `$ARGUMENTS` if present.
+  7. Explicit instructions: "Emit ONLY the markdown document. No commentary, no fences around the whole thing. Use bullets, not paragraphs, for Progress / Remaining Work / Context. Preserve the JSON code block for Task List exactly as given."
 
 **Timeout / failure handling**: if the Agent call fails, returns empty output, or produces output that does not contain the required `## Task List` heading, fall back to in-line synthesis. Prepend a single comment line to the document:
 
@@ -155,18 +133,6 @@ The sub-agent (or in-line fallback) must emit exactly this structure. **Bullets 
 ]
 ```
 
-## Team State
-```json
-{
-  "teamName": "<name>",
-  "leadAgentId": "<leadAgentId>",
-  "leadSessionId": "<leadSessionId>",
-  "members": [
-    {"name": "<name>", "agentType": "<type>", "agentFile": "<path>", "cwd": "<path>"}
-  ]
-}
-```
-
 ## Context
 - <key decision>
 - <gotcha>
@@ -179,7 +145,6 @@ Inference rules (applied by the sub-agent):
 - **Progress** — bullets only: what's been completed, decided, or abandoned this session.
 - **Remaining Work** — bullets in priority order, drawn from the todo file and unfinished conversation threads.
 - **Task List** — serialize the tasks from step 1 as a single fenced `json` code block. Array of task objects. Include only `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, `blocks`. Exclude `owner`, `metadata`, and deleted tasks. Empty array `[]` if none. Preserve original task `id` so `/pickup` can wire `blockedBy` relationships.
-- **Team State** — emit **only** when step 1b matched a team. Single fenced `json` block with `teamName`, `leadAgentId`, `leadSessionId`, `members` (`{name, agentType, agentFile, cwd}` — `agentFile` optional). Omit the section entirely otherwise.
 - **Context** — bullets only: decisions, gotchas, dead ends, external references. Keep to what the next agent genuinely needs.
 
 If `$ARGUMENTS` is provided, weave its guidance into Goal or Context.
@@ -218,8 +183,7 @@ Report the absolute path of the file written, the skip-unchanged status (e.g. `r
 - Bullets only in Progress, Remaining Work, and Context — no prose paragraphs
 - The `<!-- handoff-meta ... -->` header on line 1 is mandatory; step 1c reads it on the next run to decide what to skip
 - `.sessionkit/HANDOFF.md` in the working directory is the canonical location — never write elsewhere
-- Section order in HANDOFF.md is fixed: Goal → Progress → Git State → Remaining Work → Task List → Team State (optional) → Context
-- Legacy HANDOFFs that lack a `## Task List`, `## Team State`, or meta header remain valid inputs to `/pickup` — their absence is not an error (the next run will simply regenerate everything)
-- The `## Team State` section is omitted when no team config in `~/.claude/teams/` matches the current session by `leadSessionId` or member `cwd`
+- Section order in HANDOFF.md is fixed: Goal → Progress → Git State → Remaining Work → Task List → Context
+- Legacy HANDOFFs that lack a `## Task List` or meta header remain valid inputs to `/pickup` — their absence is not an error (the next run will simply regenerate everything)
 - Always Read `.sessionkit/HANDOFF.md` before overwriting it with Write — the Write tool refuses to overwrite paths it hasn't read in the current conversation
 - If the Haiku sub-agent fails, fall back to in-line synthesis and prepend a `<!-- handoff-warning: ... -->` line so the user knows the slow path was taken

--- a/plugins/sessionkit/skills/pickup/SKILL.md
+++ b/plugins/sessionkit/skills/pickup/SKILL.md
@@ -32,7 +32,9 @@ Then stop — do not proceed with the remaining steps.
 
 ### 2. Read and parse
 
-Read the full content of `.sessionkit/HANDOFF.md`. Parse the standard sections: **Project**, **Date**, **Branch**, **Goal**, **Progress**, **Git State**, **Remaining Work**, **Context**. The optional **Team State** section is parsed in step 4b.
+Read the full content of `.sessionkit/HANDOFF.md`. Parse the standard sections: **Project**, **Date**, **Branch**, **Goal**, **Progress**, **Git State**, **Remaining Work**, **Context**. Unknown headings are passed through unmodified — section parsing is open-ended, so any future or legacy section names (including the legacy `## Team State` block emitted by sessionkit ≤ 1.5.0) are silently ignored.
+
+> Note: handoffs written by sessionkit ≤ 1.5.0 may carry a `## Team State` section. `/pickup` ignores it intentionally — squadkit's `SessionStart` hook now reads `~/.claude/teams/*/config.json` directly and re-emits the role reminder, so the legacy artifact is inert, not a bug.
 
 ### 3. Present orientation summary
 
@@ -71,31 +73,6 @@ After all `TaskCreate` calls complete, iterate the same set of created tasks. Fo
 - Call `TaskUpdate` with `addBlockedBy` for the new task ID.
 
 Do not wire `blocks` — the inverse relationship is implicit and wiring both directions would double-write the graph.
-
-### 4b. Restore team state (if present)
-
-Parse the `## Team State` section from `.sessionkit/HANDOFF.md`:
-
-1. Locate the fenced ` ```json ` block immediately following the `## Team State` heading.
-2. If no `## Team State` section exists, or the JSON block is absent or unparseable, skip this step silently — back-compat with handoffs that pre-date team-state support.
-
-If a valid block is parsed, identify the **current role** by matching against the new session:
-
-- Resolve the current session ID via `sessionkit:get-session-id`.
-- A member matches if either its `cwd` equals `$PWD`, or the team's `leadSessionId` equals the current session ID and the member's `agentType` is the lead role (`lead` or `team-lead`).
-- If multiple members match, prefer the `cwd` match.
-
-When a member matches:
-
-- If `agentFile` is set and the file exists, Read it and fold the role's operating rules into the orientation summary (do not dump the file verbatim — surface the role's responsibilities concisely).
-- Emit exactly one orientation line:
-  > `Active team `<teamName>` detected (role: <agentType>). Loaded role context from <agentFile>.`
-- If `agentFile` is missing or unreadable, emit instead:
-  > `Active team `<teamName>` detected (role: <agentType>). No role file available.`
-
-When no member matches the current session, surface the team metadata as informational only:
-
-> `Team `<teamName>` referenced in handoff but no member matches this session.`
 
 ### 5. Restore git state (if needed)
 

--- a/plugins/squadkit/.claude-plugin/plugin.json
+++ b/plugins/squadkit/.claude-plugin/plugin.json
@@ -1,9 +1,21 @@
 {
   "name": "squadkit",
   "description": "Multi-agent team coordination for Claude Code. Roles, squads, and crews — interview-driven setup, no per-stack presets, reusable across any repo.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/pickup-team-context.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/plugins/squadkit/README.md
+++ b/plugins/squadkit/README.md
@@ -128,6 +128,18 @@ See the related flowkit skills:
 - **Idempotent** — re-running `spawn-team` against an existing `~/.claude/teams/<name>/config.json` never duplicates live members. The skill reports the existing roster and asks whether to reuse, add missing members, or cancel.
 - **Worktrees** — multi-builder configs (>1 builder) provision per-member worktrees under `.claude/worktrees/<member>/` via manual `git worktree add`. Singleton-builder profiles share the workspace; no worktree is created.
 
+## Hooks
+
+Squadkit ships a `SessionStart` hook (`hooks/pickup-team-context.sh`) that re-asserts role context whenever a session starts — both fresh sessions spawned by `spawn-team` and resumed sessions picked up via `sessionkit:pickup`.
+
+**When it fires**: every Claude Code `SessionStart` event. The hook scans `~/.claude/teams/*/config.json`, matches the current session by `leadSessionId` (preferred) or by member `cwd`, and stops at the first match. If no team matches, it exits silently with no output.
+
+**What it emits**: a single `systemMessage` reminder telling the lead (or matched member) to load its role contract from disk. The path resolution prefers a project-local override at `.claude/agents/<role>.md` and falls back to the plugin-shipped contract at `plugins/squadkit/agents/<role>.md`.
+
+**Why `SessionStart` only**: the same event fires for both startup paths the issue calls out — fresh `spawn-team` leads and `sessionkit:pickup`-resumed leads — so a single hook covers both without leaning on `PostToolUse` matchers. This keeps team-context restoration owned end-to-end by squadkit; sessionkit no longer needs to know about teams.
+
+**Override pattern**: drop a customized role file at `.claude/agents/<role>.md` in your repo (e.g. `.claude/agents/team-lead.md`) to override the shipped contract for that repo. The hook's reminder will point the agent at the override automatically.
+
 ## Configuration
 
 Squadkit reads its per-repo configuration from `.squadkit/config.json` at the repo root. Generate it once with `/squadkit:init`; edit by hand thereafter.
@@ -160,7 +172,7 @@ Squadkit complements the rest of the suite:
 
 - **[swarmkit](../swarmkit)** — `/swarm` spawns one agent per GitHub issue. Squadkit is the longer-running, role-aware sibling for crew workflows.
 - **[flowkit](../flowkit)** — squad members open PRs through flowkit-shaped commits and conventions.
-- **[sessionkit](../sessionkit)** — `/handoff` and `/pickup` already understand multi-agent team state, so squad members survive context limits.
+- **[sessionkit](../sessionkit)** — `/handoff` and `/pickup` capture and restore generic session state (goal, git, tasks, context). Squadkit's `SessionStart` hook layers team-role context on top, so members resumed via `/pickup` automatically reload their role contract.
 
 ## Roadmap
 

--- a/plugins/squadkit/hooks/pickup-team-context.sh
+++ b/plugins/squadkit/hooks/pickup-team-context.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+emit_silent() {
+  printf '{}\n'
+  exit 0
+}
+
+command -v jq >/dev/null 2>&1 || emit_silent
+
+shopt -s nullglob
+configs=( "$HOME"/.claude/teams/*/config.json )
+[ ${#configs[@]} -gt 0 ] || emit_silent
+
+SID="${CLAUDE_SESSION_ID:-}"
+if [ -z "$SID" ]; then
+  PROJECT_PATH="${PWD//\//-}"
+  PROJECT_DIR="$HOME/.claude/projects/${PROJECT_PATH}"
+  if [ -d "$PROJECT_DIR" ]; then
+    latest=$(ls -t "$PROJECT_DIR"/*.jsonl 2>/dev/null | head -1 || true)
+    [ -n "$latest" ] && SID=$(basename "$latest" .jsonl)
+  fi
+fi
+
+matched_role=""
+matched_team=""
+
+for cfg in "${configs[@]}"; do
+  [ -r "$cfg" ] || continue
+
+  role=$(jq -r --arg sid "$SID" --arg cwd "$PWD" '
+    if ($sid != "" and .leadSessionId == $sid) then
+      ((.members[]? | select(.agentType == "team-lead" or .agentType == "lead") | .agentType) // "team-lead")
+    else
+      ((.members[]? | select(.cwd == $cwd) | .agentType) // empty)
+    end
+  ' "$cfg" 2>/dev/null | head -1)
+
+  if [ -n "$role" ] && [ "$role" != "null" ]; then
+    matched_role="$role"
+    matched_team=$(jq -r '.name // "unknown"' "$cfg")
+    break
+  fi
+done
+
+[ -n "$matched_role" ] || emit_silent
+
+case "$matched_role" in
+  lead) role_file="team-lead" ;;
+  *) role_file="$matched_role" ;;
+esac
+
+project_override=".claude/agents/${role_file}.md"
+plugin_path="plugins/squadkit/agents/${role_file}.md"
+
+if [ -f "$project_override" ]; then
+  resolved="$project_override"
+else
+  resolved="$plugin_path"
+fi
+
+message="Active squadkit team \`${matched_team}\` detected for this session (role: ${matched_role}). Load your role contract from \`${resolved}\` before continuing — prefer the project-local override at \`${project_override}\` if present, otherwise fall back to \`${plugin_path}\`."
+
+jq -n --arg msg "$message" '{systemMessage: $msg}'


### PR DESCRIPTION
## Summary

Move team-context responsibility out of sessionkit and into squadkit so the team data model lives in one plugin end-to-end. Squadkit now ships a `SessionStart` hook that re-asserts the active role contract for both freshly spawned and `/pickup`-resumed leads. Sessionkit no longer knows anything about teams — handoffs written by older sessionkit versions still parse cleanly because section parsing stays open-ended.

## Changes

- Add `plugins/squadkit/hooks/pickup-team-context.sh` and wire it via `SessionStart` in `plugins/squadkit/.claude-plugin/plugin.json`. The hook resolves the current session, scans `~/.claude/teams/*/config.json`, matches by `leadSessionId` (preferred) or member `cwd`, and emits a `systemMessage` pointing at `.claude/agents/<role>.md` with `plugins/squadkit/agents/<role>.md` as fallback.
- Strip step 1b (team detection) from `plugins/sessionkit/skills/handoff/SKILL.md`; drop the `## Team State` block from the synthesis template, format spec, and section-order constraint; remove Team State from the skip-unchanged refresh list.
- Strip step 4b (team restoration) from `plugins/sessionkit/skills/pickup/SKILL.md`; add a back-compat note explaining that legacy `## Team State` blocks are intentionally ignored.
- Update `plugins/sessionkit/README.md`: remove the Team State Round-Trip subsection and table row, refresh the handoff/pickup skill descriptions, and cross-link the new squadkit ownership.
- Add a Hooks section to `plugins/squadkit/README.md` documenting fire conditions, emitted message, and the project-local override pattern.
- Bump `sessionkit` 1.5.0 → 1.6.0 and `squadkit` 0.1.0 → 0.2.0.

## Test plan

- [ ] `plugins/squadkit/hooks/pickup-team-context.sh` exists and is executable
- [ ] Squadkit `plugin.json` declares the hook on `SessionStart`
- [ ] `grep -rE 'leadSessionId|~/\.claude/teams|Team State|teamName' plugins/sessionkit/skills/` returns only the back-compat note in `pickup/SKILL.md`
- [ ] `Team State Round-Trip` section absent from `plugins/sessionkit/README.md`
- [ ] Legacy HANDOFFs with `## Team State` parse without error in new pickup
- [ ] sessionkit minor bump (1.5.0 → 1.6.0); squadkit minor bump (0.1.0 → 0.2.0)

Closes #606
Refs #611