### PR TITLE
feat(bump-versions): extract changed-plugin detection to a script

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,8 @@
       "Bash($SKILL_DIR/scripts/preflight.sh:*)",
       "Bash($SKILL_DIR/scripts/gather_issues.sh:*)",
       "Bash($SKILL_DIR/scripts/verify_agent.sh:*)",
-      "Bash($SKILL_DIR/scripts/teardown.sh:*)"
+      "Bash($SKILL_DIR/scripts/teardown.sh:*)",
+      "Bash($SKILL_DIR/scripts/detect_changed.sh:*)"
     ]
   }
 }

--- a/.claude/skills/bump-versions/SKILL.md
+++ b/.claude/skills/bump-versions/SKILL.md
@@ -34,40 +34,46 @@ Repo-level calver tags (`v2026.4.16`) are separate and not used for plugin versi
 
 ### Step 1 — Detect changed plugins
 
-For each plugin, find the most recent `{plugin-name}--v*` tag:
+Run the detection script once to get a JSON array of plugins with uncommitted changes since their last per-plugin tag:
 
 ```bash
-git tag --list 'swarmkit--v*' | sort -V | tail -1
+export SKILL_DIR="<absolute path from the 'Base directory for this skill:' header line>"
+bash "$SKILL_DIR/scripts/detect_changed.sh"
 ```
 
-If no per-plugin tag exists, use the current version in `plugin.json` as the baseline and treat all files as changed.
+The script emits a bare JSON array on stdout:
 
-Count commits touching the plugin's directory since that tag:
-
-```bash
-git log {tag}..HEAD --oneline -- plugins/{name}/ | wc -l
+```json
+[
+  {"plugin": "swarmkit", "last_tag": "swarmkit--v5.1.0", "commit_count": 2, "current_version": "5.1.0"},
+  {"plugin": "flowkit",  "last_tag": "flowkit--v1.2.0",  "commit_count": 1, "current_version": "1.2.0"}
+]
 ```
+
+Only plugins with `commit_count > 0` (or no prior tag) are included. If the array is empty, no plugins have changed — report that and stop.
+
+If `$ARGUMENTS` is provided (e.g. `patch` or `minor`), apply that bump type to all changed plugins and skip the rest of Step 2 — do not prompt.
 
 ### Step 2 — Recommend and confirm bump types
 
-Display a table of plugins with changes:
+Display a table of plugins with changes (from the Step 1 JSON):
 
 ```
 Plugin      Current   Commits since last tag
 ----------  --------  ----------------------
-swarmkit    1.0.0     4
-flowkit     1.0.0     2
+swarmkit    5.1.0     2
+flowkit     1.2.0     1
 ```
 
-If `$ARGUMENTS` is provided (e.g. `patch` or `minor`), apply that bump type to all changed plugins and skip the rest of Step 2 — do not prompt.
-
-Otherwise, for each changed plugin, list its commits since the last tag and derive a recommended bump from the conventional-commit prefixes:
+For each changed plugin, retrieve its commits since the last tag to derive a recommended bump:
 
 ```bash
-git log {tag}..HEAD --oneline -- plugins/{name}/
+git log {last_tag}..HEAD --oneline -- plugins/{plugin}/
 ```
 
-Map prefixes to bump types (take the highest bump when multiple coexist; `major > minor > patch`):
+If `last_tag` is `(none)`, use the full history: `git log --oneline -- plugins/{plugin}/`.
+
+Map conventional-commit prefixes to bump types (take the highest when multiple coexist; `major > minor > patch`):
 
 | Commit signal | Recommended bump |
 |---------------|------------------|
@@ -90,8 +96,6 @@ Semver semantics for reference when explaining options:
 - **major** — breaking changes (`1.0.0 → 2.0.0`)
 
 Fall through to free-form prompting (asking the user to type patch/minor/major inline) only if `AskUserQuestion` is unavailable.
-
-Skip plugins with 0 commits since their last tag unless explicitly included via `$ARGUMENTS`.
 
 ### Step 3 — Update plugin.json files
 

--- a/.claude/skills/bump-versions/scripts/detect_changed.sh
+++ b/.claude/skills/bump-versions/scripts/detect_changed.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# detect_changed.sh — enumerate plugins with commits since their last per-plugin
+# git tag and emit a bare-payload JSON array of changed-plugin records.
+#
+# Usage:
+#   detect_changed.sh
+#
+# On success: exit 0, JSON array on stdout:
+#   [{"plugin": "swarmkit", "last_tag": "swarmkit--v5.1.0", "commit_count": 3, "current_version": "5.1.0"}, ...]
+#   Only plugins with commit_count > 0 (or no prior tag) are included.
+# On failure: non-zero exit, empty stdout, human-readable message on stderr.
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "detect_changed: must be run inside a git repository" >&2
+  exit 1
+}
+
+for cmd in git jq; do
+  command -v "$cmd" >/dev/null 2>&1 || {
+    echo "detect_changed: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  }
+done
+
+records="[]"
+
+find "$REPO_ROOT/plugins" -maxdepth 3 -name "plugin.json" -path "*/.claude-plugin/plugin.json" | sort | while read -r manifest; do
+  plugin_dir="$(dirname "$(dirname "$manifest")")"
+  plugin_name="$(basename "$plugin_dir")"
+
+  current_version="$(jq -r '.version // empty' "$manifest" 2>/dev/null)"
+  if [[ -z "$current_version" ]]; then
+    echo "detect_changed: could not read version from $manifest" >&2
+    continue
+  fi
+
+  last_tag="$(git tag --list "${plugin_name}--v*" | sort -V | tail -1)"
+
+  if [[ -z "$last_tag" ]]; then
+    commit_count="$(git log --oneline -- "$plugin_dir/" 2>/dev/null | wc -l | tr -d ' ')"
+    last_tag="(none)"
+  else
+    commit_count="$(git log --oneline "${last_tag}..HEAD" -- "$plugin_dir/" 2>/dev/null | wc -l | tr -d ' ')"
+  fi
+
+  if [[ "$commit_count" -gt 0 ]]; then
+    jq -n \
+      --arg plugin "$plugin_name" \
+      --arg last_tag "$last_tag" \
+      --argjson commit_count "$commit_count" \
+      --arg current_version "$current_version" \
+      '{"plugin": $plugin, "last_tag": $last_tag, "commit_count": $commit_count, "current_version": $current_version}'
+  fi
+done | jq -s '.'

--- a/.claude/skills/bump-versions/scripts/detect_changed.sh
+++ b/.claude/skills/bump-versions/scripts/detect_changed.sh
@@ -24,8 +24,6 @@ for cmd in git jq; do
   }
 done
 
-records="[]"
-
 find "$REPO_ROOT/plugins" -maxdepth 3 -name "plugin.json" -path "*/.claude-plugin/plugin.json" | sort | while read -r manifest; do
   plugin_dir="$(dirname "$(dirname "$manifest")")"
   plugin_name="$(basename "$plugin_dir")"


### PR DESCRIPTION
## Summary

Extracts the deterministic changed-plugin detection step from the `bump-versions` skill into a standalone shell script. This eliminates multiple sequential bash round-trips at release time and makes plugin detection reliable and auditable.

## Changes

- Add `.claude/skills/bump-versions/scripts/detect_changed.sh` — emits a bare-payload JSON array of `{plugin, last_tag, commit_count, current_version}` records for every plugin with commits since its last per-plugin git tag.
- Rewrite `.claude/skills/bump-versions/SKILL.md` Step 1 to invoke `$SKILL_DIR/scripts/detect_changed.sh` once and iterate the resulting JSON for the bump-type decision per plugin.
- Add `Bash($SKILL_DIR/scripts/detect_changed.sh:*)` allowlist entry to `.claude/settings.json`.

## Test plan

- [ ] Run `bash .claude/skills/bump-versions/scripts/detect_changed.sh` in a clean checkout; confirm bare-payload JSON array on stdout with no envelope wrapper.
- [ ] Spot-check one plugin's `commit_count` against `git log <last_tag>..HEAD --oneline -- plugins/<plugin>/`.
- [ ] Confirm the set of changed plugins matches what the old prompted SKILL.md Step 1 would have surfaced.
- [ ] Confirm no output on stdout when all plugins are up to date (empty array `[]`).

Closes #700