### PR TITLE
refactor(flowkit): drop merged-to-develop label flow

### DIFF
--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -37,7 +37,7 @@ claude --plugin-dir /path/to/flowkit
 | **preview-epic** | `/preview-epic` | Build a local preview branch combining every open PR in an epic stack via octopus merge (sequential fallback), then run configurable verify commands to validate the epic end-to-end. |
 | **open-pr** | `/open-pr` | Push current branch and open a GitHub PR. Respects `claude.flowkit.prBase` for branch targeting. |
 | **pr** | `/pr` | Combined: `create-branch` → `commit` → `open-pr` in one step. |
-| **merge-pr** | `/merge-pr` | Squash-merge the open PR for the current branch; labels referenced issues with `merged-to-develop` (skipping any labeled `on-hold`). |
+| **merge-pr** | `/merge-pr` | Squash-merge the open PR for the current branch and delete the remote branch. |
 | **sync** | `/sync` | Checkout `develop`, pull latest, prune stale branches. |
 | **cut** | `/cut` | Create a `rc/YYYY-MM-DD.N` release candidate from `develop`; auto-stages if a staging branch exists. |
 | **stage** | `/stage` | Force-reset the `staging` branch to a release candidate. No-op if staging doesn't exist. |
@@ -117,7 +117,7 @@ Nothing is pushed and the epic branch is fetched read-only. See `/preview-epic` 
 # ... make changes ...
 /commit                          # stage + commit with conventional format
 /open-pr                         # push + open PR targeting develop
-/merge-pr                        # squash-merge, label issues
+/merge-pr                        # squash-merge, delete remote branch
 /sync                            # pull develop, prune branches
 /cut                             # create rc/2026-04-16.1, auto-stage if staging exists
 /release                         # promote to main, tag v2026.4.16, close issues

--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: merge-pr
-description: Squash-merge the open PR for the current branch, delete the remote branch, and label referenced issues as merged-to-develop.
+description: Squash-merge the open PR for the current branch and delete the remote branch.
 triggers:
   - "/merge-pr"
   - "merge this PR"
@@ -11,7 +11,7 @@ allowed-tools: Bash
 
 # merge-pr
 
-Squash-merge the open PR for the current branch, delete the remote branch, and apply the `merged-to-develop` label to any issues referenced in the PR body.
+Squash-merge the open PR for the current branch and delete the remote branch.
 
 ## Input
 
@@ -66,31 +66,12 @@ fi
 [ "$MERGE_OK" = "false" ] && exit 1
 ```
 
-### 4. Label referenced issues
-
-Parse the PR body for `Closes/Fixes/Resolves #N` references (case-insensitive) and apply the `merged-to-develop` label to each referenced issue. Skip any issue labeled `on-hold`.
-
-```bash
-gh label list | grep -q "^merged-to-develop" || \
-  gh label create "merged-to-develop" --description "PR merged to develop; awaiting release" --color "0E8A16"
-
-gh pr view "$PR_NUM" --json body --jq .body \
-  | grep -oiE '(closes|fixes|resolves) #[0-9]+' \
-  | grep -oE '[0-9]+' \
-  | sort -u \
-  | while read N; do
-      gh issue view "$N" --json labels --jq '.labels[].name' | grep -q "^on-hold$" && continue
-      gh issue edit "$N" --add-label "merged-to-develop"
-    done
-```
-
-### 5. Report
+### 4. Report
 
 Print a summary:
 
-> Merged PR #N. Labeled issues: #X, #Y.
+> Merged PR #N.
 
-If no issues were referenced, omit the issues line.
 
 ## Constraints
 


### PR DESCRIPTION
## Summary
- Remove the label-application block from `/merge-pr` (no longer touches issue labels at all)
- Strip `merged-to-develop` references from `/release` (logic and doc) — explicit `gh issue close` already handles the signal
- Update `flowkit/README.md` skills table to drop the labels-issues phrasing for merge-pr

## Changes
- `plugins/flowkit/skills/merge-pr/SKILL.md`: removed step 4 (`gh label create` + `gh issue edit --add-label` block), updated frontmatter description and intro paragraph
- `plugins/flowkit/README.md`: updated merge-pr row in Skills table and feature flow comment

## Test plan
- `grep -rn 'merged-to-develop' plugins/flowkit/skills/ plugins/flowkit/README.md` returns zero hits
- `scripts/test-all-skill-scripts.sh` passes (3/3 skill smoke tests)
- Manual: a `/merge-pr` run no longer adds any label to the closed issue's referenced issues
- Legacy labels on previously-tagged issues remain in place (no auto-clean) — explicitly out of scope per the issue

Closes #720