### PR TITLE
fix(bump-versions): add squadkit to plugin table

### DIFF
--- a/.claude/skills/bump-versions/SKILL.md
+++ b/.claude/skills/bump-versions/SKILL.md
@@ -21,6 +21,7 @@ Every kit under `plugins/*` that ships a manifest at `.claude-plugin/plugin.json
 | polishkit | `plugins/polishkit/.claude-plugin/plugin.json` |
 | sessionkit | `plugins/sessionkit/.claude-plugin/plugin.json` |
 | speckit | `plugins/speckit/.claude-plugin/plugin.json` |
+| squadkit | `plugins/squadkit/.claude-plugin/plugin.json` |
 | swarmkit | `plugins/swarmkit/.claude-plugin/plugin.json` |
 | vaultkit | `plugins/vaultkit/.claude-plugin/plugin.json` |
 


### PR DESCRIPTION
## Summary
- Add the missing `squadkit` row to the hardcoded plugin-locations table in `.claude/skills/bump-versions/SKILL.md` so /bump-versions detects squadkit changes alongside the other six plugins
- Surfaced on the v2026.4.29 release cycle where squadkit had to be detected manually because of this omission

## Changes
- `.claude/skills/bump-versions/SKILL.md` — add `squadkit | plugins/squadkit/.claude-plugin/plugin.json` row to the plugin table

## Test plan
- Run `/bump-versions` and confirm squadkit is included in the change-detection loop
- Verify the table now lists all seven plugins (flowkit, polishkit, sessionkit, speckit, squadkit, swarmkit, vaultkit) in alphabetical order