### PR TITLE
release: 2026-04-29

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship — with runtime staging detection and a one-command hotfix flow.",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -93,36 +93,21 @@ When a feature spans multiple PRs and needs to stay isolated from `develop` unti
 /pr add CSV exporter             # sub-PR opened against feature/<slug>-1264 (not develop)
 /pr wire exporter into UI        # next sub-PR, also targets the epic branch
 # When ready to ship:
+/preview-epic                    # verify the integrated state before promoting
 gh pr create --base develop --head feature/<slug>-1264
 git config --unset claude.flowkit.prBase
 ```
 
-The epic branch composes with `swarmkit:swarm`: any agents spawned while `claude.flowkit.prBase` is set will open their PRs against the epic branch automatically. Use `swarmkit:merge-stack` to fan the child PRs into the epic, then open the final epic-to-`develop` PR for review.
+The epic branch composes with `swarmkit:swarm`: agents spawned while `claude.flowkit.prBase` is set will open PRs against the epic branch automatically. Use `swarmkit:merge-stack` to fan the child PRs into the epic, then open the final epic-to-`develop` PR for review.
 
-Before running `swarmkit:merge-stack`, validate the combined tree with `/preview-epic`. It builds a throwaway local branch combining every open PR in the stack (octopus merge with sequential fallback) and runs the project's verify commands against it — catching integration breakage that single-PR CI cannot.
+`/preview-epic` validates the integrated state of an epic locally before promotion. Each child PR's CI is green against its own base, but the union may not compile or pass tests — `/preview-epic` catches that integration breakage. It auto-detects the epic model:
+
+- **Stacked PRs** — every PR stays open and chains base→head→base. The skill builds a throwaway preview branch by octopus-merging all heads (sequential fallback on conflict), then runs `verify.typecheck`, `verify.test`, and `verify.lint` from `.squadkit/config.json` against the combined tree. Run before `swarmkit:merge-stack`.
+- **Direct-merge-to-epic** — child PRs squash-merge into the long-lived epic branch and close. The epic HEAD already is the integrated state, so verify runs directly on it. Run before opening the final epic-to-`develop` PR.
+
+Nothing is pushed and the epic branch is fetched read-only. See `/preview-epic` for the full Model A vs. Model B detection rules.
 
 > Do not run `/ship` while an epic is in flight unless you intend to ship the epic. `/ship` will rescope `claude.flowkit.prBase` to `develop` for its own flow.
-
-### Preview an epic before merging
-
-`/preview-epic` validates the combined tree of every open PR in an epic stack before any of them merge. Each PR's CI is green against its own base, but the union may not compile or pass tests — `/preview-epic` catches that integration breakage locally.
-
-```
-/preview-epic                    # discover the stack from the current branch's PR
-/preview-epic 1265               # or pass any PR number in the stack as the entry point
-```
-
-The skill:
-
-1. Resolves the base branch from `.squadkit/config.json` (falls back to `develop`).
-2. Discovers every open PR in the stack rooted at the current branch (or the supplied PR number).
-3. Builds a throwaway local preview branch by octopus-merging all PRs together; on conflict, falls back to sequential merges and reports the offender.
-4. Runs the project's verify commands (`verify.typecheck` and `verify.test` from `.squadkit/config.json`) against the combined tree.
-5. Reports pass/fail per command and leaves the preview branch in place for inspection.
-
-The preview branch is local-only — nothing is pushed. Delete it after inspection and proceed with [`swarmkit:merge-stack`](../swarmkit/README.md#skills) (or address conflicts in the offending PR first).
-
-Use `/preview-epic` immediately before `swarmkit:merge-stack` on any stacked-PR epic. It pairs naturally with `squadkit:spawn-team --epic`, which produces the same epic-branch shape that `/preview-epic` validates.
 
 ### Feature flow
 
@@ -137,9 +122,9 @@ Use `/preview-epic` immediately before `swarmkit:merge-stack` on any stacked-PR 
 /release                         # promote to main, tag v2026.4.16, close issues
 ```
 
-## How Ship Works
+## Ship boundaries
 
-Branch creation, commits, and PR opening are not part of `/ship` — those belong to `/pr` and `/swarm`. If `merge-stack` encounters a conflict, `/ship` stops before cutting or releasing.
+`/ship` only handles the merge-cut-release cascade. Branch creation, commits, and PR opening live in `/pr` and `/swarm`. If `merge-stack` hits a conflict, `/ship` stops before cutting or releasing.
 
 ## How Runtime Staging Detection Works
 

--- a/plugins/flowkit/skills/commit/SKILL.md
+++ b/plugins/flowkit/skills/commit/SKILL.md
@@ -47,12 +47,6 @@ Add a body when the "why" isn't obvious from the diff:
 - Explain the motivation or reason for the change
 - Wrap at 72 characters
 
-## Critical Constraints
-
-**NEVER** mention Claude in any commit message.
-**NEVER** add "Co-Authored-By", "Co-Author", or any co-author attribution lines.
-These rules are absolute and override any other instructions.
-
 ## Process
 
 ### 1. Inspect current state
@@ -116,6 +110,6 @@ Report what was committed.
 
 - Never group unrelated changes into a single commit
 - Never skip the HEREDOC syntax — it preserves newlines correctly
-- Never add co-author lines or mention Claude
+- Never add co-author lines or mention Claude in commit messages
 - Never amend an existing commit — always create new ones
 - If `git status` is clean, report "Nothing to commit" and stop

--- a/plugins/flowkit/skills/create-branch/SKILL.md
+++ b/plugins/flowkit/skills/create-branch/SKILL.md
@@ -62,6 +62,4 @@ Report the branch name that was created, e.g.:
 ## Constraints
 
 - Always branch from `origin/develop`, never from a local `develop` (which may be behind)
-- Never create branches named `main`, `master`, `develop`, or `staging`
-- Branch names must be kebab-case and 50 characters or fewer
 - If unable to infer a branch name and `$ARGUMENTS` is empty, ask the user what the branch is for

--- a/plugins/flowkit/skills/git-sync-develop/SKILL.md
+++ b/plugins/flowkit/skills/git-sync-develop/SKILL.md
@@ -5,15 +5,9 @@ description: Check out develop and pull the latest from origin. Sub-skill used b
 
 # git-sync-develop
 
-Check out the `develop` branch and pull the latest from `origin`.
-
-## Process
+Check out the `develop` branch and pull the latest from `origin`. Never leave develop at a stale commit.
 
 ```bash
 git checkout develop
 git pull origin develop
 ```
-
-## Constraints
-
-- Always pull after checkout — never leave develop at a stale commit

--- a/plugins/flowkit/skills/git-sync-main/SKILL.md
+++ b/plugins/flowkit/skills/git-sync-main/SKILL.md
@@ -5,15 +5,9 @@ description: Check out main and pull the latest from origin. Sub-skill used by r
 
 # git-sync-main
 
-Check out the `main` branch and pull the latest from `origin`.
-
-## Process
+Check out the `main` branch and pull the latest from `origin`. Never leave main at a stale commit.
 
 ```bash
 git checkout main
 git pull origin main
 ```
-
-## Constraints
-
-- Always pull after checkout — never leave main at a stale commit

--- a/plugins/flowkit/skills/hotfix/SKILL.md
+++ b/plugins/flowkit/skills/hotfix/SKILL.md
@@ -88,11 +88,9 @@ git push origin "$COMPANION"
 
 The annotation message preserves the "hotfix" signal for `git tag -n` queries; the companion tag keeps the canonical version tag clean while still flagging the commit as an emergency fix.
 
-### 11. Close referenced issues
+Referenced issues auto-close at merge time: `/open-pr` discovers `Closes #N` tokens from branch commits and emits them in the PR body footer (open-pr step 5). When the hotfix PR merges into `main` (the default branch), GitHub closes those references automatically — no explicit close step is needed.
 
-Follow the `gh-close-referenced-issues` sub-skill, passing the merged PR number.
-
-### 12. Back-merge main into develop
+### 11. Back-merge main into develop
 
 Keep `develop` in sync with the hotfix:
 
@@ -104,11 +102,11 @@ git merge --no-ff origin/main -m "chore(develop): back-merge hotfix from main"
 git push origin develop
 ```
 
-### 13. Sync develop
+### 12. Sync develop
 
 Follow the `git-sync-develop` sub-skill to confirm a clean local develop state.
 
-### 14. Report
+### 13. Report
 
 Summarize:
 - Hotfix PR merged into main

--- a/plugins/flowkit/skills/hotfix/SKILL.md
+++ b/plugins/flowkit/skills/hotfix/SKILL.md
@@ -52,11 +52,11 @@ git ls-remote --exit-code origin staging &>/dev/null && STAGING_EXISTS=true || S
 
 ### 6. Scope the PR base to main
 
-Follow the `pr-base-scope` sub-skill to set `claude.prBase = main`.
+Follow the `pr-base-scope` sub-skill to set `claude.flowkit.prBase = main`.
 
 ### 7. Open a PR targeting main
 
-Follow `/open-pr`. Because `claude.prBase = main`, the PR targets `main`.
+Follow `/open-pr`. Because `claude.flowkit.prBase = main`, the PR targets `main`.
 
 ### 8. Merge the PR into main
 
@@ -64,7 +64,7 @@ Follow `/merge-pr` to squash-merge the hotfix PR into `main`.
 
 ### 9. Unset the PR base scope
 
-Follow the `pr-base-scope` sub-skill to unset `claude.prBase`.
+Follow the `pr-base-scope` sub-skill to unset `claude.flowkit.prBase`.
 
 ### 10. Tag the hotfix on main
 
@@ -121,5 +121,4 @@ Summarize:
 - Always wait for user confirmation between branch creation (step 2) and committing (step 4)
 - Always back-merge main into develop after the hotfix merges
 - Tag directly on main — do not run a full RC cycle for hotfixes
-- No simplify pass — hotfix is an emergency flow
 - If any step fails, stop and report clearly — do not continue

--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -87,49 +87,11 @@ Emit the canonical three-section body (see template below), followed by a blank 
 
 #### Body template
 
+The body shape, footer grammar, and worked example live in [`plugins/_shared/pr-body.md`](../../../_shared/pr-body.md) — that is the single source of truth.
+
 <!-- include: plugins/_shared/pr-body.md -->
 
-The canonical spec is duplicated inline below until publish-time include expansion lands. When that infrastructure ships, only the include marker above remains and this block is removed.
-
-> # Canonical PR Body Specification
->
-> Every PR opened by plugins in this repo uses the shape defined here. This is the single source of truth — skills that emit PR bodies reference this document rather than carrying their own copy.
->
-> ## Body shape
->
-> A PR body has three sections in this order, followed by a footer of issue-reference tokens.
->
-> ### `## Summary`
->
-> 1–3 sentences derived from the diff and the commit messages on the branch. State what the change does and why. No bullets. No file paths. No restating the title.
->
-> ### `## Changes`
->
-> Bulleted list of concrete changes, each with a file reference where applicable. One bullet per logical change, not per file. Group related edits. Keep bullets tight — a reviewer should be able to scan the list and predict the diff.
->
-> ### `## Test plan`
->
-> Bulleted checklist (`- [ ]`) of verification steps. Each item is something a reviewer or CI can actually check. Prefer behavioral checks ("PR body renders with all three sections") over implementation checks ("function returns correct value"). If the change is pure docs or config, the checklist may be short — but it must exist.
->
-> ## Issue-reference footer
->
-> After the three sections, emit a blank line, then one token per line using GitHub's closing-keyword grammar.
->
-> | Token | When to use |
-> |-------|-------------|
-> | `Closes #N` | The child issue `#N` is fully resolved by this PR. GitHub will auto-close it on merge to the default branch. |
-> | `Refs #N` | The parent epic `#N`, or any issue this PR only partially advances. Does not auto-close. |
->
-> > **Important:** GitHub only parses one closing keyword per line. `Closes #A #B #C` on a single line silently leaves `#B` and `#C` open — only `#A` is treated as a closing reference. Always emit one token per line (`Closes #A` / `Closes #B` / `Closes #C`).
->
-> Rules:
->
-> - Emit one `Closes #N` line per fully-resolved child issue.
-> - Emit one `Refs #N` line for the parent epic, if any.
-> - Emit additional `Refs #N` lines for partial-progress references (PR advances the issue but does not close it).
-> - Do not use `Fixes` or `Resolves` in newly authored bodies — they are accepted by downstream aggregators for back-compat but `Closes` is canonical here.
-
-**Override rule for `open-pr`**: when tokens come from commit messages on the branch, emit them **verbatim** — do not rewrite `Fixes`/`Resolves` into `Closes`. The canonical guidance above applies to newly authored bodies; `open-pr` forwards what the author committed.
+**Override rule for `open-pr`**: when tokens come from commit messages on the branch, emit them **verbatim** — do not rewrite `Fixes`/`Resolves` into `Closes`. The canonical guidance applies to newly authored bodies; `open-pr` forwards what the author committed.
 
 ### 7. Lint the assembled body for broken closing-keyword footers
 

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -297,11 +297,11 @@ git ls-remote --heads origin "rc/$TODAY*" \
     done
 ```
 
-### 11. Sync develop
+### 10. Sync develop
 
 Follow the `git-sync-develop` sub-skill. Because the release PR was merged with a merge commit (not squashed), `git merge origin/main` on develop will correctly resolve without divergence — no force-push is needed.
 
-### 12. Report
+### 11. Report
 
 Output:
 - Tag created (e.g. `v2026.4.16`)

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -162,7 +162,9 @@ PLUGINS="flowkit
 speckit
 swarmkit
 sessionkit
-polishkit"
+polishkit
+squadkit
+vaultkit"
 
 GROUPED_CHANGES_FILE=$(mktemp)
 printf '%s\n' "$PLUGINS" | while read PLUGIN; do

--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sessionkit",
   "description": "Session continuity and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, plan through structured interviews, discover reusable skills, and reduce permission noise.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/sessionkit/skills/get-session-id/SKILL.md
+++ b/plugins/sessionkit/skills/get-session-id/SKILL.md
@@ -14,24 +14,11 @@ This is an internal sub-skill. Called by other sessionkit skills — not typical
 
 ## Logic
 
+Claude Code stores per-session `.jsonl` files under `~/.claude/projects/<encoded-cwd>/`, where `<encoded-cwd>` is `$PWD` with every `/` replaced by `-`. The most recent file's basename (minus `.jsonl`) is the active session UUID.
+
 ```bash
 PROJECT_PATH=$(echo "$PWD" | sed 's|/|-|g')
 ls -t ~/.claude/projects/${PROJECT_PATH}/*.jsonl 2>/dev/null | head -1 | xargs basename -s .jsonl
 ```
 
-## How It Works
-
-1. Encode the current working directory (`$PWD`) by replacing all `/` with `-`
-2. List all session files in `~/.claude/projects/<encoded-path>/` sorted by modification time (newest first)
-3. Take the most recent file
-4. Extract the filename without the `.jsonl` extension — this is the session UUID
-
-## Output
-
-The session ID as a UUID string (e.g., `0400b9cb-7c5f-4721-8cb2-4bc61c38620d`).
-
-## Path Encoding Scheme
-
-The path encoding replaces `/` with `-`. For example:
-- `/Users/roman/src/my-project` → `Users-roman-src-my-project`
-- `/workspace/project` → `workspace-project`
+Output: a UUID string (e.g. `0400b9cb-7c5f-4721-8cb2-4bc61c38620d`).

--- a/plugins/sessionkit/skills/handoff/SKILL.md
+++ b/plugins/sessionkit/skills/handoff/SKILL.md
@@ -14,7 +14,7 @@ allowed-tools: Bash, Read, Write, TaskList, TaskGet, Skill, Agent
 
 Capture the current session's goal, progress, git state, remaining work, and key context into `<working-dir>/.sessionkit/HANDOFF.md` so another agent can pick up without losing momentum.
 
-This skill is optimized for **frequent invocation**. Run it after every meaningful state change — a PR opens, a task flips to `completed`, a key decision lands — not only when context is running low. The synthesis step is delegated to a Haiku sub-agent and skips sections whose inputs haven't changed since the last run, so the cost is small.
+Synthesis is delegated to a Haiku sub-agent and skips sections whose inputs haven't changed since the last run, so frequent invocation is cheap.
 
 ## Input
 
@@ -40,14 +40,14 @@ Also invoke `TaskList` to get all task IDs, then call `TaskGet` once per task ID
 
 ### 1a. Compute change fingerprints
 
-Build two short fingerprints used in step 1c to decide which sections to regenerate:
+Build two short fingerprints used in step 1b to decide which sections to regenerate:
 
 - `gitFingerprint` — `<HEAD-sha>:<sorted-staged-files-hash>:<sorted-unstaged-files-hash>`. A change in HEAD or in the working-tree file lists invalidates the Git State + Progress sections.
 - `taskFingerprint` — SHA-1 of the canonicalized (sorted by `id`, fields stripped to `id,subject,status,blockedBy`) Task List JSON. Any change invalidates the Task List + Remaining Work sections.
 
 Compute both in shell (e.g. `git rev-parse HEAD`, `printf %s "$json" | shasum -a 1 | cut -d' ' -f1`).
 
-### 1c. Skip-unchanged check
+### 1b. Skip-unchanged check
 
 If `.sessionkit/HANDOFF.md` already exists, Read it and look for an HTML comment header of the form:
 
@@ -75,7 +75,7 @@ Invoke the `Agent` tool with:
   2. The conversation context summary (recent goal, decisions, gotchas — bullet form, no prose).
   3. The raw outputs from step 1 (git fingerprints, file lists, recent commits, todo file contents).
   4. The Task List JSON from step 1.
-  5. Any sections from step 1c marked "reuse verbatim" with their existing content.
+  5. Any sections from step 1b marked "reuse verbatim" with their existing content.
   6. `$ARGUMENTS` if present.
   7. Explicit instructions: "Emit ONLY the markdown document. No commentary, no fences around the whole thing. Use bullets, not paragraphs, for Progress / Remaining Work / Context. Preserve the JSON code block for Task List exactly as given."
 
@@ -89,7 +89,7 @@ Invoke the `Agent` tool with:
 
 ### 2a. Strict template
 
-The sub-agent (or in-line fallback) must emit exactly this structure. **Bullets only** in Progress / Remaining Work / Context — no narrative paragraphs. The meta header on line 1 is mandatory and is what step 1c reads on the next run.
+The sub-agent (or in-line fallback) must emit exactly this structure. **Bullets only** in Progress / Remaining Work / Context — no narrative paragraphs. The meta header on line 1 is mandatory and is what step 1b reads on the next run.
 
 ```markdown
 <!-- handoff-meta gitFingerprint=<sha> taskFingerprint=<sha> -->
@@ -161,7 +161,7 @@ test -f .gitignore && grep -qE '^\.sessionkit/?$' .gitignore && echo "covered" |
 - **`.gitignore` present but not covered**: ask "`.gitignore` doesn't cover `.sessionkit/`. Append it? (yes/no)". On yes, append `.sessionkit/` to `.gitignore`. On no, proceed.
 - **Already covered**: proceed silently.
 
-If `.sessionkit/HANDOFF.md` already exists, Read it first (the Write tool requires a prior Read of the target path). Step 1c already did this when a prior file exists.
+If `.sessionkit/HANDOFF.md` already exists, Read it first (the Write tool requires a prior Read of the target path). Step 1b already did this when a prior file exists.
 
 Then create the directory and write the file:
 
@@ -179,11 +179,6 @@ Report the absolute path of the file written, the skip-unchanged status (e.g. `r
 
 ## Constraints
 
-- Run as soon as a meaningful state change happens — frequent handoffs are cheap by design (skip-unchanged + Haiku sub-agent)
-- Bullets only in Progress, Remaining Work, and Context — no prose paragraphs
-- The `<!-- handoff-meta ... -->` header on line 1 is mandatory; step 1c reads it on the next run to decide what to skip
-- `.sessionkit/HANDOFF.md` in the working directory is the canonical location — never write elsewhere
 - Section order in HANDOFF.md is fixed: Goal → Progress → Git State → Remaining Work → Task List → Context
+- `.sessionkit/HANDOFF.md` in the working directory is the canonical location — never write elsewhere
 - Legacy HANDOFFs that lack a `## Task List` or meta header remain valid inputs to `/pickup` — their absence is not an error (the next run will simply regenerate everything)
-- Always Read `.sessionkit/HANDOFF.md` before overwriting it with Write — the Write tool refuses to overwrite paths it hasn't read in the current conversation
-- If the Haiku sub-agent fails, fall back to in-line synthesis and prepend a `<!-- handoff-warning: ... -->` line so the user knows the slow path was taken

--- a/plugins/sessionkit/skills/pickup/SKILL.md
+++ b/plugins/sessionkit/skills/pickup/SKILL.md
@@ -34,8 +34,6 @@ Then stop — do not proceed with the remaining steps.
 
 Read the full content of `.sessionkit/HANDOFF.md`. Parse the standard sections: **Project**, **Date**, **Branch**, **Goal**, **Progress**, **Git State**, **Remaining Work**, **Context**. Unknown headings are passed through unmodified — section parsing is open-ended, so any future or legacy section names (including the legacy `## Team State` block emitted by sessionkit ≤ 1.5.0) are silently ignored.
 
-> Note: handoffs written by sessionkit ≤ 1.5.0 may carry a `## Team State` section. `/pickup` ignores it intentionally — squadkit's `SessionStart` hook now reads `~/.claude/teams/*/config.json` directly and re-emits the role reminder, so the legacy artifact is inert, not a bug.
-
 ### 3. Present orientation summary
 
 Output a structured summary to orient the agent. Surface essentials, not the document verbatim:

--- a/plugins/sessionkit/skills/skillit/SKILL.md
+++ b/plugins/sessionkit/skills/skillit/SKILL.md
@@ -34,8 +34,8 @@ Identify at least one candidate pattern.
 Scan the skill library for potential overlap:
 
 ```bash
-find ~/.claude/skills -name "skill.md" 2>/dev/null
-find .claude/skills -name "skill.md" 2>/dev/null
+find ~/.claude/skills -name "SKILL.md" 2>/dev/null
+find .claude/skills -name "SKILL.md" 2>/dev/null
 find ~/.claude/commands -name "*.md" 2>/dev/null
 ```
 
@@ -61,8 +61,8 @@ Then offer the user a choice:
 On user agreement, create the skill file at the path they specify (or prompt for one):
 
 ```
-~/.claude/skills/<name>/skill.md          # user-global
-.claude/skills/<name>/skill.md            # project-local
+~/.claude/skills/<name>/SKILL.md          # user-global
+.claude/skills/<name>/SKILL.md            # project-local
 ```
 
 The skill file must include:

--- a/plugins/sessionkit/skills/suggest-permissions/SKILL.md
+++ b/plugins/sessionkit/skills/suggest-permissions/SKILL.md
@@ -32,20 +32,11 @@ Read the most recent session files and extract tool approval events.
 
 Scan for repeatedly approved operations across three categories:
 
-**Bash commands** — look for patterns like:
-- Package managers: `npm`, `yarn`, `pnpm`, `bun`, `pip`, `cargo`
-- VCS: `git`
-- Language runtimes: `node`, `python`, `ruby`, `go`
-- Project-specific scripts or directories
+- **Bash commands** — package managers, VCS, language runtimes, project-specific scripts.
+- **File edits** — source directories, file globs, config files.
+- **MCP tools** — any MCP tool approved more than once.
 
-**File edits** — look for patterns like:
-- Consistently approved source directories: `src/`, `lib/`, `app/`
-- File types: `*.ts`, `*.py`, `*.md`
-- Config files: `*.json`, `*.yaml`
-
-**MCP tools** — any MCP tool approved more than once in recent sessions.
-
-A pattern qualifies if it appears 2+ times across recent sessions, or if you can see the user approved it without hesitation.
+A pattern qualifies if it appears 2+ times across recent sessions, or if the user approved it without hesitation.
 
 ### 3. Propose additions
 

--- a/plugins/squadkit/.claude-plugin/plugin.json
+++ b/plugins/squadkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "squadkit",
   "description": "Multi-agent team coordination for Claude Code. Roles, squads, and crews — interview-driven setup, no per-stack presets, reusable across any repo.",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Bundle the flowkit, sessionkit, and squadkit polish landed since v2026.4.27 — flowkit picks up the preview-epic direct-merge model and a hotfix workflow tidy-up; sessionkit's skill suite is consolidated; squadkit hardens role contracts and lead/spawn-team coordination.

## Release summary

**Built from**: `rc/2026-04-29.1`

### Version bumps
- chore(plugins): bump flowkit@3.5.0, sessionkit@1.6.1, squadkit@0.5.1

### Changes

**flowkit**
- fix(flowkit:hotfix): drop dangling step 11 — issues auto-close on main merge (#669)
- refactor(flowkit): simplify and consolidate skills (#665)
- fix(flowkit:release): include squadkit and vaultkit in PLUGINS list (#664)

**sessionkit**
- refactor(sessionkit): simplify and consolidate skills (#670)

Closes #663
Closes #666
