### PR TITLE
feat(swarmkit:swarm-plus): port reference trigger and abstract verify command

### DIFF
--- a/plugins/swarmkit/skills/swarm-plus/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-plus/SKILL.md
@@ -7,6 +7,7 @@ triggers:
   - "swarm with review"
   - "swarm and review"
   - "swarm review"
+  - "swarm + review pass"
 ---
 
 # Swarm Plus
@@ -37,6 +38,16 @@ Do NOT block on every swarm agent before spawning reviewers. As each swarm agent
 1. Verify the PR exists: `gh pr view <pr_number> --json url,headRefName,baseRefName,state`
 2. Fetch the original issue body: `gh issue view <issue> --json body --jq '.body'`
 3. Spawn a reviewer for that PR (see step 2). Continue handling other notifications in parallel.
+
+### 1a. Resolve the verify command
+
+Before spawning workers, resolve the project's verify command once and reuse it for every worker prompt. This keeps swarm-plus useful in any repo, not just TS repos with `tsc`. Use this lookup chain (first hit wins):
+
+1. **`.squadkit/config.json` `verifyCommand`** — repo-level explicit override. Read with `jq -r '.verifyCommand // empty' .squadkit/config.json` if the file exists.
+2. **`package.json` `scripts.verify`** — common project-local convention. If present, the verify command is `npm run verify` (or the package manager equivalent).
+3. **Fallback** — `npx tsc -b --noEmit` for TS projects. If neither of the above resolves AND no obvious TS toolchain is present (no `tsconfig.json`), print a warning and instruct the worker to skip the verify step rather than running a command that will obviously fail.
+
+Record the resolved command as `<verify_command>` and interpolate it into the worker prompt template in step 4.
 
 ### 2. Spawn reviewer per PR
 
@@ -93,7 +104,7 @@ The worker prompt MUST:
      git checkout -B <head_branch> origin/<head_branch>
      ```
   2. Apply the changes.
-  3. Run `npx tsc -b --noEmit` and the relevant test scope. Resolve any failures before proceeding — never push a red build.
+  3. Run `<verify_command>` (resolved in step 1a) and the relevant test scope. Resolve any failures before proceeding — never push a red build.
   4. Commit with conventional-commit format (no Claude mentions, no co-author lines).
   5. Push to the same branch (`git push origin <head_branch>`) — auto-updates the PR.
   6. Optionally comment on the PR summarizing what was addressed and what was deferred:

--- a/plugins/swarmkit/skills/swarm-plus/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-plus/SKILL.md
@@ -29,6 +29,18 @@ Identical to `/swarmkit:swarm`:
 
 ## Process
 
+### 0. Pre-flight: resolve verify command
+
+> Resolved once at the start of the run, before any worker is dispatched.
+
+Resolve the project's verify command once and reuse it for every worker prompt. This keeps swarm-plus useful in any repo, not just TS repos with `tsc`. Use this lookup chain (first hit wins):
+
+1. **`.squadkit/config.json` `verifyCommand`** — repo-level explicit override. Read with `jq -r '.verifyCommand // empty' .squadkit/config.json` if the file exists.
+2. **`package.json` `scripts.verify`** — common project-local convention. If present, the verify command is determined by the package manager: `yarn.lock` present → `yarn run verify`; `pnpm-lock.yaml` present → `pnpm run verify`; otherwise → `npm run verify`.
+3. **Fallback** — `npx tsc -b --noEmit` for TS projects. "TS toolchain present" means `tsconfig.json` exists at the repo root. If neither of the above resolves AND `tsconfig.json` is absent, print a warning and instruct the worker to skip the verify step rather than running a command that will obviously fail. **Note:** projects that use `tsc` via a non-standard mechanism (e.g. a wrapper script, a monorepo tool, or a config file named differently) won't be detected by this check — those repos should set `verifyCommand` in `.squadkit/config.json` to opt in explicitly.
+
+Record the resolved command as `<verify_command>` and interpolate it into the worker prompt template in step 4.
+
 ### 1. Run the swarm phase
 
 Invoke `/swarmkit:swarm` with the same args (excluding `--review-only`, `--worker-model`, and `--reviewer-model` — those are swarm-plus-only flags). Track the agent IDs and the issues each agent owns. Record `(issue, pr_number, head_branch, base_branch)` for each PR as it is produced.
@@ -38,16 +50,6 @@ Do NOT block on every swarm agent before spawning reviewers. As each swarm agent
 1. Verify the PR exists: `gh pr view <pr_number> --json url,headRefName,baseRefName,state`
 2. Fetch the original issue body: `gh issue view <issue> --json body --jq '.body'`
 3. Spawn a reviewer for that PR (see step 2). Continue handling other notifications in parallel.
-
-### 1a. Resolve the verify command
-
-Before spawning workers, resolve the project's verify command once and reuse it for every worker prompt. This keeps swarm-plus useful in any repo, not just TS repos with `tsc`. Use this lookup chain (first hit wins):
-
-1. **`.squadkit/config.json` `verifyCommand`** — repo-level explicit override. Read with `jq -r '.verifyCommand // empty' .squadkit/config.json` if the file exists.
-2. **`package.json` `scripts.verify`** — common project-local convention. If present, the verify command is `npm run verify` (or the package manager equivalent).
-3. **Fallback** — `npx tsc -b --noEmit` for TS projects. If neither of the above resolves AND no obvious TS toolchain is present (no `tsconfig.json`), print a warning and instruct the worker to skip the verify step rather than running a command that will obviously fail.
-
-Record the resolved command as `<verify_command>` and interpolate it into the worker prompt template in step 4.
 
 ### 2. Spawn reviewer per PR
 


### PR DESCRIPTION
## Summary
- Port "swarm + review pass" trigger from the vorbis-player reference SKILL.md into swarmkit:swarm-plus for parity.
- Abstract the hardcoded `npx tsc -b --noEmit` verify command into a project-config lookup chain so non-TS repos can adopt the skill.

## Changes
- `plugins/swarmkit/skills/swarm-plus/SKILL.md`: add reference trigger section; replace hardcoded verify command with lookup-chain template; document the resolution order.

## Test plan
- Trigger swarm-plus on a small test issue in a TS repo — verify trigger fires and verify command resolves to the project value.
- Trigger swarm-plus in a non-TS repo with `.squadkit/config.json verifyCommand` set — confirm it's used.
- Trigger in a repo with no verify config — confirm warning + fallback.

Closes #693
Closes #694