### PR TITLE
fix(flowkit:release): match sub-scoped commits in changelog regexes

### DIFF
--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -170,7 +170,7 @@ GROUPED_CHANGES_FILE=$(mktemp)
 printf '%s\n' "$PLUGINS" | while read PLUGIN; do
   [ -z "$PLUGIN" ] && continue
   PLUGIN_COMMITS=$(printf '%s\n' "$ALL_COMMITS" \
-    | grep -iE "\($PLUGIN\)" \
+    | grep -iE '\('"$PLUGIN"'[:)]' \
     | sed 's/^[a-f0-9]* /- /' \
     || true)
   if [ -n "$PLUGIN_COMMITS" ]; then
@@ -185,7 +185,7 @@ done
 # information value and the commits speak for themselves.
 SCOPED_PATTERN=$(printf '%s\n' "$PLUGINS" | tr '\n' '|' | sed 's/|$//')
 MEANINGFUL_UNSCOPED=$(printf '%s\n' "$ALL_COMMITS" \
-  | grep -ivE "\($SCOPED_PATTERN\)" \
+  | grep -ivE '\('"$SCOPED_PATTERN"'[:)]' \
   | grep -iE "^[a-f0-9]+ (feat|fix|refactor|perf)" \
   | sed 's/^[a-f0-9]* /- /' \
   || true)
@@ -216,7 +216,7 @@ if [ -n "$LAST_TAG" ] && [ -n "$TAG_DATE" ]; then
   printf '%s\n' "$PLUGINS" | while read PLUGIN; do
     [ -z "$PLUGIN" ] && continue
     PLUGIN_NOTES=$(printf '%s\n' "$MERGED_PR_DATA" \
-      | grep -iE "\($PLUGIN\)" \
+      | grep -iE '\('"$PLUGIN"'[:)]' \
       | while IFS=$(printf '\t') read TITLE SUMMARY; do
           if [ -n "$SUMMARY" ] && [ "$SUMMARY" != "$TITLE" ]; then
             printf '- %s — %s\n' "$TITLE" "$SUMMARY"


### PR DESCRIPTION
## Summary
- Update GROUPED_CHANGES and RELEASE_NOTES regexes from `\($PLUGIN\)` to `\($PLUGIN[:)]` so sub-scoped commits like `feat(swarmkit:swarm-plus): ...` group under the correct plugin
- Mirror the inverse update on MEANINGFUL_UNSCOPED so sub-scoped commits don't double-count under `**cross-plugin**`
- Use single-quote concatenation around the variable to dodge zsh's parameter-subscript collision when `[` follows `$VAR`

## Changes
- `plugins/flowkit/skills/release/SKILL.md`: three grep patterns updated — GROUPED_CHANGES loop, RELEASE_NOTES loop, and MEANINGFUL_UNSCOPED filter

## Test plan
- Run `scripts/test-all-skill-scripts.sh` (smoke-test runner) — all 21 tests pass
- Manual verification: a synthetic commit log containing `feat(flowkit:open-pr): ...` groups under `flowkit` and is excluded from `**cross-plugin**`
- A bare `chore: bump foo from (bar)` commit is still treated as cross-plugin (no false-positive)

Closes #731