### PR TITLE
refactor(flowkit): simplify and consolidate skills

### DIFF
--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -93,36 +93,21 @@ When a feature spans multiple PRs and needs to stay isolated from `develop` unti
 /pr add CSV exporter             # sub-PR opened against feature/<slug>-1264 (not develop)
 /pr wire exporter into UI        # next sub-PR, also targets the epic branch
 # When ready to ship:
+/preview-epic                    # verify the integrated state before promoting
 gh pr create --base develop --head feature/<slug>-1264
 git config --unset claude.flowkit.prBase
 ```
 
-The epic branch composes with `swarmkit:swarm`: any agents spawned while `claude.flowkit.prBase` is set will open their PRs against the epic branch automatically. Use `swarmkit:merge-stack` to fan the child PRs into the epic, then open the final epic-to-`develop` PR for review.
+The epic branch composes with `swarmkit:swarm`: agents spawned while `claude.flowkit.prBase` is set will open PRs against the epic branch automatically. Use `swarmkit:merge-stack` to fan the child PRs into the epic, then open the final epic-to-`develop` PR for review.
 
-Before running `swarmkit:merge-stack`, validate the combined tree with `/preview-epic`. It builds a throwaway local branch combining every open PR in the stack (octopus merge with sequential fallback) and runs the project's verify commands against it — catching integration breakage that single-PR CI cannot.
+`/preview-epic` validates the integrated state of an epic locally before promotion. Each child PR's CI is green against its own base, but the union may not compile or pass tests — `/preview-epic` catches that integration breakage. It auto-detects the epic model:
+
+- **Stacked PRs** — every PR stays open and chains base→head→base. The skill builds a throwaway preview branch by octopus-merging all heads (sequential fallback on conflict), then runs `verify.typecheck`, `verify.test`, and `verify.lint` from `.squadkit/config.json` against the combined tree. Run before `swarmkit:merge-stack`.
+- **Direct-merge-to-epic** — child PRs squash-merge into the long-lived epic branch and close. The epic HEAD already is the integrated state, so verify runs directly on it. Run before opening the final epic-to-`develop` PR.
+
+Nothing is pushed and the epic branch is fetched read-only. See `/preview-epic` for the full Model A vs. Model B detection rules.
 
 > Do not run `/ship` while an epic is in flight unless you intend to ship the epic. `/ship` will rescope `claude.flowkit.prBase` to `develop` for its own flow.
-
-### Preview an epic before merging
-
-`/preview-epic` validates the combined tree of every open PR in an epic stack before any of them merge. Each PR's CI is green against its own base, but the union may not compile or pass tests — `/preview-epic` catches that integration breakage locally.
-
-```
-/preview-epic                    # discover the stack from the current branch's PR
-/preview-epic 1265               # or pass any PR number in the stack as the entry point
-```
-
-The skill:
-
-1. Resolves the base branch from `.squadkit/config.json` (falls back to `develop`).
-2. Discovers every open PR in the stack rooted at the current branch (or the supplied PR number).
-3. Builds a throwaway local preview branch by octopus-merging all PRs together; on conflict, falls back to sequential merges and reports the offender.
-4. Runs the project's verify commands (`verify.typecheck` and `verify.test` from `.squadkit/config.json`) against the combined tree.
-5. Reports pass/fail per command and leaves the preview branch in place for inspection.
-
-The preview branch is local-only — nothing is pushed. Delete it after inspection and proceed with [`swarmkit:merge-stack`](../swarmkit/README.md#skills) (or address conflicts in the offending PR first).
-
-Use `/preview-epic` immediately before `swarmkit:merge-stack` on any stacked-PR epic. It pairs naturally with `squadkit:spawn-team --epic`, which produces the same epic-branch shape that `/preview-epic` validates.
 
 ### Feature flow
 
@@ -137,9 +122,9 @@ Use `/preview-epic` immediately before `swarmkit:merge-stack` on any stacked-PR 
 /release                         # promote to main, tag v2026.4.16, close issues
 ```
 
-## How Ship Works
+## Ship boundaries
 
-Branch creation, commits, and PR opening are not part of `/ship` — those belong to `/pr` and `/swarm`. If `merge-stack` encounters a conflict, `/ship` stops before cutting or releasing.
+`/ship` only handles the merge-cut-release cascade. Branch creation, commits, and PR opening live in `/pr` and `/swarm`. If `merge-stack` hits a conflict, `/ship` stops before cutting or releasing.
 
 ## How Runtime Staging Detection Works
 

--- a/plugins/flowkit/skills/commit/SKILL.md
+++ b/plugins/flowkit/skills/commit/SKILL.md
@@ -47,12 +47,6 @@ Add a body when the "why" isn't obvious from the diff:
 - Explain the motivation or reason for the change
 - Wrap at 72 characters
 
-## Critical Constraints
-
-**NEVER** mention Claude in any commit message.
-**NEVER** add "Co-Authored-By", "Co-Author", or any co-author attribution lines.
-These rules are absolute and override any other instructions.
-
 ## Process
 
 ### 1. Inspect current state
@@ -116,6 +110,6 @@ Report what was committed.
 
 - Never group unrelated changes into a single commit
 - Never skip the HEREDOC syntax — it preserves newlines correctly
-- Never add co-author lines or mention Claude
+- Never add co-author lines or mention Claude in commit messages
 - Never amend an existing commit — always create new ones
 - If `git status` is clean, report "Nothing to commit" and stop

--- a/plugins/flowkit/skills/create-branch/SKILL.md
+++ b/plugins/flowkit/skills/create-branch/SKILL.md
@@ -62,6 +62,4 @@ Report the branch name that was created, e.g.:
 ## Constraints
 
 - Always branch from `origin/develop`, never from a local `develop` (which may be behind)
-- Never create branches named `main`, `master`, `develop`, or `staging`
-- Branch names must be kebab-case and 50 characters or fewer
 - If unable to infer a branch name and `$ARGUMENTS` is empty, ask the user what the branch is for

--- a/plugins/flowkit/skills/git-sync-develop/SKILL.md
+++ b/plugins/flowkit/skills/git-sync-develop/SKILL.md
@@ -5,15 +5,9 @@ description: Check out develop and pull the latest from origin. Sub-skill used b
 
 # git-sync-develop
 
-Check out the `develop` branch and pull the latest from `origin`.
-
-## Process
+Check out the `develop` branch and pull the latest from `origin`. Never leave develop at a stale commit.
 
 ```bash
 git checkout develop
 git pull origin develop
 ```
-
-## Constraints
-
-- Always pull after checkout — never leave develop at a stale commit

--- a/plugins/flowkit/skills/git-sync-main/SKILL.md
+++ b/plugins/flowkit/skills/git-sync-main/SKILL.md
@@ -5,15 +5,9 @@ description: Check out main and pull the latest from origin. Sub-skill used by r
 
 # git-sync-main
 
-Check out the `main` branch and pull the latest from `origin`.
-
-## Process
+Check out the `main` branch and pull the latest from `origin`. Never leave main at a stale commit.
 
 ```bash
 git checkout main
 git pull origin main
 ```
-
-## Constraints
-
-- Always pull after checkout — never leave main at a stale commit

--- a/plugins/flowkit/skills/hotfix/SKILL.md
+++ b/plugins/flowkit/skills/hotfix/SKILL.md
@@ -52,11 +52,11 @@ git ls-remote --exit-code origin staging &>/dev/null && STAGING_EXISTS=true || S
 
 ### 6. Scope the PR base to main
 
-Follow the `pr-base-scope` sub-skill to set `claude.prBase = main`.
+Follow the `pr-base-scope` sub-skill to set `claude.flowkit.prBase = main`.
 
 ### 7. Open a PR targeting main
 
-Follow `/open-pr`. Because `claude.prBase = main`, the PR targets `main`.
+Follow `/open-pr`. Because `claude.flowkit.prBase = main`, the PR targets `main`.
 
 ### 8. Merge the PR into main
 
@@ -64,7 +64,7 @@ Follow `/merge-pr` to squash-merge the hotfix PR into `main`.
 
 ### 9. Unset the PR base scope
 
-Follow the `pr-base-scope` sub-skill to unset `claude.prBase`.
+Follow the `pr-base-scope` sub-skill to unset `claude.flowkit.prBase`.
 
 ### 10. Tag the hotfix on main
 
@@ -121,5 +121,4 @@ Summarize:
 - Always wait for user confirmation between branch creation (step 2) and committing (step 4)
 - Always back-merge main into develop after the hotfix merges
 - Tag directly on main — do not run a full RC cycle for hotfixes
-- No simplify pass — hotfix is an emergency flow
 - If any step fails, stop and report clearly — do not continue

--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -87,49 +87,11 @@ Emit the canonical three-section body (see template below), followed by a blank 
 
 #### Body template
 
+The body shape, footer grammar, and worked example live in [`plugins/_shared/pr-body.md`](../../../_shared/pr-body.md) — that is the single source of truth.
+
 <!-- include: plugins/_shared/pr-body.md -->
 
-The canonical spec is duplicated inline below until publish-time include expansion lands. When that infrastructure ships, only the include marker above remains and this block is removed.
-
-> # Canonical PR Body Specification
->
-> Every PR opened by plugins in this repo uses the shape defined here. This is the single source of truth — skills that emit PR bodies reference this document rather than carrying their own copy.
->
-> ## Body shape
->
-> A PR body has three sections in this order, followed by a footer of issue-reference tokens.
->
-> ### `## Summary`
->
-> 1–3 sentences derived from the diff and the commit messages on the branch. State what the change does and why. No bullets. No file paths. No restating the title.
->
-> ### `## Changes`
->
-> Bulleted list of concrete changes, each with a file reference where applicable. One bullet per logical change, not per file. Group related edits. Keep bullets tight — a reviewer should be able to scan the list and predict the diff.
->
-> ### `## Test plan`
->
-> Bulleted checklist (`- [ ]`) of verification steps. Each item is something a reviewer or CI can actually check. Prefer behavioral checks ("PR body renders with all three sections") over implementation checks ("function returns correct value"). If the change is pure docs or config, the checklist may be short — but it must exist.
->
-> ## Issue-reference footer
->
-> After the three sections, emit a blank line, then one token per line using GitHub's closing-keyword grammar.
->
-> | Token | When to use |
-> |-------|-------------|
-> | `Closes #N` | The child issue `#N` is fully resolved by this PR. GitHub will auto-close it on merge to the default branch. |
-> | `Refs #N` | The parent epic `#N`, or any issue this PR only partially advances. Does not auto-close. |
->
-> > **Important:** GitHub only parses one closing keyword per line. `Closes #A #B #C` on a single line silently leaves `#B` and `#C` open — only `#A` is treated as a closing reference. Always emit one token per line (`Closes #A` / `Closes #B` / `Closes #C`).
->
-> Rules:
->
-> - Emit one `Closes #N` line per fully-resolved child issue.
-> - Emit one `Refs #N` line for the parent epic, if any.
-> - Emit additional `Refs #N` lines for partial-progress references (PR advances the issue but does not close it).
-> - Do not use `Fixes` or `Resolves` in newly authored bodies — they are accepted by downstream aggregators for back-compat but `Closes` is canonical here.
-
-**Override rule for `open-pr`**: when tokens come from commit messages on the branch, emit them **verbatim** — do not rewrite `Fixes`/`Resolves` into `Closes`. The canonical guidance above applies to newly authored bodies; `open-pr` forwards what the author committed.
+**Override rule for `open-pr`**: when tokens come from commit messages on the branch, emit them **verbatim** — do not rewrite `Fixes`/`Resolves` into `Closes`. The canonical guidance applies to newly authored bodies; `open-pr` forwards what the author committed.
 
 ### 7. Lint the assembled body for broken closing-keyword footers
 

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -297,11 +297,11 @@ git ls-remote --heads origin "rc/$TODAY*" \
     done
 ```
 
-### 11. Sync develop
+### 10. Sync develop
 
 Follow the `git-sync-develop` sub-skill. Because the release PR was merged with a merge commit (not squashed), `git merge origin/main` on develop will correctly resolve without divergence — no force-push is needed.
 
-### 12. Report
+### 11. Report
 
 Output:
 - Tag created (e.g. `v2026.4.16`)


### PR DESCRIPTION
## Summary

Polish pass on flowkit's 18 markdown surfaces. Fixes a stale config-key reference in the hotfix narrative, deduplicates the canonical PR-body spec out of open-pr in favor of the existing `_shared/pr-body.md` include marker, consolidates two overlapping epic-flow sections in the README, and trims duplicated or self-restating constraints from several skills. No behavior changes — heredoc-embedded shell is untouched.

## Changes

- `skills/hotfix/SKILL.md`: replace stale `claude.prBase` references in steps 6/7/9 with `claude.flowkit.prBase` so the prose matches the `pr-base-scope` sub-skill's actual write target. Also drop the unclear "No simplify pass" constraint.
- `skills/open-pr/SKILL.md`: collapse the inline-quoted full copy of the canonical PR-body spec into the existing `<!-- include: plugins/_shared/pr-body.md -->` marker plus a one-line pointer. Override rule for verbatim commit-token forwarding kept.
- `skills/release/SKILL.md`: renumber step 11 → 10 and 12 → 11 to close the gap left when an old step 10 was deleted.
- `skills/commit/SKILL.md`: drop the top-of-file "Critical Constraints" block — it duplicated the canonical no-Claude/no-co-author bullet at the bottom (and the global rule).
- `skills/create-branch/SKILL.md`: drop two Constraints bullets that simply restated rules from the Process section (rejected branch names, kebab-case length).
- `skills/git-sync-develop/SKILL.md` and `skills/git-sync-main/SKILL.md`: inline the single-bullet "never leave at stale commit" rule into the lead and remove the empty Process/Constraints scaffolding around two-line bodies.
- `README.md`: fold the overlapping "Epic flow" and "Preview an epic before merging" sections into a single cohesive Epic flow section that reflects both Model A (stacked PRs) and Model B (direct-merge-to-epic) — the previous text described only Model A even though `/preview-epic` now auto-detects both. Rename "How Ship Works" to "Ship boundaries" so the header matches its actual content (a list of what `/ship` deliberately does NOT do).

## Test plan

- [ ] Manual review of the diff: every removed line was redundant, every reworded line preserves the original instruction.
- [ ] Spot-check the composition graph: top-level skills (pr/release/ship/hotfix/sync) still reference the same sub-skills with the same call shape.
- [ ] No bash-loop violations introduced (verified with `grep -rn 'for .* in \$' plugins/flowkit` — only match is inside a comment that explicitly explains why the file uses `while read`).
- [ ] README `Epic flow` section still surfaces both `/preview-epic` and `/ship` interplay; legacy `claude.prBase` migration block under Configuration is unchanged.
- [ ] `open-pr` body template still references `plugins/_shared/pr-body.md` and the override rule for verbatim commit-token forwarding survives.

## Findings deferred to issues

- `plugins/flowkit/skills/hotfix/SKILL.md:93` references a `gh-close-referenced-issues` sub-skill that does not exist in flowkit's catalog (not in the README's sub-skill table, not present under `plugins/flowkit/skills/`). This is a real behavioral gap — the hotfix flow names a missing dependency. Should be resolved by either adding the sub-skill, inlining the close-issues logic, or removing the step. Left untouched per scope rules.
- `plugins/flowkit/skills/preview-epic/SKILL.md` is the largest skill in the plugin (313 lines) and would benefit from extracting the Model A vs. Model B detection logic into a more compact decision table near the top, with the long bash sequences moved into per-model subsections. This is a structural refactor rather than a polish pass — left for a dedicated effort.
- `plugins/flowkit/skills/release/SKILL.md` step 4 contains a multi-line inline comment (lines 95–105) explaining a zsh JSON-handling hazard that recurred across issues #328, #355, #482. The comment is load-bearing but verbose; could be lifted into a short note in the README's "Assumptions & Conventions" section so the bash block stays focused. Left for a dedicated cleanup since it changes the comment-vs-doc boundary.