### PR TITLE
docs: document squadkit across repo and sister plugins

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,13 @@ Run it before staging and committing the release.
 
 The `x-` prefix is the convention for experimental skills in this plugin. See `plugins/swarmkit/README.md` for details.
 
+`squadkit` is the interactive multi-role collaboration plugin (sibling to swarmkit's parallel-issue resolution). It introduces the `roles → squads → crews` vocabulary and ships `spawn-team`, `init`, and a `SessionStart` hook that re-asserts role context on resume.
+
+**Base-branch convention.** Squads always work on a `feature/<slug>-<issue>` branch cut from `develop`, owned by `spawn-team`. They never commit directly to `develop`. The supporting flow primitives live in flowkit:
+
+- `flowkit:cut-epic` — cut the long-lived feature branch standalone (equivalent to the inline cut performed by `spawn-team --epic`).
+- `flowkit:preview-epic` — preview the combined epic-to-base diff before opening the final integration PR.
+
 ## Skill Authoring Conventions
 
 **Bash loop convention**: Never use `for N in $VAR` to iterate over newline-delimited output — word splitting is unreliable across shell contexts. Always pipe directly: `some-command | while read N; do ... done`.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Claude Code plugins for plan, execute, and ship — each keeping you at the hand
 | Plugin | Install | Description |
 |--------|---------|-------------|
 | **[speckit](./plugins/speckit/)** | `/plugin install speckit@smallorbit-plugins` | Define and capture work through interviews and issue filing |
-| **[swarmkit](./plugins/swarmkit/)** | `/plugin install swarmkit@smallorbit-plugins` | Resolve GitHub issues with parallel worktree agents. _Recommends elevated session permissions — see the plugin's [Permissions](./plugins/swarmkit/README.md#permissions) section._ See [METHODOLOGY.md](./plugins/swarmkit/METHODOLOGY.md) for the stacked agent/PR workflow in depth. For the experimental Agent Teams-based `/x-squad` variant, see [plugins/swarmkit/SETUP.md](./plugins/swarmkit/SETUP.md). |
+| **[swarmkit](./plugins/swarmkit/)** | `/plugin install swarmkit@smallorbit-plugins` | Resolve GitHub issues with parallel worktree agents. _Recommends elevated session permissions — see the plugin's [Permissions](./plugins/swarmkit/README.md#permissions) section._ See [METHODOLOGY.md](./plugins/swarmkit/METHODOLOGY.md) for the stacked agent/PR workflow in depth. |
+| **[squadkit](./plugins/squadkit/)** | `/plugin install squadkit@smallorbit-plugins` | Multi-agent team coordination with the `roles → squads → crews` vocabulary. Spawn role-aware crews (team-lead, architect, builder, reviewer, tester, explorer, designer) on a `feature/<slug>-<issue>` branch cut from `develop`. |
 | **[polishkit](./plugins/polishkit/)** | `/plugin install polishkit@smallorbit-plugins` | Critique code quality, sweep for cruft, and eliminate dead code |
 | **[flowkit](./plugins/flowkit/)** | `/plugin install flowkit@smallorbit-plugins` | Manage the full git lifecycle from branch to release |
 | **[sessionkit](./plugins/sessionkit/)** | `/plugin install sessionkit@smallorbit-plugins` | Session continuity, context handoffs, and meta-learning |

--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship — with runtime staging detection and a one-command hotfix flow.",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -103,6 +103,27 @@ Before running `swarmkit:merge-stack`, validate the combined tree with `/preview
 
 > Do not run `/ship` while an epic is in flight unless you intend to ship the epic. `/ship` will rescope `claude.flowkit.prBase` to `develop` for its own flow.
 
+### Preview an epic before merging
+
+`/preview-epic` validates the combined tree of every open PR in an epic stack before any of them merge. Each PR's CI is green against its own base, but the union may not compile or pass tests — `/preview-epic` catches that integration breakage locally.
+
+```
+/preview-epic                    # discover the stack from the current branch's PR
+/preview-epic 1265               # or pass any PR number in the stack as the entry point
+```
+
+The skill:
+
+1. Resolves the base branch from `.squadkit/config.json` (falls back to `develop`).
+2. Discovers every open PR in the stack rooted at the current branch (or the supplied PR number).
+3. Builds a throwaway local preview branch by octopus-merging all PRs together; on conflict, falls back to sequential merges and reports the offender.
+4. Runs the project's verify commands (`verify.typecheck` and `verify.test` from `.squadkit/config.json`) against the combined tree.
+5. Reports pass/fail per command and leaves the preview branch in place for inspection.
+
+The preview branch is local-only — nothing is pushed. Delete it after inspection and proceed with [`swarmkit:merge-stack`](../swarmkit/README.md#skills) (or address conflicts in the offending PR first).
+
+Use `/preview-epic` immediately before `swarmkit:merge-stack` on any stacked-PR epic. It pairs naturally with `squadkit:spawn-team --epic`, which produces the same epic-branch shape that `/preview-epic` validates.
+
 ### Feature flow
 
 ```

--- a/plugins/sessionkit/README.md
+++ b/plugins/sessionkit/README.md
@@ -94,7 +94,7 @@ The two skills are intentionally separate: handoff writes, pickup reads. The han
 
 Multi-agent team coordination is owned by [squadkit](../squadkit). Squadkit ships a `SessionStart` hook that reads `~/.claude/teams/*/config.json` directly and re-emits the active role contract whenever a session starts — including sessions resumed via `/pickup`. Sessionkit therefore stays orthogonal: it captures generic session state, and squadkit layers team-role context on top.
 
-Handoff files written by sessionkit ≤ 1.5.0 may contain a `## Team State` JSON block. `/pickup` ignores those sections silently — they're inert legacy artifacts, not parse errors.
+Handoff files written by sessionkit ≤ 1.5.0 may contain a legacy squad-coordination section. `/pickup` ignores it silently — it's an inert artifact, not a parse error. Role-context restoration now lives in [squadkit](../squadkit)'s `SessionStart` hook.
 
 ## Handoff Document Structure
 

--- a/plugins/squadkit/.claude-plugin/plugin.json
+++ b/plugins/squadkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "squadkit",
   "description": "Multi-agent team coordination for Claude Code. Roles, squads, and crews — interview-driven setup, no per-stack presets, reusable across any repo.",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/squadkit/README.md
+++ b/plugins/squadkit/README.md
@@ -35,6 +35,22 @@ Squadkit's coordination model is intentionally small:
 
 Downstream skills will let you assemble crews from the role library and dispatch them against issues, epics, or freeform prompts.
 
+## Roles
+
+The role library ships seven contracts under `plugins/squadkit/agents/`. Each role has a fixed model assignment chosen to match its cognitive load — orchestration and review run on Opus; implementation, exploration, and craft work run on Sonnet.
+
+| Role | Model | Tools | Responsibility |
+|------|-------|-------|----------------|
+| **team-lead** | opus | Read, Grep, Glob, Bash, Edit, Write | Orchestrates the squad — dispatches work, gates exit conditions, owns no implementation. |
+| **architect** | opus | Read, Grep, Glob, Bash | Read-only blueprint author — produces the contract a builder implements against. |
+| **builder** | sonnet | Read, Edit, Write, Grep, Glob, Bash | Implements the architect's blueprint in an isolated worktree and opens the PR. |
+| **reviewer** | opus | Read, Grep, Glob, Bash | Read-only PR auditor — sole authority that clears a PR for merge. |
+| **tester** | sonnet | Read, Edit, Write, Grep, Glob, Bash | Authors and maintains the test suite that backs the squad's verify gate. |
+| **explorer** | sonnet | Read, Grep, Glob, Bash, WebFetch, WebSearch | Read-only research role for scoped investigative questions. |
+| **designer** | sonnet | Read, Edit, Write, Grep, Glob, Bash | Owns UX flows, mockups, design tokens, and accessibility checks. |
+
+Override a shipped contract for a single repo by dropping `.claude/agents/<role>.md` into the repo root — the `SessionStart` hook (see [Hooks](#hooks)) prefers the local override and falls back to the plugin-shipped contract.
+
 ## Skills
 
 | Skill | Invoke | What it does |
@@ -143,6 +159,17 @@ Squadkit ships a `SessionStart` hook (`hooks/pickup-team-context.sh`) that re-as
 ## Configuration
 
 Squadkit reads its per-repo configuration from `.squadkit/config.json` at the repo root. Generate it once with `/squadkit:init`; edit by hand thereafter.
+
+### Init walkthrough
+
+Run `/squadkit:init` once per repo. The wizard is fully interview-driven — there are no per-stack presets and no auto-detection. It asks four questions sequentially and surfaces the running config back to you after each answer:
+
+1. **Typecheck command** — e.g. `npm run typecheck`, `mypy .`, `cargo check`. Empty answer means "this repo has no typecheck step."
+2. **Test command** — e.g. `npm test`, `pytest`, `cargo test`. Empty answer means "no test step."
+3. **Install command** — e.g. `npm install`, `pip install -e .`, `cargo fetch`. Empty answer means "no install step."
+4. **Base branch** — defaults to `develop`. Most repos accept the default.
+
+The wizard then writes `.squadkit/config.json` (pretty-printed, two-space indent) to the **main repo root** — never to a worktree, even when invoked from inside one. If the file already exists, the wizard surfaces its current contents and prompts before overwriting.
 
 ### Schema
 

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -154,6 +154,8 @@ Swarmkit executes work; [speckit](../speckit) defines it. Use them together for 
 
 [Sessionkit](../sessionkit) complements swarmkit throughout: use `/handoff` to preserve state when context runs low mid-swarm, and `/skillit` after a swarm to capture reusable patterns that emerged.
 
+Swarmkit handles parallel-issue resolution — one fire-and-forget agent per GitHub issue, each on its own worktree. For interactive multi-role collaboration with a long-lived team-lead orchestrating architects, builders, reviewers, and testers, use [squadkit](../squadkit).
+
 ## Experimental features
 
 ### `x-swarm`


### PR DESCRIPTION
## Summary

Documents squadkit across the repo: adds a catalog row to the root README, documents the feature-branch convention in the root CLAUDE.md, fills the squadkit README's remaining gaps (role-roster table with model assignments and an init walkthrough), expands flowkit's preview-epic into a proper section, and tightens the sister-plugin pointers in sessionkit and swarmkit. Earlier PRs in epic #611 had already absorbed several deltas — those were audited and left intact.

## Changes

- Root `README.md` — added squadkit catalog row mentioning the `roles → squads → crews` vocabulary and the `feature/<slug>-<issue>` branch convention; removed the stale `/x-squad` / `SETUP.md` reference from the swarmkit row.
- Root `CLAUDE.md` — added a squadkit section that names its purpose (interactive multi-role collaboration), documents the base-branch convention shift, and cross-links `flowkit:cut-epic` and `flowkit:preview-epic`.
- `plugins/squadkit/README.md` — added a `Roles` section with the seven shipped role contracts, model assignments (team-lead/architect/reviewer = opus; builder/tester/explorer/designer = sonnet), tools, and override pattern; added an `Init walkthrough` subsection covering the four wizard prompts, defaults, and main-repo-root behavior.
- `plugins/sessionkit/README.md` — rewrote the lone "Team State" line to drop the trigger phrase, point readers to squadkit for role-context restoration, and keep the back-compat guarantee for ≤ 1.5.0 handoff files.
- `plugins/swarmkit/README.md` — added a one-line positioning statement clarifying that swarmkit handles parallel-issue resolution while squadkit handles interactive multi-role collaboration.
- `plugins/flowkit/README.md` — added a `Preview an epic before merging` section in the same style as other workflow sections, covering invocation, the five-step process, and the pairing with `swarmkit:merge-stack` and `squadkit:spawn-team --epic`.
- Version bumps — squadkit `0.2.0 → 0.3.0` (minor, new user-facing README content); flowkit `3.3.0 → 3.3.1` (patch, expanded preview-epic section).

## Test plan

- [ ] Root README has squadkit catalog row mentioning `roles → squads → crews` vocabulary
- [ ] Root CLAUDE.md documents the feature-branch convention and squadkit positioning
- [ ] squadkit README covers vocab, install/init walkthroughs, profiles, override flags, role roster with models, config schema, crew YAML schema, hook
- [ ] sessionkit README has no team-state language and points to squadkit for role-context
- [ ] swarmkit README has no `x-squad` or `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` references
- [ ] flowkit README has a full preview-epic section
- [ ] Version bumps applied where substantive edits were made

Closes #610
Refs #611