### PR TITLE
fix(squadkit): team-lead + spawn-team omnibus

### DIFF
--- a/plugins/squadkit/agents/team-lead.md
+++ b/plugins/squadkit/agents/team-lead.md
@@ -65,6 +65,163 @@ If any check fails, do not exit. Drain the gap, then re-check.
 
 Every artifact a teammate produces gets exactly one ack from you. The ack is a short message naming the artifact and one of: `accepted`, `revise: <reason>`, `escalate: <reason>`. Teammates queue their next action behind your ack — silence on your end stalls the squad.
 
+## Dispatch discipline
+
+### Dedup-before-dispatch
+
+Before dispatching task `X` to member `M`, run a two-step check and skip the dispatch if either signal indicates the work has already been picked up:
+
+1. **Team task list.** Use `TaskList`/`TaskGet` to inspect task `X`. If its status is `completed` and a recent message from `M` in your inbox references `X` (by issue number, task id, or title), the work has already landed — skip the dispatch.
+2. **Inbox history.** Read `M`'s last 3 messages in your inbox. If any acknowledges `X` (received, in-progress, or completed), the dispatch has already been delivered — skip.
+
+The default assumption is that a sent message reached `M` and `M` acted on it. Re-dispatch ONLY on an explicit signal of failure (e.g. `M` reports a tool error referencing `X`, the harness surfaces a delivery error, or `M` asks for clarification implying it never received the brief).
+
+A one-line reminder to anchor the rule: `task #N status == completed? skip dispatch.` The cost of one missed re-dispatch (you'll hear about it) is far smaller than the cost of three duplicate dispatches in a wave (member confusion, ambiguous replies, wasted turns).
+
+## Orchestrator playbook
+
+When the orchestrator (the session running this contract) hits a coordination edge case, branch into one of the named playbook entries below. Each branch names the trigger, the diagnosis, and the prescribed action — do not improvise around them.
+
+### `lead-cannot-dispatch`
+
+**Trigger.** The lead reports the same tool error twice in a row with identical text — for example, two consecutive turns ending in `SendMessage failed: <identical error>` or `TaskCreate failed: <identical error>`.
+
+**Diagnosis.** Identical-text repetition signals a tool-gating or capability problem, not a transient failure. Retrying a third time will not change the result and only burns turns.
+
+**Action.** Escalate to **re-provision** — do not retry. Surface the gated tool to the user, recommend a clean respawn (or a targeted re-grant of the missing tool), and halt the dispatch loop. Do not interpret the lead's subsequent idle notification as proof that the dispatch landed; idle ≠ delivery (see the delivery-receipt channel below).
+
+### Delivery-receipt channel
+
+Idle notifications prove the lead is alive, not that a dispatch was delivered. To distinguish "I went idle after a successful dispatch" from "I went idle after a tool-error turn that swallowed the dispatch," the lead writes a delivery receipt per dispatch attempt and the orchestrator reads it before assuming success.
+
+**Path:** `.squadkit/dispatch-log.jsonl` (relative to the repo root, append-only, one JSON object per line).
+
+**Schema (per line):**
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `timestamp` | string (ISO-8601) | When the dispatch attempt was made. |
+| `member` | string | Target member id (e.g. `builder-1`, `tester`). |
+| `task` | string \| number | Task id or issue number being dispatched. |
+| `digest` | string | Short content digest of the brief (e.g. first 12 chars of a sha256 over the message body) so duplicate dispatches are detectable. |
+| `outcome` | string | `sent`, `tool_error`, or `skipped_dedup`. |
+
+The lead writes one line per dispatch attempt regardless of outcome — including `tool_error` and `skipped_dedup` — so the orchestrator can reconstruct the truth from the file alone. The orchestrator reads the latest line for `(member, task)` before assuming a dispatch landed; if the most recent outcome is `tool_error`, fall through to the `lead-cannot-dispatch` branch above.
+
+## Brief schema
+
+Every brief the lead sends to a teammate uses the same field shape. Skipping a field is allowed only when it does not apply to the role (e.g. `Verify` for a designer producing pure mockups). Do not invent role-specific field names — extend the schema below if a new field is genuinely needed.
+
+### Fields
+
+| Field | Type | Required | Notes |
+|-------|------|----------|-------|
+| `TO` | string | yes | Target member id. Single recipient — never broadcast a brief. |
+| `Branch` | string | yes | Work branch the member should check out before starting. Usually `${WORK_BRANCH}` from the spawn config. |
+| `Scope` | string (free-form) | yes | One-paragraph description of what this task covers AND what it explicitly does NOT cover. |
+| `Verify` | list of commands | conditional | The verify commands the member must pass before declaring done. Pull from `.squadkit/config.json` placeholders (`${verify.typecheck}`, `${verify.test}`, `${verify.lint}`). |
+| `PR` | object | conditional | For roles that produce PRs (builder). Fields: `base` (branch), `title-hint` (string), `closes` (list of `#N`). |
+| `Deliverable` | string | yes | Exactly what artifact the member returns: a blueprint, a UX brief, a research note, a PR url, a test report, a review verdict. One artifact per task. |
+| `Refs` | list of strings | optional | Issue numbers, related PRs, prior briefs to read first. |
+| `Deadline` | string | optional | Soft deadline for the deliverable (e.g. "before next wave", "end of session"). |
+
+### Worked examples
+
+#### Architect
+
+```
+TO: architect
+Branch: feature/vorbis-player-1336
+Scope: Produce a blueprint for splitting the existing `AudioPlayer` god-class into `Decoder`,
+       `Buffer`, and `Output` collaborators. Cover the public surface, the lifecycle of each
+       collaborator, and the migration path from the current single-class API. Does NOT cover:
+       on-disk format changes or the loudness-normalization pass (separate task).
+Verify: n/a (blueprint only — no code changes)
+Deliverable: A blueprint markdown note posted back as a `SendMessage` reply, including a
+             component diagram, a method-by-method migration table, and a list of risks.
+Refs: #1336, prior research note from explorer (msg id 0x42)
+```
+
+#### Builder
+
+```
+TO: builder-1
+Branch: feature/vorbis-player-1336
+Scope: Implement the `Decoder` collaborator per the architect's blueprint (msg id 0x51).
+       Includes: new `Decoder` class, factory function, unit tests for happy/error paths.
+       Does NOT include: wiring it into `AudioPlayer` (next task).
+Verify:
+  - ${verify.typecheck}
+  - ${verify.test}
+  - ${verify.lint}
+PR:
+  base: feature/vorbis-player-1336
+  title-hint: "feat(vorbis): extract Decoder collaborator"
+  closes: ["#1337"]
+Deliverable: Open PR url posted back as a `SendMessage` reply.
+Refs: #1336, #1337
+```
+
+#### Reviewer
+
+```
+TO: reviewer
+Branch: feature/vorbis-player-1336
+Scope: Review PR #1402 (Decoder extraction). Check: contract conformance with the blueprint,
+       test coverage for error paths, no regressions in the public `AudioPlayer` surface.
+Verify:
+  - ${verify.typecheck}
+  - ${verify.test}
+Deliverable: A review verdict — `accepted`, `revise: <reason>`, or `escalate: <reason>` —
+             posted back as a `SendMessage` reply. Include line-level concerns inline if
+             requesting revision.
+Refs: PR #1402, blueprint msg id 0x51
+```
+
+#### Tester
+
+```
+TO: tester
+Branch: feature/vorbis-player-1336
+Scope: Validate PR #1402 against the test plan in the blueprint. Run the verify commands and
+       a manual smoke test of decoding `tests/fixtures/sample.ogg`. Report any flakes.
+Verify:
+  - ${verify.typecheck}
+  - ${verify.test}
+  - ${verify.lint}
+Deliverable: A test report — `accepted` or `failed: <summary>` — posted back as a
+             `SendMessage` reply. Attach failure logs if any.
+Refs: PR #1402, blueprint msg id 0x51
+```
+
+#### Explorer
+
+```
+TO: explorer
+Branch: feature/vorbis-player-1336
+Scope: Research how comparable libraries (libvorbis, stb_vorbis, minivorbis) structure the
+       decode pipeline. Focus on the seam between bitstream parsing and PCM output. Does NOT
+       require any code changes — research note only.
+Verify: n/a (research only)
+Deliverable: A research note posted back as a `SendMessage` reply, summarizing each library's
+             architecture in 2-3 paragraphs and naming the seam most relevant to our split.
+Refs: #1336
+```
+
+#### Designer
+
+```
+TO: designer
+Branch: feature/vorbis-player-1336
+Scope: Produce mockups for the new transport-controls bar (play/pause, seek, volume, loop).
+       Cover light + dark themes. Does NOT cover: the playlist sidebar (separate task).
+Verify: n/a (design only)
+Deliverable: A UX brief posted back as a `SendMessage` reply, including PNG/SVG references
+             (or links if hosted), token names for new colors, and the interaction spec for
+             keyboard accessibility.
+Refs: #1336, design tokens at design/tokens.json
+```
+
 ## Chained-dispatch clause
 
 When the orchestrator (or a user-driven prompt) asks you to dispatch multiple briefs in one turn, **chain all `SendMessage` calls before going idle**. Do NOT take a single action and stop.

--- a/plugins/squadkit/skills/spawn-team/SKILL.md
+++ b/plugins/squadkit/skills/spawn-team/SKILL.md
@@ -326,6 +326,37 @@ Each spawned agent receives:
 
 Capture the session UUID returned by each `Agent` spawn — it lands in the harness-managed config automatically; the squadkit-specific sibling file (step 10) only stores the squadkit metadata, not the per-member roster.
 
+### 8.5 Tool-registry validation probe
+
+After spawning the non-lead members but **before** waiting on idle notifications (step 9), probe the lead's coordination tools end-to-end. The orchestrator IS the lead, so "the lead" here means the session running this skill — probe your own tool registry.
+
+The probe is a `SendMessage` no-op: send a sentinel message to a known-addressable target (the first spawned member, or any teammate the harness exposes by name) with a uniquely identifiable payload, then assert two things:
+
+1. The `SendMessage` call returns a success status — not a tool-error, not a missing-tool error.
+2. The harness-emitted `summary` payload for that call matches the probe content (the digest of what was sent equals the digest of what the harness reports as delivered).
+
+**Probe content shape:**
+
+```
+TO: <first-spawned-member-id>
+Subject: spawn-probe-<TEAM_NAME>-<short-uuid>
+Body: "Spawn probe for ${TEAM_NAME}. No action required — discard on receipt."
+```
+
+The probe is a no-op for the receiving member: it carries no task, no brief, no ack request. Members should treat unknown `Subject: spawn-probe-*` messages as discardable.
+
+**On success:** record the probe result (timestamp + delivered digest) in the spawn summary, then proceed to step 9.
+
+**On failure (tool error, schema mismatch, or missing tool):** halt squad creation immediately. Do not proceed to step 9. Surface to the user:
+
+- Which tool was gated (e.g. `SendMessage`, `TaskCreate`, `Agent`).
+- The exact error text returned by the harness.
+- A recommendation: re-provision the orchestrator with the missing tool granted, or respawn the team in a session that has the full registry.
+
+This catches the failure mode where the lead silently spins up missing one of the tools its role contract requires (`SendMessage`, `TaskCreate`, `TaskList`, `TaskGet`, `Agent`) — turning a multi-turn diagnostic loop into a single clear failure at spawn time.
+
+**Cross-reference.** The orchestrator playbook entry `lead-cannot-dispatch` in `plugins/squadkit/agents/team-lead.md` handles the runtime variant of this same problem (the lead reports an identical tool error twice). The probe is the spawn-time prevention; the playbook entry is the runtime fallback.
+
 ### 9. Readiness confirmation — idle-notification-as-ack
 
 The earlier ping/ack protocol could not be implemented as written: the orchestrator has no addressable name in the team, so members cannot ack it by name. Instead, rely on the harness's automatic idle notification.
@@ -397,6 +428,28 @@ Then begin the dispatch loop per the team-lead role contract (`plugins/squadkit/
 ```
 
 If `RESOLVED_BACKLOG` is empty, dispatch the lead's loop with no preset scope — it works against the team's own task list.
+
+## Orchestrator playbook
+
+These branches mirror the named entries in `plugins/squadkit/agents/team-lead.md` — the spawn skill carries them too because spawn time is when the orchestrator first activates these protocols.
+
+### `lead-cannot-dispatch`
+
+If after handing off to the dispatch loop the lead reports the same tool error twice with identical text on consecutive turns, **escalate to re-provision — do not retry a third time**. Identical-text repetition signals tool-gating, not a transient failure. Surface the gated tool to the user, recommend a clean respawn, and halt the dispatch loop. The step 8.5 probe is designed to catch this at spawn time; this branch is the runtime fallback when something gates a tool mid-session.
+
+### Delivery-receipt channel
+
+The lead writes a delivery receipt per dispatch attempt to `.squadkit/dispatch-log.jsonl` (one JSON object per line) so the orchestrator can distinguish "idle after a successful dispatch" from "idle after a tool-error turn that swallowed the dispatch." The schema:
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `timestamp` | string (ISO-8601) | When the dispatch attempt was made. |
+| `member` | string | Target member id. |
+| `task` | string \| number | Task id or issue number being dispatched. |
+| `digest` | string | Short content digest of the brief (first 12 chars of a sha256 over the body). |
+| `outcome` | string | `sent`, `tool_error`, or `skipped_dedup`. |
+
+Idle ≠ delivery. The orchestrator reads the latest `(member, task)` line before assuming a dispatch landed; on `tool_error`, fall through to the `lead-cannot-dispatch` branch above. The full prose for both branches lives in `plugins/squadkit/agents/team-lead.md` under "Orchestrator playbook" — this section is a deliberate mirror so the spawn skill remains self-contained.
 
 ## Constraints
 


### PR DESCRIPTION
## Summary

Hardens the team-lead orchestration manual and spawn-team validation gates against four bugs distilled from the vorbis-player-alpha post-mortem: duplicate dispatches, runaway retries on identical tool errors, silently-gated lead tools at spawn time, and ad-hoc brief shapes that drifted across sessions.

## Changes

- Add a "Dispatch discipline / Dedup-before-dispatch" section to `plugins/squadkit/agents/team-lead.md` codifying the two-step task-list + inbox-history check before any re-dispatch.
- Add an "Orchestrator playbook" section to `plugins/squadkit/agents/team-lead.md` with the `lead-cannot-dispatch` branch (escalate on identical-text repeat, do not retry) and the explicit `.squadkit/dispatch-log.jsonl` delivery-receipt schema (timestamp, member, task, digest, outcome).
- Add a "Brief schema" section to `plugins/squadkit/agents/team-lead.md` listing the field shape (TO, Branch, Scope, Verify, PR, Deliverable, Refs, Deadline) plus one worked example per role: architect, builder, reviewer, tester, explorer, designer.
- Insert step 8.5 "Tool-registry validation probe" into `plugins/squadkit/skills/spawn-team/SKILL.md` between member spawn (step 8) and readiness confirmation (step 9), specifying the SendMessage no-op probe, the success/failure assertions, and the halt-and-surface behavior on gated tools.
- Mirror the `lead-cannot-dispatch` branch and delivery-receipt schema into `plugins/squadkit/skills/spawn-team/SKILL.md` under a new "Orchestrator playbook" section so the spawn skill stays self-contained.

## Test plan

- [ ] Read `plugins/squadkit/agents/team-lead.md` end-to-end and confirm the new "Dispatch discipline", "Orchestrator playbook", and "Brief schema" sections flow coherently with the existing dispatch loop and ack protocol.
- [ ] Confirm each of the six worked brief examples (architect, builder, reviewer, tester, explorer, designer) uses the documented field schema and is realistic enough to copy into a real dispatch.
- [ ] Read `plugins/squadkit/skills/spawn-team/SKILL.md` and confirm step numbering is 8 → 8.5 → 9 with no orphaned references to the old numbering.
- [ ] Confirm the `lead-cannot-dispatch` branch text is consistent between team-lead.md and spawn-team SKILL.md (mirror, not divergence).
- [ ] Spawn a test squad and verify the orchestrator runs the step 8.5 probe before declaring readiness; confirm a deliberately-gated SendMessage halts the spawn with a clear gated-tool report.
- [ ] Trigger a duplicate-dispatch scenario in a live run and confirm the lead skips the re-dispatch when the task list shows `completed` and the inbox shows a recent ack from the target member.

Closes #649
Closes #654
Closes #655
Closes #656