### PR TITLE
refactor(flowkit:preview-epic): split into per-model sub-skills

### DIFF
--- a/plugins/flowkit/skills/preview-epic-direct/SKILL.md
+++ b/plugins/flowkit/skills/preview-epic-direct/SKILL.md
@@ -8,11 +8,45 @@ allowed-tools: Bash, Read, AskUserQuestion
 
 Sub-skill of `flowkit:preview-epic`. The long-lived `feature/<slug>-<issue>` epic branch already accumulates the squash-merged contributions — there is nothing to synthesize. This sub-skill fetches the epic branch, fast-forwards locally, and runs verify directly on its HEAD.
 
-The dispatcher (`flowkit:preview-epic`) resolves `$BASE_BRANCH` and `$EPIC_BRANCH` before invoking this sub-skill.
+The dispatcher (`flowkit:preview-epic`) resolves `$BASE_BRANCH` and `$EPIC_BRANCH` before invoking this sub-skill, encoding them as structured flags in the argument string passed via the Skill tool.
 
 ## Process
 
-### 1. Sync the epic branch locally
+### 1. Parse dispatcher arguments
+
+Extract `--base` and `--epic` from `$ARGUMENTS`.
+
+```bash
+BASE_BRANCH=""
+EPIC_BRANCH=""
+_ARGS="$ARGUMENTS"
+
+while [[ -n "$_ARGS" ]]; do
+  case "$_ARGS" in
+    --base\ *)
+      _ARGS="${_ARGS#--base }"
+      BASE_BRANCH="${_ARGS%% *}"
+      _ARGS="${_ARGS#$BASE_BRANCH}"
+      _ARGS="${_ARGS# }"
+      ;;
+    --epic\ *)
+      _ARGS="${_ARGS#--epic }"
+      EPIC_BRANCH="${_ARGS%% *}"
+      _ARGS="${_ARGS#$EPIC_BRANCH}"
+      _ARGS="${_ARGS# }"
+      ;;
+    *)
+      _ARGS=""
+      ;;
+  esac
+done
+```
+
+If either `$BASE_BRANCH` or `$EPIC_BRANCH` is empty after parsing, stop with:
+
+> Missing required arguments. This sub-skill must be invoked by `flowkit:preview-epic` with `--base <branch> --epic <branch>`.
+
+### 2. Sync the epic branch locally
 
 There is no synthesis to do — the epic branch already accumulates the squash-merged contributions. Pull it down and check it out so verify runs against the integrated state.
 
@@ -51,7 +85,7 @@ After verify completes, restore the user's pre-skill working state if any was st
 [[ "$STASHED" -eq 1 ]] && git stash pop
 ```
 
-### 2. Resolve verify commands
+### 3. Resolve verify commands
 
 Read `.squadkit/config.json` for `verify.typecheck`, `verify.test`, `verify.lint`, and `install`:
 
@@ -70,7 +104,7 @@ For each command that resolved to empty, prompt the user via `AskUserQuestion`:
 
 If the user declines any, skip that step. The skill does not hardcode `npm run test:run`, `npx tsc -b --noEmit`, or any other framework-specific command; the only source of commands is `.squadkit/config.json` or the user prompt.
 
-### 3. Run verify commands
+### 4. Run verify commands
 
 If `$INSTALL` is set and HEAD moved during the fetch/fast-forward, run install first. Then run typecheck, tests, and lint. Capture exit codes — do not abort the skill on failure; the user wants to see all results.
 
@@ -99,7 +133,7 @@ if [[ -n "$LINT" ]]; then
 fi
 ```
 
-### 4. Report
+### 5. Report
 
 Print a concise summary tagged with the model:
 

--- a/plugins/flowkit/skills/preview-epic-direct/SKILL.md
+++ b/plugins/flowkit/skills/preview-epic-direct/SKILL.md
@@ -1,0 +1,119 @@
+---
+name: preview-epic-direct
+description: Preview-epic sub-skill for the direct-merge-to-epic (Model B) flow — fast-forward the long-lived feature branch locally and run verify directly against its HEAD (no synthesis needed). Invoked by `flowkit:preview-epic` after auto-detection; not meant to be called directly.
+allowed-tools: Bash, Read, AskUserQuestion
+---
+
+# Preview Epic — Direct Merge to Epic (Model B)
+
+Sub-skill of `flowkit:preview-epic`. The long-lived `feature/<slug>-<issue>` epic branch already accumulates the squash-merged contributions — there is nothing to synthesize. This sub-skill fetches the epic branch, fast-forwards locally, and runs verify directly on its HEAD.
+
+The dispatcher (`flowkit:preview-epic`) resolves `$BASE_BRANCH` and `$EPIC_BRANCH` before invoking this sub-skill.
+
+## Process
+
+### 1. Sync the epic branch locally
+
+There is no synthesis to do — the epic branch already accumulates the squash-merged contributions. Pull it down and check it out so verify runs against the integrated state.
+
+```bash
+# Preserve any uncommitted state in the working tree.
+STASHED=0
+if ! git diff --quiet HEAD || ! git diff --cached --quiet; then
+  git stash push -u -m "preview-epic auto-stash"
+  STASHED=1
+fi
+
+git fetch origin "$EPIC_BRANCH":"refs/remotes/origin/$EPIC_BRANCH"
+
+if git show-ref --verify --quiet "refs/heads/$EPIC_BRANCH"; then
+  git checkout "$EPIC_BRANCH"
+  git pull --ff-only origin "$EPIC_BRANCH" || {
+    echo "Epic branch has diverged from origin; not auto-resolving. Aborting."
+    [[ "$STASHED" -eq 1 ]] && git stash pop
+    exit 1
+  }
+else
+  git checkout -b "$EPIC_BRANCH" "origin/$EPIC_BRANCH"
+fi
+```
+
+Record the merged-PR composition for the report:
+
+```bash
+MERGED_PRS=$(gh pr list --state merged --base "$EPIC_BRANCH" --limit 200 \
+  --json number,title,headRefName --jq '.[] | "#\(.number) \(.title)"')
+```
+
+After verify completes, restore the user's pre-skill working state if any was stashed:
+
+```bash
+[[ "$STASHED" -eq 1 ]] && git stash pop
+```
+
+### 2. Resolve verify commands
+
+Read `.squadkit/config.json` for `verify.typecheck`, `verify.test`, `verify.lint`, and `install`:
+
+```bash
+TYPECHECK=$(jq -r '.verify.typecheck // empty' .squadkit/config.json 2>/dev/null)
+TEST=$(jq -r '.verify.test // empty' .squadkit/config.json 2>/dev/null)
+LINT=$(jq -r '.verify.lint // empty' .squadkit/config.json 2>/dev/null)
+INSTALL=$(jq -r '.install // empty' .squadkit/config.json 2>/dev/null)
+```
+
+For each command that resolved to empty, prompt the user via `AskUserQuestion`:
+
+- "What command should I run for typecheck on this preview? (or skip)"
+- "What command should I run for tests on this preview? (or skip)"
+- "What command should I run for lint on this preview? (or skip)"
+
+If the user declines any, skip that step. The skill does not hardcode `npm run test:run`, `npx tsc -b --noEmit`, or any other framework-specific command; the only source of commands is `.squadkit/config.json` or the user prompt.
+
+### 3. Run verify commands
+
+If `$INSTALL` is set and HEAD moved during the fetch/fast-forward, run install first. Then run typecheck, tests, and lint. Capture exit codes — do not abort the skill on failure; the user wants to see all results.
+
+```bash
+if [[ -n "$INSTALL" ]]; then
+  echo "==> install: $INSTALL"
+  eval "$INSTALL"
+fi
+
+if [[ -n "$TYPECHECK" ]]; then
+  echo "==> typecheck: $TYPECHECK"
+  eval "$TYPECHECK"
+  TYPECHECK_RC=$?
+fi
+
+if [[ -n "$TEST" ]]; then
+  echo "==> test: $TEST"
+  eval "$TEST"
+  TEST_RC=$?
+fi
+
+if [[ -n "$LINT" ]]; then
+  echo "==> lint: $LINT"
+  eval "$LINT"
+  LINT_RC=$?
+fi
+```
+
+### 4. Report
+
+Print a concise summary tagged with the model:
+
+- Preview branch: `<epic-branch>` (Model B — direct-merge-to-epic; no synthesis needed).
+- Stack composition: list of squash-merged PRs from `gh pr list --state merged --base <epic>`.
+- Verify outcomes: typecheck pass/fail/skipped, tests pass/fail/skipped, lint pass/fail/skipped.
+- Suggested next step:
+  - All green → open the final epic-to-base PR: `gh pr create --base "$BASE_BRANCH" --head "$EPIC_BRANCH"`.
+  - Verify failure → fix on the epic branch (or open a follow-up PR targeting the epic) and re-run.
+
+No cleanup needed — the epic branch is long-lived.
+
+## Constraints
+
+- **Epic branch is fetched, not modified beyond fast-forward.** Diverged remotes abort rather than auto-resolving.
+- **Preserve working state.** Auto-stash uncommitted changes before checking out the epic branch; restore on completion.
+- **Idempotent in spirit.** Re-running simply re-fast-forwards the epic branch rather than clobbering existing local state.

--- a/plugins/flowkit/skills/preview-epic-stacked/SKILL.md
+++ b/plugins/flowkit/skills/preview-epic-stacked/SKILL.md
@@ -1,18 +1,56 @@
 ---
 name: preview-epic-stacked
 description: Preview-epic sub-skill for the stacked-PR (Model A) flow — discover the open-PR stack, octopus-merge into a throwaway preview branch (with sequential fallback), and run verify against the synthesized integrated state. Invoked by `flowkit:preview-epic` after auto-detection; not meant to be called directly.
-allowed-tools: Bash, Read, AskUserQuestion
+allowed-tools: Bash, Read, AskUserQuestion, Skill
 ---
 
 # Preview Epic — Stacked PRs (Model A)
 
 Sub-skill of `flowkit:preview-epic`. Synthesizes the integrated state of an epic whose contributions are still **open PRs** chained via `baseRefName` → previous PR's `headRefName`, ultimately rooting at `$BASE_BRANCH`. The integrated state is built locally via octopus merge (with sequential fallback) into a throwaway `preview/...` branch — nothing is pushed.
 
-The dispatcher (`flowkit:preview-epic`) resolves `$BASE_BRANCH`, `$EPIC_BRANCH`, and `$ARGUMENTS` before invoking this sub-skill.
+The dispatcher (`flowkit:preview-epic`) resolves `$BASE_BRANCH`, `$EPIC_BRANCH`, and `$ARGUMENTS` before invoking this sub-skill, encoding them as structured flags in the argument string passed via the Skill tool.
 
 ## Process
 
-### 1. Discover the stack
+### 1. Parse dispatcher arguments
+
+Extract `--base` and `--epic` from `$ARGUMENTS`. Everything after those flags (if any) is the user-supplied remainder and is treated as the original `$ARGUMENTS` for entry-PR resolution.
+
+```bash
+BASE_BRANCH=""
+EPIC_BRANCH=""
+REMAINDER=""
+_ARGS="$ARGUMENTS"
+
+while [[ -n "$_ARGS" ]]; do
+  case "$_ARGS" in
+    --base\ *)
+      _ARGS="${_ARGS#--base }"
+      BASE_BRANCH="${_ARGS%% *}"
+      _ARGS="${_ARGS#$BASE_BRANCH}"
+      _ARGS="${_ARGS# }"
+      ;;
+    --epic\ *)
+      _ARGS="${_ARGS#--epic }"
+      EPIC_BRANCH="${_ARGS%% *}"
+      _ARGS="${_ARGS#$EPIC_BRANCH}"
+      _ARGS="${_ARGS# }"
+      ;;
+    *)
+      REMAINDER="$_ARGS"
+      _ARGS=""
+      ;;
+  esac
+done
+
+ARGUMENTS="$REMAINDER"
+```
+
+If either `$BASE_BRANCH` or `$EPIC_BRANCH` is empty after parsing, stop with:
+
+> Missing required arguments. This sub-skill must be invoked by `flowkit:preview-epic` with `--base <branch> --epic <branch>`.
+
+### 2. Discover the stack
 
 List every open PR in the repo with the metadata needed to walk the base→head chain:
 
@@ -31,7 +69,7 @@ Build the stack:
 
 The result is an ordered list `[root, ..., leaf]` of PRs in the stack. If the entry PR has no chain to `$BASE_BRANCH`, the epic is malformed for Model A — fall back to Model B by invoking `flowkit:preview-epic-direct` (treat the epic branch HEAD as the integrated state).
 
-### 2. Pick the preview branch name
+### 3. Pick the preview branch name
 
 ```bash
 ROOT_NUM=<root PR number>
@@ -41,7 +79,7 @@ PREVIEW_BRANCH="preview/${ROOT_NUM}-${ROOT_SLUG}"
 
 If `$PREVIEW_BRANCH` already exists locally, append `-2`, `-3`, etc. until unused. Never overwrite an existing branch.
 
-### 3. Fetch and create the preview branch
+### 4. Fetch and create the preview branch
 
 ```bash
 git fetch origin
@@ -56,7 +94,7 @@ gh pr list --state open --json number,headRefName --jq '.[].headRefName' | while
 done
 ```
 
-### 4. Try octopus merge first; sequential fallback on conflict
+### 5. Try octopus merge first; sequential fallback on conflict
 
 Octopus merge combines every head in a single commit. It only succeeds if all branches merge cleanly together.
 
@@ -90,7 +128,7 @@ If a conflict halts the sequential merge, stop the skill and report:
 
 Do not proceed to verify commands when sequential merge fails.
 
-### 5. Resolve verify commands
+### 6. Resolve verify commands
 
 Read `.squadkit/config.json` for `verify.typecheck`, `verify.test`, `verify.lint`, and `install`:
 
@@ -109,7 +147,7 @@ For each command that resolved to empty, prompt the user via `AskUserQuestion`:
 
 If the user declines any, skip that step. The skill does not hardcode `npm run test:run`, `npx tsc -b --noEmit`, or any other framework-specific command; the only source of commands is `.squadkit/config.json` or the user prompt.
 
-### 6. Run verify commands
+### 7. Run verify commands
 
 If `$INSTALL` is set, run install first (the working tree just changed). Then run typecheck, tests, and lint. Capture exit codes — do not abort the skill on failure; the user wants to see all results.
 
@@ -138,7 +176,7 @@ if [[ -n "$LINT" ]]; then
 fi
 ```
 
-### 7. Report
+### 8. Report
 
 Print a concise summary tagged with the model:
 

--- a/plugins/flowkit/skills/preview-epic-stacked/SKILL.md
+++ b/plugins/flowkit/skills/preview-epic-stacked/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: preview-epic-stacked
+description: Preview-epic sub-skill for the stacked-PR (Model A) flow — discover the open-PR stack, octopus-merge into a throwaway preview branch (with sequential fallback), and run verify against the synthesized integrated state. Invoked by `flowkit:preview-epic` after auto-detection; not meant to be called directly.
+allowed-tools: Bash, Read, AskUserQuestion
+---
+
+# Preview Epic — Stacked PRs (Model A)
+
+Sub-skill of `flowkit:preview-epic`. Synthesizes the integrated state of an epic whose contributions are still **open PRs** chained via `baseRefName` → previous PR's `headRefName`, ultimately rooting at `$BASE_BRANCH`. The integrated state is built locally via octopus merge (with sequential fallback) into a throwaway `preview/...` branch — nothing is pushed.
+
+The dispatcher (`flowkit:preview-epic`) resolves `$BASE_BRANCH`, `$EPIC_BRANCH`, and `$ARGUMENTS` before invoking this sub-skill.
+
+## Process
+
+### 1. Discover the stack
+
+List every open PR in the repo with the metadata needed to walk the base→head chain:
+
+```bash
+gh pr list --state open --limit 200 \
+  --json number,headRefName,baseRefName,title,url
+```
+
+Build the stack:
+
+1. Determine the entry PR.
+   - If `$ARGUMENTS` is a number, use it as the entry PR.
+   - Otherwise, resolve the PR for the current branch via `gh pr view --json number,headRefName,baseRefName`.
+2. Walk **down** the chain (toward the root): from the entry PR, follow `baseRefName` → matching `headRefName` until the next base equals `$BASE_BRANCH`. That PR is the **stack root**.
+3. Walk **up** the chain (toward the leaves): starting from the root, collect every PR whose `baseRefName` matches a previously-collected `headRefName`. Repeat until no more matches.
+
+The result is an ordered list `[root, ..., leaf]` of PRs in the stack. If the entry PR has no chain to `$BASE_BRANCH`, the epic is malformed for Model A — fall back to Model B by invoking `flowkit:preview-epic-direct` (treat the epic branch HEAD as the integrated state).
+
+### 2. Pick the preview branch name
+
+```bash
+ROOT_NUM=<root PR number>
+ROOT_SLUG=<root PR headRefName, sanitized to [a-z0-9-]+>
+PREVIEW_BRANCH="preview/${ROOT_NUM}-${ROOT_SLUG}"
+```
+
+If `$PREVIEW_BRANCH` already exists locally, append `-2`, `-3`, etc. until unused. Never overwrite an existing branch.
+
+### 3. Fetch and create the preview branch
+
+```bash
+git fetch origin
+git checkout -b "$PREVIEW_BRANCH" "origin/$BASE_BRANCH"
+```
+
+Fetch every stack head ref so the merge has up-to-date refs:
+
+```bash
+gh pr list --state open --json number,headRefName --jq '.[].headRefName' | while read REF; do
+  git fetch origin "$REF":"refs/remotes/origin/$REF" 2>/dev/null || true
+done
+```
+
+### 4. Try octopus merge first; sequential fallback on conflict
+
+Octopus merge combines every head in a single commit. It only succeeds if all branches merge cleanly together.
+
+```bash
+HEADS=$(printf 'origin/%s ' "${STACK_HEADS[@]}")
+if git merge --no-ff -m "preview: epic ${PREVIEW_BRANCH}" $HEADS; then
+  STRATEGY="octopus"
+else
+  git merge --abort 2>/dev/null || true
+  STRATEGY="sequential"
+fi
+```
+
+If octopus failed, merge each head one at a time in stack order (root → leaf). Halt on the first conflict and report which PR introduced it.
+
+```bash
+for HEAD in "${STACK_HEADS[@]}"; do
+  if ! git merge --no-ff -m "preview: merge ${HEAD}" "origin/$HEAD"; then
+    CONFLICT_BRANCH="$HEAD"
+    git merge --abort
+    break
+  fi
+done
+```
+
+If a conflict halts the sequential merge, stop the skill and report:
+
+- The preview branch name (so the user can inspect partial state if they re-run without `--abort`).
+- The branch that conflicted.
+- The PRs that merged cleanly before the conflict.
+
+Do not proceed to verify commands when sequential merge fails.
+
+### 5. Resolve verify commands
+
+Read `.squadkit/config.json` for `verify.typecheck`, `verify.test`, `verify.lint`, and `install`:
+
+```bash
+TYPECHECK=$(jq -r '.verify.typecheck // empty' .squadkit/config.json 2>/dev/null)
+TEST=$(jq -r '.verify.test // empty' .squadkit/config.json 2>/dev/null)
+LINT=$(jq -r '.verify.lint // empty' .squadkit/config.json 2>/dev/null)
+INSTALL=$(jq -r '.install // empty' .squadkit/config.json 2>/dev/null)
+```
+
+For each command that resolved to empty, prompt the user via `AskUserQuestion`:
+
+- "What command should I run for typecheck on this preview? (or skip)"
+- "What command should I run for tests on this preview? (or skip)"
+- "What command should I run for lint on this preview? (or skip)"
+
+If the user declines any, skip that step. The skill does not hardcode `npm run test:run`, `npx tsc -b --noEmit`, or any other framework-specific command; the only source of commands is `.squadkit/config.json` or the user prompt.
+
+### 6. Run verify commands
+
+If `$INSTALL` is set, run install first (the working tree just changed). Then run typecheck, tests, and lint. Capture exit codes — do not abort the skill on failure; the user wants to see all results.
+
+```bash
+if [[ -n "$INSTALL" ]]; then
+  echo "==> install: $INSTALL"
+  eval "$INSTALL"
+fi
+
+if [[ -n "$TYPECHECK" ]]; then
+  echo "==> typecheck: $TYPECHECK"
+  eval "$TYPECHECK"
+  TYPECHECK_RC=$?
+fi
+
+if [[ -n "$TEST" ]]; then
+  echo "==> test: $TEST"
+  eval "$TEST"
+  TEST_RC=$?
+fi
+
+if [[ -n "$LINT" ]]; then
+  echo "==> lint: $LINT"
+  eval "$LINT"
+  LINT_RC=$?
+fi
+```
+
+### 7. Report
+
+Print a concise summary tagged with the model:
+
+- Preview branch name.
+- Merge strategy used (`octopus` or `sequential`), or the conflict report if sequential merge halted.
+- Stack composition: every PR that was merged in, in order, as `#<num> <title>`.
+- Verify outcomes: typecheck pass/fail/skipped, tests pass/fail/skipped, lint pass/fail/skipped.
+- Suggested next step:
+  - All green → `swarmkit:merge-stack` is safe.
+  - Conflict or verify failure → fix the offending PR and re-run.
+
+Suggested cleanup:
+
+```bash
+git checkout "$BASE_BRANCH"
+git branch -D "$PREVIEW_BRANCH"
+```
+
+## Constraints
+
+- **Local-only.** Never push the synthesized preview branch; it is a throwaway integration check.
+- **Halt cleanly on conflict.** Sequential merge must `git merge --abort` before reporting, so the working tree is left in a clean state on the preview branch's pre-conflict commit.
+- **Idempotent in spirit.** Re-running with the same root will pick a fresh `preview/...-N` name rather than clobbering existing local state.

--- a/plugins/flowkit/skills/preview-epic/SKILL.md
+++ b/plugins/flowkit/skills/preview-epic/SKILL.md
@@ -77,7 +77,6 @@ If `$EPIC_BRANCH` is still empty, the user invoked the skill on a non-epic conte
 
 ```bash
 OPEN_AGAINST_EPIC=$(gh pr list --state open --base "$EPIC_BRANCH" --limit 200 --json number --jq 'length')
-MERGED_AGAINST_EPIC=$(gh pr list --state merged --base "$EPIC_BRANCH" --limit 200 --json number --jq 'length')
 
 if [[ "$OPEN_AGAINST_EPIC" -gt 0 ]]; then
   MODEL="A"
@@ -94,7 +93,17 @@ fi
 
 If Model A is selected but the sub-skill's PR-chain walk cannot connect to `$BASE_BRANCH`, the sub-skill will fall back by invoking `flowkit:preview-epic-direct` (the open PRs are not actually a stack rooted at base) or report malformed epic.
 
-The dispatcher passes through `$BASE_BRANCH`, `$EPIC_BRANCH`, and `$ARGUMENTS` to the chosen sub-skill via the Skill tool.
+The dispatcher passes structured arguments to the chosen sub-skill via the Skill tool. The argument string is always `--base <BASE_BRANCH> --epic <EPIC_BRANCH>` followed by the original `$ARGUMENTS` (so any user-supplied flags like a PR number are preserved as trailing args). Example invocations:
+
+```
+# Model A
+Skill("flowkit:preview-epic-stacked", "--base develop --epic feature/payments-42 123")
+
+# Model B
+Skill("flowkit:preview-epic-direct", "--base develop --epic feature/payments-42")
+```
+
+The `--base` and `--epic` flags are the mechanism by which the dispatcher hands off the resolved branch names; sub-skills must parse them from `$ARGUMENTS` at the top of their Process section.
 
 ## Composition
 

--- a/plugins/flowkit/skills/preview-epic/SKILL.md
+++ b/plugins/flowkit/skills/preview-epic/SKILL.md
@@ -7,17 +7,17 @@ triggers:
   - "preview stack"
   - "combine open PRs locally"
   - "validate epic before merge"
-allowed-tools: Bash, Read, AskUserQuestion
+allowed-tools: Bash, Read, AskUserQuestion, Skill
 ---
 
 # Preview Epic
 
 Verify the integrated state of an epic against the project's verify commands before any merge to the base branch. The skill supports both epic-merge models that ship in this repo:
 
-- **Model A — Stacked PRs.** Every PR in the epic stays OPEN, with each PR's `baseRefName` pointing at the previous PR's `headRefName`, ultimately rooting at the base branch. The integrated state must be synthesized locally via octopus merge (with sequential fallback). Finished by `swarmkit:merge-stack`.
-- **Model B — Direct-merge-to-epic.** A long-lived `feature/<slug>-<issue>` branch is cut once (typically by `flowkit:cut-epic` or `squadkit:spawn-team --epic`). Each child PR targets that epic branch and squash-merges into it, then closes. The epic branch HEAD already IS the integrated state — there is nothing to synthesize. Finished by opening an epic-to-base PR.
+- **Model A — Stacked PRs.** Every PR in the epic stays OPEN, with each PR's `baseRefName` pointing at the previous PR's `headRefName`, ultimately rooting at the base branch. The integrated state must be synthesized locally via octopus merge (with sequential fallback). Finished by `swarmkit:merge-stack`. Per-model flow lives in `flowkit:preview-epic-stacked`.
+- **Model B — Direct-merge-to-epic.** A long-lived `feature/<slug>-<issue>` branch is cut once (typically by `flowkit:cut-epic` or `squadkit:spawn-team --epic`). Each child PR targets that epic branch and squash-merges into it, then closes. The epic branch HEAD already IS the integrated state — there is nothing to synthesize. Finished by opening an epic-to-base PR. Per-model flow lives in `flowkit:preview-epic-direct`.
 
-The skill auto-detects which model applies and runs the right flow. The synthesized preview branch (Model A only) is local-only — nothing is pushed.
+This top-level skill is a **dispatcher**: it resolves the base branch and the epic branch, classifies which model applies, and invokes the matching sub-skill via the Skill tool. The synthesized preview branch (Model A only) is local-only — nothing is pushed.
 
 ## Input
 
@@ -39,7 +39,7 @@ BASE_BRANCH=$(jq -r '.baseBranch // empty' .squadkit/config.json 2>/dev/null)
 
 If the file is absent or `baseBranch` is empty, default to `develop`. If `develop` does not exist on origin (`git ls-remote --exit-code origin develop`), prompt the user via `AskUserQuestion` for the base branch name before proceeding.
 
-### 2. Resolve the epic branch and detect the model
+### 2. Resolve the epic branch
 
 Resolve the epic branch in priority order:
 
@@ -73,7 +73,7 @@ If `$EPIC_BRANCH` is still empty, the user invoked the skill on a non-epic conte
 
 > No epic in flight. `claude.flowkit.prBase` is unset (or equals `$BASE_BRANCH`) and the current branch is not a `feature/*` epic. Run `/cut-epic` first, pass `--epic <branch>`, or check out the epic branch.
 
-Once an epic is resolved, classify the model:
+### 3. Classify the model and dispatch
 
 ```bash
 OPEN_AGAINST_EPIC=$(gh pr list --state open --base "$EPIC_BRANCH" --limit 200 --json number --jq 'length')
@@ -88,208 +88,13 @@ else
 fi
 ```
 
-- **Model A** — open PRs target the epic branch. Synthesize the union via octopus merge (steps 3–6).
-- **Model B** — zero open PRs but the epic branch exists (typically with squash-merged contributions accumulated). Run verify directly on the epic HEAD (step 6b).
+- **Model A** — open PRs target the epic branch. Invoke `flowkit:preview-epic-stacked` to synthesize the union via octopus merge and run verify against the preview branch.
+- **Model B** — zero open PRs but the epic branch exists (typically with squash-merged contributions accumulated). Invoke `flowkit:preview-epic-direct` to run verify directly on the epic HEAD.
 - **Model none** — no open PRs and no remote epic branch. Stop and report: nothing to preview.
 
-If Model A is selected but the PR-chain walk in step 3 cannot connect to `$BASE_BRANCH`, fall back to Model B (the open PRs are not actually a stack rooted at base) or report malformed epic.
+If Model A is selected but the sub-skill's PR-chain walk cannot connect to `$BASE_BRANCH`, the sub-skill will fall back by invoking `flowkit:preview-epic-direct` (the open PRs are not actually a stack rooted at base) or report malformed epic.
 
-### 3. (Model A) Discover the stack
-
-List every open PR in the repo with the metadata needed to walk the base→head chain:
-
-```bash
-gh pr list --state open --limit 200 \
-  --json number,headRefName,baseRefName,title,url
-```
-
-Build the stack:
-
-1. Determine the entry PR.
-   - If `$ARGUMENTS` is a number, use it as the entry PR.
-   - Otherwise, resolve the PR for the current branch via `gh pr view --json number,headRefName,baseRefName`.
-2. Walk **down** the chain (toward the root): from the entry PR, follow `baseRefName` → matching `headRefName` until the next base equals `$BASE_BRANCH`. That PR is the **stack root**.
-3. Walk **up** the chain (toward the leaves): starting from the root, collect every PR whose `baseRefName` matches a previously-collected `headRefName`. Repeat until no more matches.
-
-The result is an ordered list `[root, ..., leaf]` of PRs in the stack. If the entry PR has no chain to `$BASE_BRANCH`, the epic is malformed for Model A — fall back to Model B (treat the epic branch HEAD as the integrated state).
-
-### 4. (Model A) Pick the preview branch name
-
-```bash
-ROOT_NUM=<root PR number>
-ROOT_SLUG=<root PR headRefName, sanitized to [a-z0-9-]+>
-PREVIEW_BRANCH="preview/${ROOT_NUM}-${ROOT_SLUG}"
-```
-
-If `$PREVIEW_BRANCH` already exists locally, append `-2`, `-3`, etc. until unused. Never overwrite an existing branch.
-
-### 5. (Model A) Fetch and create the preview branch
-
-```bash
-git fetch origin
-git checkout -b "$PREVIEW_BRANCH" "origin/$BASE_BRANCH"
-```
-
-Fetch every stack head ref so the merge has up-to-date refs:
-
-```bash
-gh pr list --state open --json number,headRefName --jq '.[].headRefName' | while read REF; do
-  git fetch origin "$REF":"refs/remotes/origin/$REF" 2>/dev/null || true
-done
-```
-
-### 6. (Model A) Try octopus merge first; sequential fallback on conflict
-
-Octopus merge combines every head in a single commit. It only succeeds if all branches merge cleanly together.
-
-```bash
-HEADS=$(printf 'origin/%s ' "${STACK_HEADS[@]}")
-if git merge --no-ff -m "preview: epic ${PREVIEW_BRANCH}" $HEADS; then
-  STRATEGY="octopus"
-else
-  git merge --abort 2>/dev/null || true
-  STRATEGY="sequential"
-fi
-```
-
-If octopus failed, merge each head one at a time in stack order (root → leaf). Halt on the first conflict and report which PR introduced it.
-
-```bash
-for HEAD in "${STACK_HEADS[@]}"; do
-  if ! git merge --no-ff -m "preview: merge ${HEAD}" "origin/$HEAD"; then
-    CONFLICT_BRANCH="$HEAD"
-    git merge --abort
-    break
-  fi
-done
-```
-
-If a conflict halts the sequential merge, stop the skill and report:
-
-- The preview branch name (so the user can inspect partial state if they re-run without `--abort`).
-- The branch that conflicted.
-- The PRs that merged cleanly before the conflict.
-
-Do not proceed to verify commands when sequential merge fails.
-
-### 6b. (Model B) Sync the epic branch locally
-
-There is no synthesis to do — the epic branch already accumulates the squash-merged contributions. Pull it down and check it out so verify runs against the integrated state.
-
-```bash
-# Preserve any uncommitted state in the working tree.
-STASHED=0
-if ! git diff --quiet HEAD || ! git diff --cached --quiet; then
-  git stash push -u -m "preview-epic auto-stash"
-  STASHED=1
-fi
-
-git fetch origin "$EPIC_BRANCH":"refs/remotes/origin/$EPIC_BRANCH"
-
-if git show-ref --verify --quiet "refs/heads/$EPIC_BRANCH"; then
-  git checkout "$EPIC_BRANCH"
-  git pull --ff-only origin "$EPIC_BRANCH" || {
-    echo "Epic branch has diverged from origin; not auto-resolving. Aborting."
-    [[ "$STASHED" -eq 1 ]] && git stash pop
-    exit 1
-  }
-else
-  git checkout -b "$EPIC_BRANCH" "origin/$EPIC_BRANCH"
-fi
-```
-
-Record the merged-PR composition for the report:
-
-```bash
-MERGED_PRS=$(gh pr list --state merged --base "$EPIC_BRANCH" --limit 200 \
-  --json number,title,headRefName --jq '.[] | "#\(.number) \(.title)"')
-```
-
-After verify completes, restore the user's pre-skill working state if any was stashed:
-
-```bash
-[[ "$STASHED" -eq 1 ]] && git stash pop
-```
-
-### 7. Resolve verify commands
-
-Read `.squadkit/config.json` for `verify.typecheck`, `verify.test`, `verify.lint`, and `install`:
-
-```bash
-TYPECHECK=$(jq -r '.verify.typecheck // empty' .squadkit/config.json 2>/dev/null)
-TEST=$(jq -r '.verify.test // empty' .squadkit/config.json 2>/dev/null)
-LINT=$(jq -r '.verify.lint // empty' .squadkit/config.json 2>/dev/null)
-INSTALL=$(jq -r '.install // empty' .squadkit/config.json 2>/dev/null)
-```
-
-For each command that resolved to empty, prompt the user via `AskUserQuestion`:
-
-- "What command should I run for typecheck on this preview? (or skip)"
-- "What command should I run for tests on this preview? (or skip)"
-- "What command should I run for lint on this preview? (or skip)"
-
-If the user declines any, skip that step. The skill does not hardcode `npm run test:run`, `npx tsc -b --noEmit`, or any other framework-specific command; the only source of commands is `.squadkit/config.json` or the user prompt.
-
-### 8. Run verify commands
-
-If `$INSTALL` is set and the working tree just changed (Model A always; Model B if HEAD moved), run install first. Then run typecheck, tests, and lint. Capture exit codes — do not abort the skill on failure; the user wants to see all results.
-
-```bash
-if [[ -n "$INSTALL" ]]; then
-  echo "==> install: $INSTALL"
-  eval "$INSTALL"
-fi
-
-if [[ -n "$TYPECHECK" ]]; then
-  echo "==> typecheck: $TYPECHECK"
-  eval "$TYPECHECK"
-  TYPECHECK_RC=$?
-fi
-
-if [[ -n "$TEST" ]]; then
-  echo "==> test: $TEST"
-  eval "$TEST"
-  TEST_RC=$?
-fi
-
-if [[ -n "$LINT" ]]; then
-  echo "==> lint: $LINT"
-  eval "$LINT"
-  LINT_RC=$?
-fi
-```
-
-### 9. Report
-
-Print a concise summary tagged with the model:
-
-**Model A:**
-
-- Preview branch name.
-- Merge strategy used (`octopus` or `sequential`), or the conflict report if sequential merge halted.
-- Stack composition: every PR that was merged in, in order, as `#<num> <title>`.
-- Verify outcomes: typecheck pass/fail/skipped, tests pass/fail/skipped, lint pass/fail/skipped.
-- Suggested next step:
-  - All green → `swarmkit:merge-stack` is safe.
-  - Conflict or verify failure → fix the offending PR and re-run.
-
-Suggested cleanup (Model A only):
-
-```bash
-git checkout "$BASE_BRANCH"
-git branch -D "$PREVIEW_BRANCH"
-```
-
-**Model B:**
-
-- Preview branch: `<epic-branch>` (Model B — direct-merge-to-epic; no synthesis needed).
-- Stack composition: list of squash-merged PRs from `gh pr list --state merged --base <epic>`.
-- Verify outcomes: typecheck pass/fail/skipped, tests pass/fail/skipped, lint pass/fail/skipped.
-- Suggested next step:
-  - All green → open the final epic-to-base PR: `gh pr create --base "$BASE_BRANCH" --head "$EPIC_BRANCH"`.
-  - Verify failure → fix on the epic branch (or open a follow-up PR targeting the epic) and re-run.
-
-No cleanup needed — the epic branch is long-lived.
+The dispatcher passes through `$BASE_BRANCH`, `$EPIC_BRANCH`, and `$ARGUMENTS` to the chosen sub-skill via the Skill tool.
 
 ## Composition
 
@@ -300,13 +105,14 @@ No cleanup needed — the epic branch is long-lived.
 | `swarmkit:merge-stack` | Run **after** `preview-epic` (Model A) confirms the combined tree is green. Cascades the actual merges. |
 | `flowkit:ship` | Do not run while a Model A preview is checked out — switch back to the base branch first. |
 
+| Sub-skill | Role |
+|-----------|------|
+| `flowkit:preview-epic-stacked` | Model A flow — stack discovery, octopus/sequential merge into a `preview/...` branch, verify, report. |
+| `flowkit:preview-epic-direct` | Model B flow — fast-forward the epic branch locally, verify on HEAD, report. |
+
 ## Constraints
 
-- **Local-only.** Never push the synthesized preview branch (Model A); it is a throwaway integration check. The epic branch (Model B) is fetched but not modified beyond fast-forward.
 - **Read defensively.** `.squadkit/config.json` may not exist — fall back to defaults and prompts.
-- **No framework assumptions.** Verify commands come from `.squadkit/config.json` or user prompt; the skill never hardcodes `npm`, `pnpm`, `vitest`, `tsc`, `pytest`, `ruff`, `cargo`, or any other tool.
+- **No framework assumptions.** Verify commands come from `.squadkit/config.json` or user prompt; the dispatcher and its sub-skills never hardcode `npm`, `pnpm`, `vitest`, `tsc`, `pytest`, `ruff`, `cargo`, or any other tool.
 - **No PR retargeting.** This skill inspects PR metadata but never edits it. Use `swarmkit:merge-stack` for retargeting.
-- **Halt cleanly on conflict (Model A).** Sequential merge must `git merge --abort` before reporting, so the working tree is left in a clean state on the preview branch's pre-conflict commit.
-- **Preserve working state (Model B).** Auto-stash uncommitted changes before checking out the epic branch; restore on completion.
-- **Idempotent in spirit.** Re-running with the same root will pick a fresh `preview/...-N` name (Model A) or simply re-fast-forward the epic branch (Model B) rather than clobbering existing local state.
 - **Fail loud, not silent.** When no epic context can be resolved (no `--epic`, no `claude.flowkit.prBase` pin distinct from base, no `feature/*` checkout), report explicitly rather than no-op.


### PR DESCRIPTION
## Summary

Split the 313-line `flowkit:preview-epic` SKILL.md into a thin auto-detector + dispatcher that routes to per-model sub-skills. This shrinks the top-level skill to 118 lines and isolates the two epic-merge flows (stacked PRs vs direct merge to epic) into focused, independently editable sub-skills. Pure structural refactor — behavior is preserved end-to-end.

## Changes

- Extract Model A (stacked-PR octopus-merge) flow into `plugins/flowkit/skills/preview-epic-stacked/SKILL.md` as a sub-skill with frontmatter consistent with other flowkit sub-skills.
- Extract Model B (direct-merge-to-epic) flow into `plugins/flowkit/skills/preview-epic-direct/SKILL.md` as a sub-skill with the same frontmatter shape.
- Reduce `plugins/flowkit/skills/preview-epic/SKILL.md` to base-branch resolution, epic-branch resolution, model classification, and dispatch via the Skill tool. Updates `allowed-tools` to include `Skill` and adds a sub-skill composition table.

## Test plan

- [ ] `plugins/flowkit/skills/preview-epic/SKILL.md` is under 200 lines (currently 118).
- [ ] Both sub-skills have valid YAML frontmatter (`name`, `description`, `allowed-tools`) consistent with other flowkit sub-skills.
- [ ] Dispatcher classifies `MODEL=A`/`B`/`none` from `gh pr list` open count and invokes `flowkit:preview-epic-stacked` or `flowkit:preview-epic-direct` accordingly.
- [ ] **Variable-passing contract**: dispatcher Skill-tool call emits `--base <resolved-BASE_BRANCH> --epic <resolved-EPIC_BRANCH>` followed by original `$ARGUMENTS`; both sub-skills parse and assert non-empty `$BASE_BRANCH` and `$EPIC_BRANCH` before proceeding.
- [ ] Model A end-to-end: open PRs targeting an epic → octopus merge into a `preview/...` branch → verify commands run → cleanup suggestion printed.
- [ ] **Model A → Model B fallback**: when the PR-chain walk in `preview-epic-stacked` cannot connect to `$BASE_BRANCH` (malformed stack), the sub-skill invokes `flowkit:preview-epic-direct` with the same `--base`/`--epic` structured args, and Model B verify runs against the epic branch HEAD.
- [ ] Model B end-to-end: epic branch with merged PRs → fast-forward locally → verify commands run on epic HEAD → no cleanup needed.
- [ ] Auto-stash/restore behavior preserved on Model B path.
- [ ] No framework commands hardcoded; verify commands still resolved from `.squadkit/config.json` or `AskUserQuestion`.

Closes #667