### PR TITLE
fix(squadkit:spawn-team): canary-finding omnibus

### DIFF
--- a/plugins/squadkit/README.md
+++ b/plugins/squadkit/README.md
@@ -41,7 +41,7 @@ The role library ships seven contracts under `plugins/squadkit/agents/`. Each ro
 
 | Role | Model | Tools | Responsibility |
 |------|-------|-------|----------------|
-| **team-lead** | opus | Read, Grep, Glob, Bash, Edit, Write, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet, Agent | Orchestrates the squad — dispatches work, gates exit conditions, owns no implementation. |
+| **team-lead** | opus | Read, Grep, Glob, Bash, Edit, Write, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet, Agent | Orchestrates the squad — dispatches work, gates exit conditions, owns no implementation. **The orchestrator (the session that ran `/squadkit:spawn-team`) IS the lead** — squadkit never spawns a separate `team-lead` agent. The contract file is the operating manual that session loads. |
 | **architect** | opus | Read, Grep, Glob, Bash, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet | Read-only blueprint author — produces the contract a builder implements against. |
 | **builder** | sonnet | Read, Edit, Write, Grep, Glob, Bash, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet | Implements the architect's blueprint in an isolated worktree and opens the PR. |
 | **reviewer** | opus | Read, Grep, Glob, Bash, SendMessage, TaskCreate, TaskUpdate, TaskList, TaskGet | Read-only PR auditor — sole authority that clears a PR for merge. |
@@ -64,7 +64,7 @@ Historically the Claude Code harness augmented the allowlist for some of these t
 | Skill | Invoke | What it does |
 |-------|--------|--------------|
 | **init** | `/squadkit:init` | Interview-driven generator that writes `.squadkit/config.json` to the repo root. No per-stack presets — the wizard asks you for the commands directly. |
-| **spawn-team** | `/squadkit:spawn-team` | Spawn a crew from a profile. Resolves a phonetic team name, optionally cuts an epic feature branch, provisions per-builder worktrees, and waits for `SendMessage` acks before declaring the team ready. |
+| **spawn-team** | `/squadkit:spawn-team` | Spawn a crew from a profile. Resolves a phonetic team name, optionally cuts an epic feature branch, provisions per-builder worktrees, registers the team via `TeamCreate`, and waits for one idle notification per spawned member (the harness's readiness signal) before the orchestrator (which IS the lead) enters its dispatch loop. |
 
 More skills (`retro`, `role-spec`) ship in subsequent releases.
 
@@ -120,6 +120,7 @@ members:
 | `--without <role>` | none | Remove every member with the given role. Repeatable. |
 | `--name <custom>` | auto | Override the team name; skips phonetic auto-naming. |
 | `--epic <slug>` | none | Cut `feature/<slug>-<issue>` from the configured base branch and pin `claude.flowkit.prBase` for the session. If omitted, the skill prompts. |
+| `--issues <range>` | none | Issue numbers / ranges to load as the team's initial backlog (swarmkit grammar: `1319,1329,1331` or `1319-1337`). Resolved via `swarmkit:gh-fetch-issues` and forwarded to the lead's first dispatch prompt as a structured backlog table. Trailing-narrative form (`to tackle issues 1319-1337`) is also accepted. |
 
 ### Phonetic naming convention
 
@@ -150,7 +151,9 @@ See the related flowkit skills:
 ### Idempotency and per-builder worktrees
 
 - **Idempotent** — re-running `spawn-team` against an existing `~/.claude/teams/<name>/config.json` never duplicates live members. The skill reports the existing roster and asks whether to reuse, add missing members, or cancel.
-- **Worktrees** — multi-builder configs (>1 builder) provision per-member worktrees under `.claude/worktrees/<member>/` via manual `git worktree add`. Singleton-builder profiles share the workspace; no worktree is created.
+- **Worktrees** — multi-builder configs (>1 builder) provision per-member worktrees under `.claude/worktrees/<member>/` via manual `git worktree add --detach <path> <work-branch>`. Detached HEAD avoids the branch-ref contention that would otherwise fail on `git worktree add` when the main worktree already holds the work branch. Builders create per-issue branches (e.g. `worktree-agent-<issue>`) off the detached commit when they pick up a task. Singleton-builder profiles share the workspace; no worktree is created.
+- **Env-file seeding** — after each per-builder worktree is created, `spawn-team` auto-copies the repo's gitignored env files (`.env.local`, `.env.test.local`, etc.) into the worktree so builders can run the verify suite without manual setup. Override the auto-detection with the optional `worktreeSeed` config key (see [Configuration](#configuration) → Schema).
+- **Stale-worktree detection** — if a `.claude/worktrees/<member>/` already exists on a non-matching branch from a prior session, `spawn-team` prompts (sweep / reuse / abort) before reusing. It also calls `swarmkit:clean-worktrees` as a pre-flight when stale paths exist that don't match the resolved roster.
 
 ## Hooks
 
@@ -190,7 +193,8 @@ The wizard then writes `.squadkit/config.json` (pretty-printed, two-space indent
     "lint": "<command>"
   },
   "install": "<command>",
-  "baseBranch": "<branch>"
+  "baseBranch": "<branch>",
+  "worktreeSeed": ["<repo-relative-path>", "..."]
 }
 ```
 
@@ -201,6 +205,7 @@ The wizard then writes `.squadkit/config.json` (pretty-printed, two-space indent
 | `verify.lint` | Optional. Command the reviewer runs to scope lint errors to PR-touched files (e.g. `npm run lint`, `ruff check`, `cargo clippy`). Omit or set to empty string if the project has no lint step. |
 | `install` | Command a fresh worktree runs to install dependencies (e.g. `npm install`, `pip install -e .`, `cargo fetch`). Empty string if no install step is needed. |
 | `baseBranch` | Default base branch for PRs opened by squad members. Most repos use `develop` or `main`. |
+| `worktreeSeed` | Optional. Explicit list of repo-relative paths to copy into every per-builder worktree at spawn time. When present, overrides `spawn-team`'s auto-detection of ignored env files. Use for projects that need non-env files seeded too (certificates, config snippets, etc.). When absent, `spawn-team` auto-detects ignored env files matching `^(\.env(\.local|\.[a-z-]+\.local)?\|\.env-[a-z-]+)$` via `git ls-files --others --ignored --exclude-standard`. |
 
 Future role contracts and crew profiles will reference these values rather than hardcoding stack-specific commands, making the same role definitions reusable across every repo.
 

--- a/plugins/squadkit/agents/team-lead.md
+++ b/plugins/squadkit/agents/team-lead.md
@@ -9,6 +9,16 @@ tools: Read, Grep, Glob, Bash, Edit, Write, SendMessage, TaskCreate, TaskUpdate,
 
 You orchestrate a squad. You do not implement, review, or test yourself — you dispatch work to specialized teammates (architect, builder, reviewer, tester, explorer, designer) and gate progress against the squad's exit conditions. Your value is coordination discipline: clear briefs, per-deliverable acknowledgement, no orphaned claims, no premature teardown.
 
+## Orchestrator-is-lead model
+
+Squadkit's spawn flow does **not** spawn a separate `team-lead` agent. The session that ran `/squadkit:spawn-team` IS the lead — you are reading this contract because that session is loading it as its operating manual. You have no addressable name in the team's `members[]`; teammates address replies to the orchestrator implicitly via the harness's parent-session inbox.
+
+Practical consequences:
+
+- Never assume a `team-lead` slot exists in `~/.claude/teams/<team>/config.json`'s `members[]`. If you see one with empty `tmuxPaneId`, that is a phantom from a stray `TeamCreate({agent_type})` — surface it to the user and recommend a clean respawn.
+- You receive each spawned member's idle notification directly as a new conversation turn — no explicit `ping`/`ack` is required to confirm readiness.
+- `SendMessage` from you to a teammate is attributed to the orchestrator (not to a phantom `team-lead`), which is what observers and members expect.
+
 ## Coordination tools
 
 Use `SendMessage` to brief teammates and ack each deliverable. Use `TaskCreate`/`TaskUpdate` to maintain the dispatch queue, and `TaskList`/`TaskGet` to inspect outstanding work before exit-gating. Use `Agent` to spawn members when the roster grows mid-session (between-wave swaps, preemptive handoff successors).
@@ -54,6 +64,14 @@ If any check fails, do not exit. Drain the gap, then re-check.
 ## Per-deliverable ack protocol
 
 Every artifact a teammate produces gets exactly one ack from you. The ack is a short message naming the artifact and one of: `accepted`, `revise: <reason>`, `escalate: <reason>`. Teammates queue their next action behind your ack — silence on your end stalls the squad.
+
+## Chained-dispatch clause
+
+When the orchestrator (or a user-driven prompt) asks you to dispatch multiple briefs in one turn, **chain all `SendMessage` calls before going idle**. Do NOT take a single action and stop.
+
+Example: asked to "send a dispatch DM to builder-1, builder-2, builder-3, and builder-4 for Wave 1," issue all four `SendMessage` calls in the same turn before yielding. Splitting them across four turns silently doubles the wall-clock latency of every wave and frustrates the orchestrator who has to re-prompt you N times for one logical batch.
+
+If a multi-brief dispatch is too large to chain in one turn (e.g. each brief requires non-trivial composition with reads/edits between calls), say so explicitly in your reply and propose a split — never silently chunk.
 
 ## PR review gate
 

--- a/plugins/squadkit/hooks/pickup-team-context.sh
+++ b/plugins/squadkit/hooks/pickup-team-context.sh
@@ -28,13 +28,31 @@ matched_team=""
 for cfg in "${configs[@]}"; do
   [ -r "$cfg" ] || continue
 
-  role=$(jq -r --arg sid "$SID" --arg cwd "$PWD" '
-    if ($sid != "" and .leadSessionId == $sid) then
-      ((.members[]? | select(.agentType == "team-lead" or .agentType == "lead") | .agentType) // "team-lead")
-    else
-      ((.members[]? | select(.cwd == $cwd) | .agentType) // empty)
-    end
-  ' "$cfg" 2>/dev/null | head -1)
+  team_dir=$(dirname "$cfg")
+  squadkit_meta="${team_dir}/squadkit.json"
+
+  role=""
+
+  # Orchestrator-is-lead path: the sibling squadkit.json records the orchestrator's
+  # main-repo root. If it equals $PWD, this session IS the team-lead — even though
+  # it has no entry in the harness-managed members[].
+  if [ -r "$squadkit_meta" ]; then
+    repo_root=$(jq -r '.repo_root // empty' "$squadkit_meta" 2>/dev/null)
+    if [ -n "$repo_root" ] && [ "$repo_root" = "$PWD" ]; then
+      role="team-lead"
+    fi
+  fi
+
+  # Legacy path: leadSessionId match (for any team config still using it).
+  if [ -z "$role" ]; then
+    role=$(jq -r --arg sid "$SID" --arg cwd "$PWD" '
+      if ($sid != "" and .leadSessionId == $sid) then
+        ((.members[]? | select(.agentType == "team-lead" or .agentType == "lead") | .agentType) // "team-lead")
+      else
+        ((.members[]? | select(.cwd == $cwd) | .agentType) // empty)
+      end
+    ' "$cfg" 2>/dev/null | head -1)
+  fi
 
   if [ -n "$role" ] && [ "$role" != "null" ]; then
     matched_role="$role"

--- a/plugins/squadkit/skills/agent-team-retro/SKILL.md
+++ b/plugins/squadkit/skills/agent-team-retro/SKILL.md
@@ -26,10 +26,10 @@ Locate the active team config under `~/.claude/teams/`. Each squad writes a `con
 ls ~/.claude/teams/*/config.json 2>/dev/null
 ```
 
-Resolve which team this retro targets:
+Resolve which team this retro targets. Note: the session running this retro is the **orchestrator**, which IS the team-lead under squadkit's orchestrator-is-lead model — it has no addressable `members[]` entry of its own. Match by member `cwd` (the orchestrator's `$PWD` matches the repo root recorded in `squadkit.json` for one and only one team) or by current session id appearing in any historical handoff record.
 
 1. **Single config present** — use it.
-2. **Multiple configs present** — prefer the one whose `leadSessionId` matches the current session ID, or whose any-member `cwd` equals `$PWD`. If still ambiguous, present the candidates via `AskUserQuestion` and let the user pick.
+2. **Multiple configs present** — prefer the one whose sibling `squadkit.json` records a `repo_root` equal to the orchestrator's main-repo root, or whose any-member `cwd` equals `$PWD`. If still ambiguous, present the candidates via `AskUserQuestion` and let the user pick.
 3. **No configs present** — graceful no-op:
 
    > No active squad — skipping retro. Spawn a team first (`/spawn-team`) to run a retro against it.

--- a/plugins/squadkit/skills/spawn-team/SKILL.md
+++ b/plugins/squadkit/skills/spawn-team/SKILL.md
@@ -1,18 +1,20 @@
 ---
 name: spawn-team
-description: Spawn a squadkit crew from a profile. Resolves a phonetic team name, optionally cuts an epic feature branch, provisions per-builder worktrees, and waits for SendMessage acks from every member before declaring the team ready. Idempotent against ~/.claude/teams/<name>/config.json.
+description: Spawn a squadkit crew from a profile. Resolves a phonetic team name, optionally cuts an epic feature branch, provisions per-builder worktrees, registers the team via TeamCreate (orchestrator-is-lead), and waits for idle-notification readiness from every spawned member before declaring the team ready. Idempotent against ~/.claude/teams/<name>/config.json.
 triggers:
   - "/squadkit:spawn-team"
   - "spawn a squad"
   - "spawn a crew"
   - "stand up a team"
   - "bootstrap a squad"
-allowed-tools: Bash, Read, Write, Edit, AskUserQuestion, Agent, SendMessage
+allowed-tools: Bash, Read, Write, Edit, AskUserQuestion, Agent, SendMessage, TeamCreate, TeamDelete, Skill
 ---
 
 # Squadkit Spawn Team
 
-Materialize a crew of agents from a profile. The skill picks an unused phonetic name, loads the crew roster, optionally creates an epic feature branch, provisions per-builder worktrees, spawns each member, and confirms readiness via `SendMessage` ack before handing control to the team-lead.
+Materialize a crew of agents from a profile. The skill picks an unused phonetic name, loads the crew roster, optionally creates an epic feature branch, provisions per-builder worktrees, registers the team via `TeamCreate`, spawns each non-lead member, and confirms readiness via the harness's idle-notification signal before the orchestrator (which IS the team-lead) enters its dispatch loop.
+
+**Orchestrator-is-lead model.** The session running this skill IS the team-lead. The skill never spawns a separate `squadkit:team-lead` agent and never reserves a `team-lead` slot via `TeamCreate({agent_type: ...})` — both produce phantom roster entries that break sender attribution and routing. Step 8 spawns only the non-lead members from the resolved roster.
 
 ## Input
 
@@ -26,6 +28,21 @@ Materialize a crew of agents from a profile. The skill picks an unused phonetic 
 | `--without <role>` | none | Remove every member with the given role from the roster. Repeatable. |
 | `--name <custom>` | auto | Override the team name. Skips phonetic auto-naming. |
 | `--epic <slug>` | none | Cut `feature/<slug>-<issue>` from the configured base branch and pin `claude.flowkit.prBase`. If omitted, prompt. |
+| `--issues <range>` | none | Issue numbers / ranges to load as the team's initial backlog. Accepts the swarmkit grammar: `1319,1329,1331` or `1319-1337` (inclusive). Resolved (open, non-on-hold) list is forwarded to the lead's first dispatch prompt as a structured backlog table. |
+
+### Narrative-tail parsing
+
+If `$ARGUMENTS` carries a trailing narrative such as `to tackle issues 1319-1337` or `for #1319, #1329, #1331`, parse the trailing range/list and treat it as `--issues <range>`. The accepted shapes:
+
+- `to tackle issues <range>` / `tackle issues <range>`
+- `for issues <range>` / `for #N, #M, ...`
+- `on issues <range>`
+
+If parsing fails (ambiguous tail, mixed flags and narrative), do **not** error — prompt via `AskUserQuestion`:
+
+> Could not parse a `--issues` range from the trailing narrative. Continue without an issue scope, or supply one now?
+
+Options: `Skip — no scope`, `Provide range`, `Cancel`.
 
 ## Process
 
@@ -54,10 +71,11 @@ Never hardcode `develop` elsewhere in the runbook — every reference uses `${BA
 
 ### 2. Parse arguments
 
-Extract every flag from `$ARGUMENTS`. Treat unknown flags as an error and stop.
+Extract every flag from `$ARGUMENTS`. Treat unknown flags as an error and stop, but always run the **narrative-tail parser** described in the Input section before declaring an unknown-flag error — a trailing `to tackle issues 1319-1337` is valid input, not garbage.
 
 - Collect `--with` and `--without` into lists (each may appear multiple times).
 - Coerce `--builders` to an integer; reject non-numeric input. If the value exceeds 5, cap it at 5 and warn.
+- For `--issues <range>`: resolve via the swarmkit `gh-fetch-issues` sub-skill (see step 5.5) — do not implement filtering inline.
 
 ### 3. Resolve the team name
 
@@ -78,6 +96,25 @@ done
 ```
 
 If every phonetic letter is taken, stop and report: ask the user to recycle a stale team or pass `--name` explicitly. Do not invent a 27th letter.
+
+#### 3.1 UUID-orphan pre-flight sweep
+
+The harness occasionally creates UUID-named team dirs (e.g. `2c2c01f2-00d4-41f7-8892-adb4fc667428`) — typically orphans from interrupted spawn sessions. They do not collide with phonetic resolution but they accumulate under `~/.claude/teams/` and have no live members.
+
+List them:
+
+```bash
+find "$HOME/.claude/teams" -mindepth 1 -maxdepth 1 -type d \
+  -regex '.*/[0-9a-f]\{8\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{4\}-[0-9a-f]\{12\}$'
+```
+
+For each candidate, confirm it has **no live members** (every entry in `members[]` has empty/null `tmuxPaneId` or no recent activity). If at least one orphan is detectable, prompt the user via `AskUserQuestion`:
+
+> Found N UUID-named team dir(s) under `~/.claude/teams/` with no live members. Clean them via `TeamDelete`?
+
+Options: `Clean all`, `Skip`, `Pick which to clean` (multi-select via a follow-up question).
+
+For each chosen orphan, call `TeamDelete({team_name: <uuid>})`. Never delete a UUID dir that still has a live member — surface a warning instead.
 
 ### 4. Idempotency check
 
@@ -109,8 +146,21 @@ Build the resolved roster:
 2. If `--builders <N>` was given, override every `builder` instance count to N (capped at 5).
 3. Apply `--with <role>` by appending one instance per occurrence.
 4. Apply `--without <role>` by removing every instance with that role.
+5. **Strip every `team-lead` instance from the resolved roster** — the orchestrator IS the lead. The roster passed to step 8 contains only non-lead members. If a profile lists `team-lead` (legacy), drop it silently; do not re-add it.
 
-The team-lead role is always required — if the profile or overrides remove it, re-add a single instance and warn.
+### 5.5 Resolve the issue scope (optional)
+
+If `--issues <range>` was provided (or parsed from the narrative tail), invoke the swarmkit `gh-fetch-issues` sub-skill to expand the range and apply the canonical filters (open + non-on-hold + non-`status:in-progress`):
+
+```
+Skill({skill: "swarmkit:gh-fetch-issues", args: "<resolved range>"})
+```
+
+The sub-skill returns a list of `{number, title, labels, body-excerpt}` records. Persist this list as `RESOLVED_BACKLOG` for forwarding into the lead's first dispatch prompt (step 11).
+
+If the range expands to zero issues after filtering, warn the user and ask via `AskUserQuestion` whether to proceed with no preset backlog or abort. Do not silently spawn a team with an empty work-scope when one was explicitly requested.
+
+If `--issues` was not provided, skip this step — `RESOLVED_BACKLOG` stays empty and the lead is dispatched without a preset backlog (it works against the team's own task list).
 
 ### 6. Epic feature-branch ownership
 
@@ -150,31 +200,119 @@ git config --local claude.flowkit.prBase "${FEATURE_BRANCH}"
 
 The pin is local to the repo (not the worktree) so every member inherits it. `WORK_BRANCH=${FEATURE_BRANCH}` from here on; if no epic was cut, `WORK_BRANCH=${BASE_BRANCH}`.
 
+### 6.5 Stale-worktree pre-flight
+
+Before provisioning new worktrees, sweep the repo's `.claude/worktrees/` for stale paths that don't match the resolved roster.
+
+```bash
+existing=$(find .claude/worktrees -mindepth 1 -maxdepth 1 -type d -printf '%f\n' 2>/dev/null || true)
+```
+
+If any `existing` entry is **not** a member id in the resolved roster (e.g. `builder-1` survives but `tester` is no longer in scope, or the dir is from a completely different epic like `feat/library-cleanup-1298a`), invoke `swarmkit:clean-worktrees` as a sub-skill:
+
+```
+Skill({skill: "swarmkit:clean-worktrees"})
+```
+
+This removes orphan worktrees and their orphaned `worktree-agent-*` branches. It is safe to run when nothing is stale (it reports "nothing to clean" and exits).
+
+If the user has explicitly opted to keep specific stale paths, surface them via `AskUserQuestion` before invoking the sub-skill.
+
 ### 7. Worktree provisioning
 
 Count builders in the resolved roster.
 
-- **Singleton (1 builder)**: every member shares the current workspace. Skip worktree creation.
+- **Singleton (1 builder)**: every member shares the current workspace. Skip worktree creation. Skip the env-file seeding subsection — there's no destination worktree to seed.
 - **Multi-builder (>1 builder)**: create one worktree per builder under `.claude/worktrees/<member>/`:
 
 ```bash
 mkdir -p .claude/worktrees
 for member in "${MULTI_WORKTREE_MEMBERS[@]}"; do
   WT_PATH=".claude/worktrees/${member}"
+
   if [ -d "${WT_PATH}" ]; then
-    continue
+    actual_branch=$(git -C "${WT_PATH}" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "<unreadable>")
+    expected_branch="${WORK_BRANCH}"
+    if [ "${actual_branch}" != "${expected_branch}" ] && [ "${actual_branch}" != "HEAD" ]; then
+      # Stale worktree — ask user before reusing
+      # AskUserQuestion: "Worktree ${WT_PATH} exists on '${actual_branch}', expected '${expected_branch}' (or detached at the epic HEAD). Sweep, reuse, or abort?"
+      # Options:
+      #   Sweep  — git worktree remove --force "${WT_PATH}" && git branch -D "${actual_branch}" 2>/dev/null; recreate below
+      #   Reuse  — continue (caller accepts the inherited branch)
+      #   Abort  — exit the skill
+      :
+    else
+      continue
+    fi
   fi
-  git worktree add "${WT_PATH}" "${WORK_BRANCH}"
+
+  git worktree add --detach "${WT_PATH}" "${WORK_BRANCH}"
 done
 ```
 
 `<member>` is the per-instance member id (e.g. `builder-1`, `builder-2`). Non-builder members in a multi-builder config also share the workspace — only the builders fan out — unless the profile or future flags say otherwise.
 
+**Why `--detach`.** Step 6 already checks the main worktree out onto `${WORK_BRANCH}`. A bare `git worktree add <path> <work_branch>` would refuse with `'feature/<slug>-<N>' is already used by worktree at '<main>'` because git holds branch refs to a single worktree at a time. Detached HEAD lets each builder start at the epic HEAD without contention; builders create per-issue branches (e.g. `worktree-agent-<issue>`) off the detached commit when they pick up a task.
+
+**Never silently reuse a stale worktree.** The `if [ -d "${WT_PATH}" ]` short-circuit must always check the worktree's current branch against `${WORK_BRANCH}` (or detached) and prompt the user before reusing — inheriting a half-merged feature branch from a previous team is a discipline failure.
+
 `Agent({isolation: "worktree"})` is unreliable for multi-builder spawning today, so the skill always uses manual `git worktree add` and passes the resolved path into each spawned agent.
 
-### 8. Spawn members
+#### Worktree seeding (env files and other ignored files)
 
-For each resolved member, spawn a background `Agent` with the role contract loaded from `plugins/squadkit/agents/<role>.md`. If a project-local overlay exists at `.claude/agents/<role>.md`, **append** it to the contract (project-local layered on top of the plugin contract — project-local wins on conflict).
+Repo-local credential files (`.env.local`, `.env.test.local`, etc.) are gitignored and therefore do not appear in a fresh worktree. Builders that pick up a task immediately fail their `${verify.test}` step until they manually copy them.
+
+After provisioning each per-builder worktree, seed it with the project's ignored env files. Two modes:
+
+1. **Auto-detect** (default) — detect ignored env files in the main worktree and copy them in:
+
+   ```bash
+   cd "$REPO_ROOT"
+   git ls-files --others --ignored --exclude-standard \
+     | grep -E '^(\.env(\.local|\.[a-z-]+\.local)?|\.env-[a-z-]+)$' \
+     | while read -r envfile; do
+         cp "$REPO_ROOT/$envfile" "$WT_PATH/$envfile"
+       done
+   ```
+
+2. **Explicit override** — if `.squadkit/config.json` defines a `worktreeSeed: [...]` list, copy exactly that list (relative to the repo root) and skip the auto-detection. This handles projects that need non-env files seeded too (certificates, config snippets, etc.):
+
+   ```json
+   {
+     "worktreeSeed": [".env.local", ".env.test.local", "config/secrets.json"]
+   }
+   ```
+
+If a listed file is missing, warn but do not error — surface every missing path in the final summary so the user can remediate.
+
+**Skip for singleton-builder profiles.** They share the main workspace; nothing to copy.
+
+### 7.5 Register the team via TeamCreate
+
+Before spawning members, register the team with the harness:
+
+```
+TeamCreate({team_name: "${TEAM_NAME}", description: "<one-line description from the crew profile>"})
+```
+
+**Do NOT pass `agent_type`.** Passing `agent_type: "team-lead"` (or any role) reserves a placeholder slot under that name, with no live process behind it. When the actual member spawns later, the harness renames it to `<role>-2` because the slot is taken. The result is a phantom roster entry that confuses routing and observability.
+
+The orchestrator IS the lead — it does not need a slot. Members address their messages to peers (`builder-1`, `tester`, etc.) and to the orchestrator implicitly via the harness's parent-session inbox.
+
+#### Phantom-slot sanity check
+
+Immediately after `TeamCreate`, list the team's members. If any member has `agentId: "<role>@<team>"` with empty `tmuxPaneId`, that's a phantom slot from a stray `agent_type` and must be flagged:
+
+```bash
+jq '.members[] | select(.tmuxPaneId == null or .tmuxPaneId == "") | .agentId' \
+  "$HOME/.claude/teams/${TEAM_NAME}/config.json"
+```
+
+If output is non-empty, halt the skill and surface the phantom — never proceed with a polluted roster.
+
+### 8. Spawn non-lead members
+
+For each resolved member (the orchestrator is the lead — never spawn one here), spawn a background `Agent` with the role contract loaded from `plugins/squadkit/agents/<role>.md`. If a project-local overlay exists at `.claude/agents/<role>.md`, **append** it to the contract (project-local layered on top of the plugin contract — project-local wins on conflict).
 
 Each spawned agent receives:
 
@@ -186,53 +324,79 @@ Each spawned agent receives:
 - `base_branch` (`${BASE_BRANCH}`)
 - `squadkit_config_path` (`${SQUAD_CONFIG}`)
 
-Capture the session UUID returned by each `Agent` spawn — it goes into the persisted team config.
+Capture the session UUID returned by each `Agent` spawn — it lands in the harness-managed config automatically; the squadkit-specific sibling file (step 10) only stores the squadkit metadata, not the per-member roster.
 
-### 9. Readiness confirmation
+### 9. Readiness confirmation — idle-notification-as-ack
 
-Before declaring the team ready, every spawned member must `SendMessage`-ack. The skill sends each member a `ping` and waits for an `ack` reply. Members that fail to ack within a reasonable window (default 60s) are reported, and the user is asked whether to retry, drop the member, or abort.
+The earlier ping/ack protocol could not be implemented as written: the orchestrator has no addressable name in the team, so members cannot ack it by name. Instead, rely on the harness's automatic idle notification.
 
-Do not write the team config until every member has acked.
+Each spawned background `Agent` emits an idle notification to the parent session when its first turn ends. That notification proves the agent is alive and reachable. Use it as the readiness ack — no explicit ping/ack round-trip is required.
 
-### 10. Persist team config
+After all non-lead members are spawned (count = N):
 
-Write `~/.claude/teams/${TEAM_NAME}/config.json`:
+1. Wait for **N idle notifications**, one per spawned member, with a per-member timeout of **60 seconds**.
+2. As each notification arrives, mark that member ready.
+3. If any member fails to idle within 60s, surface the missing role and ask the user via `AskUserQuestion`:
+
+   > Member `<role>` did not idle within 60s. Retry, drop, or abort?
+
+   Options: `Retry — wait another 60s`, `Drop — proceed without this member`, `Abort — stop the spawn`.
+
+Because the orchestrator IS the lead, the original "lead spawned in parallel may miss member acks" problem does not apply — the orchestrator is always present to receive idle notifications as they arrive.
+
+If a future variant of this skill ever spawns a separate lead agent (legacy path), instruct that lead in its first prompt to read `~/.claude/teams/<team>/config.json` and confirm the roster from the harness-managed `members[]` array, rather than relying on inbound idle notifications it may have already missed.
+
+### 10. Persist squadkit metadata (sibling file, not the harness config)
+
+`TeamCreate` (step 7.5) and each `Agent` spawn (step 8) populate `~/.claude/teams/${TEAM_NAME}/config.json` automatically — that file is **harness-managed**. The harness adds entries on every Agent spawn, recording `agentId`, `name`, `agentType`, `model`, `cwd`, `tmuxPaneId`, `joinedAt`, `color`, etc. **Do not overwrite it** — overwriting clobbers the members[] array and breaks peer addressability.
+
+Squadkit-specific metadata (work branch, base branch, epic slug, repo root) lives in a sibling file:
+
+```
+~/.claude/teams/${TEAM_NAME}/squadkit.json
+```
+
+Schema:
 
 ```json
 {
-  "name": "<team-name>",
-  "repo": "<repo-name>",
+  "work_branch": "<branch>",
+  "base_branch": "<branch>",
+  "epic": "<slug or null>",
   "repo_root": "<absolute-path>",
   "profile": "<profile-name>",
-  "base_branch": "<base-branch>",
-  "work_branch": "<work-branch>",
-  "epic": "<slug or null>",
-  "spawned_at": "<ISO-8601 timestamp>",
-  "members": [
-    {
-      "id": "<member-id>",
-      "role": "<role>",
-      "session_uuid": "<uuid>",
-      "worktree_path": "<absolute-path>",
-      "acked_at": "<ISO-8601 timestamp>"
-    }
-  ]
+  "spawned_at": "<ISO-8601 timestamp>"
 }
 ```
 
-This file is squadkit-local state — never check it in. `mkdir -p` the parent directory before writing.
+`mkdir -p` the parent directory before writing. The harness's `config.json` is the source of truth for the roster; `squadkit.json` is the source of truth for squadkit-only coordination state. Never duplicate `members[]` here.
 
-### 11. Hand off to the team-lead
+Sibling files are squadkit-local state — never check them in.
 
-Print a summary including:
+### 11. Hand off to the team-lead (the orchestrator itself)
+
+The orchestrator IS the lead — there is no separate handoff message to send. Instead, print a summary including:
 
 - Team name and profile.
 - Work branch (and whether it was cut as an epic).
 - Roster: member id → role → worktree path.
-- Path to the persisted config.
+- Path to the harness-managed `config.json` and the sibling `squadkit.json`.
 - The fact that `claude.flowkit.prBase` is pinned (if applicable) and how to clear it (`git config --unset claude.flowkit.prBase`).
+- Any worktree-seeding warnings (missing files listed in `worktreeSeed`).
 
-Then send the team-lead its first dispatch prompt with the active roster.
+Then begin the dispatch loop per the team-lead role contract (`plugins/squadkit/agents/team-lead.md`). The first dispatch prompt sent to each builder MUST include the resolved backlog (if `RESOLVED_BACKLOG` is non-empty) as a structured section:
+
+```markdown
+## Backlog (resolved from --issues)
+
+| # | Title | Labels |
+|---|-------|--------|
+| 1319 | <title> | bug, priority:high |
+| 1329 | <title> | enhancement |
+| ...
+```
+
+If `RESOLVED_BACKLOG` is empty, dispatch the lead's loop with no preset scope — it works against the team's own task list.
 
 ## Constraints
 
@@ -240,15 +404,22 @@ Then send the team-lead its first dispatch prompt with the active roster.
 - Never spawn duplicate live members against an existing `~/.claude/teams/<name>/config.json`.
 - Never create more than 5 builders, even if the user asks.
 - Never invent a phonetic letter beyond `zulu` — stop and ask.
-- Never write the team config before every member has acked.
-- Worktrees live under `.claude/worktrees/<member>/` relative to the repo root, never an absolute scratch path.
-- Singleton-builder profiles must not create worktrees (they share the workspace).
+- Never write the squadkit sibling file before every member has idled.
+- Never overwrite the harness-managed `config.json` — append squadkit metadata to the sibling `squadkit.json` instead.
+- Never pass `agent_type` to `TeamCreate` — it reserves a phantom slot.
+- Never spawn a separate `squadkit:team-lead` agent — the orchestrator IS the lead.
+- Never silently reuse a stale `.claude/worktrees/<member>/` — always check the branch against `${WORK_BRANCH}` and prompt before reusing.
+- Worktrees live under `.claude/worktrees/<member>/` relative to the repo root, never an absolute scratch path. Always created with `--detach` to avoid branch-ref contention with the main worktree.
+- Singleton-builder profiles must not create worktrees (they share the workspace) and must not run env-file seeding.
 
 ## Harness constraints
 
-These are observed limitations of the `Agent` spawn primitive at the time of writing. The skill works around each one explicitly — do not "fix" the workarounds without first confirming the underlying constraint has been lifted.
+These are observed limitations of the `Agent` and `TeamCreate` primitives at the time of writing. The skill works around each one explicitly — do not "fix" the workarounds without first confirming the underlying constraint has been lifted.
 
-- **`Agent({isolation: "worktree"})` is unreliable when combined with `team_name`.** The auto-isolation does not fire reliably for team-scoped spawns, so the skill always provisions worktrees manually via `git worktree add` (see step 7) and passes the resolved absolute path into each spawned agent.
+- **`TeamCreate({agent_type: ...})` reserves a phantom slot.** Always call `TeamCreate({team_name, description})` without `agent_type`; let actual `Agent` spawns populate the roster.
+- **The orchestrator has no addressable name in the team.** Members cannot `SendMessage` to the orchestrator by name. The harness auto-delivers replies to the parent session's next turn; rely on that flow rather than explicit ping/ack.
+- **`Agent({isolation: "worktree"})` is unreliable when combined with `team_name`.** The auto-isolation does not fire reliably for team-scoped spawns, so the skill always provisions worktrees manually via `git worktree add --detach` (see step 7) and passes the resolved absolute path into each spawned agent.
+- **`git worktree add <path> <branch>` refuses when the main worktree is already on `<branch>`.** Always use `--detach` for per-builder worktrees so the branch ref stays free.
 - **`Agent({model})` rejects 1M-context aliases like `opus[1m]`.** The harness validates the model param against a fixed allowlist of bare names. To put a long-running role (tester, reviewer, architect) on the 1M tier, spawn with the bare alias (e.g. `opus`) and rely on the team-lead's between-wave swap protocol to rotate in a fresh successor before context fills.
 - **Frontmatter `model:` in `.claude/agents/*.md` is ignored on spawn.** Only the explicit `Agent({model})` parameter controls which model the spawned agent runs on. The frontmatter field is informational for human readers; do not expect it to override the spawn-time parameter, and do not let users assume editing frontmatter changes a live team.
 - **Frontmatter `tools:` is overridden by a default allowlist for some roles.** The harness applies its own tool subset on spawn that may strip tools the role contract declared. Always include `Bash` in the explicit spawn `tools` param so an agent missing `Glob`/`Grep`/`LS` can still fall back to `find`/`grep`/`ls` and complete its work.
@@ -260,4 +431,6 @@ These are observed limitations of the `Agent` spawn primitive at the time of wri
 | `flowkit:cut-epic` | Equivalent epic-cutting flow when run standalone. `spawn-team --epic` performs the same operation inline so the team is born on the epic branch. |
 | `flowkit:preview-epic` | Run after the team has merged sub-PRs to preview the epic-to-`${BASE_BRANCH}` diff. |
 | `flowkit:open-pr` / `flowkit:pr` | Member PRs target `claude.flowkit.prBase` automatically once the spawn pins it. |
+| `swarmkit:gh-fetch-issues` | Resolves `--issues <range>` into a filtered (open + non-on-hold) list for the lead's first dispatch prompt. |
+| `swarmkit:clean-worktrees` | Pre-flight sweep when stale `.claude/worktrees/*` paths exist that don't match the resolved roster. |
 | `swarmkit:swarm` | Independent fan-out for issue queues. Use `swarmkit` when work is already sliced into issues; use `spawn-team` when you want a coordinated long-running crew. |


### PR DESCRIPTION
## Summary

Resolve six related canary findings against `plugins/squadkit/skills/spawn-team/SKILL.md` observed live in the `vorbis-player-alpha` squad spawn on 2026-04-27. All six touch the same skill and share design principles (orchestrator-is-lead, harness-managed config, idle-notification-as-ack), so they ship as a single coherent omnibus rather than as six conflicting partial fixes.

## Changes

- **`TeamCreate` step + orchestrator-is-lead model** (#630). Insert a `TeamCreate({team_name, description})` step before member spawn — without `agent_type`, which reserves a phantom slot. Strip every `team-lead` instance from the resolved roster; the orchestrator IS the lead and the contract file is its operating manual. Add a phantom-slot sanity check after `TeamCreate`. Update `team-lead.md`, `agent-team-retro/SKILL.md`, README, and the `pickup-team-context.sh` SessionStart hook to consult sibling `squadkit.json` for orchestrator identification.
- **Worktree provisioning** (#631). Switch to `git worktree add --detach <path> <work_branch>` so per-builder worktrees no longer collide with the main worktree's branch ref. Add stale-worktree detection that prompts (sweep / reuse / abort) before reusing a worktree on a non-matching branch. Call `swarmkit:clean-worktrees` as pre-flight when stale `.claude/worktrees/*` paths exist that don't match the resolved roster.
- **Readiness ack via idle notification** (#634). Replace the unimplementable ping/ack protocol (orchestrator has no addressable name) with idle-notification-as-ack: wait for N idle notifications with a 60s per-member timeout; on miss prompt retry / drop / abort.
- **Sibling `squadkit.json`** (#634). Persist squadkit-specific metadata (work_branch, base_branch, epic, repo_root, profile, spawned_at) to `~/.claude/teams/<team>/squadkit.json` instead of overwriting the harness-managed `config.json` (which would clobber `members[]`).
- **Env-file seeding** (#635). After provisioning each per-builder worktree, auto-detect and copy gitignored env files (`.env.local`, `.env.test.local`, `.env-<name>`) into the worktree via `git ls-files --others --ignored --exclude-standard`. Optional `worktreeSeed: [...]` key in `.squadkit/config.json` overrides the auto-detection (for projects needing certificates, config snippets, etc.). Skip for singleton-builder profiles. Document `worktreeSeed` in the README config schema.
- **`--issues <range>` work-scope** (#633). Add `--issues` to the flag table with swarmkit grammar (`1319,1329,1331` or `1319-1337`). Invoke `swarmkit:gh-fetch-issues` for canonical open + non-on-hold filtering. Forward the resolved backlog into the lead's first dispatch prompt as a structured table. Parse trailing-narrative form (`to tackle issues 1319-1337`) before declaring unknown-flag errors; fall back to `AskUserQuestion` on parse failure.
- **UUID-orphan sweep + chained-dispatch clause** (#638). Add a pre-flight step that lists UUID-named dirs under `~/.claude/teams/` and prompts to clean them via `TeamDelete` (after confirming no live members). Add a chained-dispatch clause to `team-lead.md`: when asked to dispatch multiple briefs in one turn, chain all `SendMessage` calls before going idle. Document explicitly that #638's "lead spawned in parallel misses acks" problem does not apply under the orchestrator-is-lead model from #630.

## Test plan

- [ ] Run `/squadkit:spawn-team --profile all-rounder --epic <slug>` end to end. Confirm `TeamCreate` is called without `agent_type`, no phantom `team-lead@<team>` member appears, the orchestrator routes `SendMessage` with correct sender attribution, and no `team-lead-2` is spawned (#630).
- [ ] Cut a fresh epic, spawn a 2-builder squad. Confirm step 7 succeeds without `--force` and without main-worktree branch contention (#631).
- [ ] Re-run the same spawn against an existing `.claude/worktrees/builder-1/` parked on a stale branch. Confirm the skill prompts before reusing or sweeping; confirm `swarmkit:clean-worktrees` runs as pre-flight when stale paths exist (#631).
- [ ] Run `/squadkit:spawn-team --epic <slug> --issues 1319-1337`. Confirm the resolved (open, non-on-hold) list lands in the lead's first dispatch prompt as a structured backlog table (#633).
- [ ] Run `/squadkit:spawn-team to tackle issues 1319-1337` (narrative form). Confirm the same outcome (#633).
- [ ] Apply `on-hold` to one of the issues and re-run. Confirm it is excluded (#633).
- [ ] Confirm idle notifications arrive for every spawned member; confirm a timeout surfaces the missing role with retry/drop/abort options (#634).
- [ ] Confirm the harness-managed `config.json` `members[]` array is NOT overwritten, and that squadkit metadata lands in sibling `squadkit.json` (#634).
- [ ] Run `/squadkit:spawn-team` in vorbis-player. Confirm `.env.local` is auto-copied into both builder worktrees and tests pass without manual env-file intervention (#635).
- [ ] Add `worktreeSeed: ["custom-config.json"]` to `.squadkit/config.json`. Re-run, confirm only `custom-config.json` is copied (overrides auto-detection) (#635).
- [ ] Run in a project with no env files; confirm step 7 still succeeds with no warnings (#635).
- [ ] Confirm UUID-named team dirs under `~/.claude/teams/` are surfaced and prompted for cleanup; confirm `TeamDelete` runs cleanly only on orphans with no live members (#638).
- [ ] Re-run a multi-brief dispatch ask against a spawned team-lead and confirm it chains all `SendMessage` calls in one turn (#638).

Closes #630
Closes #631
Closes #633
Closes #634
Closes #635
Closes #638