### PR TITLE
fix(squadkit:agent-team-retro): poll discipline + worktree cleanup

### DIFF
--- a/plugins/squadkit/skills/agent-team-retro/SKILL.md
+++ b/plugins/squadkit/skills/agent-team-retro/SKILL.md
@@ -55,11 +55,21 @@ The three questions (verbatim, in this order):
 
 For each member, include this preamble in the `SendMessage` payload:
 
-> Respond to each of the three questions below in **at most 200 words per answer**. Be specific — name the protocol, file, or contract clause you mean. If you have nothing for a question, say "nothing notable" rather than padding.
+> Reply to this poll **via SendMessage** (not as plain assistant output) with text answers to each of the three questions below. Each answer max **200 words**. Be specific — name the protocol, file, or contract clause you mean. If you have nothing for a question, say "nothing notable" rather than padding. Going idle without a SendMessage reply will be treated as a missed response and re-pinged.
 
 After receiving each response, count words per answer. If any answer exceeds 200 words, send a single follow-up `SendMessage` asking the member to compress that answer to 200 words or fewer, then use the compressed version. Do not silently truncate.
 
 Polls run **in parallel** across members — fire all `SendMessage` calls in a single batch and collect the replies before moving on.
+
+#### Ack discipline
+
+After firing all polls, **wait for SendMessage replies (not idle notifications) from all N members** before proceeding to Phase 3. Treat an idle notification with no accompanying SendMessage payload as a **missed response**, not a completion signal — the member processed the prompt but failed to route their answer through the SendMessage channel.
+
+If any member emits an idle without a substantive SendMessage reply within **60 seconds** of the initial poll, send **one re-ping per such member** with this exact framing:
+
+> My retro prompt registered as idle — please reply via SendMessage.
+
+Wait again for SendMessage replies from the re-pinged members. Only after every polled member has returned a SendMessage reply (or the operator explicitly waives a non-responder via `AskUserQuestion`) may Phase 3 begin. Do not aggregate against a partial roster silently.
 
 ### Phase 3 — Aggregate
 
@@ -124,7 +134,35 @@ If **yes**: invoke `speckit:catalog` with the unapplied findings as input. Pass 
 Skill({skill: "speckit:catalog", args: "<serialized findings>"})
 ```
 
-If **no**: exit cleanly with a summary of what was applied.
+If **no**: proceed to Phase 7 (teardown).
+
+### Phase 7 — Teardown
+
+Before invoking `TeamDelete` to retire the team registry, perform a **worktree-cleanup pass** so per-member git worktrees are removed alongside the registry — leaving them on disk causes stale-worktree silent reuse on subsequent spawns (see #631).
+
+1. **Resolve the team's recorded worktrees.** Read both metadata files for the team resolved in Phase 1:
+
+   - `~/.claude/teams/${TEAM_NAME}/config.json` — canonical roster; each `members[]` entry records a `cwd` field.
+   - `~/.claude/teams/${TEAM_NAME}/squadkit.json` — orchestrator-is-lead metadata sidecar (may also carry per-member worktree paths).
+
+   Collect every `.claude/worktrees/<member>/` path referenced across both files. De-duplicate. Skip the orchestrator's own `cwd` (the orchestrator runs out of the main repo root, not a `.claude/worktrees/` path) — never `git worktree remove` your own working directory.
+
+2. **Remove each worktree.** For every collected path, run:
+
+   ```bash
+   git worktree remove --force <path>
+   ```
+
+   Use `--force` because builders may have left uncommitted scratch state behind; the team is being torn down, so that state is intentionally discarded. If a path does not exist (already cleaned, never created, or moved), record it as **skipped** and continue — do not error.
+
+3. **Log the result.** Emit a short summary of:
+
+   - Paths cleaned (one line each).
+   - Paths skipped, with the reason (e.g. `path missing`, `not a registered worktree`, `already removed`).
+
+4. **Then** invoke `TeamDelete` to remove the `~/.claude/teams/${TEAM_NAME}/` registry. The cleanup pass runs **before** `TeamDelete` so that the metadata files are still readable when collecting paths in step 1.
+
+Exit cleanly with a final summary that includes both the edits applied (Phase 5), the catalog handoff result (Phase 6), and the worktree-cleanup log.
 
 ## Output
 
@@ -134,6 +172,7 @@ Final report includes:
 - Action items applied (per role, per severity)
 - Action items skipped (with reasons)
 - Whether catalog handoff ran, and how many issues were filed
+- Worktrees cleaned and worktrees skipped during teardown (with reasons)
 
 ## Constraints
 
@@ -144,3 +183,5 @@ Final report includes:
 - Bundled-only edits require explicit user consent; default recommendation is to copy to project-local first
 - Solo sessions (no team config, or no spawned members) exit cleanly with a no-op message — never error
 - Catalog handoff is opt-in; never silently file issues
+- Phase 2 advances only on **SendMessage replies** — idle notifications without a SendMessage payload are treated as missed responses and re-pinged once before falling back to operator confirmation
+- Phase 7 worktree cleanup runs **before** `TeamDelete` so the team's metadata files are still readable when collecting paths; missing paths are logged as skipped, never errored


### PR DESCRIPTION
## Summary

Tighten the agent-team-retro skill against two failure modes observed in the vorbis-player-alpha post-mortem: members idle-acking the Phase 2 retro poll without sending a SendMessage reply, and per-builder worktrees being left on disk after `TeamDelete` retires the team registry. The skill now frames the poll as an explicit SendMessage interaction with an ack-discipline loop, and a new Phase 7 teardown step removes recorded worktrees before `TeamDelete` runs.

## Changes

- Rewrite the Phase 2 poll preamble in `plugins/squadkit/skills/agent-team-retro/SKILL.md` to explicitly require SendMessage replies and warn that idling will be re-pinged (#644 fix A).
- Add a Phase 2 "Ack discipline" subsection that waits for SendMessage replies from all N members, treats idle-without-payload as a missed response, and emits one re-ping per silent member with the verbatim "My retro prompt registered as idle — please reply via SendMessage." framing (#644 fix B).
- Add a new Phase 7 teardown step that reads `~/.claude/teams/${TEAM_NAME}/config.json` and the sibling `squadkit.json`, collects every recorded `.claude/worktrees/<member>/` path (skipping the orchestrator's own cwd), runs `git worktree remove --force` on each, logs cleaned vs. skipped paths, and then proceeds with the existing `TeamDelete` invocation (#657).
- Extend the Output and Constraints sections to cover the new ack-discipline gate and the worktree-cleanup log.

## Test plan

- [ ] Run `/squadkit:agent-team-retro` against a multi-member team and confirm the Phase 2 prompt opens with "Reply to this poll **via SendMessage**" framing.
- [ ] Simulate a member emitting an idle without a SendMessage payload and confirm the lead re-pings exactly once with the "My retro prompt registered as idle" wording before advancing to Phase 3.
- [ ] After all phases complete, confirm Phase 7 enumerates `.claude/worktrees/<member>/` paths from `config.json` + `squadkit.json`, runs `git worktree remove --force` on each existing path, and logs missing paths as skipped without erroring.
- [ ] Confirm the teardown log lists cleaned and skipped worktrees in the final summary, and that `TeamDelete` is invoked only after the cleanup pass completes.

Closes #644
Closes #657