### PR TITLE
feat(bump-versions): populate suggested_bump in detect_changed.sh JSON

### DIFF
--- a/.claude/skills/bump-versions/SKILL.md
+++ b/.claude/skills/bump-versions/SKILL.md
@@ -45,8 +45,8 @@ The script emits a bare JSON array on stdout:
 
 ```json
 [
-  {"plugin": "swarmkit", "last_tag": "swarmkit--v5.1.0", "commit_count": 2, "current_version": "5.1.0"},
-  {"plugin": "flowkit",  "last_tag": "flowkit--v1.2.0",  "commit_count": 1, "current_version": "1.2.0"}
+  {"plugin": "swarmkit", "last_tag": "swarmkit--v5.1.0", "commit_count": 2, "current_version": "5.1.0", "suggested_bump": "minor"},
+  {"plugin": "flowkit",  "last_tag": "flowkit--v1.2.0",  "commit_count": 1, "current_version": "1.2.0", "suggested_bump": "patch"}
 ]
 ```
 
@@ -56,32 +56,24 @@ If `$ARGUMENTS` is provided (e.g. `patch` or `minor`), apply that bump type to a
 
 ### Step 2 — Recommend and confirm bump types
 
-Display a table of plugins with changes (from the Step 1 JSON):
+Display a table of plugins with changes (from the Step 1 JSON), using the `suggested_bump` field already computed by the script:
 
 ```
-Plugin      Current   Commits since last tag
-----------  --------  ----------------------
-swarmkit    5.1.0     2
-flowkit     1.2.0     1
+Plugin      Current   Commits since last tag   Suggested bump
+----------  --------  ----------------------   --------------
+swarmkit    5.1.0     2                        minor
+flowkit     1.2.0     1                        patch
 ```
 
-For each changed plugin, retrieve its commits since the last tag to derive a recommended bump:
-
-```bash
-git log {last_tag}..HEAD --oneline -- plugins/{plugin}/
-```
-
-If `last_tag` is `(none)`, use the full history: `git log --oneline -- plugins/{plugin}/`.
-
-Map conventional-commit prefixes to bump types (take the highest when multiple coexist; `major > minor > patch`):
+The `suggested_bump` is derived from conventional-commit prefixes across all commits in the range (`major > minor > patch`):
 
 | Commit signal | Recommended bump |
 |---------------|------------------|
-| `feat:` or new skill file added | **minor** |
-| `fix:` / `docs:` / `chore:` / `refactor:` (no behavior change) | **patch** |
-| `refactor:` with noted behavior change, or `BREAKING CHANGE:` footer anywhere | **major** |
+| `!:` in subject or `BREAKING CHANGE` in commit body | **major** |
+| `feat:` / `feat(…):` prefix | **minor** |
+| Any other prefix (`fix`, `chore`, `refactor`, etc.) | **patch** |
 
-Present the choice via the `AskUserQuestion` tool — **one question per changed plugin** — with the recommendation as the first (default) option. Each question should include a one-line rationale (e.g. "recommending **minor** — adds a new skill in `feat(flowkit): …`").
+Present the choice via the `AskUserQuestion` tool — **one question per changed plugin** — with `suggested_bump` as the first (default) option. Each question should include a one-line rationale (e.g. "recommending **minor** — adds a new skill in `feat(flowkit): …`").
 
 Options for each question (in this order; default first):
 

--- a/.claude/skills/bump-versions/scripts/detect_changed.sh
+++ b/.claude/skills/bump-versions/scripts/detect_changed.sh
@@ -57,7 +57,7 @@ find "$REPO_ROOT/plugins" -maxdepth 3 -name "plugin.json" -path "*/.claude-plugi
       [[ "$suggested_bump" == "major" ]] && break
       if [[ "$line" =~ ^[^:]+\!: ]] || echo "$line" | grep -qF "BREAKING CHANGE"; then
         suggested_bump="major"
-      elif [[ "$suggested_bump" != "major" ]] && [[ "$line" =~ ^feat[:(] ]]; then
+      elif [[ "$suggested_bump" != "major" ]] && echo "$line" | grep -qE '^feat[:(]'; then
         suggested_bump="minor"
       fi
     done < <(git log "${log_range_args[@]}" --format="%s%n%b" 2>/dev/null)

--- a/.claude/skills/bump-versions/scripts/detect_changed.sh
+++ b/.claude/skills/bump-versions/scripts/detect_changed.sh
@@ -8,8 +8,10 @@ set -euo pipefail
 #   detect_changed.sh
 #
 # On success: exit 0, JSON array on stdout:
-#   [{"plugin": "swarmkit", "last_tag": "swarmkit--v5.1.0", "commit_count": 3, "current_version": "5.1.0"}, ...]
+#   [{"plugin": "swarmkit", "last_tag": "swarmkit--v5.1.0", "commit_count": 3, "current_version": "5.1.0", "suggested_bump": "minor"}, ...]
 #   Only plugins with commit_count > 0 (or no prior tag) are included.
+#   suggested_bump is one of: major | minor | patch
+#   Priority: major (BREAKING CHANGE or !:) > minor (feat) > patch (everything else)
 # On failure: non-zero exit, empty stdout, human-readable message on stderr.
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
@@ -44,11 +46,28 @@ find "$REPO_ROOT/plugins" -maxdepth 3 -name "plugin.json" -path "*/.claude-plugi
   fi
 
   if [[ "$commit_count" -gt 0 ]]; then
+    if [[ "$last_tag" == "(none)" ]]; then
+      log_range_args=("--" "$plugin_dir/")
+    else
+      log_range_args=("${last_tag}..HEAD" "--" "$plugin_dir/")
+    fi
+
+    suggested_bump="patch"
+    while IFS= read -r line; do
+      [[ "$suggested_bump" == "major" ]] && break
+      if [[ "$line" =~ ^[^:]+\!: ]] || echo "$line" | grep -qF "BREAKING CHANGE"; then
+        suggested_bump="major"
+      elif [[ "$suggested_bump" != "major" ]] && [[ "$line" =~ ^feat[:(] ]]; then
+        suggested_bump="minor"
+      fi
+    done < <(git log "${log_range_args[@]}" --format="%s%n%b" 2>/dev/null)
+
     jq -n \
       --arg plugin "$plugin_name" \
       --arg last_tag "$last_tag" \
       --argjson commit_count "$commit_count" \
       --arg current_version "$current_version" \
-      '{"plugin": $plugin, "last_tag": $last_tag, "commit_count": $commit_count, "current_version": $current_version}'
+      --arg suggested_bump "$suggested_bump" \
+      '{"plugin": $plugin, "last_tag": $last_tag, "commit_count": $commit_count, "current_version": $current_version, "suggested_bump": $suggested_bump}'
   fi
 done | jq -s '.'


### PR DESCRIPTION
## Summary
- Add `suggested_bump` field to `detect_changed.sh` records, derived from conventional-commit prefixes since the last per-plugin tag.
- `major` (`!:` in subject or `BREAKING CHANGE` in commit body) > `minor` (`feat`) > `patch` (everything else).
- SKILL.md Step 2 now reads `suggested_bump` directly from the script's JSON output instead of re-deriving it inline.

## Changes
- `.claude/skills/bump-versions/scripts/detect_changed.sh`: scan commits with `--format="%s%n%b"` (subject + body) to detect breaking signals; emit `suggested_bump` on every record where `commit_count > 0`.
- `.claude/skills/bump-versions/SKILL.md`: Step 2 updated to consume `suggested_bump` from JSON and display it in the plugin table; removed the inline git-log re-derivation step.

## Test plan
- Run `detect_changed.sh` on this repo: confirm every record includes `suggested_bump` and the highest-priority prefix wins across mixed commit types.
- Cherry-pick or create a commit with `feat!:` subject — confirm the record emits `"suggested_bump": "major"`.
- Create a commit with `BREAKING CHANGE` in the body — confirm the record emits `"suggested_bump": "major"`.
- Verify a `feat:` commit with no breaking signals emits `"suggested_bump": "minor"`.
- Verify a `fix:` or `chore:` only commit emits `"suggested_bump": "patch"`.

Closes #709