### PR TITLE
feat(squadkit): integrate crew retro findings into role contracts

### DIFF
--- a/plugins/squadkit/.claude-plugin/plugin.json
+++ b/plugins/squadkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "squadkit",
   "description": "Multi-agent team coordination for Claude Code. Roles, squads, and crews — interview-driven setup, no per-stack presets, reusable across any repo.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/squadkit/README.md
+++ b/plugins/squadkit/README.md
@@ -166,8 +166,9 @@ Run `/squadkit:init` once per repo. The wizard is fully interview-driven — the
 
 1. **Typecheck command** — e.g. `npm run typecheck`, `mypy .`, `cargo check`. Empty answer means "this repo has no typecheck step."
 2. **Test command** — e.g. `npm test`, `pytest`, `cargo test`. Empty answer means "no test step."
-3. **Install command** — e.g. `npm install`, `pip install -e .`, `cargo fetch`. Empty answer means "no install step."
-4. **Base branch** — defaults to `develop`. Most repos accept the default.
+3. **Lint command** — optional. e.g. `npm run lint`, `ruff check`, `cargo clippy`. Empty answer means "no lint step." The reviewer uses this to scope lint errors to PR-touched files.
+4. **Install command** — e.g. `npm install`, `pip install -e .`, `cargo fetch`. Empty answer means "no install step."
+5. **Base branch** — defaults to `develop`. Most repos accept the default.
 
 The wizard then writes `.squadkit/config.json` (pretty-printed, two-space indent) to the **main repo root** — never to a worktree, even when invoked from inside one. If the file already exists, the wizard surfaces its current contents and prompts before overwriting.
 
@@ -177,7 +178,8 @@ The wizard then writes `.squadkit/config.json` (pretty-printed, two-space indent
 {
   "verify": {
     "typecheck": "<command>",
-    "test": "<command>"
+    "test": "<command>",
+    "lint": "<command>"
   },
   "install": "<command>",
   "baseBranch": "<branch>"
@@ -188,6 +190,7 @@ The wizard then writes `.squadkit/config.json` (pretty-printed, two-space indent
 |-------|---------|
 | `verify.typecheck` | Command a role agent runs to validate types before opening a PR (e.g. `npm run typecheck`, `mypy .`, `cargo check`). Empty string if the project has no typecheck step. |
 | `verify.test` | Command a role agent runs to validate behavior before opening a PR (e.g. `npm test`, `pytest`, `cargo test`). Empty string if the project has no test step. |
+| `verify.lint` | Optional. Command the reviewer runs to scope lint errors to PR-touched files (e.g. `npm run lint`, `ruff check`, `cargo clippy`). Omit or set to empty string if the project has no lint step. |
 | `install` | Command a fresh worktree runs to install dependencies (e.g. `npm install`, `pip install -e .`, `cargo fetch`). Empty string if no install step is needed. |
 | `baseBranch` | Default base branch for PRs opened by squad members. Most repos use `develop` or `main`. |
 

--- a/plugins/squadkit/agents/builder.md
+++ b/plugins/squadkit/agents/builder.md
@@ -42,11 +42,21 @@ You do not merge your own PR. The reviewer is the sole authority. Your job ends 
 
 ## Universal exit gate
 
+Before reporting ship-state, run `git status --porcelain` in your worktree. If output is non-empty, either commit those edits into the verified set (re-running the full verify gate after) or explicitly call them out as deferred in your deliverable to the lead. Never report "all green" against a dirty tree.
+
 Before exiting confirm:
 
 - Your PR is merged, explicitly cancelled, or returned to the backlog with the lead's ack.
 - Your worktree is clean (no uncommitted edits, no untracked files you authored).
 - No outstanding lead deliverable is awaiting your reply.
+
+## Cross-role pings
+
+When you introduce a new module, hook, component, or other importable symbol that a sibling builder's in-flight work will depend on, post a one-line ping to the tester naming the new import path. This lets parallel test files mock the symbol from the start instead of patching it in after a rebase.
+
+## Reporting verify counts
+
+When the verify gate or a blueprint's invariant check involves multiple grep-style counts (e.g. "no `as any` left", "exactly N call sites"), report each invariant's count on its own line in the ship-state. Do not sum unrelated counts into one number — the lead and reviewer need to see the breakdown to spot regressions.
 
 ## Comment policy
 

--- a/plugins/squadkit/agents/explorer.md
+++ b/plugins/squadkit/agents/explorer.md
@@ -31,6 +31,10 @@ You do not edit. Tools are Read, Grep, Glob, read-only Bash (`ls`, `git log`, `g
 3. Write the note. Keep it short — research notes are usually under 40 lines.
 4. Deliver to the lead. Wait for ack. Exit on ack unless the lead routes a follow-up.
 
+## Cite, don't infer
+
+When citing a usage site — a function call, a render, an import, a field access — confirm the actual symbol with a `Read` of the cited line. Never infer the usage from adjacent state, hooks, or surrounding context. If a `Read` isn't worth doing for a given claim, omit the claim entirely rather than hedge it. Hedged claims downstream-poison the architect's blueprint.
+
 ## Per-deliverable ack
 
 One note = one deliverable = one ack. If the lead asks a follow-up question, treat it as a new task with its own deliverable cycle.

--- a/plugins/squadkit/agents/reviewer.md
+++ b/plugins/squadkit/agents/reviewer.md
@@ -17,11 +17,12 @@ For every PR audit, walk all of:
 
 1. **Brief alignment.** Does the diff match the architect's blueprint — scope, file plan, interface contracts? Flag scope creep and undocumented divergence.
 2. **Verify gate.** Confirm `${verify.typecheck}` and `${verify.test}` pass on the PR branch. If the builder did not run them or they were red on push, that alone is a `revise:`.
-3. **Interface fidelity.** Compare the implemented signatures against the contracts the builder surfaced and the lead acked. Drift here is a blocker.
-4. **Edge cases.** Walk the blueprint's edge-case list against the diff. Each should be handled or explicitly noted.
-5. **Comment hygiene.** Reject comments that restate what the code does. Reject commented-out code. Names should carry meaning.
-6. **Hard blocks.** Type-error suppression (`as any`, `@ts-ignore`, equivalents in other languages), empty catch blocks, deleted failing tests, secrets in commits — any of these is an immediate `escalate:`.
-7. **Conventions.** Match the codebase's established patterns. If the builder introduces a new pattern, it must be justified in the PR body or bounced for discussion.
+3. **Scoped lint.** If `${verify.lint}` is configured in `.squadkit/config.json`, run it scoped to PR-touched files: `${verify.lint} -- $(git diff --name-only ${baseBranch}...HEAD)` (or the equivalent invocation for the configured linter). Any error inside the scoped set is a HIGH-severity blocker regardless of whether a global lint run passes — pre-existing repo-wide noise is not a reason to wave through new errors the PR introduces.
+4. **Interface fidelity.** Compare the implemented signatures against the contracts the builder surfaced and the lead acked. Drift here is a blocker.
+5. **Edge cases.** Walk the blueprint's edge-case list against the diff. Each should be handled or explicitly noted.
+6. **Comment hygiene.** Reject comments that restate what the code does. Reject commented-out code. Names should carry meaning.
+7. **Hard blocks.** Type-error suppression (`as any`, `@ts-ignore`, equivalents in other languages), empty catch blocks, deleted failing tests, secrets in commits — any of these is an immediate `escalate:`.
+8. **Conventions.** Match the codebase's established patterns. If the builder introduces a new pattern, it must be justified in the PR body or bounced for discussion.
 
 ## Verdict format
 

--- a/plugins/squadkit/agents/team-lead.md
+++ b/plugins/squadkit/agents/team-lead.md
@@ -17,6 +17,7 @@ Verify and install commands also come from config. Reference them as placeholder
 
 - `${verify.typecheck}` — typecheck command
 - `${verify.test}` — test command
+- `${verify.lint}` — lint command (optional; may be absent from `.squadkit/config.json`)
 - `${install}` — dependency install command
 - `${baseBranch}` — base branch PRs target
 

--- a/plugins/squadkit/agents/tester.md
+++ b/plugins/squadkit/agents/tester.md
@@ -37,10 +37,11 @@ You produce one of two artifacts per task, depending on the lead's brief:
 ## Workflow
 
 1. **Acknowledge the brief.** Read the blueprint and the PR diff (if reviewing).
-2. **Author or update tests** per the plan.
-3. **Run `${verify.test}`.** Record pass/fail counts.
-4. **Run `${verify.typecheck}`** if your test files introduce new types or imports.
-5. **Deliver the report** to the lead. Wait for ack.
+2. **Post-rebase pre-flight.** After any rebase that pulls in a sibling builder's commit, run `${install}` and `${verify.typecheck}` before authoring or running tests. Missing transitive dependencies otherwise surface as test-collection errors that look like flakes.
+3. **Author or update tests** per the plan.
+4. **Run `${verify.test}`.** Record pass/fail counts.
+5. **Run `${verify.typecheck}`** if your test files introduce new types or imports.
+6. **Deliver the report** to the lead. Wait for ack.
 
 ## Per-deliverable ack
 

--- a/plugins/squadkit/skills/init/SKILL.md
+++ b/plugins/squadkit/skills/init/SKILL.md
@@ -50,31 +50,33 @@ If the user picks `Cancel`, exit with a one-line message naming the existing fil
 
 ### 3. Interview
 
-Ask each question via `AskUserQuestion`. **No stack presets, no auto-detection** — the user types the exact command. An empty answer is valid for `verify.typecheck`, `verify.test`, and `install` (treated as "this repo has no such step"). For `baseBranch`, default to `develop` if the user accepts the default.
+Ask each question via `AskUserQuestion`. **No stack presets, no auto-detection** — the user types the exact command. An empty answer is valid for `verify.typecheck`, `verify.test`, `verify.lint`, and `install` (treated as "this repo has no such step"). For `baseBranch`, default to `develop` if the user accepts the default.
 
-Ask the four questions sequentially, surfacing the running config back to the user after each answer so they see what's accumulated.
+Ask the five questions sequentially, surfacing the running config back to the user after each answer so they see what's accumulated.
 
 | # | Field | Question | Default |
 |---|-------|----------|---------|
 | 1 | `verify.typecheck` | `Command to run for type checking? (e.g. \`npm run typecheck\`, \`mypy .\`, \`cargo check\`. Empty = no typecheck step.)` | none |
 | 2 | `verify.test` | `Command to run the test suite? (e.g. \`npm test\`, \`pytest\`, \`cargo test\`. Empty = no test step.)` | none |
-| 3 | `install` | `Command to install dependencies in a fresh worktree? (e.g. \`npm install\`, \`pip install -e .\`. Empty = no install step.)` | none |
-| 4 | `baseBranch` | `Default base branch for PRs opened by squad members?` | `develop` |
+| 3 | `verify.lint` | `Command to run the linter? (e.g. \`npm run lint\`, \`ruff check\`, \`cargo clippy\`. Optional — empty = no lint step. The reviewer uses this to scope errors to PR-touched files.)` | none |
+| 4 | `install` | `Command to install dependencies in a fresh worktree? (e.g. \`npm install\`, \`pip install -e .\`. Empty = no install step.)` | none |
+| 5 | `baseBranch` | `Default base branch for PRs opened by squad members?` | `develop` |
 
-Trim whitespace from every answer. Treat the literal string `develop` as the accepted default if the user confirms question 4 without typing.
+Trim whitespace from every answer. Treat the literal string `develop` as the accepted default if the user confirms question 5 without typing. Omit `verify.lint` from the written JSON entirely if the user leaves it blank — the field is optional and downstream roles check for its presence before using it.
 
 ### 4. Write the config
 
-Assemble the JSON object:
+Assemble the JSON object. Include `verify.lint` only when the user provided a non-empty answer:
 
 ```json
 {
   "verify": {
     "typecheck": "<answer-1>",
-    "test": "<answer-2>"
+    "test": "<answer-2>",
+    "lint": "<answer-3>"
   },
-  "install": "<answer-3>",
-  "baseBranch": "<answer-4>"
+  "install": "<answer-4>",
+  "baseBranch": "<answer-5>"
 }
 ```
 
@@ -102,5 +104,6 @@ Print:
 - Never apply per-stack presets or auto-detect package managers. Every command comes from the user via `AskUserQuestion`.
 - Never overwrite an existing `.squadkit/config.json` without explicit confirmation through `AskUserQuestion`.
 - Empty strings are valid answers for `verify.typecheck`, `verify.test`, and `install`. Downstream skills treat empty as "skip this step."
+- `verify.lint` is optional. Omit the key entirely when the user leaves it blank rather than writing an empty string — downstream roles check for its presence.
 - `baseBranch` defaults to `develop` but is not validated against the remote — accept whatever the user provides.
 - The config is a four-field schema. Do not invent additional fields here; future role contracts will extend the schema in their own releases.

--- a/plugins/squadkit/skills/spawn-team/SKILL.md
+++ b/plugins/squadkit/skills/spawn-team/SKILL.md
@@ -114,6 +114,8 @@ The team-lead role is always required — if the profile or overrides remove it,
 
 ### 6. Epic feature-branch ownership
 
+**Pre-flight rule.** Any spawn that will produce three or more child PRs MUST run on a feature branch — not directly on `${BASE_BRANCH}`. When the resolved roster includes more than one builder, or the user's intent names three or more deliverables, default the prompt toward cutting an epic and only accept `Use ${BASE_BRANCH}` after the user confirms the work is genuinely a single PR's worth.
+
 If `--epic <slug>` was provided, the skill cuts the epic branch. Otherwise prompt via `AskUserQuestion`:
 
 - **Question**: `No --epic given. Cut a feature branch for this team, or run on ${BASE_BRANCH} directly?`
@@ -241,6 +243,15 @@ Then send the team-lead its first dispatch prompt with the active roster.
 - Never write the team config before every member has acked.
 - Worktrees live under `.claude/worktrees/<member>/` relative to the repo root, never an absolute scratch path.
 - Singleton-builder profiles must not create worktrees (they share the workspace).
+
+## Harness constraints
+
+These are observed limitations of the `Agent` spawn primitive at the time of writing. The skill works around each one explicitly — do not "fix" the workarounds without first confirming the underlying constraint has been lifted.
+
+- **`Agent({isolation: "worktree"})` is unreliable when combined with `team_name`.** The auto-isolation does not fire reliably for team-scoped spawns, so the skill always provisions worktrees manually via `git worktree add` (see step 7) and passes the resolved absolute path into each spawned agent.
+- **`Agent({model})` rejects 1M-context aliases like `opus[1m]`.** The harness validates the model param against a fixed allowlist of bare names. To put a long-running role (tester, reviewer, architect) on the 1M tier, spawn with the bare alias (e.g. `opus`) and rely on the team-lead's between-wave swap protocol to rotate in a fresh successor before context fills.
+- **Frontmatter `model:` in `.claude/agents/*.md` is ignored on spawn.** Only the explicit `Agent({model})` parameter controls which model the spawned agent runs on. The frontmatter field is informational for human readers; do not expect it to override the spawn-time parameter, and do not let users assume editing frontmatter changes a live team.
+- **Frontmatter `tools:` is overridden by a default allowlist for some roles.** The harness applies its own tool subset on spawn that may strip tools the role contract declared. Always include `Bash` in the explicit spawn `tools` param so an agent missing `Glob`/`Grep`/`LS` can still fall back to `find`/`grep`/`ls` and complete its work.
 
 ## Composition
 


### PR DESCRIPTION
## Summary

Audited the 8 crew-retro findings (and the harness-level carry-overs) against the existing squadkit role contracts, then applied only the genuinely new gaps using the placeholder vocabulary instead of stack-specific commands. Extends the `.squadkit/config.json` schema with an optional `verify.lint` field that the reviewer uses to scope lint errors to PR-touched files.

## Changes

- **builder.md** — exit gate now requires `git status --porcelain` before claiming green; new cross-role ping when introducing importable symbols a sibling builder will depend on; verify-counts rule that breaks multi-invariant grep results out per line.
- **reviewer.md** — new audit step running `${verify.lint} -- $(git diff --name-only ${baseBranch}...HEAD)` when `${verify.lint}` is configured; errors in the scoped set are HIGH-severity blockers regardless of repo-wide lint state.
- **tester.md** — post-rebase pre-flight runs `${install}` and `${verify.typecheck}` before authoring tests so missing transitive deps don't masquerade as flakes.
- **explorer.md** — cite-don't-infer prose: confirm the actual symbol with a `Read` or omit the claim entirely.
- **team-lead.md** — `${verify.lint}` added to the placeholder vocabulary briefs reference.
- **spawn-team SKILL.md** — explicit epic pre-flight rule (>=3 child PRs => feature branch); new "Harness constraints" section documenting `Agent({isolation: "worktree"}) + team_name` unreliability, `Agent({model})` 1M-alias rejection, frontmatter `model:` being ignored on spawn, and the default tool-allowlist override (workaround: always include `Bash`).
- **init SKILL.md + README.md** — schema gains optional `verify.lint`; init wizard adds a fifth interview question; the JSON omits the field entirely when the user leaves it blank.
- **plugin.json** — squadkit 0.3.0 -> 0.4.0 (meaningful role-contract additions).

### Already encoded (skipped)

- M1 architect read-only Bash — already in frontmatter and read-only-discipline prose.
- L2 TeamCreate-before-TaskCreate — N/A: spawn-team uses `Agent` spawn, not the Teams API; member-spawn-before-dispatch order already enforced by step 8.
- Carry-over: manual worktree provisioning — already documented in step 7 of spawn-team.
- Carry-over: between-wave swap protocol — already in team-lead.md.

## Audit table

| Finding | Status | Action |
|---|---|---|
| H1 git-status exit gate | missing | added to builder.md exit gate |
| H2 tester ping for new imports | missing | added cross-role-pings section to builder.md |
| H3 reviewer scoped lint | missing | added new audit step to reviewer.md + `${verify.lint}` schema |
| M1 architect read-only Bash | present | skipped |
| M2 tester post-rebase pre-flight | missing | added step 2 to tester.md workflow |
| M3 explorer cite-don't-infer | partial | added explicit cite-don't-infer prose to explorer.md |
| L1 builder grep counts | missing | added reporting-verify-counts section to builder.md |
| L2 TeamCreate-before-TaskCreate | n/a | spawn-team doesn't use Teams API |
| Carry-over: manual worktree | present | skipped |
| Carry-over: model alias rejection | missing | added to spawn-team Harness constraints |
| Carry-over: frontmatter model ignored | missing | added to spawn-team Harness constraints |
| Carry-over: tool stripping | missing | added to spawn-team Harness constraints |
| Carry-over: between-wave swap | present | skipped |
| Carry-over: epic-branch pre-flight | partial | added explicit pre-flight rule to spawn-team step 6 |

## Test plan

- [ ] All 8 findings audited; missing/partial ones patched with placeholder-translated text
- [ ] No stack-specific commands or trademark token names anywhere in `plugins/squadkit/`
- [ ] `${verify.lint}` documented in README schema and init wizard prompt; init wizard omits the field when blank
- [ ] spawn-team SKILL.md documents harness constraints (model alias, frontmatter ignored, tool stripping, isolation+team_name)
- [ ] squadkit minor bumped (0.3.0 -> 0.4.0)

Closes #612