### PR TITLE
feat(squadkit): migrate design crew to kind: discovery

### DIFF
--- a/plugins/squadkit/README.md
+++ b/plugins/squadkit/README.md
@@ -89,6 +89,7 @@ Each crew YAML conforms to:
 ```yaml
 name: <string>            # profile name; matches the filename without .yaml
 description: <string>     # one-line summary of when to use this crew
+kind: <string>            # optional, default "execution"; execution | discovery
 members:
   - role: <string>        # one of: team-lead, architect, builder, reviewer, tester, explorer, designer
     count: <int>          # optional, default 1; 1–5 for builder

--- a/plugins/squadkit/README.md
+++ b/plugins/squadkit/README.md
@@ -79,7 +79,7 @@ A **crew profile** is a YAML file under `plugins/squadkit/crews/` describing a r
 | Profile | Roster | When to use |
 |---------|--------|-------------|
 | **all-rounder** | team-lead, architect, builder×2, reviewer, tester, explorer, designer | Full-spectrum feature work end-to-end. |
-| **design** | team-lead, architect, designer, explorer | Discovery-stage exploration with no implementation yet. |
+| **design** | architect, designer, explorer | Discovery-stage exploration with no implementation yet. Read-only: produces issue comments, no worktrees, no epic branch. (`kind: discovery`) |
 | **qa** | team-lead, reviewer, tester, builder×1 | Hardening, regression, bug-fix sweeps. |
 
 ### Schema

--- a/plugins/squadkit/crews/design.yaml
+++ b/plugins/squadkit/crews/design.yaml
@@ -1,7 +1,7 @@
 name: design
-description: Discovery and design crew for early-stage exploration — architect frames the system, designer shapes the surface, explorer investigates prior art and constraints. No builders.
+description: Read-only discovery crew for early-stage exploration — architect frames the system blueprint, designer shapes the surface, explorer investigates prior art and constraints. Deliverables are issue comments, not PRs. No worktrees, no epic branch, no prBase pinning.
+kind: discovery
 members:
-  - role: team-lead
   - role: architect
   - role: designer
   - role: explorer


### PR DESCRIPTION
## Summary
- Add `kind: discovery` to the design crew profile so spawning it skips worktrees, epic-branch cutting, and prBase pinning — aligning runtime behavior with its read-only, issue-comment-deliverable description.
- Update README crew table to reflect the discovery kind and remove team-lead (discovery crews don't provision worktrees per-member, consistent with discovery-3-role).

## Changes
- `plugins/squadkit/crews/design.yaml`: add `kind: discovery`, update description to match discovery pattern, remove team-lead (no worktree orchestration needed).
- `plugins/squadkit/README.md`: crew table row for design now reflects discovery kind and updated roster.

## Test plan
- Spawn the design crew via `squadkit:spawn-team` — verify no worktree provisioning, no epic branch cut, no prBase pin.
- Confirm crew still spawns architect + designer + explorer roles correctly.

Closes #685