### PR TITLE
feat(squadkit): add builder crew profile

### DIFF
--- a/plugins/squadkit/crews/builder.yaml
+++ b/plugins/squadkit/crews/builder.yaml
@@ -1,0 +1,8 @@
+name: builder
+description: Execution-focused crew — architect drafts, two builders implement in parallel, reviewer + tester gate quality. Subset of all-rounder without explorer/designer; use when the implementation contract is already locked (e.g. blueprints exist) and the work is straight execution.
+members:
+  - role: architect
+  - role: builder
+    count: 2
+  - role: reviewer
+  - role: tester


### PR DESCRIPTION
## Summary
- Adds \`plugins/squadkit/crews/builder.yaml\` — execution-focused crew (architect + 2 builders + reviewer + tester).
- Subset of \`all-rounder\` without explorer/designer; use when the implementation contract is already locked (e.g. blueprints already exist from a discovery pass) and the work is straight execution.

## Test plan
- \`/squadkit:spawn-team --profile builder\` resolves the new YAML and registers the team
- \`--builders N\` flag still tunes builder count
- Existing \`all-rounder\`, \`design\`, \`qa\` profiles unaffected

## Context
Filed as a thin first step toward letting blueprint-producing flows (e.g. /discovery-team in vorbis-player) hand off cleanly to an execution crew without the explorer/designer overhead. See companion issues for the larger discovery-team graduation work (kind: field, --brief passthrough, etc.) — this PR is intentionally the simpler wedge.