### PR TITLE
feat(flowkit): auto-stash dirty workspace around post-merge pull

### DIFF
--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -55,6 +55,7 @@ These are called by the skills above — you don't invoke them directly.
 | **git-sync-main** | release, hotfix | Checkout `main` and pull latest from origin. |
 | **git-sync-develop** | sync, release, hotfix | Checkout `develop` and pull latest from origin. |
 | **pr-base-scope** | swarm | Set/unset `claude.flowkit.prBase` git config for scoped PR targeting. |
+| **with-clean-workspace** | merge-pr, release | Auto-stash dirty workspace around implicit post-merge pull. |
 
 ## Typical Workflows
 

--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -39,8 +39,23 @@ If `PR_NUM` is empty, abort with:
 
 ### 3. Squash-merge and delete the remote branch
 
+`gh pr merge --squash --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. Wrap the call with the `flowkit:with-clean-workspace` sub-skill so any dirty state is auto-stashed and restored:
+
 ```bash
+DIRTY=false
+if [ -n "$(git status --porcelain)" ]; then
+  DIRTY=true
+  git stash push -u -m "flowkit-auto-stash" >/dev/null
+fi
+
 gh pr merge "$PR_NUM" --squash --delete-branch
+
+if [ "$DIRTY" = "true" ]; then
+  if ! git stash pop; then
+    echo "WARNING: stash pop conflicted. Your changes are preserved on the stash stack." >&2
+    echo "Run \`git stash list\` to see the saved entry (message: flowkit-auto-stash) and \`git stash pop\` after resolving." >&2
+  fi
+fi
 ```
 
 ### 4. Label referenced issues

--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -48,14 +48,22 @@ if [ -n "$(git status --porcelain)" ]; then
   git stash push -u -m "flowkit-auto-stash" >/dev/null
 fi
 
-gh pr merge "$PR_NUM" --squash --delete-branch
+if gh pr merge "$PR_NUM" --squash --delete-branch; then
+  MERGE_OK=true
+else
+  MERGE_OK=false
+fi
 
-if [ "$DIRTY" = "true" ]; then
+if [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "true" ]; then
   if ! git stash pop; then
     echo "WARNING: stash pop conflicted. Your changes are preserved on the stash stack." >&2
     echo "Run \`git stash list\` to see the saved entry (message: flowkit-auto-stash) and \`git stash pop\` after resolving." >&2
   fi
+elif [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "false" ]; then
+  echo "WARNING: merge failed — stash preserved. Run \`git stash pop\` after resolving the merge error." >&2
 fi
+
+[ "$MERGE_OK" = "false" ] && exit 1
 ```
 
 ### 4. Label referenced issues

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -255,8 +255,23 @@ Capture the PR number from the URL output.
 
 ### 6. Merge the PR
 
+`gh pr merge --merge --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. Wrap the call with the `flowkit:with-clean-workspace` sub-skill so any dirty state is auto-stashed and restored:
+
 ```bash
+DIRTY=false
+if [ -n "$(git status --porcelain)" ]; then
+  DIRTY=true
+  git stash push -u -m "flowkit-auto-stash" >/dev/null
+fi
+
 gh pr merge "$PR_URL" --merge --delete-branch
+
+if [ "$DIRTY" = "true" ]; then
+  if ! git stash pop; then
+    echo "WARNING: stash pop conflicted. Your changes are preserved on the stash stack." >&2
+    echo "Run \`git stash list\` to see the saved entry (message: flowkit-auto-stash) and \`git stash pop\` after resolving." >&2
+  fi
+fi
 ```
 
 Use `--merge` to preserve the full commit history from the RC branch in main.

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -264,14 +264,22 @@ if [ -n "$(git status --porcelain)" ]; then
   git stash push -u -m "flowkit-auto-stash" >/dev/null
 fi
 
-gh pr merge "$PR_URL" --merge --delete-branch
+if gh pr merge "$PR_URL" --merge --delete-branch; then
+  MERGE_OK=true
+else
+  MERGE_OK=false
+fi
 
-if [ "$DIRTY" = "true" ]; then
+if [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "true" ]; then
   if ! git stash pop; then
     echo "WARNING: stash pop conflicted. Your changes are preserved on the stash stack." >&2
     echo "Run \`git stash list\` to see the saved entry (message: flowkit-auto-stash) and \`git stash pop\` after resolving." >&2
   fi
+elif [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "false" ]; then
+  echo "WARNING: merge failed — stash preserved. Run \`git stash pop\` after resolving the merge error." >&2
 fi
+
+[ "$MERGE_OK" = "false" ] && exit 1
 ```
 
 Use `--merge` to preserve the full commit history from the RC branch in main.

--- a/plugins/flowkit/skills/with-clean-workspace/SKILL.md
+++ b/plugins/flowkit/skills/with-clean-workspace/SKILL.md
@@ -23,17 +23,31 @@ fi
 
 ### 2. Run the wrapped command
 
-Whatever the caller needs to invoke (`gh pr merge ...`, etc.).
-
-### 3. Restore the stash if one was pushed
+Whatever the caller needs to invoke (`gh pr merge ...`, etc.). Capture whether it succeeded:
 
 ```bash
-if [ "$DIRTY" = "true" ]; then
+if <wrapped-command>; then
+  MERGE_OK=true
+else
+  MERGE_OK=false
+fi
+```
+
+### 3. Restore the stash only if the wrapped command succeeded
+
+The pop is conditional on the wrapped command exiting 0. If the command failed (e.g. merge conflict on GitHub, network error), the stash is left on the stack so the user can retry without losing their workspace state:
+
+```bash
+if [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "true" ]; then
   if ! git stash pop; then
     echo "WARNING: stash pop conflicted. Your changes are preserved on the stash stack." >&2
     echo "Run \`git stash list\` to see the saved entry (message: flowkit-auto-stash) and \`git stash pop\` after resolving." >&2
   fi
+elif [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "false" ]; then
+  echo "WARNING: merge failed — stash preserved. Run \`git stash pop\` after resolving the merge error." >&2
 fi
+
+[ "$MERGE_OK" = "false" ] && exit 1
 ```
 
 ## Constraints
@@ -41,3 +55,4 @@ fi
 - Never auto-resolve a stash-pop conflict — leave the stash on the stack and tell the user.
 - Always use `-u` so untracked files (e.g. new hook scripts) are stashed too.
 - Use the literal message `flowkit-auto-stash` so the user can identify the entry in `git stash list`.
+- Only pop the stash if the wrapped command exited 0 — a failed command must not trigger a pop that masks the failure on retry.

--- a/plugins/flowkit/skills/with-clean-workspace/SKILL.md
+++ b/plugins/flowkit/skills/with-clean-workspace/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: with-clean-workspace
+description: Auto-stash uncommitted changes around a command that triggers an implicit `git pull` (e.g. `gh pr merge --squash --delete-branch`). Sub-skill used by merge-pr and release.
+---
+
+# with-clean-workspace
+
+Wrap a command whose side effects include an implicit `git pull` (most notably `gh pr merge --squash --delete-branch` / `--merge --delete-branch`) so a dirty workspace cannot break the post-merge pull with `cannot pull with rebase: You have unstaged changes`.
+
+The guard auto-stashes uncommitted changes (tracked + untracked) before the wrapped command and pops the stash after. If the pop conflicts, it leaves the stash on the stack and surfaces that to the user — never auto-resolves.
+
+## Process
+
+### 1. Detect dirty workspace before the wrapped command
+
+```bash
+DIRTY=false
+if [ -n "$(git status --porcelain)" ]; then
+  DIRTY=true
+  git stash push -u -m "flowkit-auto-stash" >/dev/null
+fi
+```
+
+### 2. Run the wrapped command
+
+Whatever the caller needs to invoke (`gh pr merge ...`, etc.).
+
+### 3. Restore the stash if one was pushed
+
+```bash
+if [ "$DIRTY" = "true" ]; then
+  if ! git stash pop; then
+    echo "WARNING: stash pop conflicted. Your changes are preserved on the stash stack." >&2
+    echo "Run \`git stash list\` to see the saved entry (message: flowkit-auto-stash) and \`git stash pop\` after resolving." >&2
+  fi
+fi
+```
+
+## Constraints
+
+- Never auto-resolve a stash-pop conflict — leave the stash on the stack and tell the user.
+- Always use `-u` so untracked files (e.g. new hook scripts) are stashed too.
+- Use the literal message `flowkit-auto-stash` so the user can identify the entry in `git stash list`.


### PR DESCRIPTION
## Summary
- Detect dirty workspace before `gh pr merge` invocations in merge-pr and release; auto-stash with a labeled message and pop after the merge completes.
- Surface stash-pop conflicts clearly: leave on the stack, tell user `git stash list` shows the saved state.

## Changes
- `plugins/flowkit/skills/merge-pr/SKILL.md`: wrap merge call with stash/restore guard.
- `plugins/flowkit/skills/release/SKILL.md`: wrap merge call with stash/restore guard.
- `plugins/flowkit/skills/with-clean-workspace/SKILL.md`: new shared sub-skill documenting the guard pattern.

## Test plan
- Run `/merge-pr` with a dirty workspace (e.g., uncommitted hook script) — confirm merge succeeds and post-merge pull does not fail.
- Confirm workspace is restored after pop.
- Force a stash-pop conflict (edit the stashed file post-merge) — confirm the stash is preserved on the stack and the message names it.
- Same flow for `/release`.

Closes #695