### PR TITLE
fix(flowkit:release): include squadkit and vaultkit in PLUGINS list

### DIFF
--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -162,7 +162,9 @@ PLUGINS="flowkit
 speckit
 swarmkit
 sessionkit
-polishkit"
+polishkit
+squadkit
+vaultkit"
 
 GROUPED_CHANGES_FILE=$(mktemp)
 printf '%s\n' "$PLUGINS" | while read PLUGIN; do


### PR DESCRIPTION
## Summary
- Append `squadkit` and `vaultkit` to the hardcoded `PLUGINS` list in `flowkit:release` SKILL.md so commits scoped `(squadkit)` / `(vaultkit)` are grouped under named headings instead of falling through to `**other**` in the release PR body.
- Backfill PR #662's body to reflect the corrected grouping (squadkit/vaultkit commits moved from `**other**` to their named groups).

## Test plan
- Inspect `plugins/flowkit/skills/release/SKILL.md`: the `PLUGINS` value lists all 7 plugin scopes from `.claude-plugin/marketplace.json` in newline-delimited form.
- Inspect PR #662's edited body: squadkit/vaultkit commits now appear under `**squadkit**` / `**vaultkit**` headings; `**other**` no longer contains those commits.

Closes #663