### PR TITLE
fix(flowkit:hotfix): drop dangling step 11 — issues auto-close on main merge

### DIFF
--- a/plugins/flowkit/skills/hotfix/SKILL.md
+++ b/plugins/flowkit/skills/hotfix/SKILL.md
@@ -88,11 +88,9 @@ git push origin "$COMPANION"
 
 The annotation message preserves the "hotfix" signal for `git tag -n` queries; the companion tag keeps the canonical version tag clean while still flagging the commit as an emergency fix.
 
-### 11. Close referenced issues
+Referenced issues auto-close at merge time: `/open-pr` discovers `Closes #N` tokens from branch commits and emits them in the PR body footer (open-pr step 5). When the hotfix PR merges into `main` (the default branch), GitHub closes those references automatically — no explicit close step is needed.
 
-Follow the `gh-close-referenced-issues` sub-skill, passing the merged PR number.
-
-### 12. Back-merge main into develop
+### 11. Back-merge main into develop
 
 Keep `develop` in sync with the hotfix:
 
@@ -104,11 +102,11 @@ git merge --no-ff origin/main -m "chore(develop): back-merge hotfix from main"
 git push origin develop
 ```
 
-### 13. Sync develop
+### 12. Sync develop
 
 Follow the `git-sync-develop` sub-skill to confirm a clean local develop state.
 
-### 14. Report
+### 13. Report
 
 Summarize:
 - Hotfix PR merged into main


### PR DESCRIPTION
## Summary

`hotfix/SKILL.md` step 11 instructed the agent to follow a `gh-close-referenced-issues` sub-skill that never existed. The step was redundant on top of being broken: `/open-pr` already discovers `Closes #N` tokens from branch commits and writes them to the PR body footer, and GitHub auto-closes those references when the hotfix PR merges into `main` (the default branch). Replace the dangling reference with a one-line note explaining the auto-close behavior, and renumber subsequent steps.

## Changes

- Remove `### 11. Close referenced issues` block from `plugins/flowkit/skills/hotfix/SKILL.md` (the phantom sub-skill reference).
- Add a one-line note after the tag step explaining that `Closes #N` tokens from `/open-pr` step 5 auto-close on main merge.
- Renumber steps 12 → 11, 13 → 12, 14 → 13. The "Referenced issues closed" report bullet stays accurate.

## Test plan

- [ ] `hotfix/SKILL.md` no longer references `gh-close-referenced-issues`.
- [ ] Step numbering is contiguous (1–13) with no gap or duplicate.
- [ ] The auto-close note correctly cross-references `/open-pr` step 5.
- [ ] No other skill references `gh-close-referenced-issues` (none found).

Closes #666