### PR TITLE
fix(squadkit:agents): declare full tools allowlist on every role contract

### DIFF
--- a/plugins/squadkit/README.md
+++ b/plugins/squadkit/README.md
@@ -41,15 +41,23 @@ The role library ships seven contracts under `plugins/squadkit/agents/`. Each ro
 
 | Role | Model | Tools | Responsibility |
 |------|-------|-------|----------------|
-| **team-lead** | opus | Read, Grep, Glob, Bash, Edit, Write | Orchestrates the squad — dispatches work, gates exit conditions, owns no implementation. |
-| **architect** | opus | Read, Grep, Glob, Bash | Read-only blueprint author — produces the contract a builder implements against. |
-| **builder** | sonnet | Read, Edit, Write, Grep, Glob, Bash | Implements the architect's blueprint in an isolated worktree and opens the PR. |
-| **reviewer** | opus | Read, Grep, Glob, Bash | Read-only PR auditor — sole authority that clears a PR for merge. |
-| **tester** | sonnet | Read, Edit, Write, Grep, Glob, Bash | Authors and maintains the test suite that backs the squad's verify gate. |
-| **explorer** | sonnet | Read, Grep, Glob, Bash, WebFetch, WebSearch | Read-only research role for scoped investigative questions. |
-| **designer** | sonnet | Read, Edit, Write, Grep, Glob, Bash | Owns UX flows, mockups, design tokens, and accessibility checks. |
+| **team-lead** | opus | Read, Grep, Glob, Bash, Edit, Write, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet, Agent | Orchestrates the squad — dispatches work, gates exit conditions, owns no implementation. |
+| **architect** | opus | Read, Grep, Glob, Bash, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet | Read-only blueprint author — produces the contract a builder implements against. |
+| **builder** | sonnet | Read, Edit, Write, Grep, Glob, Bash, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet | Implements the architect's blueprint in an isolated worktree and opens the PR. |
+| **reviewer** | opus | Read, Grep, Glob, Bash, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet | Read-only PR auditor — sole authority that clears a PR for merge. |
+| **tester** | sonnet | Read, Edit, Write, Grep, Glob, Bash, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet | Authors and maintains the test suite that backs the squad's verify gate. |
+| **explorer** | sonnet | Read, Grep, Glob, Bash, WebFetch, WebSearch, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet | Read-only research role for scoped investigative questions. |
+| **designer** | sonnet | Read, Edit, Write, Grep, Glob, Bash, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet | Owns UX flows, mockups, design tokens, and accessibility checks. |
 
 Override a shipped contract for a single repo by dropping `.claude/agents/<role>.md` into the repo root — the `SessionStart` hook (see [Hooks](#hooks)) prefers the local override and falls back to the plugin-shipped contract.
+
+### Tools allowlist and harness augmentation
+
+The role contracts now declare the **full** tool set each role uses, including the squad-coordination tools (`SendMessage`, `TaskCreate`, `TaskUpdate`, `TaskList`, `TaskGet`, and `Agent` for `team-lead`). A reader of `team-lead.md` can see from frontmatter alone that the role can dispatch work — no mental model of harness magic required.
+
+Historically the Claude Code harness augmented the allowlist for some of these tools at spawn time (a spawned `team-lead` could call `SendMessage` even when its frontmatter omitted it). That augmentation still happens, but explicit declaration is preferred for documentation correctness and to keep the contracts honest about what each role actually does.
+
+**Override caveat.** If you author a project-local overlay at `.claude/agents/<role>.md`, preserve the coordination tools in the `tools:` line. Stripping them risks breaking dispatch — depending on overlay merge semantics, a restricted overlay may shadow harness augmentation and leave the role unable to message teammates or maintain the dispatch queue. When in doubt, copy the shipped contract's `tools:` line verbatim and add to it rather than replace it.
 
 ## Skills
 

--- a/plugins/squadkit/agents/architect.md
+++ b/plugins/squadkit/agents/architect.md
@@ -2,7 +2,7 @@
 name: architect
 description: Read-only role that produces implementation blueprints — scope, file plan, sequence, edge cases, verify steps — before any builder picks up work.
 model: opus
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet
 ---
 
 # Architect
@@ -10,6 +10,10 @@ tools: Read, Grep, Glob, Bash
 You design before code is written. You are read-only: you investigate the codebase, you produce blueprints, you do not edit. Your output is the contract a builder will implement against.
 
 You are a **long-running role** — you persist across multiple waves, accumulate codebase context over time, and support preemptive handoff so a fresh successor can resume your seat when your context fills.
+
+## Coordination tools
+
+Use `SendMessage` to deliver blueprints to the team-lead, send `teammate_hello` / `handoff_ready`, and answer scoped follow-ups. Use `TaskCreate`/`TaskUpdate` to track in-flight blueprint drafts, and `TaskList`/`TaskGet` to confirm no blueprint is half-written before exit.
 
 ## Blueprint quality bar
 

--- a/plugins/squadkit/agents/builder.md
+++ b/plugins/squadkit/agents/builder.md
@@ -2,7 +2,7 @@
 name: builder
 description: Implements an architect's blueprint in an isolated worktree, surfaces interface contracts before writing bodies, and opens a PR against the base branch.
 model: sonnet
-tools: Read, Edit, Write, Grep, Glob, Bash
+tools: Read, Edit, Write, Grep, Glob, Bash, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet
 ---
 
 # Builder
@@ -10,6 +10,10 @@ tools: Read, Edit, Write, Grep, Glob, Bash
 You implement. The architect hands you a blueprint; you turn it into code, run the verify gates, and open a pull request. You work in an isolated git worktree against `${baseBranch}`.
 
 A squad runs 1–5 builders in parallel. Each builder owns one task at a time and one PR per task.
+
+## Coordination tools
+
+Use `SendMessage` to deliver interface contracts, PR URLs, and post-review revisions to the team-lead, and to ping the tester when you introduce a new importable symbol. Use `TaskCreate`/`TaskUpdate` to track per-step progress through the blueprint sequence, and `TaskList`/`TaskGet` to verify no step is left dangling before opening the PR.
 
 ## Interface-contract-first protocol
 

--- a/plugins/squadkit/agents/designer.md
+++ b/plugins/squadkit/agents/designer.md
@@ -2,12 +2,16 @@
 name: designer
 description: Owns UX flows, mockups, design-system tokens, and accessibility checks; produces UX briefs the architect translates into implementation blueprints.
 model: sonnet
-tools: Read, Edit, Write, Grep, Glob, Bash
+tools: Read, Edit, Write, Grep, Glob, Bash, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet
 ---
 
 # Designer
 
 You design the user-facing surface. You produce UX briefs — not implementation. Your output feeds the architect, who translates it into the blueprint a builder will implement against. You may edit design assets and design-token files; you do not edit application code.
+
+## Coordination tools
+
+Use `SendMessage` to deliver UX briefs and design-system notes to the team-lead and to answer architect follow-ups routed through the lead. Use `TaskCreate`/`TaskUpdate` to track briefs in flight, and `TaskList`/`TaskGet` to confirm every brief or token edit has been delivered and acked before exit.
 
 ## Deliverables
 

--- a/plugins/squadkit/agents/explorer.md
+++ b/plugins/squadkit/agents/explorer.md
@@ -2,12 +2,16 @@
 name: explorer
 description: Read-only research role that answers scoped investigative questions about the codebase, dependencies, or external libraries.
 model: sonnet
-tools: Read, Grep, Glob, Bash, WebFetch, WebSearch
+tools: Read, Grep, Glob, Bash, WebFetch, WebSearch, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet
 ---
 
 # Explorer
 
 You investigate. The team-lead routes a scoped question to you — "where is X handled?", "does this library support Y?", "what calls into this module?" — and you return a concise written answer with references. You are read-only and short-lived: one question, one answer, exit.
+
+## Coordination tools
+
+Use `SendMessage` to deliver the research note to the team-lead and to acknowledge follow-ups. Use `TaskCreate`/`TaskUpdate` to track the in-flight question, and `TaskList`/`TaskGet` to confirm the note has been delivered before exit.
 
 ## Deliverable
 

--- a/plugins/squadkit/agents/reviewer.md
+++ b/plugins/squadkit/agents/reviewer.md
@@ -2,7 +2,7 @@
 name: reviewer
 description: Read-only role that audits builder PRs and gates the merge step; the sole authority that clears a PR for merge.
 model: opus
-tools: Read, Grep, Glob, Bash
+tools: Read, Grep, Glob, Bash, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet
 ---
 
 # Reviewer
@@ -10,6 +10,10 @@ tools: Read, Grep, Glob, Bash
 You audit pull requests. You are read-only — you do not edit, you do not push fixes, you do not merge. You produce a verdict per PR: `accepted`, `revise: <blockers>`, or `escalate: <reason>`. The team-lead does not merge without your `accepted`.
 
 You are a **long-running role**. You persist across waves, accumulate context on the codebase's conventions and the squad's prior decisions, and support preemptive handoff when your context fills.
+
+## Coordination tools
+
+Use `SendMessage` to deliver verdicts (`accepted`/`revise:`/`escalate:`) to the team-lead and to send `teammate_hello` / `handoff_ready`. Use `TaskCreate`/`TaskUpdate` to track audits in flight, and `TaskList`/`TaskGet` to confirm every started audit has a delivered verdict before exit.
 
 ## Audit checklist
 

--- a/plugins/squadkit/agents/team-lead.md
+++ b/plugins/squadkit/agents/team-lead.md
@@ -2,12 +2,16 @@
 name: team-lead
 description: Orchestrates a squad of specialized teammates against a queue of tasks; owns dispatch, acknowledgement, and the universal exit gate.
 model: opus
-tools: Read, Grep, Glob, Bash, Edit, Write
+tools: Read, Grep, Glob, Bash, Edit, Write, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet, Agent
 ---
 
 # Team Lead
 
 You orchestrate a squad. You do not implement, review, or test yourself — you dispatch work to specialized teammates (architect, builder, reviewer, tester, explorer, designer) and gate progress against the squad's exit conditions. Your value is coordination discipline: clear briefs, per-deliverable acknowledgement, no orphaned claims, no premature teardown.
+
+## Coordination tools
+
+Use `SendMessage` to brief teammates and ack each deliverable. Use `TaskCreate`/`TaskUpdate` to maintain the dispatch queue, and `TaskList`/`TaskGet` to inspect outstanding work before exit-gating. Use `Agent` to spawn members when the roster grows mid-session (between-wave swaps, preemptive handoff successors).
 
 ## Squad shape
 

--- a/plugins/squadkit/agents/tester.md
+++ b/plugins/squadkit/agents/tester.md
@@ -2,7 +2,7 @@
 name: tester
 description: Authors and maintains the test suite that backs the squad's verify gate; produces test reports the lead acks before merge.
 model: sonnet
-tools: Read, Edit, Write, Grep, Glob, Bash
+tools: Read, Edit, Write, Grep, Glob, Bash, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet
 ---
 
 # Tester
@@ -10,6 +10,10 @@ tools: Read, Edit, Write, Grep, Glob, Bash
 You author tests. The squad's verify gate (`${verify.test}`) only has teeth if the suite actually exercises the surfaces the architect's blueprint named. Your job is to keep that coverage honest.
 
 You are a **long-running role**. You persist across waves, accumulate context on the suite's structure and the squad's testing conventions, and support preemptive handoff.
+
+## Coordination tools
+
+Use `SendMessage` to deliver test plans and reports to the team-lead, send `teammate_hello` / `handoff_ready`, and field cross-role pings from builders introducing new importable symbols. Use `TaskCreate`/`TaskUpdate` to track plans and reports in flight, and `TaskList`/`TaskGet` to confirm every started deliverable has shipped before exit.
 
 ## Deliverables
 


### PR DESCRIPTION
## Summary

- Every role contract under `plugins/squadkit/agents/` now declares the squad-coordination tools (`SendMessage`, `TaskCreate`, `TaskUpdate`, `TaskList`, `TaskGet`; plus `Agent` for `team-lead`) in frontmatter — no more relying on silent harness augmentation.
- Each contract gets a short "Coordination tools" body section explaining how the role uses these tools (briefing, ack, dispatch-queue maintenance, exit-gating).
- Squadkit README role table is updated to match, plus a new "Tools allowlist and harness augmentation" subsection explaining the harness behavior and the overlay caveat at `.claude/agents/<role>.md`.

## Changes

- `plugins/squadkit/agents/team-lead.md` — added `SendMessage`, `TaskCreate`, `TaskUpdate`, `TaskList`, `TaskGet`, `Agent` to `tools:`; added Coordination tools section.
- `plugins/squadkit/agents/architect.md` — added `SendMessage`, `TaskCreate`, `TaskUpdate`, `TaskList`, `TaskGet`; added Coordination tools section.
- `plugins/squadkit/agents/builder.md` — same five tools added; added Coordination tools section.
- `plugins/squadkit/agents/reviewer.md` — same five tools added; added Coordination tools section.
- `plugins/squadkit/agents/tester.md` — same five tools added; added Coordination tools section.
- `plugins/squadkit/agents/explorer.md` — same five tools added; added Coordination tools section.
- `plugins/squadkit/agents/designer.md` — same five tools added; added Coordination tools section.
- `plugins/squadkit/README.md` — refreshed Tools column for all seven roles; added "Tools allowlist and harness augmentation" subsection covering the harness-augmentation history, the explicit-declaration preference, and the overlay-merge caveat.

**Spawn-team check deferred.** The proposed-fix's last checkbox (warn in `spawn-team` step 8 when a role contract's declared tools are missing the coordination tools its body claims) is **not** included in this PR. The `spawn-team` SKILL.md is being substantially rewritten in parallel for issues #630/#631/#633/#634/#635/#638; appending a check there would create merge conflicts. Recommend filing a follow-up issue once the parallel rewrites land so the warning can be added against the new structure.

## Test plan

- [ ] Spawn a `team-lead` from the updated contract and confirm it can `SendMessage`, `TaskCreate`, `TaskUpdate`, and `Agent`-spawn members as before (behavior should match the prior harness-augmented baseline).
- [ ] Repeat for `architect`, `builder`, `reviewer`, `tester`, `explorer`, `designer` — confirm `SendMessage` (deliverables, `teammate_hello`, `handoff_ready`) and Task* (in-flight tracking) work end-to-end.
- [ ] Author a project-local overlay at `.claude/agents/team-lead.md` with a restricted `tools:` list (omitting the coordination tools). Spawn and observe whether overlay merge semantics strip dispatch capability or whether harness augmentation still applies. Document the answer for a follow-up README clarification if needed.

Closes #632