### PR TITLE
feat(swarmkit): extract clean-worktrees + clean-remote-worktrees to scripts

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -18,7 +18,11 @@
       "Bash($SKILL_DIR/scripts/preflight.sh:*)",
       "Bash($SKILL_DIR/scripts/gather_issues.sh:*)",
       "Bash($SKILL_DIR/scripts/verify_agent.sh:*)",
-      "Bash($SKILL_DIR/scripts/teardown.sh:*)"
+      "Bash($SKILL_DIR/scripts/teardown.sh:*)",
+      "Bash($SKILL_DIR/scripts/gather.sh:*)",
+      "Bash($SKILL_DIR/scripts/remove.sh:*)",
+      "Bash($SKILL_DIR/scripts/classify.sh:*)",
+      "Bash($SKILL_DIR/scripts/delete.sh:*)"
     ]
   }
 }

--- a/plugins/swarmkit/skills/clean-remote-worktrees/SKILL.md
+++ b/plugins/swarmkit/skills/clean-remote-worktrees/SKILL.md
@@ -13,84 +13,140 @@ Counterpart to `swarmkit:clean-worktrees` — this skill never touches local sta
 
 Parse `$ARGUMENTS`:
 
-- **No arguments** → **interactive**: fetch, classify, present plan, proceed to deletion on confirmation
+- **No arguments** → **interactive**: classify, present plan, ask for confirmation before deletion
 - `--yes` → **non-interactive**: skip confirmation (for automation contexts)
+
+## Setup
+
+**Resolve the skill base directory first.** Capture the runtime-resolved absolute path from the harness header (`Base directory for this skill: <absolute path>`):
+
+```bash
+export SKILL_DIR="<absolute path from the 'Base directory for this skill:' header line>"
+```
+
+Use `"$SKILL_DIR/scripts/..."` for every script invocation. Do **not** hardcode `plugins/swarmkit/...`.
 
 ## Process
 
-1. **Fetch and prune** remote-tracking refs:
-   ```bash
-   git fetch origin --prune
-   ```
+### Step 1 — Classify remote branches
 
-2. **Enumerate candidates** — list every remote branch matching `worktree-agent-*` once, then reuse that list for classification:
-   ```bash
-   CANDIDATES=$(git ls-remote --heads origin 'worktree-agent-*' | awk '{print $2}' | sed 's|refs/heads/||')
-   ```
+Run the classify script. It fetches and prunes origin, lists all remote `worktree-agent-*` branches, and buckets each by PR state in a single pass:
 
-   If `CANDIDATES` is empty, report "no remote worktree-agent-* branches" and exit.
+```bash
+"$SKILL_DIR/scripts/classify.sh"
+```
 
-3. **Classify each candidate** by the state of its most-recent PR. Pipe the candidate list into a `while read` loop (do not use `for BRANCH in $CANDIDATES` — word-splitting on newline-delimited output is unreliable):
-   ```bash
-   printf '%s\n' "$CANDIDATES" | while read BRANCH; do
-     gh pr list --state all --head "$BRANCH" --json number,state,title --limit 1
-   done
-   ```
+On success the script exits 0 and emits a single JSON object on stdout:
 
-   Bucket each branch by its most-recent PR state:
+```json
+{
+  "candidates": [
+    {"branch": "worktree-agent-42", "pr_number": 210, "pr_title": "fix: ...", "state": "MERGED"},
+    {"branch": "worktree-agent-43", "pr_number": 211, "pr_title": "feat: ...", "state": "OPEN"},
+    {"branch": "worktree-agent-44", "pr_number": null, "pr_title": null, "state": "NO_PR"}
+  ],
+  "merged": ["worktree-agent-42"],
+  "closed": [],
+  "open": ["worktree-agent-43"],
+  "no_pr": ["worktree-agent-44"]
+}
+```
 
-   | Bucket | PR state | Action |
-   |--------|----------|--------|
-   | MERGED | `MERGED` | queue for deletion |
-   | CLOSED | `CLOSED` (not merged) | skip — branch holds the only copy of rejected work |
-   | OPEN | `OPEN` | skip — deletion would kill an active PR |
-   | No PR | empty array | skip — could be crashed-run debris; surface for inspection |
+If the script exits non-zero, surface stderr and stop.
 
-4. **Present the plan** — counts per bucket, plus branch names in the three skipped buckets so the user can spot anything unexpected:
-   ```
-   MERGED (to delete): 12
-   CLOSED (skipped):   2
-     - worktree-agent-47
-     - worktree-agent-89
-   OPEN (skipped):     3
-     - worktree-agent-101
-     - worktree-agent-102
-     - worktree-agent-103
-   No PR (skipped):    1
-     - worktree-agent-55
-   ```
+### Step 2 — Check if there is anything to do
 
-   If the MERGED bucket is empty, report and exit — nothing to delete.
+If `candidates` is an empty array, report:
 
-   In interactive mode, ask for confirmation before proceeding. With `--yes`, proceed immediately.
+> No remote `worktree-agent-*` branches found.
 
-5. **Delete all MERGED branches in a single push** — one refspec per branch, one network round-trip:
-   ```bash
-   git push origin :worktree-agent-12 :worktree-agent-15 :worktree-agent-18 ...
-   ```
+And stop.
 
-   Build the refspec list from the MERGED bucket. Do not loop per-branch — batch deletion is both faster and atomic in output.
+If `merged` is empty, report the counts per bucket and stop:
 
-6. **Report**:
-   ```
-   Deleted: 12 remote branches
-   Skipped: 6 branches (2 CLOSED, 3 OPEN, 1 no-PR)
+```
+Nothing to delete.
 
-   Skipped branches:
-     CLOSED (rejected work, preserved):
-       - worktree-agent-47
-       - worktree-agent-89
-     OPEN (active PR):
-       - worktree-agent-101
-       ...
-     No PR (inspect manually):
-       - worktree-agent-55
-   ```
+MERGED (to delete):  0
+CLOSED (skipped):    <count>
+OPEN (skipped):      <count>
+No PR (skipped):     <count>
+```
+
+### Step 3 — Present the plan
+
+Display the full classification to give the user visibility into what will and won't be touched:
+
+```
+MERGED (to delete):  <count>
+  - worktree-agent-42
+
+CLOSED (skipped):    <count>
+  - worktree-agent-47
+  ...
+
+OPEN (skipped):      <count>
+  - worktree-agent-101
+  ...
+
+No PR (skipped):     <count>
+  - worktree-agent-55
+  ...
+```
+
+### Step 4 — Confirm (interactive mode only)
+
+In interactive mode (no `--yes`), ask before proceeding:
+
+> Proceed with deleting **<count>** remote branch(es)?
+
+Wait for user confirmation. If the user declines, stop without deleting anything.
+
+With `--yes`, skip the prompt and proceed immediately.
+
+### Step 5 — Delete merged branches
+
+Run the delete script with the `merged` array from Step 1:
+
+```bash
+"$SKILL_DIR/scripts/delete.sh" --branches '<merged JSON array from classify output>'
+```
+
+On success the script exits 0 and emits a single JSON object on stdout:
+
+```json
+{
+  "deleted": ["worktree-agent-42"],
+  "skipped": [],
+  "errors": []
+}
+```
+
+If the script exits non-zero, surface stderr and stop.
+
+### Step 6 — Report
+
+```
+Deleted:  <count> remote branch(es)
+  - worktree-agent-42
+  ...
+
+Skipped:  <count> branch(es)
+  CLOSED (rejected work, preserved):
+    - worktree-agent-47
+  OPEN (active PR):
+    - worktree-agent-101
+  No PR (inspect manually):
+    - worktree-agent-55
+
+Errors: <list any errors; omit section if empty>
+```
 
 ## Constraints
 
 - Never delete a branch that is the head of an OPEN PR
 - Never delete a branch whose most-recent PR is CLOSED (non-merged) — the branch contains rejected work that persists nowhere else
-- Always use refspec syntax (`git push origin :branch1 :branch2 ...`) for batch deletion; never loop `git push --delete` per branch
+- Never delete a branch with no associated PR — surface it for manual inspection
+- Always use refspec syntax (`git push origin :branch1 :branch2 ...`) for batch deletion; never loop `git push --delete` per branch (handled inside delete.sh)
 - Never touch local state — worktrees and local branches are `swarmkit:clean-worktrees`'s concern
 - Idempotent: running twice on a clean repo is a no-op

--- a/plugins/swarmkit/skills/clean-remote-worktrees/scripts/classify.sh
+++ b/plugins/swarmkit/skills/clean-remote-worktrees/scripts/classify.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# classify.sh — fetch and classify remote worktree-agent-* branches by PR state.
+#
+# Usage:
+#   classify.sh
+#
+# Fetches origin, lists remote worktree-agent-* branches, queries each branch's
+# most-recent PR state via `gh pr list`, and buckets them by state.
+#
+# On success: exit 0, single JSON object on stdout with keys:
+#   {candidates: [{branch, pr_number, pr_title, state}], merged: [string],
+#    closed: [string], open: [string], no_pr: [string]}
+# On failure: non-zero exit, empty stdout, human-readable message on stderr.
+
+for cmd in git gh jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "classify: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "classify: gh is not authenticated — run 'gh auth login' first" >&2
+  exit 1
+fi
+
+if ! git fetch origin --prune >/dev/null 2>&1; then
+  echo "classify: 'git fetch origin --prune' failed" >&2
+  exit 1
+fi
+
+candidates_raw="$(git ls-remote --heads origin 'worktree-agent-*' 2>/dev/null | awk '{print $2}' | sed 's|refs/heads/||')"
+
+if [[ -z "$candidates_raw" ]]; then
+  jq -n '{candidates: [], merged: [], closed: [], open: [], no_pr: []}'
+  exit 0
+fi
+
+candidates_json="[]"
+merged=()
+closed_list=()
+open_list=()
+no_pr=()
+
+while IFS= read -r branch; do
+  [[ -z "$branch" ]] && continue
+
+  pr_json="$(gh pr list --state all --head "$branch" --json number,state,title --limit 1 2>/dev/null || echo '[]')"
+
+  pr_count="$(printf '%s' "$pr_json" | jq 'length')"
+
+  if [[ "$pr_count" -eq 0 ]]; then
+    entry="$(jq -n --arg branch "$branch" '{"branch": $branch, "pr_number": null, "pr_title": null, "state": "NO_PR"}')"
+    no_pr+=("$branch")
+  else
+    pr_number="$(printf '%s' "$pr_json" | jq -r '.[0].number')"
+    pr_title="$(printf '%s' "$pr_json" | jq -r '.[0].title')"
+    pr_state="$(printf '%s' "$pr_json" | jq -r '.[0].state')"
+    entry="$(jq -n --arg branch "$branch" --argjson pr_number "$pr_number" --arg pr_title "$pr_title" --arg state "$pr_state" \
+      '{"branch": $branch, "pr_number": $pr_number, "pr_title": $pr_title, "state": $state}')"
+
+    case "$pr_state" in
+      MERGED) merged+=("$branch") ;;
+      CLOSED) closed_list+=("$branch") ;;
+      OPEN)   open_list+=("$branch") ;;
+      *)      no_pr+=("$branch") ;;
+    esac
+  fi
+
+  candidates_json="$(printf '%s' "$candidates_json" | jq --argjson entry "$entry" '. + [$entry]')"
+done < <(printf '%s\n' "$candidates_raw")
+
+_to_json_array() {
+  local -a arr=("$@")
+  if [[ ${#arr[@]} -eq 0 ]]; then
+    echo '[]'
+  else
+    printf '%s\n' "${arr[@]}" | jq -R '.' | jq -s '.'
+  fi
+}
+merged_json="$(_to_json_array "${merged[@]+"${merged[@]}"}")"
+closed_json="$(_to_json_array "${closed_list[@]+"${closed_list[@]}"}")"
+open_json="$(_to_json_array "${open_list[@]+"${open_list[@]}"}")"
+no_pr_json="$(_to_json_array "${no_pr[@]+"${no_pr[@]}"}")"
+
+jq -n \
+  --argjson candidates "$candidates_json" \
+  --argjson merged "$merged_json" \
+  --argjson closed "$closed_json" \
+  --argjson open "$open_json" \
+  --argjson no_pr "$no_pr_json" \
+  '{candidates: $candidates, merged: $merged, closed: $closed, open: $open, no_pr: $no_pr}'

--- a/plugins/swarmkit/skills/clean-remote-worktrees/scripts/delete.sh
+++ b/plugins/swarmkit/skills/clean-remote-worktrees/scripts/delete.sh
@@ -35,6 +35,9 @@ done
 
 [[ -n "$BRANCHES_JSON" ]] || { echo "delete: --branches is required" >&2; exit 2; }
 
+T_PUSH_ERR=$(mktemp)
+trap "rm -f $T_PUSH_ERR" EXIT
+
 branch_count="$(printf '%s' "$BRANCHES_JSON" | jq 'length')"
 
 if [[ "$branch_count" -eq 0 ]]; then
@@ -51,13 +54,13 @@ done < <(printf '%s' "$BRANCHES_JSON" | jq -r '.[]')
 deleted=()
 errors=()
 
-if git push origin "${refspecs[@]}" 2>/tmp/push_err; then
+if git push origin "${refspecs[@]}" 2>"$T_PUSH_ERR"; then
   while IFS= read -r branch; do
     [[ -z "$branch" ]] && continue
     deleted+=("$branch")
   done < <(printf '%s' "$BRANCHES_JSON" | jq -r '.[]')
 else
-  err="$(cat /tmp/push_err)"
+  err="$(cat "$T_PUSH_ERR")"
   errors+=("$err")
 fi
 

--- a/plugins/swarmkit/skills/clean-remote-worktrees/scripts/delete.sh
+++ b/plugins/swarmkit/skills/clean-remote-worktrees/scripts/delete.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# delete.sh — batch-delete a list of remote branches in a single push call.
+#
+# Usage:
+#   delete.sh --branches <json-array-of-branch-names>
+#
+# Only pass branches that are confirmed safe to delete (MERGED state).
+# The caller is responsible for safety classification — this script deletes
+# whatever it receives without further state checks.
+#
+# On success: exit 0, single JSON object on stdout with keys:
+#   {deleted: [string], skipped: [{branch, reason}], errors: [string]}
+# On failure: non-zero exit, empty stdout, human-readable message on stderr.
+
+for cmd in git jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "delete: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+BRANCHES_JSON=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --branches)
+      [[ $# -ge 2 ]] || { echo "delete: --branches requires a value" >&2; exit 2; }
+      BRANCHES_JSON="$2"; shift 2 ;;
+    *)
+      echo "delete: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$BRANCHES_JSON" ]] || { echo "delete: --branches is required" >&2; exit 2; }
+
+branch_count="$(printf '%s' "$BRANCHES_JSON" | jq 'length')"
+
+if [[ "$branch_count" -eq 0 ]]; then
+  jq -n '{deleted: [], skipped: [], errors: []}'
+  exit 0
+fi
+
+refspecs=()
+while IFS= read -r branch; do
+  [[ -z "$branch" ]] && continue
+  refspecs+=(":$branch")
+done < <(printf '%s' "$BRANCHES_JSON" | jq -r '.[]')
+
+deleted=()
+errors=()
+
+if git push origin "${refspecs[@]}" 2>/tmp/push_err; then
+  while IFS= read -r branch; do
+    [[ -z "$branch" ]] && continue
+    deleted+=("$branch")
+  done < <(printf '%s' "$BRANCHES_JSON" | jq -r '.[]')
+else
+  err="$(cat /tmp/push_err)"
+  errors+=("$err")
+fi
+
+if [[ ${#deleted[@]} -gt 0 ]]; then
+  deleted_json="$(printf '%s\n' "${deleted[@]}" | jq -R '.' | jq -s '.')"
+else
+  deleted_json="[]"
+fi
+
+if [[ ${#errors[@]} -gt 0 ]]; then
+  errors_json="$(printf '%s\n' "${errors[@]}" | jq -R '.' | jq -s '.')"
+else
+  errors_json="[]"
+fi
+
+jq -n \
+  --argjson deleted "$deleted_json" \
+  --argjson errors "$errors_json" \
+  '{deleted: $deleted, skipped: [], errors: $errors}'

--- a/plugins/swarmkit/skills/clean-worktrees/SKILL.md
+++ b/plugins/swarmkit/skills/clean-worktrees/SKILL.md
@@ -9,43 +9,124 @@ Remove all agent worktrees and their orphaned local branches.
 
 For remote branch cleanup, see `swarmkit:clean-remote-worktrees`.
 
+## Setup
+
+**Resolve the skill base directory first.** Capture the runtime-resolved absolute path from the harness header (`Base directory for this skill: <absolute path>`):
+
+```bash
+export SKILL_DIR="<absolute path from the 'Base directory for this skill:' header line>"
+```
+
+Use `"$SKILL_DIR/scripts/..."` for every script invocation. Do **not** hardcode `plugins/swarmkit/...`.
+
 ## Process
 
-0. Capture the current branch: run `git branch --show-current` and store the result as `<caller-branch>`
-0.5. Run `git worktree prune` to clear any already-deleted worktree references before the removal loop begins
-0.6. Derive the main worktree path and cd to it so subsequent git commands are not issued from a worktree directory that may itself be removed:
-   ```bash
-   MAIN_WORKTREE=$(git worktree list --porcelain | grep '^worktree' | head -1 | awk '{print $2}')
-   cd "$MAIN_WORKTREE"
-   ```
-1. Run `git worktree list` to find all worktrees
-2. For each worktree that is NOT the main working directory:
-   - Run `git worktree remove <path> -f -f` (double-force) to handle agent-locked worktrees
-   - If the command fails (exit code non-zero): report the path and error, continue to the next worktree — do not abort
-3. Run `git worktree prune` to clean up any remaining stale worktree references
-4. Find and delete orphaned local branches left by worktrees:
-   - Run `git branch --format='%(refname:short)'` to list all local branches (avoids `*`/`+` markers in raw `git branch` output)
-   - Filter for branches starting with `worktree-agent-`
-   - Before deleting, cross-reference each target branch against `git worktree list` output. If any target branch is still checked out by an active worktree, **stop immediately** — report the stuck worktree path and branch name so the user can decide how to proceed. Do not attempt deletion of any remaining branches.
-   - Delete each safe branch with `git branch -D <branch>`
-   - Note: `swarm` names all agent branches with this prefix by convention
-5. Report what was cleaned:
-   - Number of worktrees removed
-   - Number of branches deleted
-   - If any worktree removals failed: list the paths so the user can resolve them manually
-   - If nothing to clean, say so
-   - Whether the caller's branch was restored or skipped (with the branch name)
-6. Restore the caller's branch:
-   - Check whether `<caller-branch>` still exists: run `git branch --list <caller-branch>`
-   - If it exists: run `git checkout <caller-branch>`
-   - If it no longer exists: skip the restore and warn the user that `<caller-branch>` was removed as part of the cleanup
+### Step 1 — Gather state
+
+Run the gather script to enumerate what would be removed:
+
+```bash
+"$SKILL_DIR/scripts/gather.sh"
+```
+
+On success the script exits 0 and emits a single JSON object on stdout:
+
+```json
+{
+  "caller_branch": "develop",
+  "main_worktree": "/abs/path/to/repo",
+  "worktrees_to_remove": [{"path": "/abs/path/to/repo/.claude/worktrees/worktree-agent-42"}],
+  "branches_to_delete": ["worktree-agent-42", "worktree-agent-43"],
+  "stuck": []
+}
+```
+
+If the script exits non-zero, surface stderr and stop.
+
+### Step 2 — Check for stuck worktrees
+
+Parse the `stuck` array. If it is non-empty, **stop immediately** and report:
+
+> The following branches are still checked out by active worktrees — cannot delete:
+>
+> - `<branch>` (worktree still active)
+>
+> Remove or force-stop those worktrees manually before re-running clean-worktrees.
+
+Do **not** proceed to removal if `stuck` is non-empty.
+
+### Step 3 — Check if there is anything to do
+
+If both `worktrees_to_remove` and `branches_to_delete` are empty arrays, report:
+
+> Nothing to clean — no agent worktrees or orphaned branches found.
+
+And stop.
+
+### Step 4 — Present plan and confirm
+
+Summarize what will happen:
+
+```
+Worktrees to remove: <count>
+  - /path/to/worktree-agent-42
+  ...
+Branches to delete: <count>
+  - worktree-agent-42
+  ...
+```
+
+Proceed immediately (no confirmation prompt needed for this automated cleanup step).
+
+### Step 5 — Perform removal
+
+Run the remove script with the gathered state:
+
+```bash
+"$SKILL_DIR/scripts/remove.sh" \
+  --main-worktree "<main_worktree from gather output>" \
+  --caller-branch "<caller_branch from gather output>" \
+  --worktrees '<worktrees_to_remove JSON array from gather output>' \
+  --branches '<branches_to_delete JSON array from gather output>'
+```
+
+On success the script exits 0 and emits a single JSON object on stdout:
+
+```json
+{
+  "removed": ["/abs/path/worktree-agent-42"],
+  "remove_errors": [],
+  "pruned_branches": ["worktree-agent-42", "worktree-agent-43"],
+  "branch_errors": [],
+  "caller_branch_restored": true
+}
+```
+
+If the script exits non-zero, surface stderr and stop.
+
+### Step 6 — Report
+
+Parse the JSON and produce a clean summary:
+
+```
+Cleaned:
+  Worktrees removed:  <count>  (<list of paths, or "none">)
+  Branches deleted:   <count>  (<list of branches, or "none">)
+  Caller branch:      restored to <caller_branch> / skipped (branch was removed)
+
+Errors:
+  <list any remove_errors or branch_errors; omit section if both are empty>
+```
+
+If `caller_branch_restored` is `false` and there were no errors, warn:
+
+> `<caller_branch>` was removed as part of cleanup — no branch to restore to.
 
 ## Constraints
 
 - Never remove the main working directory — only non-main worktrees
 - Never abort on a single worktree removal failure — always continue and report failures at the end
 - If any orphaned branch is still checked out by an active worktree, stop and report — do not attempt deletion
-- Always run `git worktree prune` both before the removal loop (step 0.5) and after removals (step 3) to clear stale references
-- Always cd to the main worktree root (step 0.6) before running the removal loop to avoid stale CWD errors when the caller's own worktree directory is removed
-- Use `git worktree remove <path> -f -f` (double-force) to handle agent-locked worktrees that a single `--force` cannot remove
+- Always run `git worktree prune` both before the removal loop and after removals to clear stale references (handled inside the scripts)
+- Use `git worktree remove <path> -f -f` (double-force) to handle agent-locked worktrees (handled inside remove.sh)
 - Always attempt to restore the caller's branch after cleanup; warn instead of erroring if the branch no longer exists

--- a/plugins/swarmkit/skills/clean-worktrees/scripts/gather.sh
+++ b/plugins/swarmkit/skills/clean-worktrees/scripts/gather.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# gather.sh — enumerate worktrees and orphaned local branches slated for cleanup.
+#
+# Usage:
+#   gather.sh
+#
+# On success: exit 0, single JSON object on stdout with keys:
+#   {caller_branch, main_worktree, worktrees_to_remove: [{path}], branches_to_delete: [string], stuck: [{path, branch}]}
+# On failure: non-zero exit, empty stdout, human-readable message on stderr.
+
+for cmd in git jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "gather: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+caller_branch="$(git branch --show-current 2>/dev/null || true)"
+
+main_worktree="$(git worktree list --porcelain | grep '^worktree' | head -1 | awk '{print $2}')"
+if [[ -z "$main_worktree" ]]; then
+  echo "gather: could not determine main worktree path" >&2
+  exit 1
+fi
+
+worktrees_to_remove=()
+while IFS= read -r line; do
+  path="${line#worktree }"
+  if [[ "$path" != "$main_worktree" ]]; then
+    worktrees_to_remove+=("$path")
+  fi
+done < <(git worktree list --porcelain | grep '^worktree ')
+
+active_worktree_branches=()
+while IFS= read -r line; do
+  branch="${line#branch refs/heads/}"
+  if [[ "$line" == branch\ * ]]; then
+    active_worktree_branches+=("$branch")
+  fi
+done < <(git worktree list --porcelain)
+
+branches_to_delete=()
+stuck=()
+while IFS= read -r branch; do
+  if [[ "$branch" == worktree-agent-* ]]; then
+    is_active=false
+    for active in "${active_worktree_branches[@]+"${active_worktree_branches[@]}"}"; do
+      if [[ "$active" == "$branch" ]]; then
+        is_active=true
+        break
+      fi
+    done
+
+    if [[ "$is_active" == true ]]; then
+      stuck+=("$branch")
+    else
+      branches_to_delete+=("$branch")
+    fi
+  fi
+done < <(git branch --format='%(refname:short)')
+
+if [[ ${#worktrees_to_remove[@]} -gt 0 ]]; then
+  worktrees_json="$(printf '%s\n' "${worktrees_to_remove[@]}" | jq -R '{"path": .}' | jq -s '.')"
+else
+  worktrees_json="[]"
+fi
+
+if [[ ${#branches_to_delete[@]} -gt 0 ]]; then
+  branches_json="$(printf '%s\n' "${branches_to_delete[@]}" | jq -R '.' | jq -s '.')"
+else
+  branches_json="[]"
+fi
+
+if [[ ${#stuck[@]} -gt 0 ]]; then
+  stuck_json="$(printf '%s\n' "${stuck[@]}" | jq -R '{"branch": .}' | jq -s '.')"
+else
+  stuck_json="[]"
+fi
+
+jq -n \
+  --arg caller_branch "$caller_branch" \
+  --arg main_worktree "$main_worktree" \
+  --argjson worktrees_to_remove "$worktrees_json" \
+  --argjson branches_to_delete "$branches_json" \
+  --argjson stuck "$stuck_json" \
+  '{caller_branch: $caller_branch, main_worktree: $main_worktree, worktrees_to_remove: $worktrees_to_remove, branches_to_delete: $branches_to_delete, stuck: $stuck}'

--- a/plugins/swarmkit/skills/clean-worktrees/scripts/remove.sh
+++ b/plugins/swarmkit/skills/clean-worktrees/scripts/remove.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# remove.sh — perform worktree removal, prune, and orphaned branch deletion.
+#
+# Usage:
+#   remove.sh --main-worktree <path> --caller-branch <branch> \
+#             --worktrees <json-array-of-paths> --branches <json-array>
+#
+# All arguments are required. Pass empty JSON arrays ([]) when there is nothing
+# to remove in that category.
+#
+# On success: exit 0, single JSON object on stdout with keys:
+#   {removed: [string], remove_errors: [{path, error}], pruned_branches: [string],
+#    branch_errors: [{branch, error}], caller_branch_restored: bool}
+# On failure: non-zero exit, empty stdout, human-readable message on stderr.
+
+for cmd in git jq; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "remove: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+MAIN_WORKTREE=""
+CALLER_BRANCH=""
+WORKTREES_JSON="[]"
+BRANCHES_JSON="[]"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --main-worktree)
+      [[ $# -ge 2 ]] || { echo "remove: --main-worktree requires a value" >&2; exit 2; }
+      MAIN_WORKTREE="$2"; shift 2 ;;
+    --caller-branch)
+      [[ $# -ge 2 ]] || { echo "remove: --caller-branch requires a value" >&2; exit 2; }
+      CALLER_BRANCH="$2"; shift 2 ;;
+    --worktrees)
+      [[ $# -ge 2 ]] || { echo "remove: --worktrees requires a value" >&2; exit 2; }
+      WORKTREES_JSON="$2"; shift 2 ;;
+    --branches)
+      [[ $# -ge 2 ]] || { echo "remove: --branches requires a value" >&2; exit 2; }
+      BRANCHES_JSON="$2"; shift 2 ;;
+    *)
+      echo "remove: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$MAIN_WORKTREE" ]] || { echo "remove: --main-worktree is required" >&2; exit 2; }
+[[ -n "$CALLER_BRANCH" ]] || { echo "remove: --caller-branch is required" >&2; exit 2; }
+
+git worktree prune >/dev/null 2>&1 || true
+
+cd "$MAIN_WORKTREE"
+
+removed=()
+remove_errors_parts=()
+
+while IFS= read -r path; do
+  [[ -z "$path" ]] && continue
+  if git worktree remove "$path" -f -f 2>/tmp/wt_remove_err; then
+    removed+=("$path")
+  else
+    err="$(cat /tmp/wt_remove_err)"
+    remove_errors_parts+=("$(jq -n --arg path "$path" --arg error "$err" '{"path": $path, "error": $error}')")
+  fi
+done < <(printf '%s\n' "$WORKTREES_JSON" | jq -r '.[] | .path')
+
+git worktree prune >/dev/null 2>&1 || true
+
+pruned_branches=()
+branch_errors_parts=()
+
+while IFS= read -r branch; do
+  [[ -z "$branch" ]] && continue
+  if git branch -D "$branch" 2>/tmp/br_delete_err; then
+    pruned_branches+=("$branch")
+  else
+    err="$(cat /tmp/br_delete_err)"
+    branch_errors_parts+=("$(jq -n --arg branch "$branch" --arg error "$err" '{"branch": $branch, "error": $error}')")
+  fi
+done < <(printf '%s\n' "$BRANCHES_JSON" | jq -r '.[]')
+
+caller_branch_restored=false
+if [[ -n "$CALLER_BRANCH" ]]; then
+  if git branch --list "$CALLER_BRANCH" | grep -q .; then
+    if git checkout "$CALLER_BRANCH" >/dev/null 2>&1; then
+      caller_branch_restored=true
+    fi
+  fi
+fi
+
+if [[ ${#removed[@]} -gt 0 ]]; then
+  removed_json="$(printf '%s\n' "${removed[@]}" | jq -R '.' | jq -s '.')"
+else
+  removed_json="[]"
+fi
+
+if [[ ${#pruned_branches[@]} -gt 0 ]]; then
+  pruned_json="$(printf '%s\n' "${pruned_branches[@]}" | jq -R '.' | jq -s '.')"
+else
+  pruned_json="[]"
+fi
+
+if [[ ${#remove_errors_parts[@]} -gt 0 ]]; then
+  remove_errors_json="$(printf '%s\n' "${remove_errors_parts[@]}" | jq -s '.')"
+else
+  remove_errors_json="[]"
+fi
+
+if [[ ${#branch_errors_parts[@]} -gt 0 ]]; then
+  branch_errors_json="$(printf '%s\n' "${branch_errors_parts[@]}" | jq -s '.')"
+else
+  branch_errors_json="[]"
+fi
+
+jq -n \
+  --argjson removed "$removed_json" \
+  --argjson remove_errors "$remove_errors_json" \
+  --argjson pruned_branches "$pruned_json" \
+  --argjson branch_errors "$branch_errors_json" \
+  --argjson caller_branch_restored "$caller_branch_restored" \
+  '{removed: $removed, remove_errors: $remove_errors, pruned_branches: $pruned_branches, branch_errors: $branch_errors, caller_branch_restored: $caller_branch_restored}'

--- a/plugins/swarmkit/skills/clean-worktrees/scripts/remove.sh
+++ b/plugins/swarmkit/skills/clean-worktrees/scripts/remove.sh
@@ -47,7 +47,10 @@ while [[ $# -gt 0 ]]; do
 done
 
 [[ -n "$MAIN_WORKTREE" ]] || { echo "remove: --main-worktree is required" >&2; exit 2; }
-[[ -n "$CALLER_BRANCH" ]] || { echo "remove: --caller-branch is required" >&2; exit 2; }
+
+T_WT_ERR=$(mktemp)
+T_BR_ERR=$(mktemp)
+trap "rm -f $T_WT_ERR $T_BR_ERR" EXIT
 
 git worktree prune >/dev/null 2>&1 || true
 
@@ -58,10 +61,10 @@ remove_errors_parts=()
 
 while IFS= read -r path; do
   [[ -z "$path" ]] && continue
-  if git worktree remove "$path" -f -f 2>/tmp/wt_remove_err; then
+  if git worktree remove "$path" -f -f 2>"$T_WT_ERR"; then
     removed+=("$path")
   else
-    err="$(cat /tmp/wt_remove_err)"
+    err="$(cat "$T_WT_ERR")"
     remove_errors_parts+=("$(jq -n --arg path "$path" --arg error "$err" '{"path": $path, "error": $error}')")
   fi
 done < <(printf '%s\n' "$WORKTREES_JSON" | jq -r '.[] | .path')
@@ -73,10 +76,10 @@ branch_errors_parts=()
 
 while IFS= read -r branch; do
   [[ -z "$branch" ]] && continue
-  if git branch -D "$branch" 2>/tmp/br_delete_err; then
+  if git branch -D "$branch" 2>"$T_BR_ERR"; then
     pruned_branches+=("$branch")
   else
-    err="$(cat /tmp/br_delete_err)"
+    err="$(cat "$T_BR_ERR")"
     branch_errors_parts+=("$(jq -n --arg branch "$branch" --arg error "$err" '{"branch": $branch, "error": $error}')")
   fi
 done < <(printf '%s\n' "$BRANCHES_JSON" | jq -r '.[]')


### PR DESCRIPTION
## Summary

Extracts the deterministic shell work from `clean-worktrees` and `clean-remote-worktrees` into per-skill `scripts/` directories, reducing model round-trips and eliminating word-splitting hazards. Both SKILL.md files are rewritten to invoke `$SKILL_DIR/scripts/...` for all bash phases while retaining judgment prose (stuck-worktree gates, confirmation prompts) in markdown.

## Changes

- Add `plugins/swarmkit/skills/clean-worktrees/scripts/gather.sh` — enumerates worktrees + orphaned branches, detects stuck branches, emits bare-payload JSON.
- Add `plugins/swarmkit/skills/clean-worktrees/scripts/remove.sh` — performs `git worktree remove`, prune, and branch deletion; emits result JSON with per-item error tracking.
- Rewrite `plugins/swarmkit/skills/clean-worktrees/SKILL.md` to invoke the two scripts; keep stuck-worktree stop gate and empty-state early-exit in markdown.
- Add `plugins/swarmkit/skills/clean-remote-worktrees/scripts/classify.sh` — fetches origin, lists `worktree-agent-*` remote branches, classifies each by PR state via `gh pr list`, emits bucket arrays.
- Add `plugins/swarmkit/skills/clean-remote-worktrees/scripts/delete.sh` — batch-deletes a list of branches via single `git push origin :branch1 :branch2 ...` call; emits deleted/errors JSON.
- Rewrite `plugins/swarmkit/skills/clean-remote-worktrees/SKILL.md` to invoke the two scripts; keep interactive confirmation prompt and safety constraints in markdown.
- Add four allowlist entries to `.claude/settings.json` for the new scripts, using `$SKILL_DIR` interpolation per the established precedent.

## Test plan

- [ ] Run `bash plugins/swarmkit/skills/clean-worktrees/scripts/gather.sh` — verify valid JSON to stdout, no stderr output.
- [ ] Run `bash plugins/swarmkit/skills/clean-worktrees/scripts/remove.sh --main-worktree <path> --caller-branch <branch> --worktrees '[]' --branches '[]'` — verify empty-result JSON to stdout, exit 0.
- [ ] Run `bash plugins/swarmkit/skills/clean-remote-worktrees/scripts/classify.sh` — verify valid JSON with candidate/bucket arrays; confirm `open` and `no_pr` are clean empty arrays `[]` when no such branches exist.
- [ ] Run `bash plugins/swarmkit/skills/clean-remote-worktrees/scripts/delete.sh --branches '[]'` — verify `{deleted: [], skipped: [], errors: []}` to stdout, exit 0.
- [ ] Confirm both SKILL.md files reference `$SKILL_DIR/scripts/...` for all deterministic phases and contain no inline multi-step bash blocks.
- [ ] Confirm `.claude/settings.json` contains `gather.sh`, `remove.sh`, `classify.sh`, and `delete.sh` allowlist entries.

Closes #699