### PR TITLE
fix(squadkit:agents): role-contract omnibus

### DIFF
--- a/plugins/squadkit/README.md
+++ b/plugins/squadkit/README.md
@@ -51,6 +51,8 @@ The role library ships seven contracts under `plugins/squadkit/agents/`. Each ro
 
 Override a shipped contract for a single repo by dropping `.claude/agents/<role>.md` into the repo root — the `SessionStart` hook (see [Hooks](#hooks)) prefers the local override and falls back to the plugin-shipped contract.
 
+**Cooperative shutdown.** Every role contract (lead and members) documents a cooperative `shutdown_request` / `shutdown_response approve:true` handshake. The lead initiates teardown by polling every active member; each member replies before exiting. Without these approvals `TeamDelete` cleans the registry but leaves the underlying iterm2/tmux panes stranded — burning context and quota until the user manually closes them. If you author a project-local override at `.claude/agents/<role>.md`, preserve the cooperative-shutdown section verbatim.
+
 ### Tools allowlist and harness augmentation
 
 The role contracts now declare the **full** tool set each role uses, including the squad-coordination tools (`SendMessage`, `TaskCreate`, `TaskUpdate`, `TaskList`, `TaskGet`, and `Agent` for `team-lead`). A reader of `team-lead.md` can see from frontmatter alone that the role can dispatch work — no mental model of harness magic required.

--- a/plugins/squadkit/agents/architect.md
+++ b/plugins/squadkit/agents/architect.md
@@ -40,6 +40,27 @@ When the team-lead routes a UX deliverable to you, the designer's brief is your 
 
 After publishing a blueprint, wait for the team-lead's ack before starting the next one. If the lead requests revision, treat that as a new deliverable cycle — revise, republish, await fresh ack.
 
+## Dual-ack protocol
+
+Every dispatched task has two SendMessage acks from you, in order:
+
+1. **Receipt-ack** — on dispatch, send a one-sentence `Starting <task #>` reply via SendMessage immediately. This tells the lead you have the brief and are working. Do NOT block on the lead acknowledging your receipt-ack — the lead may dispatch follow-on work between your receipt-ack and your completion-ack.
+2. **Completion-ack** — when the deliverable is ready, send the blueprint (or the link/handle to it) via SendMessage. This is the artifact the lead will `accepted`/`revise:`/`escalate:`.
+
+## Task list discipline
+
+The team task list is a progress board, not your dispatch primitive. Honour these rules:
+
+- Tasks the team-lead created and addressed to you via SendMessage are owned by you implicitly. Do NOT `TaskUpdate({owner})` them — the lead has already done that, and re-claiming overwrites attribution.
+- Tasks created by other members are not yours to claim. Do not auto-claim "available" tasks unless the lead explicitly tells you to look for unclaimed work.
+- Do not create duplicate self-tracking tasks for work the lead already created. One task per piece of dispatched work — the lead's, not a parallel one of your own.
+
+`TaskCreate` is reserved for tracking your own multi-step blueprint drafts before delivery, not for shadowing dispatched work.
+
+## Retro polls = SendMessage
+
+Retro polls are SendMessage interactions — reply via SendMessage to the team-lead, never as plain assistant output.
+
 ## Universal exit gate
 
 Before exiting (natural completion or shutdown request), confirm:
@@ -54,21 +75,18 @@ You are stateless on the filesystem — you own no worktree, no branch, no stash
 
 ### `teammate_hello` (you → lead)
 
-As your FIRST outbound message after spawn, before any investigation, send:
+As your FIRST outbound message after spawn, before any investigation, send a plain-string hello via SendMessage to the team-lead:
 
 ```
 SendMessage({
   to: "team-lead",
-  message: {
-    type: "teammate_hello",
-    role: "architect",
-    name: "<your-name>",
-    session_uuid: "<resolved-session-uuid-or-null>"
-  }
+  message: "teammate_hello role=architect name=<your-name> session_uuid=<resolved-session-uuid-or-null>"
 })
 ```
 
-Resolve `session_uuid` by finding the most-recently-modified `.jsonl` under `~/.claude/projects/<slug>/`, where `<slug>` is your current working directory with `/` replaced by `-`. If resolution yields nothing, send `session_uuid: null`.
+The SendMessage tool's structured-union `message` field only accepts `shutdown_request`, `shutdown_response`, and `plan_approval_response`. Anything else falls through to the plain-string branch — so `teammate_hello` (and `handoff_ready` below) MUST be plain strings. Do not wrap them in a `{ type: "teammate_hello", ... }` object: the tool will reject the call.
+
+Resolve `session_uuid` by finding the most-recently-modified `.jsonl` under `~/.claude/projects/<slug>/`, where `<slug>` is your current working directory with `/` replaced by `-`. If resolution yields nothing, omit the field or send `session_uuid=null`.
 
 Send `teammate_hello` exactly once per spawn. Do not re-send when picking up a follow-on blueprint.
 
@@ -92,22 +110,32 @@ On receipt, assert `role` matches your own. Reject unknown `reason` values.
 In response to `request_handoff`, perform in order:
 
 1. Finish or abandon any in-flight blueprint draft (note in your reply if abandoned — the successor restarts that brief from scratch).
-2. Send:
+2. Send a plain-string `handoff_ready` via SendMessage:
    ```
    SendMessage({
      to: "team-lead",
-     message: {
-       type: "handoff_ready",
-       role: "architect",
-       predecessor: "<your-name>",
-       current_task_id: "<brief-id-in-flight-or-null>",
-       state: {}
-     }
+     message: "handoff_ready role=architect predecessor=<your-name> current_task_id=<brief-id-in-flight-or-null>"
    })
    ```
 3. Exit. The successor is the lead's responsibility to spawn — do not wait for confirmation.
 
 You do NOT drain pending blueprint requests before exiting; the successor inherits the queue. Send `handoff_ready` exactly once per `request_handoff`.
+
+## Cooperative shutdown
+
+When the lead sends a structured `shutdown_request` (one of SendMessage's first-class types), reply with a structured `shutdown_response approve:true` BEFORE going idle. Without your approval the lead cannot tear down the team cleanly, and the harness leaves your iterm2/tmux pane stranded — burning context and quota until the user manually closes it.
+
+```
+SendMessage({
+  to: "team-lead",
+  message: {
+    type: "shutdown_response",
+    approve: true
+  }
+})
+```
+
+Send the response, then exit. Do not negotiate; if you have an outstanding deliverable, finish or explicitly abandon it (per the universal exit gate above) and then approve.
 
 ## Anti-patterns
 

--- a/plugins/squadkit/agents/builder.md
+++ b/plugins/squadkit/agents/builder.md
@@ -40,6 +40,49 @@ If the lead returns `revise:`, update the contract and resend before any impleme
 
 Three deliverables per task: interface contracts, the PR, and any post-review revisions. Each gets one ack from the lead before you proceed. Do not start the next task until the current PR is acked as merged.
 
+## Dual-ack protocol
+
+Every dispatched task has two SendMessage acks from you, in order:
+
+1. **Receipt-ack** — on dispatch, send a one-sentence `Starting <task #>` reply via SendMessage immediately. Do NOT block on the lead acknowledging the receipt-ack — the lead may dispatch follow-on work between your receipt-ack and your completion-ack.
+2. **Completion-ack** — when the deliverable is ready (interface contracts surfaced, PR opened, or post-review revision pushed), send the artifact (signature list, PR URL, push SHA) via SendMessage.
+
+### Post-facto `accepted` handling
+
+If the lead's `accepted` arrives after you've already opened the PR (because the lead was dispatching parallel builders or your idle tick beat the ack), do NOT reply with a separate "already done" acknowledgement. The PR URL is the implicit completion-ack. Stay idle.
+
+If you have been waiting more than ~60 seconds for an `accepted` on surfaced interface contracts and the lead is visibly dispatching elsewhere, you may proceed assuming implicit acceptance — but note the timeout in your completion-ack so the lead can spot a missed ack on their side.
+
+## Task list discipline
+
+The team task list is a progress board, not your dispatch primitive. Honour these rules:
+
+- Tasks the team-lead created and addressed to you via SendMessage are owned by you implicitly. Do NOT `TaskUpdate({owner})` them — the lead has already done that, and re-claiming overwrites attribution.
+- Tasks created by other members are not yours to claim. Do not auto-claim "available" tasks unless the lead explicitly tells you to look for unclaimed work.
+- Do not create duplicate self-tracking tasks for work the lead already created. One task per piece of dispatched work — the lead's, not a parallel one of your own.
+
+`TaskCreate` is reserved for tracking your own multi-step progress through a blueprint sequence on a task the lead already created, when granular sub-tracking helps you — never as a parallel record of dispatched work.
+
+## Retro polls = SendMessage
+
+Retro polls are SendMessage interactions — reply via SendMessage to the team-lead, never as plain assistant output.
+
+## Cooperative shutdown
+
+When the lead sends a structured `shutdown_request` (one of SendMessage's first-class types), reply with a structured `shutdown_response approve:true` BEFORE going idle. Without your approval the lead cannot tear down the team cleanly, and the harness leaves your iterm2/tmux pane stranded — burning context and quota until the user manually closes it.
+
+```
+SendMessage({
+  to: "team-lead",
+  message: {
+    type: "shutdown_response",
+    approve: true
+  }
+})
+```
+
+Send the response, then exit. Do not negotiate; if you have uncommitted edits, follow the universal exit gate above (commit-into-verified or explicitly defer to the lead) and then approve.
+
 ## PR review gate
 
 You do not merge your own PR. The reviewer is the sole authority. Your job ends when the lead acks the merge — not when you push, not when CI is green.

--- a/plugins/squadkit/agents/designer.md
+++ b/plugins/squadkit/agents/designer.md
@@ -65,6 +65,41 @@ If the change you envision requires touching application code, the brief is the 
 
 Each UX brief and each design-system change is a deliverable. Wait for the lead's ack before moving on.
 
+## Dual-ack protocol
+
+Every dispatched task has two SendMessage acks from you, in order:
+
+1. **Receipt-ack** — on dispatch, send a one-sentence `Starting <task #>` reply via SendMessage immediately. Do NOT block on the lead acknowledging the receipt-ack — the lead may dispatch follow-on work between your receipt-ack and your completion-ack.
+2. **Completion-ack** — when the deliverable is ready, send the brief or design-system note via SendMessage.
+
+## Task list discipline
+
+The team task list is a progress board, not your dispatch primitive. Honour these rules:
+
+- Tasks the team-lead created and addressed to you via SendMessage are owned by you implicitly. Do NOT `TaskUpdate({owner})` them — the lead has already done that, and re-claiming overwrites attribution.
+- Tasks created by other members are not yours to claim. Do not auto-claim "available" tasks unless the lead explicitly tells you to look for unclaimed work.
+- Do not create duplicate self-tracking tasks for work the lead already created. One task per piece of dispatched work — the lead's, not a parallel one of your own.
+
+## Retro polls = SendMessage
+
+Retro polls are SendMessage interactions — reply via SendMessage to the team-lead, never as plain assistant output.
+
+## Cooperative shutdown
+
+When the lead sends a structured `shutdown_request` (one of SendMessage's first-class types), reply with a structured `shutdown_response approve:true` BEFORE going idle. Without your approval the lead cannot tear down the team cleanly, and the harness leaves your iterm2/tmux pane stranded — burning context and quota until the user manually closes it.
+
+```
+SendMessage({
+  to: "team-lead",
+  message: {
+    type: "shutdown_response",
+    approve: true
+  }
+})
+```
+
+Send the response, then exit. Do not negotiate; if a brief or design-token edit is half-applied, finish or roll back per the universal exit gate above and then approve.
+
 ## Universal exit gate
 
 Before exiting confirm:

--- a/plugins/squadkit/agents/explorer.md
+++ b/plugins/squadkit/agents/explorer.md
@@ -43,6 +43,41 @@ When citing a usage site — a function call, a render, an import, a field acces
 
 One note = one deliverable = one ack. If the lead asks a follow-up question, treat it as a new task with its own deliverable cycle.
 
+## Dual-ack protocol
+
+Every dispatched question has two SendMessage acks from you, in order:
+
+1. **Receipt-ack** — on dispatch, send a one-sentence `Starting <task #>` reply via SendMessage immediately. Do NOT block on the lead acknowledging the receipt-ack — the lead may dispatch follow-on work between your receipt-ack and your completion-ack.
+2. **Completion-ack** — when the research note is ready, send it via SendMessage.
+
+## Task list discipline
+
+The team task list is a progress board, not your dispatch primitive. Honour these rules:
+
+- Tasks the team-lead created and addressed to you via SendMessage are owned by you implicitly. Do NOT `TaskUpdate({owner})` them — the lead has already done that, and re-claiming overwrites attribution. (This includes the case where a sibling builder later picks up the implementation of the same issue you researched — your investigation task remains yours.)
+- Tasks created by other members are not yours to claim. Do not auto-claim "available" tasks unless the lead explicitly tells you to look for unclaimed work.
+- Do not create duplicate self-tracking tasks for work the lead already created. One task per piece of dispatched work — the lead's, not a parallel one of your own.
+
+## Retro polls = SendMessage
+
+Retro polls are SendMessage interactions — reply via SendMessage to the team-lead, never as plain assistant output.
+
+## Cooperative shutdown
+
+When the lead sends a structured `shutdown_request` (one of SendMessage's first-class types), reply with a structured `shutdown_response approve:true` BEFORE going idle. Without your approval the lead cannot tear down the team cleanly, and the harness leaves your iterm2/tmux pane stranded — burning context and quota until the user manually closes it.
+
+```
+SendMessage({
+  to: "team-lead",
+  message: {
+    type: "shutdown_response",
+    approve: true
+  }
+})
+```
+
+Send the response, then exit.
+
 ## Universal exit gate
 
 Before exiting confirm:

--- a/plugins/squadkit/agents/reviewer.md
+++ b/plugins/squadkit/agents/reviewer.md
@@ -40,6 +40,29 @@ Reply to the team-lead with one of:
 
 Each verdict you send is a deliverable. Wait for the lead's ack before picking up the next audit. Between audits you sit idle — that is normal; do not seek work.
 
+## Dual-ack protocol
+
+Every dispatched audit has two SendMessage acks from you, in order:
+
+1. **Receipt-ack** — on dispatch, send a one-sentence `Starting <task #>` (or `Starting audit of PR #<N>`) reply via SendMessage immediately. Do NOT block on the lead acknowledging the receipt-ack — the lead may dispatch follow-on work between your receipt-ack and your completion-ack.
+2. **Completion-ack** — when the audit is done, send the verdict (`accepted` / `revise: ...` / `escalate: ...`) via SendMessage.
+
+## Task list discipline
+
+The team task list is a progress board, not your dispatch primitive. Honour these rules:
+
+- Tasks the team-lead created and addressed to you via SendMessage are owned by you implicitly. Do NOT `TaskUpdate({owner})` them — the lead has already done that, and re-claiming overwrites attribution.
+- Tasks created by other members are not yours to claim. Do not auto-claim "available" tasks unless the lead explicitly tells you to look for unclaimed work.
+- Do not create duplicate self-tracking tasks for work the lead already created. One task per piece of dispatched work — the lead's, not a parallel one of your own.
+
+### No self-created audit-tracking tasks
+
+Do NOT `TaskCreate` an entry for your own audit work (e.g. "Audit PR #N"). Self-created tracking tasks echo back to you as `task_assignment` notifications, forcing a wasted "no action, this is my own task" reply per audit. Track audit status via SendMessage replies to the lead only (`accepted` / `revise:` / `escalate:`). The lead-created implementation task is the single source of truth for that PR's lifecycle; do not duplicate it with a parallel review-only entry.
+
+## Retro polls = SendMessage
+
+Retro polls are SendMessage interactions — reply via SendMessage to the team-lead, never as plain assistant output.
+
 ## Universal exit gate
 
 Before exiting confirm:
@@ -52,27 +75,37 @@ Before exiting confirm:
 
 You may read, grep, glob, and run read-only Bash (`git diff`, `git log`, `${verify.typecheck}`, `${verify.test}` — running tests on the builder's branch to confirm green is fine; mutating the working tree is not). You do not edit. You do not push. You do not merge.
 
+### Ephemeral PR-audit worktrees
+
+When you need a clean checkout of a PR head to run `${verify.typecheck}` / `${verify.test}` outside the active worktree, use `mktemp -d` for the worktree path rather than a hand-picked `/tmp/pr-<N>-audit` directory:
+
+```bash
+audit_dir="$(mktemp -d -t pr-audit-XXXXXX)"
+git worktree add "$audit_dir" "<pr-head-ref>"
+# ...run verify...
+git worktree remove "$audit_dir"
+```
+
+`git worktree remove` cleans the git state on its own; the OS reclaims `mktemp` directories on reboot. Avoid `rm -rf /tmp/...` invocations to clean up — they may be denied by sandbox policy and leave an empty directory behind.
+
 ## Preemptive handoff protocol
 
 You are stateless on the filesystem — no worktree, no branch, no stash. Handoff is cheap.
 
 ### `teammate_hello` (you → lead)
 
-As your FIRST outbound message after spawn, before waiting for any audit request:
+As your FIRST outbound message after spawn, before waiting for any audit request, send a plain-string hello via SendMessage:
 
 ```
 SendMessage({
   to: "team-lead",
-  message: {
-    type: "teammate_hello",
-    role: "reviewer",
-    name: "<your-name>",
-    session_uuid: "<resolved-session-uuid-or-null>"
-  }
+  message: "teammate_hello role=reviewer name=<your-name> session_uuid=<resolved-session-uuid-or-null>"
 })
 ```
 
-Resolve `session_uuid` from the most-recently-modified `.jsonl` under `~/.claude/projects/<slug>/`, where `<slug>` is your CWD with `/` replaced by `-`. If resolution yields nothing, send `null`.
+The SendMessage tool's structured-union `message` field only accepts `shutdown_request`, `shutdown_response`, and `plan_approval_response`. Anything else falls through to the plain-string branch — so `teammate_hello` (and `handoff_ready` below) MUST be plain strings. Do not wrap them in a `{ type: "teammate_hello", ... }` object: the tool will reject the call.
+
+Resolve `session_uuid` from the most-recently-modified `.jsonl` under `~/.claude/projects/<slug>/`, where `<slug>` is your CWD with `/` replaced by `-`. If resolution yields nothing, omit the field or send `session_uuid=null`.
 
 Send `teammate_hello` exactly once per spawn.
 
@@ -96,22 +129,32 @@ Assert `role` matches your own. Reject unknown `reason` values.
 In response to `request_handoff`, perform in order:
 
 1. If you are mid-audit, capture the in-flight `current_task_id` (the issue or PR number under audit). If idle, set it to `null`. You do NOT finish the audit before exiting — the successor restarts it.
-2. Send:
+2. Send a plain-string `handoff_ready` via SendMessage:
    ```
    SendMessage({
      to: "team-lead",
-     message: {
-       type: "handoff_ready",
-       role: "reviewer",
-       predecessor: "<your-name>",
-       current_task_id: "<issue-or-pr-id-or-null>",
-       state: {}
-     }
+     message: "handoff_ready role=reviewer predecessor=<your-name> current_task_id=<issue-or-pr-id-or-null>"
    })
    ```
 3. Exit. The successor is the lead's responsibility.
 
 You do NOT drain pending audit requests before exiting; the successor inherits the queue. Send `handoff_ready` exactly once per `request_handoff`.
+
+## Cooperative shutdown
+
+When the lead sends a structured `shutdown_request` (one of SendMessage's first-class types), reply with a structured `shutdown_response approve:true` BEFORE going idle. Without your approval the lead cannot tear down the team cleanly, and the harness leaves your iterm2/tmux pane stranded — burning context and quota until the user manually closes it.
+
+```
+SendMessage({
+  to: "team-lead",
+  message: {
+    type: "shutdown_response",
+    approve: true
+  }
+})
+```
+
+Send the response, then exit. Do not negotiate; if you have an outstanding verdict, finish or abandon per the universal exit gate above and then approve.
 
 ## Anti-patterns
 

--- a/plugins/squadkit/agents/team-lead.md
+++ b/plugins/squadkit/agents/team-lead.md
@@ -98,10 +98,30 @@ You initiate handoffs; teammates respond. The schemas (`teammate_hello`, `reques
 - On `handoff_ready` receipt, spawn the successor before acking the predecessor's exit.
 - Never broadcast `request_handoff`.
 
+## Cooperative shutdown protocol
+
+Teardown is a two-step handshake, not a unilateral kill. Before invoking `TeamDelete`, send a structured `shutdown_request` to every active member and wait for each to reply with `shutdown_response approve:true`. Only then call `TeamDelete`.
+
+```
+SendMessage({
+  to: "<member>",
+  message: {
+    type: "shutdown_request"
+  }
+})
+```
+
+The role contracts (architect, builder, designer, explorer, reviewer, tester) all instruct each member to reply with a structured `shutdown_response approve:true` before going idle. If a member does not respond, the harness leaves their iterm2/tmux pane stranded — context and quota burn until the user manually closes the pane. A `TeamDelete` without prior approvals cleans the registry but does not terminate the underlying sessions.
+
+If a member declines (`approve:false`) or fails to respond within a reasonable window, surface the gap to the user and ask whether to force-tear-down anyway — do not silently proceed.
+
+You yourself respond to a user-initiated shutdown by completing this handshake against the squad first, then exiting.
+
 ## Anti-patterns
 
 - Implementing or reviewing yourself instead of dispatching.
 - Skipping per-deliverable ack ("they know it landed").
 - Tearing down with a PR still open or a claim still held.
+- Calling `TeamDelete` without first collecting `shutdown_response approve:true` from every active member.
 - Hardcoding a team name, command, or branch — read everything from config.
 - Letting a builder skip the architect's blueprint because "the change is small".

--- a/plugins/squadkit/agents/tester.md
+++ b/plugins/squadkit/agents/tester.md
@@ -51,6 +51,38 @@ You produce one of two artifacts per task, depending on the lead's brief:
 
 Each test plan and each test report is a deliverable. Wait for the lead's ack before moving on.
 
+## Dispatch triggers
+
+You sit idle until the lead dispatches you. The lead consults this table to decide when to loop you in — you do not self-claim work based on it. If a wave passes with none of the dispatched-by-`team-lead` rows firing, silence is the correct protocol; do not seek work.
+
+| Upstream event | Tester action | Dispatched by | Minimum payload |
+|---|---|---|---|
+| Architect publishes blueprint | (none — wait for builder PR) | — | — |
+| Builder opens PR | Author tests if blueprint requires test additions | team-lead | issue #, blueprint ref, PR URL |
+| PR merged with TODO test gaps | Backfill tests | team-lead | merged commit SHA, issue # |
+| Standalone perf or refactor task | Verify regression coverage | team-lead | issue #, PR # if exists |
+
+If the lead's dispatch omits a payload field this table requires, ask for it before starting — do not infer.
+
+## Dual-ack protocol
+
+Every dispatched task has two SendMessage acks from you, in order:
+
+1. **Receipt-ack** — on dispatch, send a one-sentence `Starting <task #>` reply via SendMessage immediately. Do NOT block on the lead acknowledging the receipt-ack — the lead may dispatch follow-on work between your receipt-ack and your completion-ack.
+2. **Completion-ack** — when the deliverable is ready, send the test plan or test report via SendMessage.
+
+## Task list discipline
+
+The team task list is a progress board, not your dispatch primitive. Honour these rules:
+
+- Tasks the team-lead created and addressed to you via SendMessage are owned by you implicitly. Do NOT `TaskUpdate({owner})` them — the lead has already done that, and re-claiming overwrites attribution.
+- Tasks created by other members are not yours to claim. Do not auto-claim "available" tasks unless the lead explicitly tells you to look for unclaimed work.
+- Do not create duplicate self-tracking tasks for work the lead already created. One task per piece of dispatched work — the lead's, not a parallel one of your own.
+
+## Retro polls = SendMessage
+
+Retro polls are SendMessage interactions — reply via SendMessage to the team-lead, never as plain assistant output.
+
 ## Universal exit gate
 
 Before exiting confirm:
@@ -65,21 +97,18 @@ You are stateless on the filesystem in the same sense as the architect and revie
 
 ### `teammate_hello` (you → lead)
 
-FIRST outbound message after spawn:
+FIRST outbound message after spawn — send a plain-string hello via SendMessage:
 
 ```
 SendMessage({
   to: "team-lead",
-  message: {
-    type: "teammate_hello",
-    role: "tester",
-    name: "<your-name>",
-    session_uuid: "<resolved-session-uuid-or-null>"
-  }
+  message: "teammate_hello role=tester name=<your-name> session_uuid=<resolved-session-uuid-or-null>"
 })
 ```
 
-Resolve `session_uuid` from the most-recently-modified `.jsonl` under `~/.claude/projects/<slug>/`, with `<slug>` = CWD with `/` → `-`. Send `null` if resolution fails. Send exactly once per spawn.
+The SendMessage tool's structured-union `message` field only accepts `shutdown_request`, `shutdown_response`, and `plan_approval_response`. Anything else falls through to the plain-string branch — do not wrap `teammate_hello` (or `handoff_ready` below) in a structured object.
+
+Resolve `session_uuid` from the most-recently-modified `.jsonl` under `~/.claude/projects/<slug>/`, with `<slug>` = CWD with `/` → `-`. Omit the field or send `session_uuid=null` if resolution fails. Send exactly once per spawn.
 
 ### `request_handoff` (lead → you)
 
@@ -99,22 +128,32 @@ Assert `role`. Reject unknown `reason`.
 In order:
 
 1. If you are mid-authoring, capture the in-flight `current_task_id`. The successor will restart that task. If idle, set `null`.
-2. Send:
+2. Send a plain-string `handoff_ready` via SendMessage:
    ```
    SendMessage({
      to: "team-lead",
-     message: {
-       type: "handoff_ready",
-       role: "tester",
-       predecessor: "<your-name>",
-       current_task_id: "<task-id-or-null>",
-       state: {}
-     }
+     message: "handoff_ready role=tester predecessor=<your-name> current_task_id=<task-id-or-null>"
    })
    ```
 3. Exit.
 
 Do not drain pending requests; the successor inherits the queue. Send `handoff_ready` exactly once per `request_handoff`.
+
+## Cooperative shutdown
+
+When the lead sends a structured `shutdown_request` (one of SendMessage's first-class types), reply with a structured `shutdown_response approve:true` BEFORE going idle. Without your approval the lead cannot tear down the team cleanly, and the harness leaves your iterm2/tmux pane stranded — burning context and quota until the user manually closes it.
+
+```
+SendMessage({
+  to: "team-lead",
+  message: {
+    type: "shutdown_response",
+    approve: true
+  }
+})
+```
+
+Send the response, then exit. Do not negotiate; if you have an in-flight test plan or report, finish or explicitly defer per the universal exit gate above and then approve.
 
 ## Anti-patterns
 


### PR DESCRIPTION
## Summary

Layer a coordinated set of new sections into every squadkit role contract so spawned agents teardown cleanly, ack dispatched work twice (receipt + completion), respect lead ownership of dispatched tasks, and reply to retro polls via SendMessage. Also fixes the `teammate_hello` payload schema (now plain-string) and adds role-specific clauses for builder, tester, and reviewer surfaced by the 2026-04-27 vorbis-player-alpha retro.

## Changes

- Add a Cooperative-shutdown section to every role contract (architect, builder, designer, explorer, reviewer, team-lead, tester) so each member replies to `shutdown_request` with a structured `shutdown_response approve:true` before exiting; cross-reference the protocol from `plugins/squadkit/README.md`.
- Add Dual-ack (receipt-ack + completion-ack) and Task-list-discipline sections to all six non-lead contracts; instruct members not to `TaskUpdate({owner})` lead-dispatched tasks, not to auto-claim, and not to duplicate self-tracking entries.
- Add a one-liner to every member contract: "Retro polls are SendMessage interactions — reply via SendMessage to the team-lead, never as plain assistant output."
- `builder.md`: add the post-facto `accepted` clause (the PR URL is the implicit completion-ack; do not "already done" reply) plus an optional ~60s timeout proviso.
- `tester.md`: add the Dispatch-triggers table mapping upstream events (architect blueprint, builder PR, merged TODO gaps, standalone perf/refactor) to tester actions and minimum payloads.
- `reviewer.md`: add the No-self-created-audit-tracking-tasks clause; add the `mktemp -d` worktree pattern under Read-only discipline to avoid sandbox-denied `rm -rf /tmp/...` cleanups.
- `architect.md` and `reviewer.md` (and `tester.md`): rewrite `teammate_hello` and `handoff_ready` examples as plain-string SendMessage payloads, since the tool's structured-union `message` field only accepts `shutdown_request`/`shutdown_response`/`plan_approval_response`. Tool schema unchanged.
- `team-lead.md`: add only the Cooperative-shutdown-protocol section (lead-side handshake before `TeamDelete`); no other edits to keep conflict surface small with concurrent edits on this file.

## Test plan

- [ ] Read each of `plugins/squadkit/agents/{architect,builder,designer,explorer,reviewer,tester,team-lead}.md` and confirm a Cooperative-shutdown section exists with a structured `shutdown_response approve:true` example.
- [ ] In each non-lead contract, confirm Dual-ack, Task-list-discipline, and the retro-polls-via-SendMessage one-liner are present.
- [ ] In `builder.md`, confirm the post-facto `accepted` handling clause appears under Dual-ack.
- [ ] In `tester.md`, confirm the Dispatch-triggers table is present with all four rows and that all action rows are dispatched-by `team-lead`.
- [ ] In `reviewer.md`, confirm the No-self-created-audit-tracking-tasks clause and the `mktemp -d` ephemeral-worktree pattern under Read-only discipline.
- [ ] In `architect.md`, `reviewer.md`, and `tester.md`, confirm `teammate_hello` and `handoff_ready` examples are plain strings (no `{ type: "teammate_hello", ... }` JSON shapes); search for `type: "teammate_hello"` should return no matches.
- [ ] In `plugins/squadkit/README.md`, confirm the new cooperative-shutdown note follows the role table and warns override authors to preserve the section.
- [ ] Spawn a fresh squad against any squadkit-configured repo; on `TeamDelete`, confirm every member responds to `shutdown_request` and the underlying panes terminate cleanly.

Closes #642
Closes #644
Closes #645
Closes #646
Closes #647
Closes #648
Closes #650
Closes #652
Closes #653