### PR TITLE
refactor(swarmkit:swarm): detect default branch instead of hardcoding main

### DIFF
--- a/plugins/swarmkit/skills/swarm/scripts/preflight.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/preflight.sh
@@ -48,12 +48,13 @@ base_existed=true
 base_created=false
 if ! git rev-parse --verify --quiet "refs/remotes/origin/$BASE" >/dev/null; then
   base_existed=false
-  if ! git rev-parse --verify --quiet refs/remotes/origin/main >/dev/null; then
-    echo "preflight: base '$BASE' is missing on origin and 'main' does not exist to seed it from" >&2
+  DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || echo "main")
+  if ! git rev-parse --verify --quiet "refs/remotes/origin/$DEFAULT_BRANCH" >/dev/null; then
+    echo "preflight: base '$BASE' is missing on origin and '$DEFAULT_BRANCH' does not exist to seed it from" >&2
     exit 1
   fi
-  if ! git push origin "refs/remotes/origin/main:refs/heads/$BASE" >/dev/null 2>&1; then
-    echo "preflight: failed to create '$BASE' on origin from 'main'" >&2
+  if ! git push origin "refs/remotes/origin/$DEFAULT_BRANCH:refs/heads/$BASE" >/dev/null 2>&1; then
+    echo "preflight: failed to create '$BASE' on origin from '$DEFAULT_BRANCH'" >&2
     exit 1
   fi
   base_created=true

--- a/plugins/swarmkit/skills/swarm/scripts/preflight.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/preflight.sh
@@ -49,6 +49,7 @@ base_created=false
 if ! git rev-parse --verify --quiet "refs/remotes/origin/$BASE" >/dev/null; then
   base_existed=false
   DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || echo "main")
+  DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
   if ! git rev-parse --verify --quiet "refs/remotes/origin/$DEFAULT_BRANCH" >/dev/null; then
     echo "preflight: base '$BASE' is missing on origin and '$DEFAULT_BRANCH' does not exist to seed it from" >&2
     exit 1

--- a/plugins/swarmkit/skills/swarm/scripts/test.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/test.sh
@@ -78,6 +78,73 @@ assert_invalid_args gather_issues.sh "no-args"
 assert_invalid_args gather_issues.sh "non-integer"  abc
 assert_invalid_args gather_issues.sh "mixed-bad"    1 abc
 
+echo "swarm: DEFAULT_BRANCH empty-string guard"
+echo
+
+# preflight.sh: gh returns empty defaultBranchRef → guard falls back to "main"
+# Stubs: gh returns empty string (exit 0); git fetch succeeds; rev-parse fails
+# for the custom base branch but succeeds for "main"; jq and git push are not
+# reached because the test asserts on the error path.
+(
+  stub_dir="$(mktemp -d)"
+  trap 'rm -rf "$stub_dir"' EXIT
+
+  cat >"$stub_dir/gh" <<'STUB'
+#!/usr/bin/env bash
+# Simulate: gh repo view returns empty defaultBranchRef; auth check fails so
+# the authenticated block is skipped; "gh repo view" for nameWithOwner is also
+# not exercised on this path.
+if [[ "$*" == *"defaultBranchRef"* ]]; then
+  printf ''
+  exit 0
+fi
+# auth status — report unauthenticated so the gh_authenticated block is skipped
+exit 1
+STUB
+  chmod +x "$stub_dir/gh"
+
+  cat >"$stub_dir/git" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" == "fetch" ]]; then exit 0; fi
+if [[ "$1" == "rev-parse" ]]; then
+  # Fail for "refs/remotes/origin/nonexistent-base" (the custom --base value),
+  # succeed for "refs/remotes/origin/main" (the guard fallback).
+  if [[ "$*" == *"nonexistent-base"* ]]; then exit 1; fi
+  if [[ "$*" == *"refs/remotes/origin/main"* ]]; then exit 1; fi
+  exit 1
+fi
+if [[ "$1" == "config" ]]; then exit 0; fi
+exec /usr/bin/git "$@"
+STUB
+  chmod +x "$stub_dir/git"
+
+  # jq must be real; only gh and git are stubbed
+  PATH="$stub_dir:$PATH" \
+    tmp_out="$(mktemp)" tmp_err="$(mktemp)" rc=0
+  set +e
+  PATH="$stub_dir:$PATH" "$SCRIPT_DIR/preflight.sh" --base nonexistent-base \
+    >"$tmp_out" 2>"$tmp_err"
+  rc=$?
+  set -e
+  stderr_out="$(cat "$tmp_err")"
+  stdout_out="$(cat "$tmp_out")"
+  rm -f "$tmp_out" "$tmp_err"
+
+  if [[ $rc -eq 0 ]]; then
+    red   "  FAIL [preflight.sh empty-gh-result]: expected non-zero exit, got 0"
+    FAIL=$((FAIL + 1))
+  elif [[ -n "$stdout_out" ]]; then
+    red   "  FAIL [preflight.sh empty-gh-result]: expected empty stdout, got: $stdout_out"
+    FAIL=$((FAIL + 1))
+  elif [[ "$stderr_out" == *"''"* ]] || [[ "$stderr_out" != *"main"* ]]; then
+    red   "  FAIL [preflight.sh empty-gh-result]: error message should reference 'main', got: $stderr_out"
+    FAIL=$((FAIL + 1))
+  else
+    green "  PASS [preflight.sh empty-gh-result]: exit=$rc, stderr references 'main'"
+    PASS=$((PASS + 1))
+  fi
+)
+
 echo
 echo "swarm: ${PASS} passed, ${FAIL} failed"
 [[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Replace the hardcoded `main` fallback in swarmkit preflight with `gh repo view`-based default-branch detection. Repos where `develop` (or any other branch) is the default and `main` does not exist can now seed a missing base branch without the script aborting. Falls back to `main` only when `gh` itself is unavailable or the API call fails, preserving current behavior in unconfigured environments.

## Changes

- `plugins/swarmkit/skills/swarm/scripts/preflight.sh`: detect default branch via `gh repo view --json defaultBranchRef` before the seed-fallback existence check; cache result in `DEFAULT_BRANCH`; replace both `main` references (existence check and push refspec) with `$DEFAULT_BRANCH`; update both error messages to surface the detected branch name.

## Test plan

- [ ] Run `scripts/test-all-skill-scripts.sh` — all 21 smoke tests pass (confirmed during implementation).
- [ ] Manual: in a repo with `develop` as default and no `main`, swarmkit preflight no longer aborts when seeding a missing base branch.
- [ ] Manual: in a repo with `main` as default, behavior is unchanged.
- [ ] Manual: with `gh` unavailable (PATH stripped), `$DEFAULT_BRANCH` falls back to `main` and the legacy-style error is emitted.

Closes #722
Refs #723