### PR TITLE
refactor(sessionkit): simplify and consolidate skills

### DIFF
--- a/plugins/sessionkit/skills/get-session-id/SKILL.md
+++ b/plugins/sessionkit/skills/get-session-id/SKILL.md
@@ -14,24 +14,11 @@ This is an internal sub-skill. Called by other sessionkit skills — not typical
 
 ## Logic
 
+Claude Code stores per-session `.jsonl` files under `~/.claude/projects/<encoded-cwd>/`, where `<encoded-cwd>` is `$PWD` with every `/` replaced by `-`. The most recent file's basename (minus `.jsonl`) is the active session UUID.
+
 ```bash
 PROJECT_PATH=$(echo "$PWD" | sed 's|/|-|g')
 ls -t ~/.claude/projects/${PROJECT_PATH}/*.jsonl 2>/dev/null | head -1 | xargs basename -s .jsonl
 ```
 
-## How It Works
-
-1. Encode the current working directory (`$PWD`) by replacing all `/` with `-`
-2. List all session files in `~/.claude/projects/<encoded-path>/` sorted by modification time (newest first)
-3. Take the most recent file
-4. Extract the filename without the `.jsonl` extension — this is the session UUID
-
-## Output
-
-The session ID as a UUID string (e.g., `0400b9cb-7c5f-4721-8cb2-4bc61c38620d`).
-
-## Path Encoding Scheme
-
-The path encoding replaces `/` with `-`. For example:
-- `/Users/roman/src/my-project` → `Users-roman-src-my-project`
-- `/workspace/project` → `workspace-project`
+Output: a UUID string (e.g. `0400b9cb-7c5f-4721-8cb2-4bc61c38620d`).

--- a/plugins/sessionkit/skills/handoff/SKILL.md
+++ b/plugins/sessionkit/skills/handoff/SKILL.md
@@ -14,7 +14,7 @@ allowed-tools: Bash, Read, Write, TaskList, TaskGet, Skill, Agent
 
 Capture the current session's goal, progress, git state, remaining work, and key context into `<working-dir>/.sessionkit/HANDOFF.md` so another agent can pick up without losing momentum.
 
-This skill is optimized for **frequent invocation**. Run it after every meaningful state change — a PR opens, a task flips to `completed`, a key decision lands — not only when context is running low. The synthesis step is delegated to a Haiku sub-agent and skips sections whose inputs haven't changed since the last run, so the cost is small.
+Synthesis is delegated to a Haiku sub-agent and skips sections whose inputs haven't changed since the last run, so frequent invocation is cheap.
 
 ## Input
 
@@ -179,11 +179,6 @@ Report the absolute path of the file written, the skip-unchanged status (e.g. `r
 
 ## Constraints
 
-- Run as soon as a meaningful state change happens — frequent handoffs are cheap by design (skip-unchanged + Haiku sub-agent)
-- Bullets only in Progress, Remaining Work, and Context — no prose paragraphs
-- The `<!-- handoff-meta ... -->` header on line 1 is mandatory; step 1b reads it on the next run to decide what to skip
-- `.sessionkit/HANDOFF.md` in the working directory is the canonical location — never write elsewhere
 - Section order in HANDOFF.md is fixed: Goal → Progress → Git State → Remaining Work → Task List → Context
+- `.sessionkit/HANDOFF.md` in the working directory is the canonical location — never write elsewhere
 - Legacy HANDOFFs that lack a `## Task List` or meta header remain valid inputs to `/pickup` — their absence is not an error (the next run will simply regenerate everything)
-- Always Read `.sessionkit/HANDOFF.md` before overwriting it with Write — the Write tool refuses to overwrite paths it hasn't read in the current conversation
-- If the Haiku sub-agent fails, fall back to in-line synthesis and prepend a `<!-- handoff-warning: ... -->` line so the user knows the slow path was taken

--- a/plugins/sessionkit/skills/handoff/SKILL.md
+++ b/plugins/sessionkit/skills/handoff/SKILL.md
@@ -40,14 +40,14 @@ Also invoke `TaskList` to get all task IDs, then call `TaskGet` once per task ID
 
 ### 1a. Compute change fingerprints
 
-Build two short fingerprints used in step 1c to decide which sections to regenerate:
+Build two short fingerprints used in step 1b to decide which sections to regenerate:
 
 - `gitFingerprint` — `<HEAD-sha>:<sorted-staged-files-hash>:<sorted-unstaged-files-hash>`. A change in HEAD or in the working-tree file lists invalidates the Git State + Progress sections.
 - `taskFingerprint` — SHA-1 of the canonicalized (sorted by `id`, fields stripped to `id,subject,status,blockedBy`) Task List JSON. Any change invalidates the Task List + Remaining Work sections.
 
 Compute both in shell (e.g. `git rev-parse HEAD`, `printf %s "$json" | shasum -a 1 | cut -d' ' -f1`).
 
-### 1c. Skip-unchanged check
+### 1b. Skip-unchanged check
 
 If `.sessionkit/HANDOFF.md` already exists, Read it and look for an HTML comment header of the form:
 
@@ -75,7 +75,7 @@ Invoke the `Agent` tool with:
   2. The conversation context summary (recent goal, decisions, gotchas — bullet form, no prose).
   3. The raw outputs from step 1 (git fingerprints, file lists, recent commits, todo file contents).
   4. The Task List JSON from step 1.
-  5. Any sections from step 1c marked "reuse verbatim" with their existing content.
+  5. Any sections from step 1b marked "reuse verbatim" with their existing content.
   6. `$ARGUMENTS` if present.
   7. Explicit instructions: "Emit ONLY the markdown document. No commentary, no fences around the whole thing. Use bullets, not paragraphs, for Progress / Remaining Work / Context. Preserve the JSON code block for Task List exactly as given."
 
@@ -89,7 +89,7 @@ Invoke the `Agent` tool with:
 
 ### 2a. Strict template
 
-The sub-agent (or in-line fallback) must emit exactly this structure. **Bullets only** in Progress / Remaining Work / Context — no narrative paragraphs. The meta header on line 1 is mandatory and is what step 1c reads on the next run.
+The sub-agent (or in-line fallback) must emit exactly this structure. **Bullets only** in Progress / Remaining Work / Context — no narrative paragraphs. The meta header on line 1 is mandatory and is what step 1b reads on the next run.
 
 ```markdown
 <!-- handoff-meta gitFingerprint=<sha> taskFingerprint=<sha> -->
@@ -161,7 +161,7 @@ test -f .gitignore && grep -qE '^\.sessionkit/?$' .gitignore && echo "covered" |
 - **`.gitignore` present but not covered**: ask "`.gitignore` doesn't cover `.sessionkit/`. Append it? (yes/no)". On yes, append `.sessionkit/` to `.gitignore`. On no, proceed.
 - **Already covered**: proceed silently.
 
-If `.sessionkit/HANDOFF.md` already exists, Read it first (the Write tool requires a prior Read of the target path). Step 1c already did this when a prior file exists.
+If `.sessionkit/HANDOFF.md` already exists, Read it first (the Write tool requires a prior Read of the target path). Step 1b already did this when a prior file exists.
 
 Then create the directory and write the file:
 
@@ -181,7 +181,7 @@ Report the absolute path of the file written, the skip-unchanged status (e.g. `r
 
 - Run as soon as a meaningful state change happens — frequent handoffs are cheap by design (skip-unchanged + Haiku sub-agent)
 - Bullets only in Progress, Remaining Work, and Context — no prose paragraphs
-- The `<!-- handoff-meta ... -->` header on line 1 is mandatory; step 1c reads it on the next run to decide what to skip
+- The `<!-- handoff-meta ... -->` header on line 1 is mandatory; step 1b reads it on the next run to decide what to skip
 - `.sessionkit/HANDOFF.md` in the working directory is the canonical location — never write elsewhere
 - Section order in HANDOFF.md is fixed: Goal → Progress → Git State → Remaining Work → Task List → Context
 - Legacy HANDOFFs that lack a `## Task List` or meta header remain valid inputs to `/pickup` — their absence is not an error (the next run will simply regenerate everything)

--- a/plugins/sessionkit/skills/pickup/SKILL.md
+++ b/plugins/sessionkit/skills/pickup/SKILL.md
@@ -34,8 +34,6 @@ Then stop — do not proceed with the remaining steps.
 
 Read the full content of `.sessionkit/HANDOFF.md`. Parse the standard sections: **Project**, **Date**, **Branch**, **Goal**, **Progress**, **Git State**, **Remaining Work**, **Context**. Unknown headings are passed through unmodified — section parsing is open-ended, so any future or legacy section names (including the legacy `## Team State` block emitted by sessionkit ≤ 1.5.0) are silently ignored.
 
-> Note: handoffs written by sessionkit ≤ 1.5.0 may carry a `## Team State` section. `/pickup` ignores it intentionally — squadkit's `SessionStart` hook now reads `~/.claude/teams/*/config.json` directly and re-emits the role reminder, so the legacy artifact is inert, not a bug.
-
 ### 3. Present orientation summary
 
 Output a structured summary to orient the agent. Surface essentials, not the document verbatim:

--- a/plugins/sessionkit/skills/skillit/SKILL.md
+++ b/plugins/sessionkit/skills/skillit/SKILL.md
@@ -34,8 +34,8 @@ Identify at least one candidate pattern.
 Scan the skill library for potential overlap:
 
 ```bash
-find ~/.claude/skills -name "skill.md" 2>/dev/null
-find .claude/skills -name "skill.md" 2>/dev/null
+find ~/.claude/skills -name "SKILL.md" 2>/dev/null
+find .claude/skills -name "SKILL.md" 2>/dev/null
 find ~/.claude/commands -name "*.md" 2>/dev/null
 ```
 
@@ -61,8 +61,8 @@ Then offer the user a choice:
 On user agreement, create the skill file at the path they specify (or prompt for one):
 
 ```
-~/.claude/skills/<name>/skill.md          # user-global
-.claude/skills/<name>/skill.md            # project-local
+~/.claude/skills/<name>/SKILL.md          # user-global
+.claude/skills/<name>/SKILL.md            # project-local
 ```
 
 The skill file must include:

--- a/plugins/sessionkit/skills/suggest-permissions/SKILL.md
+++ b/plugins/sessionkit/skills/suggest-permissions/SKILL.md
@@ -32,20 +32,11 @@ Read the most recent session files and extract tool approval events.
 
 Scan for repeatedly approved operations across three categories:
 
-**Bash commands** — look for patterns like:
-- Package managers: `npm`, `yarn`, `pnpm`, `bun`, `pip`, `cargo`
-- VCS: `git`
-- Language runtimes: `node`, `python`, `ruby`, `go`
-- Project-specific scripts or directories
+- **Bash commands** — package managers, VCS, language runtimes, project-specific scripts.
+- **File edits** — source directories, file globs, config files.
+- **MCP tools** — any MCP tool approved more than once.
 
-**File edits** — look for patterns like:
-- Consistently approved source directories: `src/`, `lib/`, `app/`
-- File types: `*.ts`, `*.py`, `*.md`
-- Config files: `*.json`, `*.yaml`
-
-**MCP tools** — any MCP tool approved more than once in recent sessions.
-
-A pattern qualifies if it appears 2+ times across recent sessions, or if you can see the user approved it without hesitation.
+A pattern qualifies if it appears 2+ times across recent sessions, or if the user approved it without hesitation.
 
 ### 3. Propose additions
 


### PR DESCRIPTION
## Summary

Behavior-preserving polish pass on sessionkit. Trims doc bloat that restates code or restates the body in a Constraints section, fixes a casing bug in `skillit` that would cause its overlap survey to silently miss every existing skill on case-sensitive filesystems, and closes a sub-step numbering gap in `handoff`. No skill contracts, file formats, or sub-skill call shapes change.

## Changes

- `handoff/SKILL.md` — renumber `### 1c.` to `### 1b.` (no `1b.` previously existed); update five back-references.
- `handoff/SKILL.md` — drop five Constraints bullets that repeat rules already stated in the Process section (frequent invocation, bullets-only, mandatory meta header, prior-Read-before-Write, sub-agent fallback). Collapse the lead paragraph that restated the frontmatter description's "frequent invocation" pitch.
- `get-session-id/SKILL.md` — collapse "How It Works" / "Output" / "Path Encoding Scheme" sections that all narrated what the two-line bash already shows. Replace with a single lead sentence covering the encoding scheme plus a one-line output note.
- `pickup/SKILL.md` — drop the `> Note:` block restating the legacy-section behavior already covered by the preceding sentence and by the README's Team Coordination section.
- `skillit/SKILL.md` — fix `skill.md` → `SKILL.md` casing in both the library survey `find` commands and the target write paths. The lowercase form would silently return zero results on case-sensitive filesystems.
- `suggest-permissions/SKILL.md` — trim the language-vocabulary list (every common package manager / runtime / extension) in step 2. The agent has the .jsonl logs in front of it and does not need a vocabulary lookup to recognize repeated commands.

## Test plan

- [ ] Manual review: every removed line was redundant; every reworded line preserves the original instruction.
- [ ] handoff↔pickup contract preserved: section order (Goal → Progress → Git State → Remaining Work → Task List → Context), Task List JSON shape, meta header grammar, and skip-unchanged fingerprint logic all untouched.
- [ ] All sub-skill references still point at extant sub-skill names (`get-session-id` still referenced from `suggest-permissions`).
- [ ] No bash-loop convention violations introduced (no `for X in $VAR` patterns added).
- [ ] `skillit` `find -name "SKILL.md"` now matches the actual on-disk filename across this repo and `~/.claude/skills`.

## Findings deferred to issues

- `plugins/sessionkit/skills/handoff/SKILL.md:60-63` — the skip-unchanged matrix conflates two orthogonal axes. "If only `gitFingerprint` matches: reuse Git State and Progress. Regenerate the rest" forces Task List regeneration on a pure-git change even when `taskFingerprint` was unchanged. Both fingerprints are computed independently and could be honored independently.
- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:22-28` — step 1 says "Use `/get-session-id` to resolve the current session" but then inlines the same shell instead of invoking the sub-skill. Either the prose lies or the shell is dead. Behavioral question (call sub-skill vs. inline) — left for follow-up.
- `plugins/sessionkit/README.md:39` — the sub-skills table claims `get-session-id` is "Used by suggest-permissions, handoff, pickup", but `handoff/SKILL.md` and `pickup/SKILL.md` never invoke it. Either README drift or missing sub-skill calls. Defer pending decision on the bullet above.
