### PR TITLE
chore(plugins): bump flowkit, sessionkit, squadkit, swarmkit (minor)

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "flowkit",
-  "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship — with runtime staging detection and a one-command hotfix flow.",
-  "version": "3.6.0",
+  "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship \u2014 with runtime staging detection and a one-command hotfix flow.",
+  "version": "3.7.0",
   "license": "MIT",
   "author": {
-    "name": "Román M. Pacheco"
+    "name": "Rom\u00e1n M. Pacheco"
   }
 }

--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "sessionkit",
   "description": "Session continuity and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, plan through structured interviews, discover reusable skills, and reduce permission noise.",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "license": "MIT",
   "author": {
-    "name": "Román M. Pacheco"
+    "name": "Rom\u00e1n M. Pacheco"
   }
 }

--- a/plugins/squadkit/.claude-plugin/plugin.json
+++ b/plugins/squadkit/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
   "name": "squadkit",
-  "description": "Multi-agent team coordination for Claude Code. Roles, squads, and crews — interview-driven setup, no per-stack presets, reusable across any repo.",
-  "version": "0.6.0",
+  "description": "Multi-agent team coordination for Claude Code. Roles, squads, and crews \u2014 interview-driven setup, no per-stack presets, reusable across any repo.",
+  "version": "0.7.0",
   "license": "MIT",
   "author": {
-    "name": "Román M. Pacheco"
+    "name": "Rom\u00e1n M. Pacheco"
   },
   "hooks": {
     "SessionStart": [

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "license": "MIT",
   "author": {
-    "name": "Román M. Pacheco"
+    "name": "Rom\u00e1n M. Pacheco"
   }
 }


### PR DESCRIPTION
## Summary
- Bump four plugins to minor versions ahead of the next release cycle:
  - flowkit 3.6.0 → 3.7.0
  - sessionkit 1.6.3 → 1.7.0
  - squadkit 0.6.0 → 0.7.0
  - swarmkit 5.2.0 → 5.3.0
- All four had `feat:` commits since their last per-plugin tag (suggested_bump=minor from detect_changed.sh post-#728-fix).

## Changes
- `plugins/flowkit/.claude-plugin/plugin.json`
- `plugins/sessionkit/.claude-plugin/plugin.json`
- `plugins/squadkit/.claude-plugin/plugin.json`
- `plugins/swarmkit/.claude-plugin/plugin.json`

## Test plan
- [x] `bash .claude/skills/bump-versions/scripts/detect_changed.sh` reports `suggested_bump=minor` for all 4.
- [x] Each plugin.json has the new version field; every other field unchanged.
- [ ] Per-plugin git tags will be created on the squash-merge commit after this PR lands (tag push deferred to release flow).