### PR TITLE
fix(sessionkit/pickup): use AskUserQuestion for closing prompt

### DIFF
--- a/plugins/sessionkit/skills/pickup/SKILL.md
+++ b/plugins/sessionkit/skills/pickup/SKILL.md
@@ -7,7 +7,7 @@ triggers:
   - "load handoff"
   - "resume from handoff"
   - "continue previous session"
-allowed-tools: Bash, Read, TaskCreate, TaskUpdate, TaskList, Skill
+allowed-tools: Bash, Read, TaskCreate, TaskUpdate, TaskList, AskUserQuestion, Skill
 ---
 
 # Pickup
@@ -90,9 +90,17 @@ Only suggest this when there's a mismatch. Do not switch branches automatically.
 
 ### 6. Confirm readiness
 
-End with:
+End by asking the user what to tackle first via the `AskUserQuestion` tool. Frame the question around the handoff's `Goal` and derive 2–4 concrete options from the `Remaining Work` list (highest-priority items first):
+
+- **question**: `Context loaded. Ready to continue work on: <Goal>. What would you like to tackle first?`
+- **header**: `Next action` (or similar short label)
+- **options**: one option per top Remaining Work item, with a short description summarizing scope/effort
+
+If `Remaining Work` has fewer than 2 actionable items, fall back to plain text:
 
 > Context loaded. Ready to continue work on: `<Goal>`. What would you like to tackle first?
+
+Do not pose this as a plain-text question when `AskUserQuestion` is viable — the structured prompt is the canonical end-of-pickup interaction.
 
 ## Constraints
 


### PR DESCRIPTION
## Summary
- Step 6 of `/sessionkit:pickup` literally prescribed a plain-text closing question (\"What would you like to tackle first?\"), which contradicts the AskUserQuestion preference and was the root cause of a friction point in the prior session.
- This PR updates step 6 to mandate `AskUserQuestion` (with options derived from `Remaining Work`) and adds `AskUserQuestion` to the skill's `allowed-tools`.

## Changes
- `plugins/sessionkit/skills/pickup/SKILL.md`: rewrote step 6 to use `AskUserQuestion` and added `AskUserQuestion` to allowed-tools. Plain-text fallback retained when `Remaining Work` has fewer than 2 actionable items.

## Test plan
- [ ] Invoke \`/sessionkit:pickup\` in a session with a populated handoff and confirm the closing prompt renders as a structured AskUserQuestion with options sourced from Remaining Work.
- [ ] Confirm the plain-text fallback fires when Remaining Work is sparse.