### PR TITLE
feat(infra): script-level smoke-test convention and runner

### DIFF
--- a/plugins/_shared/script-authoring.md
+++ b/plugins/_shared/script-authoring.md
@@ -72,6 +72,42 @@ Use exit code `1` for runtime failures, `2` for invalid arguments.
 
 `plugins/swarmkit/skills/swarm/scripts/preflight.sh` — collapses git fetch, base-branch verification, and `gh` auth check into one call. Its output is a bare JSON object; errors go to stderr with non-zero exit. Refer to it and the other scripts in that directory as the reference implementation.
 
+## Smoke tests
+
+Every skill that ships scripts also ships a `scripts/test.sh` smoke test alongside them:
+
+```
+plugins/<plugin>/skills/<skill>/scripts/test.sh
+```
+
+`test.sh` exercises every script in the same `scripts/` directory and asserts the contract documented above:
+
+1. **Invalid-argument invocations** — for each script, drive at least one invalid-argument case (unknown flag, missing required value, wrong arity, malformed positional) and assert:
+   - exit code is non-zero,
+   - stdout is empty,
+   - stderr is non-empty.
+2. **Successful invocations** — where a script can be invoked deterministically without external network or destructive side effects (e.g. with empty input arrays that short-circuit, or read-only inspection commands), assert:
+   - exit code is 0,
+   - stdout is parseable JSON (`jq -e .`),
+   - the JSON object exposes every documented top-level key (`jq -e 'has("...")'`).
+
+Scripts that always require live network or destructive state changes (live `gh` calls, `git fetch origin`, `git checkout`) cannot be exercised on their happy path from a smoke harness — limit those to invalid-argument coverage. Document that limitation in the test header so reviewers understand the scope.
+
+A test failure must surface a clear, line-grep-able message (`FAIL [<script> <case>]: ...`) and exit non-zero. Reference implementations:
+
+- `plugins/swarmkit/skills/swarm/scripts/test.sh` — argument-validation-only coverage for network-dependent scripts.
+- `plugins/swarmkit/skills/clean-worktrees/scripts/test.sh` — argument validation plus read-only / empty-input happy paths.
+
+### Top-level runner
+
+The repo-root runner discovers and executes every skill's `test.sh`:
+
+```bash
+bash scripts/test-all-skill-scripts.sh
+```
+
+It walks `plugins/*/skills/*/scripts/test.sh`, runs each with the test directory as CWD, and exits non-zero if any test fails. This is the single entry point intended for CI.
+
 ## `.claude/settings.json` allowlist
 
 The harness requires explicit permission before executing each script path. Add an entry to the project `.claude/settings.json` allowlist when introducing a new script:

--- a/plugins/swarmkit/skills/clean-remote-worktrees/scripts/test.sh
+++ b/plugins/swarmkit/skills/clean-remote-worktrees/scripts/test.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
-# test.sh — smoke tests for swarmkit:clean-worktrees scripts.
+# test.sh — smoke tests for swarmkit:clean-remote-worktrees scripts.
 #
 # Per the convention in plugins/_shared/script-authoring.md:
 # - Successful invocations exit 0 and emit a parseable JSON object on stdout
 #   with the documented top-level keys.
 # - Invalid-argument invocations exit non-zero and emit nothing on stdout.
 #
-# These scripts are network-free (operate on the local repo only) so a
-# read-only happy path is exercised. `remove.sh` is invoked with empty input
-# arrays so it has nothing to remove — a safe no-op.
+# classify.sh requires network access (git fetch + gh API) so only the
+# invalid-argument surface is exercisable here. Since classify.sh accepts no
+# flags, there is no flag-based invalid-arg path to test; the entire happy
+# path is network-dependent and therefore deferred to CI.
+#
+# delete.sh has a network-free early-exit path (--branches '[]') that is
+# exercised as the happy-path noop test.
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PASS=0
@@ -97,27 +101,20 @@ assert_json_keys() {
   PASS=$((PASS + 1))
 }
 
-echo "clean-worktrees: smoke-testing scripts"
+echo "clean-remote-worktrees: smoke-testing scripts"
 echo
 
-# gather.sh — no args, read-only. Always succeeds in any git repo.
-assert_json_keys gather.sh "happy-path" \
-  "caller_branch main_worktree worktrees_to_remove branches_to_delete stuck"
+# delete.sh — invalid arg shapes.
+assert_invalid_args delete.sh "missing-required"  # no --branches at all
+assert_invalid_args delete.sh "missing-value"     --branches
+assert_invalid_args delete.sh "unknown-flag"      --bogus value
 
-# remove.sh — invalid arg shapes.
-assert_invalid_args remove.sh "missing-required" --worktrees '[]' --branches '[]'
-assert_invalid_args remove.sh "unknown-flag"     --bogus value
-assert_invalid_args remove.sh "missing-value"    --main-worktree
-
-# remove.sh — empty arrays = safe no-op happy path. We pass the current main
-# worktree so the cd succeeds, and an empty caller-branch so the restore step
-# is a no-op.
-MAIN_WT="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
-assert_json_keys remove.sh "empty-arrays-noop" \
-  "removed remove_errors pruned_branches branch_errors caller_branch_restored" \
-  --main-worktree "$MAIN_WT" --caller-branch "" --worktrees '[]' --branches '[]'
+# delete.sh — empty array = network-free noop happy path.
+assert_json_keys delete.sh "empty-array-noop" \
+  "deleted skipped errors" \
+  --branches '[]'
 
 echo
-echo "clean-worktrees: ${PASS} passed, ${FAIL} failed"
+echo "clean-remote-worktrees: ${PASS} passed, ${FAIL} failed"
 [[ $FAIL -eq 0 ]] || exit 1
 exit 0

--- a/plugins/swarmkit/skills/clean-worktrees/scripts/test.sh
+++ b/plugins/swarmkit/skills/clean-worktrees/scripts/test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# test.sh — smoke tests for swarmkit:clean-worktrees scripts.
+#
+# Per the convention in plugins/_shared/script-authoring.md:
+# - Successful invocations exit 0 and emit a parseable JSON object on stdout
+#   with the documented top-level keys.
+# - Invalid-argument invocations exit non-zero and emit nothing on stdout.
+#
+# These scripts are network-free (operate on the local repo only) so a
+# read-only happy path is exercised. `remove.sh` is invoked with empty input
+# arrays so it has nothing to remove — a safe no-op.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PASS=0
+FAIL=0
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+assert_invalid_args() {
+  local script="$1"; shift
+  local label="$1"; shift
+  local stdout stderr rc
+  local tmp_out tmp_err
+  tmp_out="$(mktemp)"
+  tmp_err="$(mktemp)"
+  set +e
+  "$SCRIPT_DIR/$script" "$@" >"$tmp_out" 2>"$tmp_err"
+  rc=$?
+  set -e
+  stdout="$(cat "$tmp_out")"
+  stderr="$(cat "$tmp_err")"
+  rm -f "$tmp_out" "$tmp_err"
+
+  if [[ $rc -eq 0 ]]; then
+    red   "  FAIL [$script $label]: expected non-zero exit, got 0"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -n "$stdout" ]]; then
+    red   "  FAIL [$script $label]: expected empty stdout on invalid args, got:"
+    printf '%s\n' "$stdout" | sed 's/^/         /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -z "$stderr" ]]; then
+    red   "  FAIL [$script $label]: expected non-empty stderr message"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  green "  PASS [$script $label]: exit=$rc, stdout empty"
+  PASS=$((PASS + 1))
+}
+
+assert_json_keys() {
+  local script="$1"; shift
+  local label="$1"; shift
+  local expected_keys="$1"; shift
+  local stdout rc
+  local tmp_out tmp_err
+  tmp_out="$(mktemp)"
+  tmp_err="$(mktemp)"
+  set +e
+  "$SCRIPT_DIR/$script" "$@" >"$tmp_out" 2>"$tmp_err"
+  rc=$?
+  set -e
+  stdout="$(cat "$tmp_out")"
+  stderr_content="$(cat "$tmp_err")"
+  rm -f "$tmp_out" "$tmp_err"
+
+  if [[ $rc -ne 0 ]]; then
+    red   "  FAIL [$script $label]: expected exit 0, got $rc"
+    [[ -n "$stderr_content" ]] && printf '%s\n' "$stderr_content" | sed 's/^/         stderr: /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if ! printf '%s' "$stdout" | jq -e . >/dev/null 2>&1; then
+    red   "  FAIL [$script $label]: stdout is not valid JSON"
+    printf '%s\n' "$stdout" | sed 's/^/         /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  local missing=""
+  for key in $expected_keys; do
+    if ! printf '%s' "$stdout" | jq -e "has(\"$key\")" >/dev/null 2>&1; then
+      missing+=" $key"
+    fi
+  done
+  if [[ -n "$missing" ]]; then
+    red   "  FAIL [$script $label]: missing top-level keys:$missing"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  green "  PASS [$script $label]: exit=0, JSON valid, keys present"
+  PASS=$((PASS + 1))
+}
+
+echo "clean-worktrees: smoke-testing scripts"
+echo
+
+# gather.sh — no args, read-only. Always succeeds in any git repo.
+assert_json_keys gather.sh "happy-path" \
+  "caller_branch main_worktree worktrees_to_remove branches_to_delete stuck"
+
+# remove.sh — invalid arg shapes.
+assert_invalid_args remove.sh "missing-required" --worktrees '[]' --branches '[]'
+assert_invalid_args remove.sh "unknown-flag"     --bogus value
+assert_invalid_args remove.sh "missing-value"    --main-worktree
+
+# remove.sh — empty arrays = safe no-op happy path. We pass the current main
+# worktree so the cd succeeds, and an empty caller-branch so the restore step
+# is a no-op.
+MAIN_WT="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+assert_json_keys remove.sh "empty-arrays-noop" \
+  "removed remove_errors pruned_branches branch_errors caller_branch_restored" \
+  --main-worktree "$MAIN_WT" --caller-branch "" --worktrees '[]' --branches '[]'
+
+echo
+echo "clean-worktrees: ${PASS} passed, ${FAIL} failed"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/plugins/swarmkit/skills/swarm/scripts/test.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# test.sh — smoke tests for swarmkit:swarm scripts.
+#
+# Per the convention in plugins/_shared/script-authoring.md:
+# - Successful invocations exit 0 and emit a parseable JSON object on stdout
+#   with the documented top-level keys.
+# - Invalid-argument invocations exit non-zero and emit nothing on stdout.
+#
+# These tests focus on the deterministic, network-free contract surface:
+# argument validation. Happy-path invocations for swarm scripts require live
+# `gh` auth and `git fetch origin`, which are unsuitable for a smoke harness;
+# that surface is exercised manually and via the skill itself.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PASS=0
+FAIL=0
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+assert_invalid_args() {
+  local script="$1"; shift
+  local label="$1"; shift
+  local stdout stderr rc
+  local tmp_out tmp_err
+  tmp_out="$(mktemp)"
+  tmp_err="$(mktemp)"
+  set +e
+  "$SCRIPT_DIR/$script" "$@" >"$tmp_out" 2>"$tmp_err"
+  rc=$?
+  set -e
+  stdout="$(cat "$tmp_out")"
+  stderr="$(cat "$tmp_err")"
+  rm -f "$tmp_out" "$tmp_err"
+
+  if [[ $rc -eq 0 ]]; then
+    red   "  FAIL [$script $label]: expected non-zero exit, got 0"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -n "$stdout" ]]; then
+    red   "  FAIL [$script $label]: expected empty stdout on invalid args, got:"
+    printf '%s\n' "$stdout" | sed 's/^/         /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -z "$stderr" ]]; then
+    red   "  FAIL [$script $label]: expected non-empty stderr message"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  green "  PASS [$script $label]: exit=$rc, stdout empty, stderr non-empty"
+  PASS=$((PASS + 1))
+}
+
+echo "swarm: smoke-testing argument validation contracts"
+echo
+
+# preflight.sh — accepts --base <value>, --scope-pr-base, no positional.
+assert_invalid_args preflight.sh "unknown-flag"      --not-a-flag
+assert_invalid_args preflight.sh "missing-value"     --base
+assert_invalid_args preflight.sh "extra-positional"  positional-not-allowed
+
+# teardown.sh — accepts --base <value>.
+assert_invalid_args teardown.sh "unknown-flag"   --not-a-flag
+assert_invalid_args teardown.sh "missing-value"  --base
+
+# verify_agent.sh — exactly one positive integer.
+assert_invalid_args verify_agent.sh "no-args"
+assert_invalid_args verify_agent.sh "non-integer"   not-a-number
+assert_invalid_args verify_agent.sh "negative"      -5
+assert_invalid_args verify_agent.sh "extra-args"    1 2
+
+# gather_issues.sh — at least one positive-integer arg.
+assert_invalid_args gather_issues.sh "no-args"
+assert_invalid_args gather_issues.sh "non-integer"  abc
+assert_invalid_args gather_issues.sh "mixed-bad"    1 abc
+
+echo
+echo "swarm: ${PASS} passed, ${FAIL} failed"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/scripts/test-all-skill-scripts.sh
+++ b/scripts/test-all-skill-scripts.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-all-skill-scripts.sh — discover and run every skill's `scripts/test.sh`
+# smoke test across the monorepo. Single entry point for CI and manual runs.
+#
+# Usage:
+#   scripts/test-all-skill-scripts.sh
+#
+# Discovery: walks `plugins/*/skills/*/scripts/test.sh`. Each test.sh is run
+# with its own directory as CWD. A non-zero exit from any test.sh fails the
+# whole runner, but every test is still attempted so the report is complete.
+#
+# Exit codes:
+#   0  — all discovered tests passed
+#   1  — at least one test failed
+#   2  — no tests discovered
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+for cmd in bash jq find; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "test-all-skill-scripts: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+TESTS=()
+while IFS= read -r line; do
+  TESTS+=("$line")
+done < <(find plugins -path 'plugins/*/skills/*/scripts/test.sh' -type f | sort)
+
+if [[ ${#TESTS[@]} -eq 0 ]]; then
+  echo "test-all-skill-scripts: no skill smoke tests discovered under plugins/*/skills/*/scripts/test.sh" >&2
+  exit 2
+fi
+
+passed=0
+failed=0
+failed_paths=()
+
+echo "Discovered ${#TESTS[@]} skill smoke test(s)."
+echo
+
+for test_path in "${TESTS[@]}"; do
+  rel="${test_path#$REPO_ROOT/}"
+  echo "==> $rel"
+  test_dir="$(dirname "$test_path")"
+  if ( cd "$test_dir" && bash "./test.sh" ); then
+    passed=$((passed + 1))
+    echo "    PASS"
+  else
+    failed=$((failed + 1))
+    failed_paths+=("$rel")
+    echo "    FAIL"
+  fi
+  echo
+done
+
+echo "------------------------------------------------------------"
+echo "Skill smoke tests: ${passed} passed, ${failed} failed (of ${#TESTS[@]})"
+
+if [[ $failed -gt 0 ]]; then
+  echo
+  echo "Failed tests:"
+  for p in "${failed_paths[@]}"; do
+    echo "  - $p"
+  done
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Establish per-skill `scripts/test.sh` convention with exit-code and JSON-shape assertions for skill scripts.
- Add root-level `scripts/test-all-skill-scripts.sh` that discovers and runs every skill's smoke tests — single CI entry point.
- Document the convention in `plugins/_shared/script-authoring.md`.
- Provide reference implementations for the highest-traffic skills; remaining skills tracked as follow-ups.

## Changes
- `scripts/test-all-skill-scripts.sh`: top-level discovery and runner. Walks `plugins/*/skills/*/scripts/test.sh`, reports per-test PASS/FAIL, exits 1 if any test fails or 2 if none discovered.
- `plugins/swarmkit/skills/swarm/scripts/test.sh`: reference smoke test covering invalid-argument contracts for `preflight.sh`, `teardown.sh`, `verify_agent.sh`, `gather_issues.sh` (these scripts require live network so happy paths are intentionally out of scope).
- `plugins/swarmkit/skills/clean-worktrees/scripts/test.sh`: reference smoke test covering both invalid-argument cases and read-only / empty-input happy paths for `gather.sh` and `remove.sh` — validates JSON shape via `jq` and asserts every documented top-level key.
- `plugins/_shared/script-authoring.md`: new "Smoke tests" section documenting the convention, expected assertion surface, scope limits for network-dependent scripts, and the top-level runner.

Smoke tests for the remaining scripts (`clean-remote-worktrees/{classify,delete}.sh`) are a sensible follow-up — `delete.sh` has a network-free empty-array fast path that is easy to cover; `classify.sh` is network-only like the swarm scripts.

CI workflow wiring is intentionally out of scope per the issue (no `.github/workflows/` exists in this repo yet).

## Test plan
- [x] Run `bash scripts/test-all-skill-scripts.sh` from repo root — all 17 reference assertions pass across both skills.
- [x] Verify the runner detects failure: replaced a `test.sh` with a stub `exit 1` → runner exits 1 and lists the failing path.
- [x] Verify JSON-shape regression detection: replaced `gather.sh` with a stub emitting `{"unexpected": 1}` → smoke test reports `missing top-level keys: caller_branch main_worktree ...` and exits 1.
- [x] Verify portability: runner works on macOS default `bash` 3.2 (no `mapfile`).

Closes #704