### PR TITLE
release: 2026-05-02

### DIFF
--- a/.claude/skills/bump-versions/SKILL.md
+++ b/.claude/skills/bump-versions/SKILL.md
@@ -45,8 +45,8 @@ The script emits a bare JSON array on stdout:
 
 ```json
 [
-  {"plugin": "swarmkit", "last_tag": "swarmkit--v5.1.0", "commit_count": 2, "current_version": "5.1.0"},
-  {"plugin": "flowkit",  "last_tag": "flowkit--v1.2.0",  "commit_count": 1, "current_version": "1.2.0"}
+  {"plugin": "swarmkit", "last_tag": "swarmkit--v5.1.0", "commit_count": 2, "current_version": "5.1.0", "suggested_bump": "minor"},
+  {"plugin": "flowkit",  "last_tag": "flowkit--v1.2.0",  "commit_count": 1, "current_version": "1.2.0", "suggested_bump": "patch"}
 ]
 ```
 
@@ -56,32 +56,24 @@ If `$ARGUMENTS` is provided (e.g. `patch` or `minor`), apply that bump type to a
 
 ### Step 2 — Recommend and confirm bump types
 
-Display a table of plugins with changes (from the Step 1 JSON):
+Display a table of plugins with changes (from the Step 1 JSON), using the `suggested_bump` field already computed by the script:
 
 ```
-Plugin      Current   Commits since last tag
-----------  --------  ----------------------
-swarmkit    5.1.0     2
-flowkit     1.2.0     1
+Plugin      Current   Commits since last tag   Suggested bump
+----------  --------  ----------------------   --------------
+swarmkit    5.1.0     2                        minor
+flowkit     1.2.0     1                        patch
 ```
 
-For each changed plugin, retrieve its commits since the last tag to derive a recommended bump:
-
-```bash
-git log {last_tag}..HEAD --oneline -- plugins/{plugin}/
-```
-
-If `last_tag` is `(none)`, use the full history: `git log --oneline -- plugins/{plugin}/`.
-
-Map conventional-commit prefixes to bump types (take the highest when multiple coexist; `major > minor > patch`):
+The `suggested_bump` is derived from conventional-commit prefixes across all commits in the range (`major > minor > patch`):
 
 | Commit signal | Recommended bump |
 |---------------|------------------|
-| `feat:` or new skill file added | **minor** |
-| `fix:` / `docs:` / `chore:` / `refactor:` (no behavior change) | **patch** |
-| `refactor:` with noted behavior change, or `BREAKING CHANGE:` footer anywhere | **major** |
+| `!:` in subject or `BREAKING CHANGE` in commit body | **major** |
+| `feat:` / `feat(…):` prefix | **minor** |
+| Any other prefix (`fix`, `chore`, `refactor`, etc.) | **patch** |
 
-Present the choice via the `AskUserQuestion` tool — **one question per changed plugin** — with the recommendation as the first (default) option. Each question should include a one-line rationale (e.g. "recommending **minor** — adds a new skill in `feat(flowkit): …`").
+Present the choice via the `AskUserQuestion` tool — **one question per changed plugin** — with `suggested_bump` as the first (default) option. Each question should include a one-line rationale (e.g. "recommending **minor** — adds a new skill in `feat(flowkit): …`").
 
 Options for each question (in this order; default first):
 

--- a/.claude/skills/bump-versions/scripts/detect_changed.sh
+++ b/.claude/skills/bump-versions/scripts/detect_changed.sh
@@ -60,7 +60,7 @@ find "$REPO_ROOT/plugins" -maxdepth 3 -name "plugin.json" -path "*/.claude-plugi
       elif [[ "$suggested_bump" != "major" ]] && echo "$line" | grep -qE '^feat[:(]'; then
         suggested_bump="minor"
       fi
-    done < <(git log "${log_range_args[@]}" --format="%s%n%b" 2>/dev/null)
+    done < <(git log --format="%s%n%b" "${log_range_args[@]}" 2>/dev/null)
 
     jq -n \
       --arg plugin "$plugin_name" \

--- a/.claude/skills/bump-versions/scripts/detect_changed.sh
+++ b/.claude/skills/bump-versions/scripts/detect_changed.sh
@@ -8,8 +8,10 @@ set -euo pipefail
 #   detect_changed.sh
 #
 # On success: exit 0, JSON array on stdout:
-#   [{"plugin": "swarmkit", "last_tag": "swarmkit--v5.1.0", "commit_count": 3, "current_version": "5.1.0"}, ...]
+#   [{"plugin": "swarmkit", "last_tag": "swarmkit--v5.1.0", "commit_count": 3, "current_version": "5.1.0", "suggested_bump": "minor"}, ...]
 #   Only plugins with commit_count > 0 (or no prior tag) are included.
+#   suggested_bump is one of: major | minor | patch
+#   Priority: major (BREAKING CHANGE or !:) > minor (feat) > patch (everything else)
 # On failure: non-zero exit, empty stdout, human-readable message on stderr.
 
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
@@ -44,11 +46,28 @@ find "$REPO_ROOT/plugins" -maxdepth 3 -name "plugin.json" -path "*/.claude-plugi
   fi
 
   if [[ "$commit_count" -gt 0 ]]; then
+    if [[ "$last_tag" == "(none)" ]]; then
+      log_range_args=("--" "$plugin_dir/")
+    else
+      log_range_args=("${last_tag}..HEAD" "--" "$plugin_dir/")
+    fi
+
+    suggested_bump="patch"
+    while IFS= read -r line; do
+      [[ "$suggested_bump" == "major" ]] && break
+      if [[ "$line" =~ ^[^:]+\!: ]] || echo "$line" | grep -qF "BREAKING CHANGE"; then
+        suggested_bump="major"
+      elif [[ "$suggested_bump" != "major" ]] && echo "$line" | grep -qE '^feat[:(]'; then
+        suggested_bump="minor"
+      fi
+    done < <(git log "${log_range_args[@]}" --format="%s%n%b" 2>/dev/null)
+
     jq -n \
       --arg plugin "$plugin_name" \
       --arg last_tag "$last_tag" \
       --argjson commit_count "$commit_count" \
       --arg current_version "$current_version" \
-      '{"plugin": $plugin, "last_tag": $last_tag, "commit_count": $commit_count, "current_version": $current_version}'
+      --arg suggested_bump "$suggested_bump" \
+      '{"plugin": $plugin, "last_tag": $last_tag, "commit_count": $commit_count, "current_version": $current_version, "suggested_bump": $suggested_bump}'
   fi
 done | jq -s '.'

--- a/plugins/_shared/script-authoring.md
+++ b/plugins/_shared/script-authoring.md
@@ -72,6 +72,42 @@ Use exit code `1` for runtime failures, `2` for invalid arguments.
 
 `plugins/swarmkit/skills/swarm/scripts/preflight.sh` — collapses git fetch, base-branch verification, and `gh` auth check into one call. Its output is a bare JSON object; errors go to stderr with non-zero exit. Refer to it and the other scripts in that directory as the reference implementation.
 
+## Smoke tests
+
+Every skill that ships scripts also ships a `scripts/test.sh` smoke test alongside them:
+
+```
+plugins/<plugin>/skills/<skill>/scripts/test.sh
+```
+
+`test.sh` exercises every script in the same `scripts/` directory and asserts the contract documented above:
+
+1. **Invalid-argument invocations** — for each script, drive at least one invalid-argument case (unknown flag, missing required value, wrong arity, malformed positional) and assert:
+   - exit code is non-zero,
+   - stdout is empty,
+   - stderr is non-empty.
+2. **Successful invocations** — where a script can be invoked deterministically without external network or destructive side effects (e.g. with empty input arrays that short-circuit, or read-only inspection commands), assert:
+   - exit code is 0,
+   - stdout is parseable JSON (`jq -e .`),
+   - the JSON object exposes every documented top-level key (`jq -e 'has("...")'`).
+
+Scripts that always require live network or destructive state changes (live `gh` calls, `git fetch origin`, `git checkout`) cannot be exercised on their happy path from a smoke harness — limit those to invalid-argument coverage. Document that limitation in the test header so reviewers understand the scope.
+
+A test failure must surface a clear, line-grep-able message (`FAIL [<script> <case>]: ...`) and exit non-zero. Reference implementations:
+
+- `plugins/swarmkit/skills/swarm/scripts/test.sh` — argument-validation-only coverage for network-dependent scripts.
+- `plugins/swarmkit/skills/clean-worktrees/scripts/test.sh` — argument validation plus read-only / empty-input happy paths.
+
+### Top-level runner
+
+The repo-root runner discovers and executes every skill's `test.sh`:
+
+```bash
+bash scripts/test-all-skill-scripts.sh
+```
+
+It walks `plugins/*/skills/*/scripts/test.sh`, runs each with the test directory as CWD, and exits non-zero if any test fails. This is the single entry point intended for CI.
+
 ## `.claude/settings.json` allowlist
 
 The harness requires explicit permission before executing each script path. Add an entry to the project `.claude/settings.json` allowlist when introducing a new script:

--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "flowkit",
-  "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship — with runtime staging detection and a one-command hotfix flow.",
-  "version": "3.6.0",
+  "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship \u2014 with runtime staging detection and a one-command hotfix flow.",
+  "version": "3.7.0",
   "license": "MIT",
   "author": {
-    "name": "Román M. Pacheco"
+    "name": "Rom\u00e1n M. Pacheco"
   }
 }

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -55,6 +55,7 @@ These are called by the skills above — you don't invoke them directly.
 | **git-sync-main** | release, hotfix | Checkout `main` and pull latest from origin. |
 | **git-sync-develop** | sync, release, hotfix | Checkout `develop` and pull latest from origin. |
 | **pr-base-scope** | swarm | Set/unset `claude.flowkit.prBase` git config for scoped PR targeting. |
+| **with-clean-workspace** | merge-pr, release | Auto-stash dirty workspace around implicit post-merge pull. |
 
 ## Typical Workflows
 

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -186,6 +186,14 @@ Flowkit is opinionated. Understanding these assumptions upfront will save you fr
 
 Feature work merges into `develop`. Release candidates are cut from `develop`. Staging (if present) is an intermediate promotion gate. `main` always reflects what's in production.
 
+### Default Branch
+
+Flowkit assumes `main` is the GitHub default branch for the repo. GitHub's `Closes #N` auto-close keywords only fire when a PR merges into the default branch — so the staging→`main` (or RC→`main`) merge that `/release` performs is what closes the issues referenced in PRs that landed on `develop` during the cycle. Likewise, `/hotfix` relies on the merge into `main` to close hotfix-referenced issues.
+
+If you've configured `develop` (or any non-`main` branch) as the GitHub default, the auto-close path on the release PR silently no-ops and aggregated issues stay open. To stay safe regardless of which branch is set as default, `/release` and `/hotfix` run an explicit `gh issue close` loop after the merge succeeds — closing every aggregated issue directly so the lifecycle works on either configuration. Issues that were closed earlier (e.g., already resolved) are skipped idempotently.
+
+If you set a non-`main` default branch, also note the `/open-pr` warning: when a feature PR targeting `develop` includes `Closes #N` keywords, those won't auto-close at squash-merge time — they'll close when `/release` later runs the explicit close loop.
+
 ### RC Naming: `rc/YYYY-MM-DD.N`
 
 Release candidates are named by date and sequence number (e.g., `rc/2026-04-16.1`). A second cut on the same day becomes `rc/2026-04-16.2`.

--- a/plugins/flowkit/skills/hotfix/SKILL.md
+++ b/plugins/flowkit/skills/hotfix/SKILL.md
@@ -56,7 +56,14 @@ Follow the `pr-base-scope` sub-skill to set `claude.flowkit.prBase = main`.
 
 ### 7. Open a PR targeting main
 
-Follow `/open-pr`. Because `claude.flowkit.prBase = main`, the PR targets `main`.
+Follow `/open-pr`. Because `claude.flowkit.prBase = main`, the PR targets `main`. After `/open-pr` completes, capture the PR URL by querying GitHub for the open PR on the current head branch:
+
+```bash
+HOTFIX_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+HOTFIX_PR_URL=$(gh pr view --head "$HOTFIX_BRANCH" --json url --jq '.url')
+```
+
+Step 11 needs `$HOTFIX_PR_URL` to re-aggregate `Closes #N` references for the explicit close loop after the merge deletes the branch.
 
 ### 8. Merge the PR into main
 
@@ -88,9 +95,35 @@ git push origin "$COMPANION"
 
 The annotation message preserves the "hotfix" signal for `git tag -n` queries; the companion tag keeps the canonical version tag clean while still flagging the commit as an emergency fix.
 
-Referenced issues auto-close at merge time: `/open-pr` discovers `Closes #N` tokens from branch commits and emits them in the PR body footer (open-pr step 5). When the hotfix PR merges into `main` (the default branch), GitHub closes those references automatically — no explicit close step is needed.
+Referenced issues are closed at merge time: `/open-pr` discovers `Closes #N` tokens from branch commits and emits them in the PR body footer (open-pr step 5). When the hotfix PR merges into `main` (which must be your repo's GitHub default branch for `Closes #N` keywords to fire — if not, the explicit close loop below handles it), GitHub closes those references automatically.
 
-### 11. Back-merge main into develop
+### 11. Close referenced issues explicitly
+
+Re-aggregate the `Closes/Fixes/Resolves #N` references from the merged hotfix PR body and close each issue directly. This is idempotent — already-closed issues are skipped — so it works whether or not GitHub auto-close fired at merge time:
+
+```bash
+HOTFIX_PR_BODY=$(gh pr view "$HOTFIX_PR_URL" --json body --jq '.body' 2>/dev/null)
+ISSUE_NUMBERS=$(printf '%s\n' "$HOTFIX_PR_BODY" \
+  | grep -oiE '(closes|fixes|resolves) #[0-9]+' \
+  | grep -oE '[0-9]+' \
+  | sort -u)
+
+printf '%s\n' "$ISSUE_NUMBERS" | while read N; do
+  [ -z "$N" ] && continue
+  STATE=$(gh issue view "$N" --json state --jq '.state' 2>/dev/null)
+  if [ "$STATE" != "OPEN" ] && [ "$STATE" != "CLOSED" ]; then
+    echo "note: could not determine state of #$N — attempting close anyway" >&2
+  fi
+  if [ "$STATE" != "CLOSED" ]; then
+    gh issue close "$N" --reason completed || \
+      echo "warning: failed to close issue #$N — close manually if needed" >&2
+  fi
+done
+```
+
+If a hotfix is targeting a repo where `main` is the GitHub default, the auto-close already fired and every issue is `CLOSED` by the time this loop runs — the loop is a no-op in that case. When `main` is not the default branch, this loop is what actually closes the referenced issues.
+
+### 12. Back-merge main into develop
 
 Keep `develop` in sync with the hotfix:
 
@@ -102,16 +135,16 @@ git merge --no-ff origin/main -m "chore(develop): back-merge hotfix from main"
 git push origin develop
 ```
 
-### 12. Sync develop
+### 13. Sync develop
 
 Follow the `git-sync-develop` sub-skill to confirm a clean local develop state.
 
-### 13. Report
+### 14. Report
 
 Summarize:
 - Hotfix PR merged into main
 - Tags created (include both the canonical version tag and the `hotfix/` companion tag)
-- Referenced issues closed
+- Referenced issues closed (list each issue number from step 11's explicit close loop; idempotent against issues already closed by GitHub auto-close)
 - develop updated with back-merge
 
 ## Constraints

--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -39,8 +39,31 @@ If `PR_NUM` is empty, abort with:
 
 ### 3. Squash-merge and delete the remote branch
 
+`gh pr merge --squash --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. Wrap the call with the `flowkit:with-clean-workspace` sub-skill so any dirty state is auto-stashed and restored:
+
 ```bash
-gh pr merge "$PR_NUM" --squash --delete-branch
+DIRTY=false
+if [ -n "$(git status --porcelain)" ]; then
+  DIRTY=true
+  git stash push -u -m "flowkit-auto-stash" >/dev/null
+fi
+
+if gh pr merge "$PR_NUM" --squash --delete-branch; then
+  MERGE_OK=true
+else
+  MERGE_OK=false
+fi
+
+if [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "true" ]; then
+  if ! git stash pop; then
+    echo "WARNING: stash pop conflicted. Your changes are preserved on the stash stack." >&2
+    echo "Run \`git stash list\` to see the saved entry (message: flowkit-auto-stash) and \`git stash pop\` after resolving." >&2
+  fi
+elif [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "false" ]; then
+  echo "WARNING: merge failed — stash preserved. Run \`git stash pop\` after resolving the merge error." >&2
+fi
+
+[ "$MERGE_OK" = "false" ] && exit 1
 ```
 
 ### 4. Label referenced issues

--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -32,10 +32,27 @@ If the current branch is `develop`, `main`, `master`, or `staging`, stop immedia
 
 ### 2. Determine base branch
 
-Resolve the base branch using the `pr-base-scope` read order: new key → legacy key (with deprecation notice) → `develop` default.
+Resolve the base branch using the following precedence order:
+
+1. **Explicit caller arg** — if `$ARGUMENTS` contains a `--base <branch>` flag, extract and use it.
+2. **`claude.flowkit.prBase`** — per-session config key (set by swarm loop / cut-epic).
+3. **Legacy `claude.prBase`** — deprecated key (with migration notice).
+4. **`develop` if it exists on the remote** — check with `git ls-remote`.
+5. **GitHub default** — fall through to gh CLI default, but emit a one-line warning.
 
 ```bash
-BASE=$(git config claude.flowkit.prBase 2>/dev/null)
+# 1. Explicit caller arg
+BASE=""
+if echo "$ARGUMENTS" | grep -qE '(^|[[:space:]])\-\-base[= ]'; then
+  BASE=$(echo "$ARGUMENTS" | grep -oE '(^|[[:space:]])\-\-base[= ][^ ]+' | head -1 | sed 's/.*--base[= ]//')
+fi
+
+# 2. claude.flowkit.prBase config key
+if [ -z "$BASE" ]; then
+  BASE=$(git config claude.flowkit.prBase 2>/dev/null)
+fi
+
+# 3. Legacy claude.prBase (deprecated)
 if [ -z "$BASE" ]; then
   LEGACY=$(git config claude.prBase 2>/dev/null)
   if [ -n "$LEGACY" ]; then
@@ -43,13 +60,25 @@ if [ -z "$BASE" ]; then
     echo "note: claude.prBase is deprecated. Migrate with:" >&2
     echo "  git config --unset claude.prBase" >&2
     echo "  git config claude.flowkit.prBase $LEGACY" >&2
-  else
+  fi
+fi
+
+# 4. develop if it exists on the remote
+if [ -z "$BASE" ]; then
+  if git ls-remote --heads origin develop | grep -q 'refs/heads/develop'; then
     BASE="develop"
   fi
 fi
+
+# 5. Fallback — use the repo default and warn
+if [ -z "$BASE" ]; then
+  REPO_DEFAULT=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
+  echo "warning: no base branch configured and 'develop' not found on remote; falling back to repo default ($REPO_DEFAULT)" >&2
+  BASE="$REPO_DEFAULT"
+fi
 ```
 
-Use `$BASE` as the PR target. This respects any scoped override set by the `pr-base-scope` sub-skill.
+`$BASE` is always non-empty after step 2 — pass it explicitly as `--base "$BASE"` to `gh pr create`. This respects any scoped override set by the `pr-base-scope` sub-skill.
 
 ### 3. Push branch to origin
 
@@ -113,6 +142,8 @@ Fail loudly rather than auto-rewriting — the author should see and fix the foo
 
 ### 8. Open the PR
 
+`$BASE` is always non-empty at this point (step 2 guarantees it). Pass it explicitly:
+
 ```bash
 gh pr create \
   --base "$BASE" \
@@ -127,6 +158,7 @@ Output the PR URL returned by `gh pr create`.
 
 ## Constraints
 
+- Always resolve `--base` before calling `gh pr create` using the precedence: explicit caller arg → `claude.flowkit.prBase` → legacy `claude.prBase` → `develop` (if remote exists) → repo default (with warning). `$BASE` is always non-empty; `--base "$BASE"` is always passed.
 - Never target `main` directly unless `claude.flowkit.prBase` (or legacy `claude.prBase`) is explicitly set to `main`
 - Never open a PR from a protected branch (`develop`, `main`, `master`, `staging`)
 - If `gh` is not installed or not authenticated, report the error and stop — do not attempt workarounds

--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -122,7 +122,22 @@ The body shape, footer grammar, and worked example live in [`plugins/_shared/pr-
 
 **Override rule for `open-pr`**: when tokens come from commit messages on the branch, emit them **verbatim** — do not rewrite `Fixes`/`Resolves` into `Closes`. The canonical guidance applies to newly authored bodies; `open-pr` forwards what the author committed.
 
-### 7. Lint the assembled body for broken closing-keyword footers
+### 7. Warn when closing keywords target a non-default branch
+
+GitHub's auto-close keywords (`Closes/Fixes/Resolves #N`) only fire when a PR merges into the repo's default branch. If the assembled body contains any closing keyword and `$BASE` is not the GitHub default, emit a one-line note pointing the user at `/flowkit:release`, which runs an explicit `gh issue close` loop after the staging→main merge:
+
+```bash
+if printf '%s\n' "$PR_BODY" | grep -qiE '(closes|fixes|resolves) #[0-9]+'; then
+  DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null)
+  if [ -n "$DEFAULT_BRANCH" ] && [ "$BASE" != "$DEFAULT_BRANCH" ]; then
+    echo "note: 'Closes #N' won't fire auto-close on PRs into $BASE when default branch is $DEFAULT_BRANCH. /flowkit:release will close those issues at release time." >&2
+  fi
+fi
+```
+
+This is informational only — do not abort or rewrite the body. The `/release` and `/hotfix` skills explicitly close aggregated issues after their respective merges, so the lifecycle still completes.
+
+### 8. Lint the assembled body for broken closing-keyword footers
 
 GitHub only parses one closing keyword per line. A footer like `Closes #1 #2 #3` silently leaves `#2` and `#3` open. Reject the body before calling `gh pr create` if any line packs multiple issue refs onto a single closing keyword:
 
@@ -140,7 +155,7 @@ fi
 
 Fail loudly rather than auto-rewriting — the author should see and fix the footer themselves so the same mistake does not recur in the source commits.
 
-### 8. Open the PR
+### 9. Open the PR
 
 `$BASE` is always non-empty at this point (step 2 guarantees it). Pass it explicitly:
 
@@ -152,7 +167,7 @@ gh pr create \
   --body "<assembled body from step 6>"
 ```
 
-### 9. Report
+### 10. Report
 
 Output the PR URL returned by `gh pr create`.
 

--- a/plugins/flowkit/skills/pr-base-scope/SKILL.md
+++ b/plugins/flowkit/skills/pr-base-scope/SKILL.md
@@ -35,26 +35,15 @@ git config --unset claude.flowkit.prBase
 
 ### Read
 
-Resolve the current target branch (used by `/open-pr`). Apply this resolution order:
+Resolve the current target branch (used by `/open-pr`). The authoritative five-step resolution order lives in [`open-pr/SKILL.md`](../open-pr/SKILL.md) — step 2. In summary:
 
-1. `claude.flowkit.prBase` — primary source of truth
-2. `claude.prBase` — legacy fallback (emits deprecation notice when hit)
-3. Built-in default: `develop`
+1. Explicit `--base <branch>` caller arg in `$ARGUMENTS`
+2. `claude.flowkit.prBase` — primary config key
+3. `claude.prBase` — legacy fallback (emits deprecation notice when hit)
+4. `develop` — if the branch exists on the remote
+5. Repo default branch (via `gh repo view`) — with a warning; always assigned so `$BASE` is never empty
 
-```bash
-BASE=$(git config claude.flowkit.prBase 2>/dev/null)
-if [ -z "$BASE" ]; then
-  LEGACY=$(git config claude.prBase 2>/dev/null)
-  if [ -n "$LEGACY" ]; then
-    BASE="$LEGACY"
-    echo "note: claude.prBase is deprecated. Migrate with:" >&2
-    echo "  git config --unset claude.prBase" >&2
-    echo "  git config claude.flowkit.prBase $LEGACY" >&2
-  else
-    BASE="develop"
-  fi
-fi
-```
+`$BASE` is guaranteed non-empty after resolution; `/open-pr` always passes `--base "$BASE"` to `gh pr create`.
 
 ## Usage by Callers
 
@@ -63,7 +52,7 @@ fi
 | `/ship` | Sets `claude.flowkit.prBase develop` before opening PRs, then unsets after the flow completes |
 | `/swarm` loop mode | Sets `claude.flowkit.prBase` to the appropriate integration branch for the loop session |
 | `/cut-epic` | Sets `claude.flowkit.prBase` to the long-lived epic branch so sub-PRs target it; user runs **Unset** when the epic ships |
-| `/open-pr` | Reads the resolved base (new key → legacy key → `develop`) before creating the PR |
+| `/open-pr` | Reads the resolved base (explicit arg → new key → legacy key → `develop` → repo default) before creating the PR; `$BASE` is always non-empty |
 
 ## Constraints
 

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -376,7 +376,36 @@ git tag "$TAG"
 git push origin "$TAG"
 ```
 
-### 9. Clean up RC branches for today
+### 9. Close referenced issues explicitly
+
+When `main` is the GitHub default branch, the merged release PR's `Closes #N` footer auto-closed every aggregated issue. When the repo's default is `develop` (or any other non-`main` branch), the auto-close path silently no-ops and aggregated issues stay open. Run an explicit `gh issue close` loop over the same `$ISSUE_REFS` collected in step 4 so the lifecycle works on either default-branch configuration. The loop is idempotent — already-closed issues are skipped — so it's safe even when auto-close already fired.
+
+```bash
+ISSUE_NUMBERS=$(printf '%s\n' "$ISSUE_REFS" \
+  | grep -oE '[0-9]+' \
+  | sort -u)
+
+CLOSED_ISSUES_FILE=$(mktemp)
+printf '%s\n' "$ISSUE_NUMBERS" | while read N; do
+  [ -z "$N" ] && continue
+  STATE=$(gh issue view "$N" --json state --jq '.state' 2>/dev/null)
+  if [ "$STATE" != "OPEN" ] && [ "$STATE" != "CLOSED" ]; then
+    echo "note: could not determine state of #$N — attempting close anyway" >&2
+  fi
+  if [ "$STATE" != "CLOSED" ]; then
+    if gh issue close "$N" --reason completed >/dev/null; then
+      echo "$N" >> "$CLOSED_ISSUES_FILE"
+    else
+      echo "warning: failed to close issue #$N — close manually if needed" >&2
+    fi
+  fi
+done
+EXPLICITLY_CLOSED=$(sort -u "$CLOSED_ISSUES_FILE" 2>/dev/null); rm -f "$CLOSED_ISSUES_FILE"
+```
+
+`$EXPLICITLY_CLOSED` is the set of issues this loop closed (i.e. those that were still `OPEN` after the merge). On a `main`-default repo this list is typically empty because GitHub's auto-close already ran; on a `develop`-default repo it contains every aggregated issue. Surface it in the final report.
+
+### 10. Clean up RC branches for today
 
 ```bash
 TODAY=$(date +%Y-%m-%d)
@@ -388,16 +417,16 @@ git ls-remote --heads origin "rc/$TODAY*" \
     done
 ```
 
-### 10. Sync develop
+### 11. Sync develop
 
 Follow the `git-sync-develop` sub-skill. Because the release PR was merged with a merge commit (not squashed), `git merge origin/main` on develop will correctly resolve without divergence — no force-push is needed.
 
-### 11. Report
+### 12. Report
 
 Output:
 - Tag created (e.g. `v2026.4.16`)
 - PR number and URL
-- Issues closed
+- Issues closed — list the aggregated `$ISSUE_REFS` numbers, and note which subset was closed by step 9's explicit loop (`$EXPLICITLY_CLOSED`) versus by GitHub's auto-close at merge time
 - RC branches deleted
 - Epics skipped due to sub_issues parse error, if any — read `$SKIPPED_EPICS` (set in step 4). When non-empty, list each epic number and remind the operator to check manually and add `Closes #N` to the release PR body if needed.
 

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -137,7 +137,7 @@ If no tags exist yet, `ISSUE_REFS` remains empty and the PR body is unchanged.
 
 ### 5. Build release summary and create a PR from SOURCE → main
 
-Compute the git log range between the source branch and main, then derive version bumps and grouped changes from that range.
+Compute the git log range between the source branch and main, then derive version bumps, synthesized release notes, and grouped changes from that range.
 
 ```bash
 RELEASE_DATE=$(date +%Y-%m-%d)
@@ -178,17 +178,78 @@ printf '%s\n' "$PLUGINS" | while read PLUGIN; do
   fi
 done
 
-# Commits with no recognised scope (chore, docs without scope, etc.)
+# Unscoped commits: filter out mechanical chore/docs entries — they don't
+# belong in release notes and account for nearly all "other" noise. Unscoped
+# commits with feat/fix/refactor/perf type are inlined after the last plugin
+# group without an **other** header; the header adds visual weight without
+# information value and the commits speak for themselves.
 SCOPED_PATTERN=$(printf '%s\n' "$PLUGINS" | tr '\n' '|' | sed 's/|$//')
-UNSCOPED_COMMITS=$(printf '%s\n' "$ALL_COMMITS" \
+MEANINGFUL_UNSCOPED=$(printf '%s\n' "$ALL_COMMITS" \
   | grep -ivE "\($SCOPED_PATTERN\)" \
+  | grep -iE "^[a-f0-9]+ (feat|fix|refactor|perf)" \
   | sed 's/^[a-f0-9]* /- /' \
   || true)
-if [ -n "$UNSCOPED_COMMITS" ]; then
-  printf '\n**other**\n%s\n' "$UNSCOPED_COMMITS" >> "$GROUPED_CHANGES_FILE"
+if [ -n "$MEANINGFUL_UNSCOPED" ]; then
+  printf '\n**cross-plugin**\n%s\n' "$MEANINGFUL_UNSCOPED" >> "$GROUPED_CHANGES_FILE"
 fi
 
 GROUPED_CHANGES=$(cat "$GROUPED_CHANGES_FILE"); rm -f "$GROUPED_CHANGES_FILE"
+
+# --- synthesized release notes ---
+# Fetch merged-PR titles and the first sentence of each PR's ## Summary section
+# since the last release tag. Group per plugin using the same scope list as
+# ### Changes. Render as human-readable bullets — one bullet per PR, phrased
+# from the PR title with the Summary's first sentence appended if it adds
+# context beyond the title. This is the canonical "what shipped" view;
+# ### Changes remains the raw commit log for completeness.
+RELEASE_NOTES_FILE=$(mktemp)
+if [ -n "$LAST_TAG" ] && [ -n "$TAG_DATE" ]; then
+  MERGED_PR_DATA=$(gh pr list --base develop --state merged --limit 200 \
+    --json title,body,mergedAt \
+    | jq --arg td "$TAG_DATE" -r \
+        '.[] | select((.mergedAt | fromdateiso8601) > ($td | fromdateiso8601))
+               | [.title,
+                  (.body // "" | gsub("\r";"")
+                    | capture("(?i)## Summary\n+(?<s>[^\n]+)").s // "")]
+                 | @tsv')
+
+  printf '%s\n' "$PLUGINS" | while read PLUGIN; do
+    [ -z "$PLUGIN" ] && continue
+    PLUGIN_NOTES=$(printf '%s\n' "$MERGED_PR_DATA" \
+      | grep -iE "\($PLUGIN\)" \
+      | while IFS=$(printf '\t') read TITLE SUMMARY; do
+          if [ -n "$SUMMARY" ] && [ "$SUMMARY" != "$TITLE" ]; then
+            printf '- %s — %s\n' "$TITLE" "$SUMMARY"
+          else
+            printf '- %s\n' "$TITLE"
+          fi
+        done \
+      || true)
+    if [ -n "$PLUGIN_NOTES" ]; then
+      printf '\n**%s**\n%s\n' "$PLUGIN" "$PLUGIN_NOTES" >> "$RELEASE_NOTES_FILE"
+    fi
+  done
+fi
+RELEASE_NOTES=$(cat "$RELEASE_NOTES_FILE"); rm -f "$RELEASE_NOTES_FILE"
+
+# Smoke-test: verify the synthesis produced output before proceeding.
+# Run this one-liner against the real repo to confirm jq parses the regex
+# and at least one PR is matched:
+#
+#   TAG_DATE=$(git log -1 --format=%aI $(git for-each-ref --sort=-creatordate \
+#     --format='%(refname:short)' 'refs/tags/v[0-9]*' | head -1) \
+#     | python3 -c "import sys; from datetime import datetime, timezone; \
+#       print(datetime.fromisoformat(sys.stdin.read().strip()) \
+#             .astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))") \
+#   && gh pr list --base develop --state merged --limit 200 --json title,body,mergedAt \
+#   | jq --arg td "$TAG_DATE" -r \
+#       '.[] | select((.mergedAt | fromdateiso8601) > ($td | fromdateiso8601))
+#              | [.title, (.body // "" | gsub("\r";"")
+#                 | capture("(?i)## Summary\n+(?<s>[^\n]+)").s // "")] | @tsv' \
+#   | head -5
+#
+# A non-empty result (exit 0) confirms the pipeline is healthy.
+# An empty result or non-zero exit means the tag range or jq regex needs investigation.
 
 # --- narrative summary ---
 # Synthesize a 1–3 sentence narrative from the collected merged-PR summaries
@@ -203,7 +264,7 @@ Example: "Ship swarmkit stacked-merge bugfix alongside flowkit hotfix workflow t
 # <!-- include: plugins/_shared/pr-body.md -->
 # The body shape below follows the canonical PR body spec defined in
 # plugins/_shared/pr-body.md: Summary → Release summary → Version bumps →
-# Changes → issue-reference footer. Keep that order.
+# Release notes → Changes → issue-reference footer. Keep that order.
 PR_BODY="## Summary
 
 $NARRATIVE_SUMMARY
@@ -217,6 +278,13 @@ if [ -n "$VERSION_BUMPS" ]; then
 
 ### Version bumps
 $VERSION_BUMPS"
+fi
+
+if [ -n "$RELEASE_NOTES" ]; then
+  PR_BODY="$PR_BODY
+
+### Release notes
+$RELEASE_NOTES"
 fi
 
 if [ -n "$GROUPED_CHANGES" ]; then

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -255,8 +255,31 @@ Capture the PR number from the URL output.
 
 ### 6. Merge the PR
 
+`gh pr merge --merge --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. Wrap the call with the `flowkit:with-clean-workspace` sub-skill so any dirty state is auto-stashed and restored:
+
 ```bash
-gh pr merge "$PR_URL" --merge --delete-branch
+DIRTY=false
+if [ -n "$(git status --porcelain)" ]; then
+  DIRTY=true
+  git stash push -u -m "flowkit-auto-stash" >/dev/null
+fi
+
+if gh pr merge "$PR_URL" --merge --delete-branch; then
+  MERGE_OK=true
+else
+  MERGE_OK=false
+fi
+
+if [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "true" ]; then
+  if ! git stash pop; then
+    echo "WARNING: stash pop conflicted. Your changes are preserved on the stash stack." >&2
+    echo "Run \`git stash list\` to see the saved entry (message: flowkit-auto-stash) and \`git stash pop\` after resolving." >&2
+  fi
+elif [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "false" ]; then
+  echo "WARNING: merge failed — stash preserved. Run \`git stash pop\` after resolving the merge error." >&2
+fi
+
+[ "$MERGE_OK" = "false" ] && exit 1
 ```
 
 Use `--merge` to preserve the full commit history from the RC branch in main.

--- a/plugins/flowkit/skills/with-clean-workspace/SKILL.md
+++ b/plugins/flowkit/skills/with-clean-workspace/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: with-clean-workspace
+description: Auto-stash uncommitted changes around a command that triggers an implicit `git pull` (e.g. `gh pr merge --squash --delete-branch`). Sub-skill used by merge-pr and release.
+---
+
+# with-clean-workspace
+
+Wrap a command whose side effects include an implicit `git pull` (most notably `gh pr merge --squash --delete-branch` / `--merge --delete-branch`) so a dirty workspace cannot break the post-merge pull with `cannot pull with rebase: You have unstaged changes`.
+
+The guard auto-stashes uncommitted changes (tracked + untracked) before the wrapped command and pops the stash after. If the pop conflicts, it leaves the stash on the stack and surfaces that to the user — never auto-resolves.
+
+## Process
+
+### 1. Detect dirty workspace before the wrapped command
+
+```bash
+DIRTY=false
+if [ -n "$(git status --porcelain)" ]; then
+  DIRTY=true
+  git stash push -u -m "flowkit-auto-stash" >/dev/null
+fi
+```
+
+### 2. Run the wrapped command
+
+Whatever the caller needs to invoke (`gh pr merge ...`, etc.). Capture whether it succeeded:
+
+```bash
+if <wrapped-command>; then
+  MERGE_OK=true
+else
+  MERGE_OK=false
+fi
+```
+
+### 3. Restore the stash only if the wrapped command succeeded
+
+The pop is conditional on the wrapped command exiting 0. If the command failed (e.g. merge conflict on GitHub, network error), the stash is left on the stack so the user can retry without losing their workspace state:
+
+```bash
+if [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "true" ]; then
+  if ! git stash pop; then
+    echo "WARNING: stash pop conflicted. Your changes are preserved on the stash stack." >&2
+    echo "Run \`git stash list\` to see the saved entry (message: flowkit-auto-stash) and \`git stash pop\` after resolving." >&2
+  fi
+elif [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "false" ]; then
+  echo "WARNING: merge failed — stash preserved. Run \`git stash pop\` after resolving the merge error." >&2
+fi
+
+[ "$MERGE_OK" = "false" ] && exit 1
+```
+
+## Constraints
+
+- Never auto-resolve a stash-pop conflict — leave the stash on the stack and tell the user.
+- Always use `-u` so untracked files (e.g. new hook scripts) are stashed too.
+- Use the literal message `flowkit-auto-stash` so the user can identify the entry in `git stash list`.
+- Only pop the stash if the wrapped command exited 0 — a failed command must not trigger a pop that masks the failure on retry.

--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "sessionkit",
   "description": "Session continuity and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, plan through structured interviews, discover reusable skills, and reduce permission noise.",
-  "version": "1.6.3",
+  "version": "1.7.0",
   "license": "MIT",
   "author": {
-    "name": "Román M. Pacheco"
+    "name": "Rom\u00e1n M. Pacheco"
   }
 }

--- a/plugins/sessionkit/skills/handoff/SKILL.md
+++ b/plugins/sessionkit/skills/handoff/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: handoff
-description: Capture session context to a handoff document so another agent can take over seamlessly. Fast enough to run after every meaningful state change (PR opened, task completed, decision made) — not just when context is running low.
+description: Capture session context to a handoff document so another agent can take over seamlessly. Run it after every meaningful state change (PR opened, task completed, decision made) — delta mode keeps the cost trivial so you don't have to wait for context pressure.
 triggers:
   - "/handoff"
   - "write a handoff"
@@ -14,11 +14,21 @@ allowed-tools: Bash, Read, Write, TaskList, TaskGet, Skill, Agent
 
 Capture the current session's goal, progress, git state, remaining work, and key context into `<working-dir>/.sessionkit/HANDOFF.md` so another agent can pick up without losing momentum.
 
-Synthesis is delegated to a Haiku sub-agent and skips sections whose inputs haven't changed since the last run, so frequent invocation is cheap.
+Synthesis has three paths, picked automatically based on what's actually changed:
+
+- **Delta mode** (no sub-agent, in-line surgical Edits) — the default fast path when a prior `HANDOFF.md` exists, its git fingerprint is an ancestor of HEAD, and only a handful of sections need updating. Median wall time well under 3s.
+- **Full regenerate via Haiku sub-agent** — used when no prior file exists, the prior file is structurally divergent, drift exceeds the delta threshold, or `--full` is passed. Skips synthesis for sections whose fingerprints still match.
+- **Both-fingerprints-match short-circuit** — if both fingerprints match, all four reusable sections come straight from the prior file and the sub-agent is skipped entirely (this case is unchanged from prior behavior).
 
 ## Input
 
 `$ARGUMENTS` — optional freeform notes to fold into the handoff (e.g. "focus on the auth refactor, skip the docs work"). If omitted, auto-infer everything from session state.
+
+Recognized flags (parsed from `$ARGUMENTS`):
+
+- `--full` — force the full-regenerate Haiku path even if delta mode would otherwise apply. Use when you want a fresh narrative pass (e.g. Goal/Context have meaningfully drifted but the structural fingerprints haven't).
+
+If `--full` is present, strip it from `$ARGUMENTS` before folding the remaining text into Goal/Context.
 
 ## Process
 
@@ -64,11 +74,48 @@ Compare against the fingerprints from step 1a using two **independent** reuse de
 
 If no prior file exists, or the meta header is absent, treat both fingerprints as non-matching and regenerate all sections.
 
-When **both** fingerprints match, all four reusable sections come straight from the prior file — skip the sub-agent call entirely and rewrite the file in-line. Report the reuse outcome in the confirmation (e.g. `reused 4 sections`, `reused 2 sections (git)`, `reused 2 sections (task)`, or `regenerated all sections`).
+When **both** fingerprints match, all four reusable sections come straight from the prior file. The actual routing decision — including whether to skip the sub-agent — is made in step 1c after this check. Report the reuse outcome in the confirmation (e.g. `reused 4 sections`, `reused 2 sections (git)`, `reused 2 sections (task)`, or `regenerated all sections`).
+
+### 1c. Delta-mode decision
+
+After step 1b classifies which sections need to be regenerated, decide whether to use the in-line **delta-mode** path or dispatch the Haiku sub-agent.
+
+**Pick delta mode when ALL of these hold:**
+
+1. A prior `.sessionkit/HANDOFF.md` exists and parsed cleanly in step 1b (meta header found, all six canonical sections present in the documented order, fenced `json` block in `## Task List` parses).
+2. The prior `gitFingerprint`'s HEAD-sha component is an ancestor of the current HEAD — verify with `git merge-base --is-ancestor <prior-head-sha> HEAD` (exit 0 = ancestor). This confirms session continuity rather than a branch swap. (The staged/unstaged drift is already captured by step 1b's fingerprint comparison; this ancestor check only guards against branch-swap or force-push scenarios where the commit graph has diverged.)
+3. At most **two** of the four reusable sections (`Git State`, `Progress`, `Task List`, `Remaining Work`) need regeneration. Goal and Context are always refreshed and don't count toward the threshold.
+4. `$ARGUMENTS` does not contain `--full` and does not look like a structural-rewrite directive (a freeform note longer than ~200 chars or one that explicitly mentions reframing/rewriting the goal/context counts as structural — when in doubt, fall back to full regenerate). The 200-char threshold is a heuristic; `--full` remains the deterministic override when you want a guaranteed full pass regardless of note length.
+
+**Otherwise, use the full Haiku regenerate path** (step 2). Specifically, fall back when:
+
+- No prior file, or prior file is missing the meta header / required sections / parseable Task List JSON.
+- Prior `gitFingerprint`'s HEAD is not an ancestor of current HEAD (branch swap, force-push, unrelated session).
+- Three or four reusable sections need regeneration (drift exceeds threshold).
+- `$ARGUMENTS` contains `--full`, or its freeform content suggests a structural rewrite.
+
+Record the chosen mode (`delta` vs `full`) for the step 4 confirmation.
+
+### 1d. Delta-mode mechanics (only when step 1c picked `delta`)
+
+In delta mode, do **not** invoke the Agent tool. Instead, surgically Edit the existing `.sessionkit/HANDOFF.md`:
+
+1. Always refresh `## Goal` and `## Context` in-line — synthesize new bullets directly from the conversation arc and the raw step-1 outputs (and `$ARGUMENTS` if present). Use the Edit tool, replacing the prior section bodies between their headings.
+2. For each of the four reusable sections, regenerate only those flagged in step 1b:
+   - `## Git State` — emit from the raw git outputs in step 1 using the template in step 2a.
+   - `## Progress` — bullets from staged/unstaged file lists, recent commits, and any conversation signals about completed/decided/abandoned threads.
+   - `## Task List` — serialize the Task List JSON exactly per the rules in step 2a.
+   - `## Remaining Work` — bullets in priority order from the (refreshed or reused) Task List plus unfinished conversation threads.
+3. Update the meta header in place: replace `gitFingerprint=<sha>` and `taskFingerprint=<sha>` with the values computed in step 1a, even if only one of them changed. Refresh the `**Date**` field.
+4. Preserve byte-exact content of any reusable section that step 1b marked verbatim — do not touch its bullets, ordering, or whitespace.
+
+The output of delta mode must be byte-equivalent (modulo touched sections and the meta-header / Date refresh) to what a full regenerate would have produced from the same inputs. `/pickup` parses both outputs identically — there is no parser-level distinction.
+
+After all Edits land, skip step 2 entirely and proceed to step 3.
 
 ### 2. Synthesize via Haiku sub-agent
 
-Delegate markdown synthesis to a sub-agent running on Haiku. The handoff document is structured output and does not need the main model.
+Reached only when step 1c picked the `full` path (no prior file, structural divergence, drift over threshold, or `--full`). Delegate markdown synthesis to a sub-agent running on Haiku — the handoff document is structured output and does not need the main model.
 
 Invoke the `Agent` tool with:
 
@@ -79,9 +126,11 @@ Invoke the `Agent` tool with:
   2. The conversation context summary (recent goal, decisions, gotchas — bullet form, no prose).
   3. The raw outputs from step 1 (git fingerprints, file lists, recent commits, todo file contents).
   4. The Task List JSON from step 1.
-  5. Any sections from step 1b marked "reuse verbatim" with their existing content.
-  6. `$ARGUMENTS` if present.
-  7. Explicit instructions: "Emit ONLY the markdown document. No commentary, no fences around the whole thing. Use bullets, not paragraphs, for Progress / Remaining Work / Context. Preserve the JSON code block for Task List exactly as given."
+  5. For each section from step 1b: an explicit per-section directive of either `reuse verbatim` (with the existing content) or `regenerate`. List the four reusable sections (`Git State`, `Progress`, `Task List`, `Remaining Work`) with their directive; `Goal` and `Context` are always `regenerate`.
+  6. `$ARGUMENTS` if present (with `--full` already stripped).
+  7. Explicit instructions, including the verbatim contract:
+
+     > "Sections marked `reuse verbatim` MUST be emitted byte-for-byte unchanged from the content provided — do not paraphrase, reorder, re-format, or re-wrap them. Generate fresh content ONLY for sections marked `regenerate`. Emit ONLY the markdown document. No commentary, no fences around the whole thing. Use bullets, not paragraphs, for Progress / Remaining Work / Context. Preserve the JSON code block for Task List exactly as given when reusing it verbatim."
 
 **Timeout / failure handling**: if the Agent call fails, returns empty output, or produces output that does not contain the required `## Task List` heading, fall back to in-line synthesis. Prepend a single comment line to the document:
 
@@ -167,17 +216,18 @@ test -f .gitignore && grep -qE '^\.sessionkit/?$' .gitignore && echo "covered" |
 
 If `.sessionkit/HANDOFF.md` already exists, Read it first (the Write tool requires a prior Read of the target path). Step 1b already did this when a prior file exists.
 
-Then create the directory and write the file:
+Then create the directory if needed:
 
 ```bash
 mkdir -p .sessionkit
 ```
 
-Write the synthesized document to `.sessionkit/HANDOFF.md` using the Write tool, silently overwriting any existing file.
+- **Delta mode** (step 1d): the surgical Edits in step 1d already updated the file in place. Nothing more to do here beyond the `.gitignore` check above.
+- **Full path** (step 2): Write the synthesized document to `.sessionkit/HANDOFF.md` using the Write tool, silently overwriting any existing file.
 
 ### 4. Confirm
 
-Report the absolute path of the file written, the reuse outcome from step 1b (e.g. `regenerated all sections` / `reused 4 sections` / `reused 2 sections (git)` / `reused 2 sections (task)`), and suggest:
+Report the absolute path of the file written, the chosen mode and reuse outcome (e.g. `delta mode — refreshed Goal/Context, regenerated Git State + Progress`, `full regenerate — reused 2 sections (task)`, `full regenerate — regenerated all sections`), and suggest:
 
 > Start a new session and run `/pickup` to resume.
 

--- a/plugins/squadkit/.claude-plugin/plugin.json
+++ b/plugins/squadkit/.claude-plugin/plugin.json
@@ -1,10 +1,10 @@
 {
   "name": "squadkit",
-  "description": "Multi-agent team coordination for Claude Code. Roles, squads, and crews — interview-driven setup, no per-stack presets, reusable across any repo.",
-  "version": "0.6.0",
+  "description": "Multi-agent team coordination for Claude Code. Roles, squads, and crews \u2014 interview-driven setup, no per-stack presets, reusable across any repo.",
+  "version": "0.7.0",
   "license": "MIT",
   "author": {
-    "name": "Román M. Pacheco"
+    "name": "Rom\u00e1n M. Pacheco"
   },
   "hooks": {
     "SessionStart": [

--- a/plugins/squadkit/README.md
+++ b/plugins/squadkit/README.md
@@ -79,7 +79,7 @@ A **crew profile** is a YAML file under `plugins/squadkit/crews/` describing a r
 | Profile | Roster | When to use |
 |---------|--------|-------------|
 | **all-rounder** | team-lead, architect, builder×2, reviewer, tester, explorer, designer | Full-spectrum feature work end-to-end. |
-| **design** | team-lead, architect, designer, explorer | Discovery-stage exploration with no implementation yet. |
+| **design** | architect, designer, explorer | Discovery-stage exploration with no implementation yet. Read-only: produces issue comments, no worktrees, no epic branch. (`kind: discovery`) |
 | **qa** | team-lead, reviewer, tester, builder×1 | Hardening, regression, bug-fix sweeps. |
 
 ### Schema
@@ -89,6 +89,7 @@ Each crew YAML conforms to:
 ```yaml
 name: <string>            # profile name; matches the filename without .yaml
 description: <string>     # one-line summary of when to use this crew
+kind: <string>            # optional, default "execution"; execution | discovery
 members:
   - role: <string>        # one of: team-lead, architect, builder, reviewer, tester, explorer, designer
     count: <int>          # optional, default 1; 1–5 for builder

--- a/plugins/squadkit/crews/design.yaml
+++ b/plugins/squadkit/crews/design.yaml
@@ -1,7 +1,7 @@
 name: design
-description: Discovery and design crew for early-stage exploration — architect frames the system, designer shapes the surface, explorer investigates prior art and constraints. No builders.
+description: Read-only discovery crew for early-stage exploration — architect frames the system blueprint, designer shapes the surface, explorer investigates prior art and constraints. Deliverables are issue comments, not PRs. No worktrees, no epic branch, no prBase pinning.
+kind: discovery
 members:
-  - role: team-lead
   - role: architect
   - role: designer
   - role: explorer

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,9 +1,9 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "5.2.0",
+  "version": "5.3.0",
   "license": "MIT",
   "author": {
-    "name": "Román M. Pacheco"
+    "name": "Rom\u00e1n M. Pacheco"
   }
 }

--- a/plugins/swarmkit/skills/clean-remote-worktrees/scripts/test.sh
+++ b/plugins/swarmkit/skills/clean-remote-worktrees/scripts/test.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# test.sh — smoke tests for swarmkit:clean-remote-worktrees scripts.
+#
+# Per the convention in plugins/_shared/script-authoring.md:
+# - Successful invocations exit 0 and emit a parseable JSON object on stdout
+#   with the documented top-level keys.
+# - Invalid-argument invocations exit non-zero and emit nothing on stdout.
+#
+# classify.sh requires network access (git fetch + gh API) so only the
+# invalid-argument surface is exercisable here. Since classify.sh accepts no
+# flags, there is no flag-based invalid-arg path to test; the entire happy
+# path is network-dependent and therefore deferred to CI.
+#
+# delete.sh has a network-free early-exit path (--branches '[]') that is
+# exercised as the happy-path noop test.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PASS=0
+FAIL=0
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+assert_invalid_args() {
+  local script="$1"; shift
+  local label="$1"; shift
+  local stdout stderr rc
+  local tmp_out tmp_err
+  tmp_out="$(mktemp)"
+  tmp_err="$(mktemp)"
+  set +e
+  "$SCRIPT_DIR/$script" "$@" >"$tmp_out" 2>"$tmp_err"
+  rc=$?
+  set -e
+  stdout="$(cat "$tmp_out")"
+  stderr="$(cat "$tmp_err")"
+  rm -f "$tmp_out" "$tmp_err"
+
+  if [[ $rc -eq 0 ]]; then
+    red   "  FAIL [$script $label]: expected non-zero exit, got 0"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -n "$stdout" ]]; then
+    red   "  FAIL [$script $label]: expected empty stdout on invalid args, got:"
+    printf '%s\n' "$stdout" | sed 's/^/         /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -z "$stderr" ]]; then
+    red   "  FAIL [$script $label]: expected non-empty stderr message"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  green "  PASS [$script $label]: exit=$rc, stdout empty"
+  PASS=$((PASS + 1))
+}
+
+assert_json_keys() {
+  local script="$1"; shift
+  local label="$1"; shift
+  local expected_keys="$1"; shift
+  local stdout rc stderr_content
+  local tmp_out tmp_err
+  tmp_out="$(mktemp)"
+  tmp_err="$(mktemp)"
+  set +e
+  "$SCRIPT_DIR/$script" "$@" >"$tmp_out" 2>"$tmp_err"
+  rc=$?
+  set -e
+  stdout="$(cat "$tmp_out")"
+  stderr_content="$(cat "$tmp_err")"
+  rm -f "$tmp_out" "$tmp_err"
+
+  if [[ $rc -ne 0 ]]; then
+    red   "  FAIL [$script $label]: expected exit 0, got $rc"
+    [[ -n "$stderr_content" ]] && printf '%s\n' "$stderr_content" | sed 's/^/         stderr: /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if ! printf '%s' "$stdout" | jq -e . >/dev/null 2>&1; then
+    red   "  FAIL [$script $label]: stdout is not valid JSON"
+    printf '%s\n' "$stdout" | sed 's/^/         /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  local missing=""
+  for key in $expected_keys; do
+    if ! printf '%s' "$stdout" | jq -e "has(\"$key\")" >/dev/null 2>&1; then
+      missing+=" $key"
+    fi
+  done
+  if [[ -n "$missing" ]]; then
+    red   "  FAIL [$script $label]: missing top-level keys:$missing"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  green "  PASS [$script $label]: exit=0, JSON valid, keys present"
+  PASS=$((PASS + 1))
+}
+
+echo "clean-remote-worktrees: smoke-testing scripts"
+echo
+
+# delete.sh — invalid arg shapes.
+assert_invalid_args delete.sh "missing-required"  # no --branches at all
+assert_invalid_args delete.sh "missing-value"     --branches
+assert_invalid_args delete.sh "unknown-flag"      --bogus value
+
+# delete.sh — empty array = network-free noop happy path.
+assert_json_keys delete.sh "empty-array-noop" \
+  "deleted skipped errors" \
+  --branches '[]'
+
+echo
+echo "clean-remote-worktrees: ${PASS} passed, ${FAIL} failed"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/plugins/swarmkit/skills/clean-worktrees/scripts/test.sh
+++ b/plugins/swarmkit/skills/clean-worktrees/scripts/test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# test.sh — smoke tests for swarmkit:clean-worktrees scripts.
+#
+# Per the convention in plugins/_shared/script-authoring.md:
+# - Successful invocations exit 0 and emit a parseable JSON object on stdout
+#   with the documented top-level keys.
+# - Invalid-argument invocations exit non-zero and emit nothing on stdout.
+#
+# These scripts are network-free (operate on the local repo only) so a
+# read-only happy path is exercised. `remove.sh` is invoked with empty input
+# arrays so it has nothing to remove — a safe no-op.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PASS=0
+FAIL=0
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+assert_invalid_args() {
+  local script="$1"; shift
+  local label="$1"; shift
+  local stdout stderr rc
+  local tmp_out tmp_err
+  tmp_out="$(mktemp)"
+  tmp_err="$(mktemp)"
+  set +e
+  "$SCRIPT_DIR/$script" "$@" >"$tmp_out" 2>"$tmp_err"
+  rc=$?
+  set -e
+  stdout="$(cat "$tmp_out")"
+  stderr="$(cat "$tmp_err")"
+  rm -f "$tmp_out" "$tmp_err"
+
+  if [[ $rc -eq 0 ]]; then
+    red   "  FAIL [$script $label]: expected non-zero exit, got 0"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -n "$stdout" ]]; then
+    red   "  FAIL [$script $label]: expected empty stdout on invalid args, got:"
+    printf '%s\n' "$stdout" | sed 's/^/         /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -z "$stderr" ]]; then
+    red   "  FAIL [$script $label]: expected non-empty stderr message"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  green "  PASS [$script $label]: exit=$rc, stdout empty"
+  PASS=$((PASS + 1))
+}
+
+assert_json_keys() {
+  local script="$1"; shift
+  local label="$1"; shift
+  local expected_keys="$1"; shift
+  local stdout rc stderr_content
+  local tmp_out tmp_err
+  tmp_out="$(mktemp)"
+  tmp_err="$(mktemp)"
+  set +e
+  "$SCRIPT_DIR/$script" "$@" >"$tmp_out" 2>"$tmp_err"
+  rc=$?
+  set -e
+  stdout="$(cat "$tmp_out")"
+  stderr_content="$(cat "$tmp_err")"
+  rm -f "$tmp_out" "$tmp_err"
+
+  if [[ $rc -ne 0 ]]; then
+    red   "  FAIL [$script $label]: expected exit 0, got $rc"
+    [[ -n "$stderr_content" ]] && printf '%s\n' "$stderr_content" | sed 's/^/         stderr: /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if ! printf '%s' "$stdout" | jq -e . >/dev/null 2>&1; then
+    red   "  FAIL [$script $label]: stdout is not valid JSON"
+    printf '%s\n' "$stdout" | sed 's/^/         /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  local missing=""
+  for key in $expected_keys; do
+    if ! printf '%s' "$stdout" | jq -e "has(\"$key\")" >/dev/null 2>&1; then
+      missing+=" $key"
+    fi
+  done
+  if [[ -n "$missing" ]]; then
+    red   "  FAIL [$script $label]: missing top-level keys:$missing"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  green "  PASS [$script $label]: exit=0, JSON valid, keys present"
+  PASS=$((PASS + 1))
+}
+
+echo "clean-worktrees: smoke-testing scripts"
+echo
+
+# gather.sh — no args, read-only. Always succeeds in any git repo.
+assert_json_keys gather.sh "happy-path" \
+  "caller_branch main_worktree worktrees_to_remove branches_to_delete stuck"
+
+# remove.sh — invalid arg shapes.
+assert_invalid_args remove.sh "missing-required" --worktrees '[]' --branches '[]'
+assert_invalid_args remove.sh "unknown-flag"     --bogus value
+assert_invalid_args remove.sh "missing-value"    --main-worktree
+
+# remove.sh — empty arrays = safe no-op happy path. We pass the current main
+# worktree so the cd succeeds, and an empty caller-branch so the restore step
+# is a no-op.
+MAIN_WT="$(git worktree list --porcelain | awk '/^worktree /{print $2; exit}')"
+assert_json_keys remove.sh "empty-arrays-noop" \
+  "removed remove_errors pruned_branches branch_errors caller_branch_restored" \
+  --main-worktree "$MAIN_WT" --caller-branch "" --worktrees '[]' --branches '[]'
+
+echo
+echo "clean-worktrees: ${PASS} passed, ${FAIL} failed"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/plugins/swarmkit/skills/swarm-plus/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-plus/SKILL.md
@@ -7,6 +7,7 @@ triggers:
   - "swarm with review"
   - "swarm and review"
   - "swarm review"
+  - "swarm + review pass"
 ---
 
 # Swarm Plus
@@ -27,6 +28,18 @@ Identical to `/swarmkit:swarm`:
 - `--reviewer-model <tier>` — override reviewer model (default: `sonnet`)
 
 ## Process
+
+### 0. Pre-flight: resolve verify command
+
+> Resolved once at the start of the run, before any worker is dispatched.
+
+Resolve the project's verify command once and reuse it for every worker prompt. This keeps swarm-plus useful in any repo, not just TS repos with `tsc`. Use this lookup chain (first hit wins):
+
+1. **`.squadkit/config.json` `verifyCommand`** — repo-level explicit override. Read with `jq -r '.verifyCommand // empty' .squadkit/config.json` if the file exists.
+2. **`package.json` `scripts.verify`** — common project-local convention. If present, the verify command is determined by the package manager: `yarn.lock` present → `yarn run verify`; `pnpm-lock.yaml` present → `pnpm run verify`; otherwise → `npm run verify`.
+3. **Fallback** — `npx tsc -b --noEmit` for TS projects. "TS toolchain present" means `tsconfig.json` exists at the repo root. If neither of the above resolves AND `tsconfig.json` is absent, print a warning and instruct the worker to skip the verify step rather than running a command that will obviously fail. **Note:** projects that use `tsc` via a non-standard mechanism (e.g. a wrapper script, a monorepo tool, or a config file named differently) won't be detected by this check — those repos should set `verifyCommand` in `.squadkit/config.json` to opt in explicitly.
+
+Record the resolved command as `<verify_command>` and interpolate it into the worker prompt template in step 4.
 
 ### 1. Run the swarm phase
 
@@ -93,7 +106,7 @@ The worker prompt MUST:
      git checkout -B <head_branch> origin/<head_branch>
      ```
   2. Apply the changes.
-  3. Run `npx tsc -b --noEmit` and the relevant test scope. Resolve any failures before proceeding — never push a red build.
+  3. Run `<verify_command>` (resolved in step 1a) and the relevant test scope. Resolve any failures before proceeding — never push a red build.
   4. Commit with conventional-commit format (no Claude mentions, no co-author lines).
   5. Push to the same branch (`git push origin <head_branch>`) — auto-updates the PR.
   6. Optionally comment on the PR summarizing what was addressed and what was deferred:

--- a/plugins/swarmkit/skills/swarm/scripts/test.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/test.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# test.sh — smoke tests for swarmkit:swarm scripts.
+#
+# Per the convention in plugins/_shared/script-authoring.md:
+# - Successful invocations exit 0 and emit a parseable JSON object on stdout
+#   with the documented top-level keys.
+# - Invalid-argument invocations exit non-zero and emit nothing on stdout.
+#
+# These tests focus on the deterministic, network-free contract surface:
+# argument validation. Happy-path invocations for swarm scripts require live
+# `gh` auth and `git fetch origin`, which are unsuitable for a smoke harness;
+# that surface is exercised manually and via the skill itself.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PASS=0
+FAIL=0
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+assert_invalid_args() {
+  local script="$1"; shift
+  local label="$1"; shift
+  local stdout stderr rc
+  local tmp_out tmp_err
+  tmp_out="$(mktemp)"
+  tmp_err="$(mktemp)"
+  set +e
+  "$SCRIPT_DIR/$script" "$@" >"$tmp_out" 2>"$tmp_err"
+  rc=$?
+  set -e
+  stdout="$(cat "$tmp_out")"
+  stderr="$(cat "$tmp_err")"
+  rm -f "$tmp_out" "$tmp_err"
+
+  if [[ $rc -eq 0 ]]; then
+    red   "  FAIL [$script $label]: expected non-zero exit, got 0"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -n "$stdout" ]]; then
+    red   "  FAIL [$script $label]: expected empty stdout on invalid args, got:"
+    printf '%s\n' "$stdout" | sed 's/^/         /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -z "$stderr" ]]; then
+    red   "  FAIL [$script $label]: expected non-empty stderr message"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  green "  PASS [$script $label]: exit=$rc, stdout empty, stderr non-empty"
+  PASS=$((PASS + 1))
+}
+
+echo "swarm: smoke-testing argument validation contracts"
+echo
+
+# preflight.sh — accepts --base <value>, --scope-pr-base, no positional.
+assert_invalid_args preflight.sh "unknown-flag"      --not-a-flag
+assert_invalid_args preflight.sh "missing-value"     --base
+assert_invalid_args preflight.sh "extra-positional"  positional-not-allowed
+
+# teardown.sh — accepts --base <value>.
+assert_invalid_args teardown.sh "unknown-flag"   --not-a-flag
+assert_invalid_args teardown.sh "missing-value"  --base
+
+# verify_agent.sh — exactly one positive integer.
+assert_invalid_args verify_agent.sh "no-args"
+assert_invalid_args verify_agent.sh "non-integer"   not-a-number
+assert_invalid_args verify_agent.sh "negative"      -5
+assert_invalid_args verify_agent.sh "extra-args"    1 2
+
+# gather_issues.sh — at least one positive-integer arg.
+assert_invalid_args gather_issues.sh "no-args"
+assert_invalid_args gather_issues.sh "non-integer"  abc
+assert_invalid_args gather_issues.sh "mixed-bad"    1 abc
+
+echo
+echo "swarm: ${PASS} passed, ${FAIL} failed"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/scripts/test-all-skill-scripts.sh
+++ b/scripts/test-all-skill-scripts.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# test-all-skill-scripts.sh — discover and run every skill's `scripts/test.sh`
+# smoke test across the monorepo. Single entry point for CI and manual runs.
+#
+# Usage:
+#   scripts/test-all-skill-scripts.sh
+#
+# Discovery: walks `plugins/*/skills/*/scripts/test.sh`. Each test.sh is run
+# with its own directory as CWD. A non-zero exit from any test.sh fails the
+# whole runner, but every test is still attempted so the report is complete.
+#
+# Exit codes:
+#   0  — all discovered tests passed
+#   1  — at least one test failed
+#   2  — no tests discovered
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+for cmd in bash jq find; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "test-all-skill-scripts: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+TESTS=()
+while IFS= read -r line; do
+  TESTS+=("$line")
+done < <(find plugins -path 'plugins/*/skills/*/scripts/test.sh' -type f | sort)
+
+if [[ ${#TESTS[@]} -eq 0 ]]; then
+  echo "test-all-skill-scripts: no skill smoke tests discovered under plugins/*/skills/*/scripts/test.sh" >&2
+  exit 2
+fi
+
+passed=0
+failed=0
+failed_paths=()
+
+echo "Discovered ${#TESTS[@]} skill smoke test(s)."
+echo
+
+for test_path in "${TESTS[@]}"; do
+  rel="${test_path#$REPO_ROOT/}"
+  echo "==> $rel"
+  test_dir="$(dirname "$test_path")"
+  if ( cd "$test_dir" && bash "./test.sh" ); then
+    passed=$((passed + 1))
+    echo "    PASS"
+  else
+    failed=$((failed + 1))
+    failed_paths+=("$rel")
+    echo "    FAIL"
+  fi
+  echo
+done
+
+echo "------------------------------------------------------------"
+echo "Skill smoke tests: ${passed} passed, ${failed} failed (of ${#TESTS[@]})"
+
+if [[ $failed -gt 0 ]]; then
+  echo
+  echo "Failed tests:"
+  for p in "${failed_paths[@]}"; do
+    echo "  - $p"
+  done
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Wraps up two cycles of swarm+review work: cycle 1 ships flowkit auto-stash, sessionkit handoff delta mode, swarmkit verify-command portability, squadkit discovery crews, and the script-level smoke-test runner; cycle 2 closes the flowkit release-notes synthesis and develop-as-default issue-close lifecycle. Plus a bash-3.2-safe fix and a `--format` ordering fix to `bump-versions` so suggested_bump correctly reads conventional-commit signal on macOS.

## Release summary

**Built from**: `rc/2026-05-02.1`

### Version bumps
- chore(plugins): bump flowkit@3.7.0, sessionkit@1.7.0, squadkit@0.7.0, swarmkit@5.3.0 (#729)
- fix(bump-versions): place --format before -- in git log invocation (#728)
- feat(bump-versions): populate suggested_bump in detect_changed.sh JSON (#718)

### Release notes

**flowkit**
- feat(flowkit): align issue-close lifecycle with GitHub-native conventions — Document flowkit's `main`-as-default-branch assumption and add explicit `gh issue close` loops to `/release` and `/hotfix` so referenced issues close on `develop`-as-default repos too.
- feat(flowkit:release): synthesize release notes and drop other group — Add a `### Release notes` section to release PR bodies, synthesized from merged-PR titles + summaries since the previous release tag.
- feat(flowkit): auto-stash dirty workspace around post-merge pull — Detect dirty workspace before `gh pr merge`; auto-stash with a labeled message and pop after the merge completes.
- fix(flowkit:open-pr): resolve --base from prBase config or develop default — Resolve PR base via explicit arg → `claude.flowkit.prBase` → `develop` → GitHub default; harden against `--base` substrings in titles/bodies.

**swarmkit**
- feat(swarmkit:swarm-plus): port reference trigger and abstract verify command — Port "swarm + review pass" trigger from vorbis-player reference; resolve verify command via `.squadkit/config.json` → `package.json scripts.verify` → `tsc` fallback.
- feat(bump-versions): populate suggested_bump in detect_changed.sh JSON — `detect_changed.sh` now derives `suggested_bump` per record from conventional-commit prefixes since the last per-plugin tag.
- feat(infra): script-level smoke-test convention and runner — Root-level `scripts/test-all-skill-scripts.sh` discovers and runs `scripts/test.sh` in every skill that ships scripts.

**sessionkit**
- feat(sessionkit:handoff): add delta mode and clarify reuse-verbatim contract — Add delta-mode branch that skips Haiku dispatch when fingerprints partially match — sub-3s handoffs for incremental updates.

**squadkit**
- feat(squadkit): migrate design crew to kind: discovery — Add `kind: discovery` to the design crew profile so spawning skips worktrees, epic-branch cutting, and prBase pinning.

### Changes

**flowkit**
- feat(flowkit): align issue-close lifecycle with GitHub-native conventions (#726)
- feat(flowkit:release): synthesize release notes and drop other group (#725)
- feat(flowkit): auto-stash dirty workspace around post-merge pull (#717)
- fix(flowkit:open-pr): resolve --base from prBase config or develop default (#715)

**swarmkit**
- feat(swarmkit:swarm-plus): port reference trigger and abstract verify command (#714)

**sessionkit**
- feat(sessionkit:handoff): add delta mode and clarify reuse-verbatim contract (#716)

**squadkit**
- feat(squadkit): migrate design crew to kind: discovery (#713)

**cross-plugin**
- feat(infra): script-level smoke-test convention and runner (#719)

Closes #684
Closes #685
Closes #686
Closes #693
Closes #694
Closes #695
Closes #702
Closes #703
Closes #704
Closes #709
Closes #712
