### PR TITLE
feat(swarmkit): graduate swarm-plus skill with vendored reviewer agent

### DIFF
--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -51,6 +51,7 @@ Swarmkit is designed to run best when agents don't have to pause for per-command
 | Skill | Invoke | What it does |
 |-------|--------|--------------|
 | **swarm** | `/swarm` | Spawn parallel isolated-worktree agents to resolve GitHub issues. Supports one-shot mode (specific issues) and loop mode (clear the board). Auto-creates PRs targeting `develop`. |
+| **swarm-plus** | `/swarm-plus` | Wraps `/swarm` with an automatic review/fix pass. After each swarm PR opens, dispatches the vendored `swarm-reviewer` agent per PR; if the reviewer flags blockers or concerns, dispatches a worker to push follow-up commits. Single pass per PR. |
 | **x-swarm** | `/x-swarm` | Experimental parallel variant of `/swarm`. Script-backed mechanical phases (preflight, teardown) reduce model round-trips. Same arg grammar and behavior as `/swarm` — prefer `/swarm` for stable workflows. |
 | **next-issue** | `/next-issue` | Fetches open issues, ranks them by priority, specificity, and architectural impact, and recommends what to work on next. |
 | **merge-stack** | `/merge-stack` | Merges all open swarm PRs bottom-up (root PRs first, leaves last) after retargeting non-root PRs to `$BASE`. |
@@ -66,6 +67,14 @@ These are called by the skills above — you don't invoke them directly.
 | **conventional-commit-message** | swarm | Enforces `type(scope): description` commit format. |
 | **gh-fetch-issues** | next-issue, swarm | Fetches open issues and filters out `on-hold` labeled ones. |
 | **issue-rank** | next-issue, swarm | Ranks issues by priority labels, specificity, and architectural impact. |
+
+### Agents
+
+Swarmkit vendors a specialized reviewer agent used by `/swarm-plus`. It is not a general-purpose reviewer — it is purpose-built for comparing a swarm-produced PR against its originating issue.
+
+| Agent | Used by | Purpose |
+|-------|---------|---------|
+| **swarm-reviewer** | swarm-plus | Reviews a swarm PR against the originating issue's acceptance criteria. Returns findings inline (never via `gh pr comment`) using a fixed five-section output structure: Verdict / Blockers / Concerns / Nits / Coverage gaps. |
 
 ## Typical Workflow
 
@@ -95,6 +104,27 @@ These are called by the skills above — you don't invoke them directly.
 
 - `--model <sonnet|opus>` — override model selection for all agents
 - `--base <branch>` — override the default base branch (`develop`)
+
+## How Swarm Plus Works
+
+`/swarm-plus` runs `/swarm` first, then layers a review/fix pass on each resulting PR:
+
+1. Invokes `/swarm` with the same args. Records `(issue, pr_number, head_branch)` for each PR produced.
+2. As each swarm agent finishes, immediately dispatches `swarm-reviewer` against that PR in the background — no waiting for other swarm agents.
+3. The reviewer compares the PR diff against the originating issue's acceptance criteria and returns findings inline (never as a `gh pr comment`).
+4. If the reviewer's verdict is clean (Approve, no blockers, no concerns, no recommended coverage gaps), the PR is left as-is.
+5. If the reviewer surfaces blockers or concerns, a worker agent is spawned to address them. The worker branches from the existing PR head — never from `develop` — so its commits stack directly onto the PR.
+6. After all workers finish, a final table summarizes verdict and worker action per PR.
+
+**Single pass** — there is no reviewer-after-worker re-review. Use `/review <pr>` manually if a second pass is desired.
+
+### Swarm Plus Flags
+
+All `/swarm` flags are inherited. Swarm-plus adds:
+
+- `--no-worker` — dispatch reviewers but never spawn workers (triage mode)
+- `--reviewer-model <sonnet|opus>` — override reviewer model (default: `sonnet`)
+- `--worker-model <sonnet|opus>` — override worker model (default: `sonnet`)
 
 ## Assumptions & Conventions
 

--- a/plugins/swarmkit/agents/swarm-reviewer.md
+++ b/plugins/swarmkit/agents/swarm-reviewer.md
@@ -1,0 +1,74 @@
+---
+name: swarm-reviewer
+description: Specialized reviewer for swarm-produced PRs. Reviews a PR against the originating issue's acceptance criteria and returns findings inline — never via gh pr comment. Output always follows the required five-section structure (Verdict / Blockers / Concerns / Nits / Coverage gaps) so the swarm-plus orchestrator can parse the result and decide whether to spawn a worker.
+tools: Bash, Read
+---
+
+You are a specialized code reviewer for swarm-produced pull requests. Your job is to evaluate whether the PR satisfies the originating issue's acceptance criteria and surface any problems the swarm agent may have introduced or missed.
+
+## Required inputs
+
+The prompt invoking you MUST include:
+
+- **PR number** — e.g. `#1390`
+- **PR title** — the title of the pull request
+- **Closes reference** — e.g. `Closes #42`
+- **Original issue body** — the full text of the issue the PR claims to close
+
+## How to gather context
+
+1. Fetch the PR diff and metadata:
+   ```bash
+   gh pr view <pr_number> --json title,body,headRefName,baseRefName,additions,deletions,files
+   gh pr diff <pr_number>
+   ```
+2. Read the files touched by the diff to understand surrounding context where relevant.
+3. Cross-reference the issue body's acceptance criteria against the diff.
+
+## What to evaluate
+
+- **Correctness**: Does the implementation satisfy each acceptance criterion in the issue?
+- **Completeness**: Are there acceptance criteria the diff does not address at all?
+- **Regressions**: Does the change break anything adjacent to the modified files?
+- **Conventions**: Does the code follow project conventions (naming, structure, commit format)?
+- **Test coverage**: Are the changes tested? Are there gaps that would leave the feature unverifiable?
+
+## Output format (REQUIRED — do not deviate)
+
+Return your findings in this exact structure. Every section must be present even if empty.
+
+---
+
+**Verdict**: `Approve` | `Request changes` | `Comment`
+
+**Blockers** (must fix before merge):
+- <item> — or "None"
+
+**Concerns** (worth raising; address or explicitly defer):
+- <item> — or "None"
+
+**Nits** (style, optional; not actionable enough to warrant a worker round):
+- <item> — or "None"
+
+**Coverage gaps**:
+- `[recommended]` <gap> — reviewer considers this important enough to warrant a worker addressing it
+- `[optional]` <gap> — noted for completeness; worker should skip
+- "None" if no gaps
+
+---
+
+## Verdict rules
+
+| Conditions | Verdict |
+|------------|---------|
+| No blockers, no concerns, no recommended coverage gaps | `Approve` |
+| Any blocker present | `Request changes` |
+| Concerns or recommended coverage gaps but no blockers | `Comment` |
+
+## Critical constraints
+
+- **Return the review inline.** Never post it as a `gh pr comment`. The orchestrator reads your output directly.
+- **Do not merge the PR.** Your role ends with the review output.
+- **Do not close the issue.** Leave issue lifecycle to the PR merge.
+- **Be specific.** Vague findings ("consider improving X") waste the worker's time. Cite file paths and line numbers where possible.
+- **Defer rather than guess.** If you are uncertain whether something is a blocker vs. a concern, classify it as a concern and say so.

--- a/plugins/swarmkit/skills/swarm-plus/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-plus/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: swarm-plus
+description: Wrap /swarmkit:swarm with an automatic review/fix pass. After each swarm PR opens, dispatch a swarmkit-vendored reviewer; if the reviewer flags blockers or concerns, dispatch a worker to address them and update the PR. Single pass — stop after one reviewer + at-most-one worker per PR.
+triggers:
+  - "swarm plus"
+  - "swarm+"
+  - "swarm with review"
+  - "swarm and review"
+  - "swarm review"
+---
+
+# Swarm Plus
+
+Layer an automatic review/fix pass over `/swarmkit:swarm`. Same arg grammar; same isolation; same final state (open PRs awaiting human merge). The only addition: each PR gets one reviewer, and if the reviewer surfaces blockers or concerns, one worker pushes follow-up commits to the same branch.
+
+## Input
+
+Identical to `/swarmkit:swarm`:
+
+- No args → loop mode, all open issues → `develop`
+- Label text (e.g. `bug`, `priority:high`) → loop mode filtered by label → `develop`
+- Issue numbers (`12 15 18`, `#12 #15 #18`, range `12-18`) → one-shot mode → `develop`
+- `--model <tier>` (`sonnet`, `opus`) — model override for swarm agents (reviewer + worker have their own defaults; see below)
+- `--base <branch>` — override default base branch
+- `--no-worker` — review only; never dispatch worker (useful for triage)
+- `--worker-model <tier>` — override worker model (default: `sonnet`)
+- `--reviewer-model <tier>` — override reviewer model (default: `sonnet`)
+
+## Process
+
+### 1. Run the swarm phase
+
+Invoke `/swarmkit:swarm` with the same args (excluding `--no-worker`, `--worker-model`, and `--reviewer-model` — those are swarm-plus-only flags). Track the agent IDs and the issues each agent owns. Record `(issue, pr_number, head_branch, base_branch)` for each PR as it is produced.
+
+Do NOT block on every swarm agent before spawning reviewers. As each swarm agent's task notification arrives:
+
+1. Verify the PR exists: `gh pr view <pr_number> --json url,headRefName,baseRefName,state`
+2. Fetch the original issue body: `gh issue view <issue> --json body --jq '.body'`
+3. Spawn a reviewer for that PR (see step 2). Continue handling other notifications in parallel.
+
+### 2. Spawn reviewer per PR
+
+Spawn the **`swarmkit:swarm-reviewer`** agent with `run_in_background: true`. Default model `sonnet`; override via `--reviewer-model`.
+
+The reviewer prompt MUST include:
+
+- The PR number, title, and `Closes #<issue>` reference
+- The original issue body (for spec / acceptance-criteria comparison)
+- An explicit instruction: **return the review inline; do NOT post it as a `gh pr comment`**
+- A required output structure:
+  - **Verdict**: Approve / Request changes / Comment
+  - **Blockers** (must fix)
+  - **Concerns** (worth raising, not blocking)
+  - **Nits** (style, optional)
+  - **Coverage gaps** (with `[recommended]` or `[optional]` tag per gap)
+
+Track each reviewer's agent ID against the PR it covers.
+
+### 3. Decide whether to spawn a worker
+
+When a reviewer's task notification arrives, parse its result. Apply the **skip-on-clean** rule:
+
+| Reviewer output | Worker action |
+|-----------------|---------------|
+| Verdict `Approve` AND no blockers AND no concerns AND no `[recommended]` coverage gaps | **Skip worker.** Nits and `[optional]` coverage gaps are not actionable enough to warrant a worker round. |
+| Any blockers | **Spawn worker.** Blockers are mandatory. |
+| Any concerns | **Spawn worker.** Concerns get addressed or explicitly deferred. |
+| Coverage gaps flagged `[recommended]` | **Spawn worker.** Treat recommended coverage gaps as concerns. |
+| `--no-worker` flag set | Skip regardless. |
+
+Print one line announcing the decision per PR:
+
+```
+PR #1390: reviewer clean (no blockers/concerns) → skipping worker
+PR #1391: reviewer flagged 1 blocker, 2 concerns → dispatching worker
+```
+
+### 4. Spawn worker
+
+For each PR that needs follow-up work, spawn a `general-purpose` agent with `isolation: worktree`, `mode: bypassPermissions`, `run_in_background: true`. Default model `sonnet`; override via `--worker-model`.
+
+The worker prompt MUST:
+
+- Include the **PR number** and **head branch** (e.g. `worktree-agent-42`).
+- Include the **full reviewer output** verbatim under a `REVIEWER FINDINGS` section.
+- State explicit scope:
+  - **In scope**: blockers (mandatory), concerns (address or explicitly defer with stated reason in a PR comment), reviewer-recommended coverage gaps.
+  - **Out of scope**: nits (skip unless trivially co-located with a fix), `[optional]` coverage gaps, unrelated cleanups, scope creep.
+- Instruct the worker to:
+  1. Branch from the **existing PR branch**, NOT from `develop`:
+     ```bash
+     git fetch origin <head_branch>
+     git checkout -B <head_branch> origin/<head_branch>
+     ```
+  2. Apply the changes.
+  3. Run `npx tsc -b --noEmit` and the relevant test scope. Resolve any failures before proceeding — never push a red build.
+  4. Commit with conventional-commit format (no Claude mentions, no co-author lines).
+  5. Push to the same branch (`git push origin <head_branch>`) — auto-updates the PR.
+  6. Optionally comment on the PR summarizing what was addressed and what was deferred:
+     ```bash
+     gh pr comment <pr_number> --body "Addressed reviewer feedback: <summary>. Deferred: <items with reasons>."
+     ```
+- Forbid: branching off `develop`, force-pushing, rewriting prior commits, closing the issue manually.
+- Termination: report the new commit SHAs and confirm `gh pr view <pr_number> --json commits` includes them.
+
+### 5. Wait for all workers
+
+Continue until every dispatched worker reports completion. Verify each PR's HEAD has advanced:
+
+```bash
+gh pr view <pr_number> --json commits | jq '.commits[-1].oid'
+```
+
+### 6. Final report
+
+```
+── swarm-review complete ─────────────────────
+PRs opened by swarm: #1390 #1391 #1392
+  #1390: reviewed → clean → no worker
+  #1391: reviewed → 2 concerns → worker pushed 2 commits
+  #1392: reviewed → 1 blocker → worker pushed 1 commit
+All PRs ready for human merge.
+─────────────────────────────────────────────
+```
+
+Suggest next step: `/merge-pr` for one PR or `/merge-stack` for two or more.
+
+## Constraints
+
+- **Single pass** — no reviewer-after-worker re-review. The user can manually trigger another review with `/review <pr>` if desired.
+- **Skip-on-clean** — never dispatch a worker against a clean approval. Manufactured churn is worse than a no-op.
+- **Worker branches off PR head, never off `develop`** — commits must stack on the existing PR.
+- **Reviewer output stays inline, never posted as a PR comment** by the reviewer itself. The worker is the only sub-agent that may comment on the PR (and only with a brief "addressed feedback" summary).
+- **Never merge** any PR — final state is open PRs awaiting human merge.
+- **Never close issues** — `Closes #N` in PR bodies handles it on merge.
+- **Defer rather than guess** — if the reviewer's findings are ambiguous (e.g. "consider X"), the worker should explicitly defer in a PR comment rather than implement guesses.
+- All swarm constraints from `/swarmkit:swarm` apply transitively: worktree isolation, conventional commits, no Claude/co-author mentions, no absolute repo paths in agent prompts, never commit directly to develop or main.
+
+## Failure modes
+
+| Symptom | Handling |
+|---------|----------|
+| Swarm agent fails to produce a PR | Skip review/worker for that issue; report in final summary |
+| Reviewer crashes or returns no output | Note in final summary; leave PR open without worker pass |
+| Worker push rejected (branch advanced underneath) | Worker re-fetches and rebases (`git fetch origin <head>; git rebase origin/<head>`); if conflicts arise, abort and report to user |
+| Worker introduces new test failures | Worker MUST resolve before push — never push a red build |


### PR DESCRIPTION
## Summary

Graduates the project-local `/swarm-plus` skill into swarmkit so every project can use the automatic review/fix layer on top of `/swarm`. Adds a swarmkit-vendored reviewer agent so there is no cross-plugin dependency on `pr-review-toolkit`. Worker scope on coverage gaps follows reference behavior: `[recommended]` gaps treated as concerns and addressed, `[optional]` gaps skipped.

## Changes

- Add `plugins/swarmkit/agents/swarm-reviewer.md` — vendored reviewer agent with required output structure (Verdict / Blockers / Concerns / Nits / Coverage gaps), inline-only output constraint, and verdict rules.
- Add `plugins/swarmkit/skills/swarm-plus/SKILL.md` — orchestrator skill that runs `/swarmkit:swarm`, dispatches the vendored reviewer per PR as notifications land (no blocking wait), and conditionally spawns a worker on blockers, concerns, or recommended coverage gaps. Documents failure modes and all swarm constraints.
- Update `plugins/swarmkit/README.md` to list `/swarm-plus` in the user-facing skills table, document the new `swarm-reviewer` agent in an Agents table under Sub-Skills, and add a "How Swarm Plus Works" section with its additional flags.

## Test plan

- [ ] Invoke `/swarmkit:swarm-plus <issue>` against a small open issue in a sibling repo; confirm reviewer runs inline and returns the five-section structure.
- [ ] Confirm worker spawns only when blockers or concerns are present, and skips on a clean Approve verdict.
- [ ] Confirm final report table lists all PRs with verdict and worker action.
- [ ] Confirm no `pr-review-toolkit` references exist in `plugins/swarmkit/` (`grep -r "pr-review-toolkit" plugins/swarmkit/` returns empty).
- [ ] Confirm README cross-links render correctly on GitHub.
- [ ] Verify triggers ("swarm plus", "swarm+", "swarm with review", "swarm and review", "swarm review") appear in the skill frontmatter.

Closes #683