### PR TITLE
chore(swarmkit/swarm-plus): rename --no-worker to --review-only

### DIFF
--- a/plugins/swarmkit/METHODOLOGY.md
+++ b/plugins/swarmkit/METHODOLOGY.md
@@ -130,7 +130,7 @@ The single-pass rule is intentional. There is no reviewer-after-worker re-review
 
 The reviewer is vendored into swarmkit (`plugins/swarmkit/agents/swarm-reviewer.md`) rather than imported from another plugin, so `/swarm-plus` carries no cross-marketplace dependency. Worker scope is constrained: blockers and concerns are in scope, recommended coverage gaps are in scope, optional coverage gaps and nits are out of scope along with any unrelated cleanups. The worker may comment once on the PR summarizing what it addressed and what it deferred; the reviewer never posts comments.
 
-The skill exposes three flags beyond the inherited `/swarm` set: `--no-worker` for triage runs that review without dispatching workers, `--reviewer-model <tier>`, and `--worker-model <tier>`. Both model overrides default to `sonnet`.
+The skill exposes three flags beyond the inherited `/swarm` set: `--review-only` for triage runs that review without dispatching workers, `--reviewer-model <tier>`, and `--worker-model <tier>`. Both model overrides default to `sonnet`.
 
 `/swarm-plus` is the right layer when you want every swarm PR to land with at least one independent pass against its acceptance criteria, and when the acceptance criteria in the originating issue are crisp enough for a reviewer to evaluate against. It is not a replacement for human review on the final merge — every PR still ends in the same place: open, awaiting your merge.
 

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -121,7 +121,7 @@ Swarmkit vendors a specialized reviewer agent used by `/swarm-plus`. It is not a
 
 All `/swarm` flags are inherited. Swarm-plus adds:
 
-- `--no-worker` — dispatch reviewers but never spawn workers (triage mode)
+- `--review-only` — dispatch reviewers but never spawn workers (triage mode)
 - `--reviewer-model <sonnet|opus>` — override reviewer model (default: `sonnet`)
 - `--worker-model <sonnet|opus>` — override worker model (default: `sonnet`)
 

--- a/plugins/swarmkit/skills/swarm-plus/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-plus/SKILL.md
@@ -22,7 +22,7 @@ Identical to `/swarmkit:swarm`:
 - Issue numbers (`12 15 18`, `#12 #15 #18`, range `12-18`) → one-shot mode → `develop`
 - `--model <tier>` (`sonnet`, `opus`) — model override for swarm agents (reviewer + worker have their own defaults; see below)
 - `--base <branch>` — override default base branch
-- `--no-worker` — review only; never dispatch worker (useful for triage)
+- `--review-only` — review only; never dispatch worker (useful for triage)
 - `--worker-model <tier>` — override worker model (default: `sonnet`)
 - `--reviewer-model <tier>` — override reviewer model (default: `sonnet`)
 
@@ -30,7 +30,7 @@ Identical to `/swarmkit:swarm`:
 
 ### 1. Run the swarm phase
 
-Invoke `/swarmkit:swarm` with the same args (excluding `--no-worker`, `--worker-model`, and `--reviewer-model` — those are swarm-plus-only flags). Track the agent IDs and the issues each agent owns. Record `(issue, pr_number, head_branch, base_branch)` for each PR as it is produced.
+Invoke `/swarmkit:swarm` with the same args (excluding `--review-only`, `--worker-model`, and `--reviewer-model` — those are swarm-plus-only flags). Track the agent IDs and the issues each agent owns. Record `(issue, pr_number, head_branch, base_branch)` for each PR as it is produced.
 
 Do NOT block on every swarm agent before spawning reviewers. As each swarm agent's task notification arrives:
 
@@ -66,7 +66,7 @@ When a reviewer's task notification arrives, parse its result. Apply the **skip-
 | Any blockers | **Spawn worker.** Blockers are mandatory. |
 | Any concerns | **Spawn worker.** Concerns get addressed or explicitly deferred. |
 | Coverage gaps flagged `[recommended]` | **Spawn worker.** Treat recommended coverage gaps as concerns. |
-| `--no-worker` flag set | Skip regardless. |
+| `--review-only` flag set | Skip regardless. |
 
 Print one line announcing the decision per PR:
 


### PR DESCRIPTION
## Summary
- Rename the swarm-plus triage flag from `--no-worker` to `--review-only`. The new name describes the user's intent (skip the worker phase, run review only) instead of the implementation detail (don't dispatch a worker).
- Updates three docs:
  - `plugins/swarmkit/skills/swarm-plus/SKILL.md` (3 sites: input list, swarm-passthrough exclusion, skip-rule table)
  - `plugins/swarmkit/README.md` (1 site: flag table)
  - `plugins/swarmkit/METHODOLOGY.md` (1 site: design notes)
- Clean rename, no alias retained. The flag is parsed inline by the skill prompt itself (no schema/CLI parser), so the markdown update is the entire change.

## Test plan
- [x] No remaining `--no-worker` references in the repo (excluding `.claude/worktrees/` agent state)
- [ ] Spot-check by running `/swarmkit:swarm-plus --review-only <issue>` against any open PR after merge