### PR TITLE
fix(swarmkit:clean-worktrees): derive branch names from porcelain output

### DIFF
--- a/plugins/swarmkit/skills/clean-worktrees/scripts/gather.sh
+++ b/plugins/swarmkit/skills/clean-worktrees/scripts/gather.sh
@@ -30,7 +30,7 @@ fi
 # Lines with no branch line (detached HEAD) are omitted.
 all_wt_pairs="$(git worktree list --porcelain | awk '
   /^worktree / { path = $2; branch = "" }
-  /^branch refs\/heads\// { branch = substr($0, 20) }
+  /^branch refs\/heads\// { branch = substr($0, 19) }
   /^$/ { if (path != "" && branch != "") print path "\t" branch; path = ""; branch = "" }
   END  { if (path != "" && branch != "") print path "\t" branch }
 ')"
@@ -43,15 +43,6 @@ while IFS=$'\t' read -r path branch; do
     worktrees_to_remove+=("$path")
   fi
 done <<< "$all_wt_pairs"
-
-# Produce a newline-delimited list of branches checked out by the removal set.
-removing_branches_list=""
-for path in "${worktrees_to_remove[@]+"${worktrees_to_remove[@]}"}"; do
-  branch="$(printf '%s\n' "$all_wt_pairs" | awk -F'\t' -v p="$path" '$1==p{print $2}')"
-  if [[ -n "$branch" ]]; then
-    removing_branches_list+="$branch"$'\n'
-  fi
-done
 
 # Produce a newline-delimited list of branches checked out by worktrees NOT in
 # the removal set (excluding main worktree).

--- a/plugins/swarmkit/skills/clean-worktrees/scripts/gather.sh
+++ b/plugins/swarmkit/skills/clean-worktrees/scripts/gather.sh
@@ -25,35 +25,56 @@ if [[ -z "$main_worktree" ]]; then
   exit 1
 fi
 
+# Parse porcelain output into tab-separated "path<TAB>branch" pairs, one per
+# worktree stanza that has a checked-out (non-detached) branch.
+# Lines with no branch line (detached HEAD) are omitted.
+all_wt_pairs="$(git worktree list --porcelain | awk '
+  /^worktree / { path = $2; branch = "" }
+  /^branch refs\/heads\// { branch = substr($0, 20) }
+  /^$/ { if (path != "" && branch != "") print path "\t" branch; path = ""; branch = "" }
+  END  { if (path != "" && branch != "") print path "\t" branch }
+')"
+
+# Worktrees to remove: non-main paths whose basename matches agent-* or worktree-agent-*.
 worktrees_to_remove=()
-while IFS= read -r line; do
-  path="${line#worktree }"
-  if [[ "$path" != "$main_worktree" ]]; then
+while IFS=$'\t' read -r path branch; do
+  [[ "$path" == "$main_worktree" ]] && continue
+  if [[ "$path" =~ worktrees/(agent-|worktree-agent-) ]]; then
     worktrees_to_remove+=("$path")
   fi
-done < <(git worktree list --porcelain | grep '^worktree ')
+done <<< "$all_wt_pairs"
 
-active_worktree_branches=()
-while IFS= read -r line; do
-  branch="${line#branch refs/heads/}"
-  if [[ "$line" == branch\ * ]]; then
-    active_worktree_branches+=("$branch")
+# Produce a newline-delimited list of branches checked out by the removal set.
+removing_branches_list=""
+for path in "${worktrees_to_remove[@]+"${worktrees_to_remove[@]}"}"; do
+  branch="$(printf '%s\n' "$all_wt_pairs" | awk -F'\t' -v p="$path" '$1==p{print $2}')"
+  if [[ -n "$branch" ]]; then
+    removing_branches_list+="$branch"$'\n'
   fi
-done < <(git worktree list --porcelain)
+done
+
+# Produce a newline-delimited list of branches checked out by worktrees NOT in
+# the removal set (excluding main worktree).
+other_active_branches_list=""
+while IFS=$'\t' read -r path branch; do
+  [[ "$path" == "$main_worktree" ]] && continue
+  # Skip if this path is in the removal set.
+  in_removal=false
+  for rpath in "${worktrees_to_remove[@]+"${worktrees_to_remove[@]}"}"; do
+    if [[ "$rpath" == "$path" ]]; then
+      in_removal=true
+      break
+    fi
+  done
+  [[ "$in_removal" == true ]] && continue
+  other_active_branches_list+="$branch"$'\n'
+done <<< "$all_wt_pairs"
 
 branches_to_delete=()
 stuck=()
 while IFS= read -r branch; do
   if [[ "$branch" == worktree-agent-* ]]; then
-    is_active=false
-    for active in "${active_worktree_branches[@]+"${active_worktree_branches[@]}"}"; do
-      if [[ "$active" == "$branch" ]]; then
-        is_active=true
-        break
-      fi
-    done
-
-    if [[ "$is_active" == true ]]; then
+    if printf '%s' "$other_active_branches_list" | grep -qxF "$branch"; then
       stuck+=("$branch")
     else
       branches_to_delete+=("$branch")

--- a/plugins/swarmkit/skills/clean-worktrees/scripts/test.sh
+++ b/plugins/swarmkit/skills/clean-worktrees/scripts/test.sh
@@ -172,6 +172,56 @@ else
   fi
 fi
 
+# gather.sh — stuck-from-outside test.
+# A worktree at a path that does NOT match worktrees/(agent-|worktree-agent-)
+# checks out a worktree-agent-* branch. That branch must land in stuck[], not
+# branches_to_delete. An agent-path worktree on a different worktree-agent-*
+# branch must land in branches_to_delete and worktrees_to_remove.
+echo "  [gather.sh stuck-from-outside] setting up scratch repo..."
+SCRATCH2_DIR="$(mktemp -d)"
+cleanup_scratch2() { rm -rf "$SCRATCH2_DIR"; }
+trap cleanup_scratch2 EXIT
+
+MAIN2_REPO="$SCRATCH2_DIR/main"
+git init -q "$MAIN2_REPO"
+git -C "$MAIN2_REPO" commit -q --allow-empty -m "init"
+
+git -C "$MAIN2_REPO" branch worktree-agent-700
+git -C "$MAIN2_REPO" branch worktree-agent-701
+
+# Agent-path worktree (will land in worktrees_to_remove + branches_to_delete).
+AGENT_WT="$SCRATCH2_DIR/main/.claude/worktrees/agent-c30dff96334b28284"
+mkdir -p "$(dirname "$AGENT_WT")"
+git -C "$MAIN2_REPO" worktree add -q "$AGENT_WT" worktree-agent-700
+
+# External-path worktree (NOT an agent path — checks out worktree-agent-701).
+EXTERNAL_WT="$SCRATCH2_DIR/main/external-wt"
+git -C "$MAIN2_REPO" worktree add -q "$EXTERNAL_WT" worktree-agent-701
+
+GATHER2_OUT="$(cd "$MAIN2_REPO" && bash "$SCRIPT_DIR/gather.sh" 2>/tmp/gather2_stderr)"
+GATHER2_RC=$?
+
+if [[ $GATHER2_RC -ne 0 ]]; then
+  red   "  FAIL [gather.sh stuck-from-outside]: gather.sh exited $GATHER2_RC"
+  sed 's/^/         stderr: /' /tmp/gather2_stderr || true
+  FAIL=$((FAIL + 1))
+else
+  WT2_COUNT="$(printf '%s' "$GATHER2_OUT" | jq '.worktrees_to_remove | length')"
+  B700="$(printf '%s' "$GATHER2_OUT" | jq -r '.branches_to_delete[] | select(. == "worktree-agent-700")')"
+  B701_IN_DELETE="$(printf '%s' "$GATHER2_OUT" | jq -r '.branches_to_delete[] | select(. == "worktree-agent-701")')"
+  B701_IN_STUCK="$(printf '%s' "$GATHER2_OUT" | jq -r '.stuck[].branch | select(. == "worktree-agent-701")')"
+  STUCK2_COUNT="$(printf '%s' "$GATHER2_OUT" | jq '.stuck | length')"
+
+  if [[ "$WT2_COUNT" -eq 1 && -n "$B700" && -z "$B701_IN_DELETE" && -n "$B701_IN_STUCK" && "$STUCK2_COUNT" -eq 1 ]]; then
+    green "  PASS [gather.sh stuck-from-outside]: agent worktree in remove set, external worktree-agent branch in stuck"
+    PASS=$((PASS + 1))
+  else
+    red   "  FAIL [gather.sh stuck-from-outside]: unexpected output"
+    printf '%s\n' "$GATHER2_OUT" | jq . | sed 's/^/         /'
+    FAIL=$((FAIL + 1))
+  fi
+fi
+
 echo
 echo "clean-worktrees: ${PASS} passed, ${FAIL} failed"
 [[ $FAIL -eq 0 ]] || exit 1

--- a/plugins/swarmkit/skills/clean-worktrees/scripts/test.sh
+++ b/plugins/swarmkit/skills/clean-worktrees/scripts/test.sh
@@ -117,6 +117,61 @@ assert_json_keys remove.sh "empty-arrays-noop" \
   "removed remove_errors pruned_branches branch_errors caller_branch_restored" \
   --main-worktree "$MAIN_WT" --caller-branch "" --worktrees '[]' --branches '[]'
 
+# gather.sh — path/branch decoupling test.
+# Simulate swarm worktrees where path name (agent-<hex>) differs from branch name
+# (worktree-agent-<n>). Build a scratch git repo with two registered worktrees
+# whose paths and branches are intentionally mismatched, verify gather.sh:
+#   - emits those worktrees in worktrees_to_remove
+#   - emits the checked-out branches in branches_to_delete (not stuck)
+#   - stuck is empty (the only checked-out branches are in the removal set)
+echo "  [gather.sh path-branch-mismatch] setting up scratch repo..."
+SCRATCH_DIR="$(mktemp -d)"
+cleanup_scratch() { rm -rf "$SCRATCH_DIR"; }
+trap cleanup_scratch EXIT
+
+# Main repo.
+MAIN_REPO="$SCRATCH_DIR/main"
+git init -q "$MAIN_REPO"
+git -C "$MAIN_REPO" commit -q --allow-empty -m "init"
+
+# Create the worktree-agent-* branches in the main repo.
+git -C "$MAIN_REPO" branch worktree-agent-694
+git -C "$MAIN_REPO" branch worktree-agent-695
+
+# Create two agent worktrees with hex-style paths but issue-numbered branches.
+WT1="$SCRATCH_DIR/main/.claude/worktrees/agent-a08bdd74112e06062"
+WT2="$SCRATCH_DIR/main/.claude/worktrees/agent-b19cee85223f17173"
+mkdir -p "$(dirname "$WT1")"
+git -C "$MAIN_REPO" worktree add -q "$WT1" worktree-agent-694
+git -C "$MAIN_REPO" worktree add -q "$WT2" worktree-agent-695
+
+# Run gather.sh from within the main repo so git commands resolve correctly.
+GATHER_OUT="$(cd "$MAIN_REPO" && bash "$SCRIPT_DIR/gather.sh" 2>/tmp/gather_stderr)"
+GATHER_RC=$?
+
+if [[ $GATHER_RC -ne 0 ]]; then
+  red   "  FAIL [gather.sh path-branch-mismatch]: gather.sh exited $GATHER_RC"
+  cat /tmp/gather_stderr | sed 's/^/         stderr: /' || true
+  FAIL=$((FAIL + 1))
+else
+  # Verify worktrees_to_remove has 2 entries.
+  WT_COUNT="$(printf '%s' "$GATHER_OUT" | jq '.worktrees_to_remove | length')"
+  # Verify branches_to_delete contains both worktree-agent-694 and worktree-agent-695.
+  B694="$(printf '%s' "$GATHER_OUT" | jq -r '.branches_to_delete[] | select(. == "worktree-agent-694")')"
+  B695="$(printf '%s' "$GATHER_OUT" | jq -r '.branches_to_delete[] | select(. == "worktree-agent-695")')"
+  # Verify stuck is empty.
+  STUCK_COUNT="$(printf '%s' "$GATHER_OUT" | jq '.stuck | length')"
+
+  if [[ "$WT_COUNT" -eq 2 && -n "$B694" && -n "$B695" && "$STUCK_COUNT" -eq 0 ]]; then
+    green "  PASS [gather.sh path-branch-mismatch]: 2 worktrees to remove, branches in delete list, stuck empty"
+    PASS=$((PASS + 1))
+  else
+    red   "  FAIL [gather.sh path-branch-mismatch]: unexpected output"
+    printf '%s\n' "$GATHER_OUT" | jq . | sed 's/^/         /'
+    FAIL=$((FAIL + 1))
+  fi
+fi
+
 echo
 echo "clean-worktrees: ${PASS} passed, ${FAIL} failed"
 [[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

`gather.sh` was deriving orphan branch names from the worktree path basename, but swarm-spawned worktrees use a hex path (`agent-<hash>`) while the checked-out branch carries the issue number (`worktree-agent-<n>`). This made every `worktree-agent-*` branch appear stuck (checked out by an active worktree), aborting cleanup on every post-swarm run.

## Changes

- `plugins/swarmkit/skills/clean-worktrees/scripts/gather.sh`: rewrite worktree enumeration to parse `git worktree list --porcelain` stanzas and map each path to its actual checked-out branch; filter agent worktrees by path pattern (`worktrees/(agent-|worktree-agent-)`); mark a branch stuck only when it is checked out by a worktree NOT in the removal set.
- `plugins/swarmkit/skills/clean-worktrees/scripts/test.sh`: add `path-branch-mismatch` case — builds a scratch git repo with two hex-path worktrees checking out issue-numbered branches, then asserts both appear in `worktrees_to_remove` and `branches_to_delete` with `stuck` empty.

## Test plan

- [ ] Run `scripts/test-all-skill-scripts.sh`; all 3 skill suites pass (22 tests total).
- [ ] After a swarm run with merged PRs, `/swarmkit:clean-worktrees` removes both worktrees and their `worktree-agent-<n>` branches in one pass without hitting the stuck-abort path.
- [ ] A branch genuinely checked out by an unrelated worktree still lands in `stuck` and halts cleanup.

Closes #724