### PR TITLE
fix(flowkit:open-pr): resolve --base from prBase config or develop default

### DIFF
--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -32,10 +32,27 @@ If the current branch is `develop`, `main`, `master`, or `staging`, stop immedia
 
 ### 2. Determine base branch
 
-Resolve the base branch using the `pr-base-scope` read order: new key → legacy key (with deprecation notice) → `develop` default.
+Resolve the base branch using the following precedence order:
+
+1. **Explicit caller arg** — if `$ARGUMENTS` contains a `--base <branch>` flag, extract and use it.
+2. **`claude.flowkit.prBase`** — per-session config key (set by swarm loop / cut-epic).
+3. **Legacy `claude.prBase`** — deprecated key (with migration notice).
+4. **`develop` if it exists on the remote** — check with `git ls-remote`.
+5. **GitHub default** — fall through to gh CLI default, but emit a one-line warning.
 
 ```bash
-BASE=$(git config claude.flowkit.prBase 2>/dev/null)
+# 1. Explicit caller arg
+BASE=""
+if echo "$ARGUMENTS" | grep -qE '\-\-base[= ]'; then
+  BASE=$(echo "$ARGUMENTS" | grep -oE '\-\-base[= ][^ ]+' | head -1 | sed 's/--base[= ]//')
+fi
+
+# 2. claude.flowkit.prBase config key
+if [ -z "$BASE" ]; then
+  BASE=$(git config claude.flowkit.prBase 2>/dev/null)
+fi
+
+# 3. Legacy claude.prBase (deprecated)
 if [ -z "$BASE" ]; then
   LEGACY=$(git config claude.prBase 2>/dev/null)
   if [ -n "$LEGACY" ]; then
@@ -43,13 +60,24 @@ if [ -z "$BASE" ]; then
     echo "note: claude.prBase is deprecated. Migrate with:" >&2
     echo "  git config --unset claude.prBase" >&2
     echo "  git config claude.flowkit.prBase $LEGACY" >&2
-  else
+  fi
+fi
+
+# 4. develop if it exists on the remote
+if [ -z "$BASE" ]; then
+  if git ls-remote --heads origin develop | grep -q 'refs/heads/develop'; then
     BASE="develop"
   fi
 fi
+
+# 5. Fallback — let gh CLI use the repo default, but warn
+if [ -z "$BASE" ]; then
+  REPO_DEFAULT=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "unknown")
+  echo "warning: no base branch configured and 'develop' not found on remote; falling back to repo default ($REPO_DEFAULT)" >&2
+fi
 ```
 
-Use `$BASE` as the PR target. This respects any scoped override set by the `pr-base-scope` sub-skill.
+When `$BASE` is non-empty, pass it explicitly as `--base "$BASE"` to `gh pr create`. When empty (fallback), omit `--base` and let gh CLI determine the target. Use `$BASE` as the PR target. This respects any scoped override set by the `pr-base-scope` sub-skill.
 
 ### 3. Push branch to origin
 
@@ -113,9 +141,20 @@ Fail loudly rather than auto-rewriting — the author should see and fix the foo
 
 ### 8. Open the PR
 
+When `$BASE` is set (resolved in step 2), pass it explicitly:
+
 ```bash
 gh pr create \
   --base "$BASE" \
+  --head "$(git rev-parse --abbrev-ref HEAD)" \
+  --title "<title>" \
+  --body "<assembled body from step 6>"
+```
+
+When `$BASE` is empty (fallback path — warning already emitted in step 2), omit `--base` and let gh CLI determine the target:
+
+```bash
+gh pr create \
   --head "$(git rev-parse --abbrev-ref HEAD)" \
   --title "<title>" \
   --body "<assembled body from step 6>"
@@ -127,6 +166,7 @@ Output the PR URL returned by `gh pr create`.
 
 ## Constraints
 
+- Always resolve `--base` before calling `gh pr create` using the precedence: explicit caller arg → `claude.flowkit.prBase` → legacy `claude.prBase` → `develop` (if remote exists) → gh CLI default with warning
 - Never target `main` directly unless `claude.flowkit.prBase` (or legacy `claude.prBase`) is explicitly set to `main`
 - Never open a PR from a protected branch (`develop`, `main`, `master`, `staging`)
 - If `gh` is not installed or not authenticated, report the error and stop — do not attempt workarounds

--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -43,8 +43,8 @@ Resolve the base branch using the following precedence order:
 ```bash
 # 1. Explicit caller arg
 BASE=""
-if echo "$ARGUMENTS" | grep -qE '\-\-base[= ]'; then
-  BASE=$(echo "$ARGUMENTS" | grep -oE '\-\-base[= ][^ ]+' | head -1 | sed 's/--base[= ]//')
+if echo "$ARGUMENTS" | grep -qE '(^|[[:space:]])\-\-base[= ]'; then
+  BASE=$(echo "$ARGUMENTS" | grep -oE '(^|[[:space:]])\-\-base[= ][^ ]+' | head -1 | sed 's/.*--base[= ]//')
 fi
 
 # 2. claude.flowkit.prBase config key
@@ -70,14 +70,15 @@ if [ -z "$BASE" ]; then
   fi
 fi
 
-# 5. Fallback — let gh CLI use the repo default, but warn
+# 5. Fallback — use the repo default and warn
 if [ -z "$BASE" ]; then
-  REPO_DEFAULT=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "unknown")
+  REPO_DEFAULT=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
   echo "warning: no base branch configured and 'develop' not found on remote; falling back to repo default ($REPO_DEFAULT)" >&2
+  BASE="$REPO_DEFAULT"
 fi
 ```
 
-When `$BASE` is non-empty, pass it explicitly as `--base "$BASE"` to `gh pr create`. When empty (fallback), omit `--base` and let gh CLI determine the target. Use `$BASE` as the PR target. This respects any scoped override set by the `pr-base-scope` sub-skill.
+`$BASE` is always non-empty after step 2 — pass it explicitly as `--base "$BASE"` to `gh pr create`. This respects any scoped override set by the `pr-base-scope` sub-skill.
 
 ### 3. Push branch to origin
 
@@ -141,20 +142,11 @@ Fail loudly rather than auto-rewriting — the author should see and fix the foo
 
 ### 8. Open the PR
 
-When `$BASE` is set (resolved in step 2), pass it explicitly:
+`$BASE` is always non-empty at this point (step 2 guarantees it). Pass it explicitly:
 
 ```bash
 gh pr create \
   --base "$BASE" \
-  --head "$(git rev-parse --abbrev-ref HEAD)" \
-  --title "<title>" \
-  --body "<assembled body from step 6>"
-```
-
-When `$BASE` is empty (fallback path — warning already emitted in step 2), omit `--base` and let gh CLI determine the target:
-
-```bash
-gh pr create \
   --head "$(git rev-parse --abbrev-ref HEAD)" \
   --title "<title>" \
   --body "<assembled body from step 6>"
@@ -166,7 +158,7 @@ Output the PR URL returned by `gh pr create`.
 
 ## Constraints
 
-- Always resolve `--base` before calling `gh pr create` using the precedence: explicit caller arg → `claude.flowkit.prBase` → legacy `claude.prBase` → `develop` (if remote exists) → gh CLI default with warning
+- Always resolve `--base` before calling `gh pr create` using the precedence: explicit caller arg → `claude.flowkit.prBase` → legacy `claude.prBase` → `develop` (if remote exists) → repo default (with warning). `$BASE` is always non-empty; `--base "$BASE"` is always passed.
 - Never target `main` directly unless `claude.flowkit.prBase` (or legacy `claude.prBase`) is explicitly set to `main`
 - Never open a PR from a protected branch (`develop`, `main`, `master`, `staging`)
 - If `gh` is not installed or not authenticated, report the error and stop — do not attempt workarounds

--- a/plugins/flowkit/skills/pr-base-scope/SKILL.md
+++ b/plugins/flowkit/skills/pr-base-scope/SKILL.md
@@ -35,26 +35,15 @@ git config --unset claude.flowkit.prBase
 
 ### Read
 
-Resolve the current target branch (used by `/open-pr`). Apply this resolution order:
+Resolve the current target branch (used by `/open-pr`). The authoritative five-step resolution order lives in [`open-pr/SKILL.md`](../open-pr/SKILL.md) — step 2. In summary:
 
-1. `claude.flowkit.prBase` — primary source of truth
-2. `claude.prBase` — legacy fallback (emits deprecation notice when hit)
-3. Built-in default: `develop`
+1. Explicit `--base <branch>` caller arg in `$ARGUMENTS`
+2. `claude.flowkit.prBase` — primary config key
+3. `claude.prBase` — legacy fallback (emits deprecation notice when hit)
+4. `develop` — if the branch exists on the remote
+5. Repo default branch (via `gh repo view`) — with a warning; always assigned so `$BASE` is never empty
 
-```bash
-BASE=$(git config claude.flowkit.prBase 2>/dev/null)
-if [ -z "$BASE" ]; then
-  LEGACY=$(git config claude.prBase 2>/dev/null)
-  if [ -n "$LEGACY" ]; then
-    BASE="$LEGACY"
-    echo "note: claude.prBase is deprecated. Migrate with:" >&2
-    echo "  git config --unset claude.prBase" >&2
-    echo "  git config claude.flowkit.prBase $LEGACY" >&2
-  else
-    BASE="develop"
-  fi
-fi
-```
+`$BASE` is guaranteed non-empty after resolution; `/open-pr` always passes `--base "$BASE"` to `gh pr create`.
 
 ## Usage by Callers
 
@@ -63,7 +52,7 @@ fi
 | `/ship` | Sets `claude.flowkit.prBase develop` before opening PRs, then unsets after the flow completes |
 | `/swarm` loop mode | Sets `claude.flowkit.prBase` to the appropriate integration branch for the loop session |
 | `/cut-epic` | Sets `claude.flowkit.prBase` to the long-lived epic branch so sub-PRs target it; user runs **Unset** when the epic ships |
-| `/open-pr` | Reads the resolved base (new key → legacy key → `develop`) before creating the PR |
+| `/open-pr` | Reads the resolved base (explicit arg → new key → legacy key → `develop` → repo default) before creating the PR; `$BASE` is always non-empty |
 
 ## Constraints
 


### PR DESCRIPTION
## Summary
- Resolve PR base in order: explicit caller arg → `claude.flowkit.prBase` → legacy `claude.prBase` → `develop` (if remote exists) → GitHub default with warning.
- Always pass an explicit `--base` to `gh pr create` so develop-first repos no longer silently target main.

## Changes
- `plugins/flowkit/skills/open-pr/SKILL.md`: expand step 2 base-resolution chain to include explicit `--base` arg extraction, remote `develop` existence check via `git ls-remote`, and a one-line fallback warning naming the repo default; document full precedence; update step 8 to conditionally include `--base`; add constraint entry for the resolution order.

## Test plan
- [ ] In a develop-first repo with no override: open a PR via flowkit:open-pr — confirm `--base develop` is passed.
- [ ] With `claude.flowkit.prBase=feature/foo` set: confirm that wins over the develop default.
- [ ] With an explicit `--base staging` in `$ARGUMENTS`: confirm that wins over all config.
- [ ] In a repo with no develop branch and no config: confirm fallback warning is emitted naming the repo default before opening the PR.
- [ ] flowkit:pr (composes open-pr): verify same resolution applies without changes to pr/SKILL.md.

Closes #703