### PR TITLE
chore: register squadkit in marketplace manifest

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -25,6 +25,11 @@
       "description": "Define and capture work as GitHub issues. Interview a feature into existence with /spec, bulk-convert findings with /catalog, or quickly file a single issue with /issue."
     },
     {
+      "name": "squadkit",
+      "source": "./plugins/squadkit",
+      "description": "Multi-agent team coordination with the roles → squads → crews vocabulary. Spawn role-aware crews (team-lead, architect, builder, reviewer, tester, explorer, designer) on a feature/<slug>-<issue> branch cut from develop."
+    },
+    {
       "name": "polishkit",
       "source": "./plugins/polishkit",
       "description": "Codebase quality toolkit. Assess code craft with /critique, sweep for cruft with /tidy-codebase, and eliminate unused code with /dead-code."


### PR DESCRIPTION
## Summary

squadkit shipped across epic #611 but was never registered in `.claude-plugin/marketplace.json`. Without this entry, `/plugin install squadkit@smallorbit-plugins` fails even after a release lands on main. This adds the missing entry so the next release surfaces the plugin to consumers.

## Changes

- Add squadkit entry to `.claude-plugin/marketplace.json` between speckit and polishkit, mirroring the description style used by sister plugins.

## Test plan

- [ ] `jq . .claude-plugin/marketplace.json` parses cleanly
- [ ] After release, `/plugin install squadkit@smallorbit-plugins` resolves
- [ ] Marketplace listing surfaces squadkit alongside the other six plugins

Refs #611