### PR TITLE
fix(pr-body): warn and lint against space-separated Closes footers

### DIFF
--- a/plugins/_shared/pr-body.md
+++ b/plugins/_shared/pr-body.md
@@ -27,6 +27,8 @@ After the three sections, emit a blank line, then one token per line using GitHu
 | `Closes #N` | The child issue `#N` is fully resolved by this PR. GitHub will auto-close it on merge to the default branch. |
 | `Refs #N` | The parent epic `#N`, or any issue this PR only partially advances. Does not auto-close. |
 
+> **Important:** GitHub only parses one closing keyword per line. `Closes #A #B #C` on a single line silently leaves `#B` and `#C` open — only `#A` is treated as a closing reference. Always emit one token per line (`Closes #A` / `Closes #B` / `Closes #C`).
+
 Rules:
 
 - Emit one `Closes #N` line per fully-resolved child issue.

--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -120,6 +120,8 @@ The canonical spec is duplicated inline below until publish-time include expansi
 > | `Closes #N` | The child issue `#N` is fully resolved by this PR. GitHub will auto-close it on merge to the default branch. |
 > | `Refs #N` | The parent epic `#N`, or any issue this PR only partially advances. Does not auto-close. |
 >
+> > **Important:** GitHub only parses one closing keyword per line. `Closes #A #B #C` on a single line silently leaves `#B` and `#C` open — only `#A` is treated as a closing reference. Always emit one token per line (`Closes #A` / `Closes #B` / `Closes #C`).
+>
 > Rules:
 >
 > - Emit one `Closes #N` line per fully-resolved child issue.
@@ -129,7 +131,25 @@ The canonical spec is duplicated inline below until publish-time include expansi
 
 **Override rule for `open-pr`**: when tokens come from commit messages on the branch, emit them **verbatim** — do not rewrite `Fixes`/`Resolves` into `Closes`. The canonical guidance above applies to newly authored bodies; `open-pr` forwards what the author committed.
 
-### 7. Open the PR
+### 7. Lint the assembled body for broken closing-keyword footers
+
+GitHub only parses one closing keyword per line. A footer like `Closes #1 #2 #3` silently leaves `#2` and `#3` open. Reject the body before calling `gh pr create` if any line packs multiple issue refs onto a single closing keyword:
+
+```bash
+if printf '%s\n' "$PR_BODY" | grep -qiE '(Closes|Fixes|Resolves) #[0-9]+[[:space:]]+#[0-9]+'; then
+  echo "ERROR: PR body contains a space-separated closing-keyword footer (e.g. 'Closes #1 #2 #3')." >&2
+  echo "GitHub only parses one closing keyword per line; the trailing refs would silently stay open." >&2
+  echo "Rewrite the footer with one token per line:" >&2
+  echo "  Closes #1" >&2
+  echo "  Closes #2" >&2
+  echo "  Closes #3" >&2
+  exit 1
+fi
+```
+
+Fail loudly rather than auto-rewriting — the author should see and fix the footer themselves so the same mistake does not recur in the source commits.
+
+### 8. Open the PR
 
 ```bash
 gh pr create \
@@ -139,7 +159,7 @@ gh pr create \
   --body "<assembled body from step 6>"
 ```
 
-### 8. Report
+### 9. Report
 
 Output the PR URL returned by `gh pr create`.
 

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -231,6 +231,17 @@ $ARGUMENTS"
 
 $ISSUE_REFS"
 
+# Lint: GitHub only parses one closing keyword per line. A footer like
+# `Closes #1 #2 #3` silently leaves `#2` and `#3` open. Aggregation produces
+# one token per line, but $ARGUMENTS or upstream PR bodies could smuggle the
+# broken form into $PR_BODY — abort before opening the release PR.
+if printf '%s\n' "$PR_BODY" | grep -qiE '(Closes|Fixes|Resolves) #[0-9]+[[:space:]]+#[0-9]+'; then
+  echo "ERROR: Release PR body contains a space-separated closing-keyword footer (e.g. 'Closes #1 #2 #3')." >&2
+  echo "GitHub only parses one closing keyword per line; the trailing refs would silently stay open." >&2
+  echo "Rewrite the offending lines with one token per line (Closes #1 / Closes #2 / Closes #3) and re-run." >&2
+  exit 1
+fi
+
 gh pr create \
   --base main \
   --head "$SOURCE" \

--- a/plugins/swarmkit/skills/merge-stack/SKILL.md
+++ b/plugins/swarmkit/skills/merge-stack/SKILL.md
@@ -79,9 +79,24 @@ For each chain, work from the root up to the leaf. For each PR in order:
 gh pr view <N> --json mergeable,mergeStateStatus,baseRefName
 ```
 
-If `mergeStateStatus` is `BEHIND` (or `UNKNOWN` — retry after a short sleep): run the local rebase step from 5d against this branch, then re-check.
+If `mergeStateStatus` is `BEHIND` (or `UNKNOWN` — retry after a short sleep): run the local rebase step from 5e against this branch, then re-check.
 
-#### 5b. Merge
+#### 5b. Warn on broken closing-keyword footers
+
+Each PR's own body closes its own issues natively on merge, so a malformed footer is silently lossy — the merge succeeds and the trailing refs stay open. Before merging, scan the body for the space-separated form and warn:
+
+```bash
+BODY=$(gh pr view <N> --json body --jq '.body')
+if printf '%s\n' "$BODY" | grep -qiE '(Closes|Fixes|Resolves) #[0-9]+[[:space:]]+#[0-9]+'; then
+  echo "WARNING: PR #<N> body contains a space-separated closing-keyword footer (e.g. 'Closes #A #B #C')." >&2
+  echo "GitHub will only auto-close the first ref; the rest will stay open after merge." >&2
+  echo "Consider editing the PR body (one 'Closes #N' per line) before merging." >&2
+fi
+```
+
+Warn-only — do not block. Merge-stack runs after review and the operator may choose to fix the trailing issues by hand.
+
+#### 5c. Merge
 
 Every PR uses the same strategy — uniform squash with branch deletion:
 
@@ -91,16 +106,16 @@ gh pr merge <N> --squash --delete-branch
 
 Each PR's own body closes its own issues natively on merge. No ref injection, no body rewriting.
 
-#### 5c. Conflict handling
+#### 5d. Conflict handling
 
-If a merge fails with `CONFLICTING`, or if the rebase in 5d fails with a genuine content conflict (not a patch-id-matchable duplicate):
+If a merge fails with `CONFLICTING`, or if the rebase in 5e fails with a genuine content conflict (not a patch-id-matchable duplicate):
 - Stop the chain at this PR
 - Report the conflict with the PR number and branch names
 - Mark all PRs above it in the same chain as blocked
 - Continue with any independent PRs or unrelated chains
 - At the end, list all stopped and blocked PRs so the user can resolve and re-run
 
-#### 5d. Rebase downstream PRs before merging the next one
+#### 5e. Rebase downstream PRs before merging the next one
 
 After merging a non-leaf PR in a chain, every still-open downstream PR in that chain has its predecessor's commits in its history under the old (pre-squash) SHAs. `$BASE` now carries the same content under a new squash SHA, so GitHub will flag the next PR as `DIRTY`/`CONFLICTING` even though the content overlap is benign. `gh pr update-branch` cannot resolve this — it fails with `Cannot update PR branch due to conflicts`. A local rebase is required because only `git rebase`'s patch-id matching drops the already-applied commits.
 
@@ -112,7 +127,7 @@ git checkout <head-branch>
 if ! git rebase origin/$BASE; then
   git rebase --abort
   # Real content conflict (e.g. add/add on a file two chains both created).
-  # Fall through to 5c: stop this chain, block its dependents, continue with
+  # Fall through to 5d: stop this chain, block its dependents, continue with
   # other chains/independents. Do NOT force-push; leave the PR untouched so
   # the user can resolve by hand.
   continue  # or equivalent control flow in the skill's execution loop
@@ -120,13 +135,13 @@ fi
 git push --force-with-lease origin <head-branch>
 ```
 
-`git rebase` will emit `warning: skipped previously applied commit <sha>` for each predecessor commit it drops via patch-id — that's the expected happy path, not an error. A non-zero exit from `git rebase` means a real merge conflict git could not auto-resolve; handle it per 5c. Always `git rebase --abort` before falling through so the branch returns to its pre-rebase state and no partial work is pushed.
+`git rebase` will emit `warning: skipped previously applied commit <sha>` for each predecessor commit it drops via patch-id — that's the expected happy path, not an error. A non-zero exit from `git rebase` means a real merge conflict git could not auto-resolve; handle it per 5d. Always `git rebase --abort` before falling through so the branch returns to its pre-rebase state and no partial work is pushed.
 
-After the rebases, re-query `mergeStateStatus` for the next PR to merge and proceed to 5b. GitHub may report `UNKNOWN` briefly after a force-push; poll with `sleep 3` until it resolves to `CLEAN`, `BEHIND`, or `DIRTY`.
+After the rebases, re-query `mergeStateStatus` for the next PR to merge and proceed to 5c. GitHub may report `UNKNOWN` briefly after a force-push; poll with `sleep 3` until it resolves to `CLEAN`, `BEHIND`, or `DIRTY`.
 
 For independent PRs (no chain), skip this step — they target `$BASE` directly and have no predecessor commits to drop.
 
-#### 5e. Pause between merges
+#### 5f. Pause between merges
 
 ```bash
 sleep 3


### PR DESCRIPTION
## Summary

GitHub's auto-close-on-merge only fires when each issue reference is its own keyword token; the space-separated form `Closes #A #B #C` silently leaves `#B` and `#C` open (real-world hit on `vorbis-player` PR #1315). Document the gotcha in the canonical PR-body spec and lint for it in every skill that emits or merges PR bodies.

## Changes

- Add an "Important" callout under the issue-reference footer table in `plugins/_shared/pr-body.md` (and mirror it in the inline copy embedded in `flowkit:open-pr`) explaining that GitHub only parses one closing keyword per line.
- Add a hard lint in `plugins/flowkit/skills/open-pr/SKILL.md` (new step 7) that scans `$PR_BODY` for `(Closes|Fixes|Resolves) #N <space> #M` and aborts with a clear remediation message before `gh pr create`. Renumber the report step to 9.
- Mirror the lint in `plugins/flowkit/skills/release/SKILL.md` after assembling the release PR body, catching footers smuggled in via `$ARGUMENTS` or upstream PR bodies before the release PR is opened.
- Add a warn-only check in `plugins/swarmkit/skills/merge-stack/SKILL.md` (new step 5b) that scans the merging PR body and warns the operator without blocking the merge. Renumber 5b–5e to 5c–5f and update internal cross-references.

## Test plan

- [ ] Render `plugins/_shared/pr-body.md` and confirm the new callout appears under the footer table.
- [ ] Author a PR body containing `Closes #1 #2 #3` and run the `flowkit:open-pr` lint snippet against it; confirm it exits non-zero with the remediation message.
- [ ] Author a PR body containing `Closes #1\nCloses #2\nCloses #3` and run the same lint; confirm it passes.
- [ ] Run the `flowkit:release` lint snippet against an `$ISSUE_REFS` value polluted with `Closes #10 #11`; confirm it aborts.
- [ ] Run the `swarmkit:merge-stack` warn snippet against a PR body containing `Closes #5 #6`; confirm it emits the warning to stderr and does not exit.

Closes #629