### PR TITLE
feat(flowkit): align issue-close lifecycle with GitHub-native conventions

### DIFF
--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -186,6 +186,14 @@ Flowkit is opinionated. Understanding these assumptions upfront will save you fr
 
 Feature work merges into `develop`. Release candidates are cut from `develop`. Staging (if present) is an intermediate promotion gate. `main` always reflects what's in production.
 
+### Default Branch
+
+Flowkit assumes `main` is the GitHub default branch for the repo. GitHub's `Closes #N` auto-close keywords only fire when a PR merges into the default branch — so the staging→`main` (or RC→`main`) merge that `/release` performs is what closes the issues referenced in PRs that landed on `develop` during the cycle. Likewise, `/hotfix` relies on the merge into `main` to close hotfix-referenced issues.
+
+If you've configured `develop` (or any non-`main` branch) as the GitHub default, the auto-close path on the release PR silently no-ops and aggregated issues stay open. To stay safe regardless of which branch is set as default, `/release` and `/hotfix` run an explicit `gh issue close` loop after the merge succeeds — closing every aggregated issue directly so the lifecycle works on either configuration. Issues that were closed earlier (e.g., already resolved) are skipped idempotently.
+
+If you set a non-`main` default branch, also note the `/open-pr` warning: when a feature PR targeting `develop` includes `Closes #N` keywords, those won't auto-close at squash-merge time — they'll close when `/release` later runs the explicit close loop.
+
 ### RC Naming: `rc/YYYY-MM-DD.N`
 
 Release candidates are named by date and sequence number (e.g., `rc/2026-04-16.1`). A second cut on the same day becomes `rc/2026-04-16.2`.

--- a/plugins/flowkit/skills/hotfix/SKILL.md
+++ b/plugins/flowkit/skills/hotfix/SKILL.md
@@ -56,7 +56,7 @@ Follow the `pr-base-scope` sub-skill to set `claude.flowkit.prBase = main`.
 
 ### 7. Open a PR targeting main
 
-Follow `/open-pr`. Because `claude.flowkit.prBase = main`, the PR targets `main`.
+Follow `/open-pr`. Because `claude.flowkit.prBase = main`, the PR targets `main`. Capture the PR URL from `/open-pr`'s output as `$HOTFIX_PR_URL` — step 11 needs it to re-aggregate `Closes #N` references for the explicit close loop after the merge deletes the branch.
 
 ### 8. Merge the PR into main
 
@@ -88,9 +88,32 @@ git push origin "$COMPANION"
 
 The annotation message preserves the "hotfix" signal for `git tag -n` queries; the companion tag keeps the canonical version tag clean while still flagging the commit as an emergency fix.
 
-Referenced issues auto-close at merge time: `/open-pr` discovers `Closes #N` tokens from branch commits and emits them in the PR body footer (open-pr step 5). When the hotfix PR merges into `main` (the default branch), GitHub closes those references automatically — no explicit close step is needed.
+Referenced issues are closed at merge time: `/open-pr` discovers `Closes #N` tokens from branch commits and emits them in the PR body footer (open-pr step 5). When the hotfix PR merges into `main` (which must be your repo's GitHub default branch for `Closes #N` keywords to fire — if not, the explicit close loop below handles it), GitHub closes those references automatically.
 
-### 11. Back-merge main into develop
+### 11. Close referenced issues explicitly
+
+Re-aggregate the `Closes/Fixes/Resolves #N` references from the merged hotfix PR body and close each issue directly. This is idempotent — already-closed issues are skipped — so it works whether or not GitHub auto-close fired at merge time:
+
+```bash
+HOTFIX_PR_BODY=$(gh pr view "$HOTFIX_PR_URL" --json body --jq '.body' 2>/dev/null)
+ISSUE_NUMBERS=$(printf '%s\n' "$HOTFIX_PR_BODY" \
+  | grep -oiE '(closes|fixes|resolves) #[0-9]+' \
+  | grep -oE '[0-9]+' \
+  | sort -u)
+
+printf '%s\n' "$ISSUE_NUMBERS" | while read N; do
+  [ -z "$N" ] && continue
+  STATE=$(gh issue view "$N" --json state --jq '.state' 2>/dev/null)
+  if [ "$STATE" = "OPEN" ]; then
+    gh issue close "$N" --reason completed || \
+      echo "warning: failed to close issue #$N — close manually if needed" >&2
+  fi
+done
+```
+
+If a hotfix is targeting a repo where `main` is the GitHub default, the auto-close already fired and every issue is `CLOSED` by the time this loop runs — the loop is a no-op in that case. When `main` is not the default branch, this loop is what actually closes the referenced issues.
+
+### 12. Back-merge main into develop
 
 Keep `develop` in sync with the hotfix:
 
@@ -102,16 +125,16 @@ git merge --no-ff origin/main -m "chore(develop): back-merge hotfix from main"
 git push origin develop
 ```
 
-### 12. Sync develop
+### 13. Sync develop
 
 Follow the `git-sync-develop` sub-skill to confirm a clean local develop state.
 
-### 13. Report
+### 14. Report
 
 Summarize:
 - Hotfix PR merged into main
 - Tags created (include both the canonical version tag and the `hotfix/` companion tag)
-- Referenced issues closed
+- Referenced issues closed (list each issue number from step 11's explicit close loop; idempotent against issues already closed by GitHub auto-close)
 - develop updated with back-merge
 
 ## Constraints

--- a/plugins/flowkit/skills/hotfix/SKILL.md
+++ b/plugins/flowkit/skills/hotfix/SKILL.md
@@ -56,7 +56,14 @@ Follow the `pr-base-scope` sub-skill to set `claude.flowkit.prBase = main`.
 
 ### 7. Open a PR targeting main
 
-Follow `/open-pr`. Because `claude.flowkit.prBase = main`, the PR targets `main`. Capture the PR URL from `/open-pr`'s output as `$HOTFIX_PR_URL` — step 11 needs it to re-aggregate `Closes #N` references for the explicit close loop after the merge deletes the branch.
+Follow `/open-pr`. Because `claude.flowkit.prBase = main`, the PR targets `main`. After `/open-pr` completes, capture the PR URL by querying GitHub for the open PR on the current head branch:
+
+```bash
+HOTFIX_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+HOTFIX_PR_URL=$(gh pr view --head "$HOTFIX_BRANCH" --json url --jq '.url')
+```
+
+Step 11 needs `$HOTFIX_PR_URL` to re-aggregate `Closes #N` references for the explicit close loop after the merge deletes the branch.
 
 ### 8. Merge the PR into main
 
@@ -104,7 +111,10 @@ ISSUE_NUMBERS=$(printf '%s\n' "$HOTFIX_PR_BODY" \
 printf '%s\n' "$ISSUE_NUMBERS" | while read N; do
   [ -z "$N" ] && continue
   STATE=$(gh issue view "$N" --json state --jq '.state' 2>/dev/null)
-  if [ "$STATE" = "OPEN" ]; then
+  if [ "$STATE" != "OPEN" ] && [ "$STATE" != "CLOSED" ]; then
+    echo "note: could not determine state of #$N — attempting close anyway" >&2
+  fi
+  if [ "$STATE" != "CLOSED" ]; then
     gh issue close "$N" --reason completed || \
       echo "warning: failed to close issue #$N — close manually if needed" >&2
   fi

--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -122,7 +122,22 @@ The body shape, footer grammar, and worked example live in [`plugins/_shared/pr-
 
 **Override rule for `open-pr`**: when tokens come from commit messages on the branch, emit them **verbatim** — do not rewrite `Fixes`/`Resolves` into `Closes`. The canonical guidance applies to newly authored bodies; `open-pr` forwards what the author committed.
 
-### 7. Lint the assembled body for broken closing-keyword footers
+### 7. Warn when closing keywords target a non-default branch
+
+GitHub's auto-close keywords (`Closes/Fixes/Resolves #N`) only fire when a PR merges into the repo's default branch. If the assembled body contains any closing keyword and `$BASE` is not the GitHub default, emit a one-line note pointing the user at `/flowkit:release`, which runs an explicit `gh issue close` loop after the staging→main merge:
+
+```bash
+if printf '%s\n' "$PR_BODY" | grep -qiE '(closes|fixes|resolves) #[0-9]+'; then
+  DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null)
+  if [ -n "$DEFAULT_BRANCH" ] && [ "$BASE" != "$DEFAULT_BRANCH" ]; then
+    echo "note: 'Closes #N' won't fire auto-close on PRs into $BASE when default branch is $DEFAULT_BRANCH. /flowkit:release will close those issues at release time." >&2
+  fi
+fi
+```
+
+This is informational only — do not abort or rewrite the body. The `/release` and `/hotfix` skills explicitly close aggregated issues after their respective merges, so the lifecycle still completes.
+
+### 8. Lint the assembled body for broken closing-keyword footers
 
 GitHub only parses one closing keyword per line. A footer like `Closes #1 #2 #3` silently leaves `#2` and `#3` open. Reject the body before calling `gh pr create` if any line packs multiple issue refs onto a single closing keyword:
 
@@ -140,7 +155,7 @@ fi
 
 Fail loudly rather than auto-rewriting — the author should see and fix the footer themselves so the same mistake does not recur in the source commits.
 
-### 8. Open the PR
+### 9. Open the PR
 
 `$BASE` is always non-empty at this point (step 2 guarantees it). Pass it explicitly:
 
@@ -152,7 +167,7 @@ gh pr create \
   --body "<assembled body from step 6>"
 ```
 
-### 9. Report
+### 10. Report
 
 Output the PR URL returned by `gh pr create`.
 

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -376,7 +376,33 @@ git tag "$TAG"
 git push origin "$TAG"
 ```
 
-### 9. Clean up RC branches for today
+### 9. Close referenced issues explicitly
+
+When `main` is the GitHub default branch, the merged release PR's `Closes #N` footer auto-closed every aggregated issue. When the repo's default is `develop` (or any other non-`main` branch), the auto-close path silently no-ops and aggregated issues stay open. Run an explicit `gh issue close` loop over the same `$ISSUE_REFS` collected in step 4 so the lifecycle works on either default-branch configuration. The loop is idempotent — already-closed issues are skipped — so it's safe even when auto-close already fired.
+
+```bash
+ISSUE_NUMBERS=$(printf '%s\n' "$ISSUE_REFS" \
+  | grep -oE '[0-9]+' \
+  | sort -u)
+
+CLOSED_ISSUES_FILE=$(mktemp)
+printf '%s\n' "$ISSUE_NUMBERS" | while read N; do
+  [ -z "$N" ] && continue
+  STATE=$(gh issue view "$N" --json state --jq '.state' 2>/dev/null)
+  if [ "$STATE" = "OPEN" ]; then
+    if gh issue close "$N" --reason completed >/dev/null 2>&1; then
+      echo "$N" >> "$CLOSED_ISSUES_FILE"
+    else
+      echo "warning: failed to close issue #$N — close manually if needed" >&2
+    fi
+  fi
+done
+EXPLICITLY_CLOSED=$(sort -u "$CLOSED_ISSUES_FILE" 2>/dev/null); rm -f "$CLOSED_ISSUES_FILE"
+```
+
+`$EXPLICITLY_CLOSED` is the set of issues this loop closed (i.e. those that were still `OPEN` after the merge). On a `main`-default repo this list is typically empty because GitHub's auto-close already ran; on a `develop`-default repo it contains every aggregated issue. Surface it in the final report.
+
+### 10. Clean up RC branches for today
 
 ```bash
 TODAY=$(date +%Y-%m-%d)
@@ -388,16 +414,16 @@ git ls-remote --heads origin "rc/$TODAY*" \
     done
 ```
 
-### 10. Sync develop
+### 11. Sync develop
 
 Follow the `git-sync-develop` sub-skill. Because the release PR was merged with a merge commit (not squashed), `git merge origin/main` on develop will correctly resolve without divergence — no force-push is needed.
 
-### 11. Report
+### 12. Report
 
 Output:
 - Tag created (e.g. `v2026.4.16`)
 - PR number and URL
-- Issues closed
+- Issues closed — list the aggregated `$ISSUE_REFS` numbers, and note which subset was closed by step 9's explicit loop (`$EXPLICITLY_CLOSED`) versus by GitHub's auto-close at merge time
 - RC branches deleted
 - Epics skipped due to sub_issues parse error, if any — read `$SKIPPED_EPICS` (set in step 4). When non-empty, list each epic number and remind the operator to check manually and add `Closes #N` to the release PR body if needed.
 

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -389,8 +389,11 @@ CLOSED_ISSUES_FILE=$(mktemp)
 printf '%s\n' "$ISSUE_NUMBERS" | while read N; do
   [ -z "$N" ] && continue
   STATE=$(gh issue view "$N" --json state --jq '.state' 2>/dev/null)
-  if [ "$STATE" = "OPEN" ]; then
-    if gh issue close "$N" --reason completed >/dev/null 2>&1; then
+  if [ "$STATE" != "OPEN" ] && [ "$STATE" != "CLOSED" ]; then
+    echo "note: could not determine state of #$N — attempting close anyway" >&2
+  fi
+  if [ "$STATE" != "CLOSED" ]; then
+    if gh issue close "$N" --reason completed >/dev/null; then
       echo "$N" >> "$CLOSED_ISSUES_FILE"
     else
       echo "warning: failed to close issue #$N — close manually if needed" >&2


### PR DESCRIPTION
## Summary

- Document flowkit's `main`-as-default-branch assumption explicitly in the Assumptions section of `plugins/flowkit/README.md` so users on `develop`-as-default know what to expect.
- Add a one-line warning in `/open-pr` when the assembled body contains `Closes/Fixes/Resolves #N` and the base branch isn't the GitHub default — points users at `/flowkit:release` as the eventual close path.
- Add an idempotent explicit `gh issue close` loop to both `/release` (step 9, after tag push) and `/hotfix` (step 11, after the merge into main) so aggregated issues close regardless of which branch is set as the GitHub default. Already-closed issues are skipped, so behavior is unchanged on `main`-as-default repos.

## Changes

- `plugins/flowkit/README.md` — new `### Default Branch` subsection under Assumptions explaining the dependency and how the explicit close loops cover both default-branch configurations.
- `plugins/flowkit/skills/open-pr/SKILL.md` — new step 7 (renumbers subsequent steps) emits a `note:` to stderr when any `Closes/Fixes/Resolves #N` token is present and `$BASE` differs from the resolved GitHub default.
- `plugins/flowkit/skills/hotfix/SKILL.md` — qualifies the `"main (the default branch)"` parenthetical at line 91; captures the hotfix PR URL from `/open-pr` (step 7); new step 11 re-aggregates `Closes #N` from the merged PR body and closes each issue idempotently. Subsequent steps renumbered (back-merge → 12, sync develop → 13, report → 14).
- `plugins/flowkit/skills/release/SKILL.md` — new step 9 closes every aggregated `$ISSUE_REFS` number with `gh issue close --reason completed` after the tag is pushed; tracks the closed set as `$EXPLICITLY_CLOSED` for the final report. Subsequent steps renumbered (cleanup RC → 10, sync develop → 11, report → 12).

## Test plan

- [ ] **README dependency documented**: open `plugins/flowkit/README.md`, confirm the new `### Default Branch` subsection appears under Assumptions and explicitly states flowkit assumes `main` is the GitHub default branch and that explicit close loops cover non-`main` defaults.
- [ ] **`/open-pr` warns on develop-targeted `Closes #N`**: on a repo where `develop` is set as the GitHub default, run `/open-pr` for a feature branch whose body contains `Closes #N` and target develop — confirm the one-line `note:` appears on stderr citing the default branch name.
- [ ] **`/release` closes referenced issues on `develop`-as-default repos**: on a repo with `develop` set as the GitHub default, accumulate a few `Closes #N` PRs into develop, cut an RC, and run `/release` — confirm each aggregated issue ends up `CLOSED` (closed by step 9's explicit loop, since the staging→main merge can't fire auto-close).
- [ ] **No behavior change on `main`-as-default repos**: on a standard repo where `main` is the GitHub default, run `/release` after merging some `Closes #N` PRs into develop — confirm GitHub auto-close still closes them at merge time, and step 9's loop is a no-op (`$EXPLICITLY_CLOSED` empty in the report).
- [ ] **`/hotfix` closes referenced issues on `develop`-as-default**: run `/hotfix` with a `Closes #N` in the commit; confirm the issue is closed by step 11's explicit loop after the hotfix merges into main.
- [ ] **Idempotency**: re-run the close loops on a release where every issue is already closed — confirm no errors and no spurious "warning: failed to close" lines.

Closes #712