### PR TITLE
fix(bump-versions): place --format before -- in git log invocation

### DIFF
--- a/.claude/skills/bump-versions/scripts/detect_changed.sh
+++ b/.claude/skills/bump-versions/scripts/detect_changed.sh
@@ -60,7 +60,7 @@ find "$REPO_ROOT/plugins" -maxdepth 3 -name "plugin.json" -path "*/.claude-plugi
       elif [[ "$suggested_bump" != "major" ]] && echo "$line" | grep -qE '^feat[:(]'; then
         suggested_bump="minor"
       fi
-    done < <(git log "${log_range_args[@]}" --format="%s%n%b" 2>/dev/null)
+    done < <(git log --format="%s%n%b" "${log_range_args[@]}" 2>/dev/null)
 
     jq -n \
       --arg plugin "$plugin_name" \


### PR DESCRIPTION
## Summary
- Move `--format=%s%n%b` ahead of the `--` separator in detect_changed.sh's `git log` call so git parses it as a format option instead of a path filter.
- Without this, `suggested_bump` always resolved to `patch` because the `^feat[:(]` regex never matched the 4-space-indented subjects of the default medium format.

## Changes
- `.claude/skills/bump-versions/scripts/detect_changed.sh` — single-line reorder.

## Test plan
- [x] Run `bash .claude/skills/bump-versions/scripts/detect_changed.sh` against current develop after the fix; verify `suggested_bump=minor` for plugins with `feat:` commits since their last per-plugin tag.
- [x] Compare against pre-fix output (all `patch`) — confirms the conventional-commit signal is now being read.