### PR TITLE
epic: skill follow-up bugs (release regex, clean-worktrees, swarm-plus standby)

### DIFF
--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -170,7 +170,7 @@ GROUPED_CHANGES_FILE=$(mktemp)
 printf '%s\n' "$PLUGINS" | while read PLUGIN; do
   [ -z "$PLUGIN" ] && continue
   PLUGIN_COMMITS=$(printf '%s\n' "$ALL_COMMITS" \
-    | grep -iE "\($PLUGIN\)" \
+    | grep -iE '\('"$PLUGIN"'[:)]' \
     | sed 's/^[a-f0-9]* /- /' \
     || true)
   if [ -n "$PLUGIN_COMMITS" ]; then
@@ -185,7 +185,7 @@ done
 # information value and the commits speak for themselves.
 SCOPED_PATTERN=$(printf '%s\n' "$PLUGINS" | tr '\n' '|' | sed 's/|$//')
 MEANINGFUL_UNSCOPED=$(printf '%s\n' "$ALL_COMMITS" \
-  | grep -ivE "\($SCOPED_PATTERN\)" \
+  | grep -ivE '\('"$SCOPED_PATTERN"'[:)]' \
   | grep -iE "^[a-f0-9]+ (feat|fix|refactor|perf)" \
   | sed 's/^[a-f0-9]* /- /' \
   || true)
@@ -216,7 +216,7 @@ if [ -n "$LAST_TAG" ] && [ -n "$TAG_DATE" ]; then
   printf '%s\n' "$PLUGINS" | while read PLUGIN; do
     [ -z "$PLUGIN" ] && continue
     PLUGIN_NOTES=$(printf '%s\n' "$MERGED_PR_DATA" \
-      | grep -iE "\($PLUGIN\)" \
+      | grep -iE '\('"$PLUGIN"'[:)]' \
       | while IFS=$(printf '\t') read TITLE SUMMARY; do
           if [ -n "$SUMMARY" ] && [ "$SUMMARY" != "$TITLE" ]; then
             printf '- %s — %s\n' "$TITLE" "$SUMMARY"

--- a/plugins/swarmkit/skills/clean-worktrees/scripts/gather.sh
+++ b/plugins/swarmkit/skills/clean-worktrees/scripts/gather.sh
@@ -25,35 +25,47 @@ if [[ -z "$main_worktree" ]]; then
   exit 1
 fi
 
+# Parse porcelain output into tab-separated "path<TAB>branch" pairs, one per
+# worktree stanza that has a checked-out (non-detached) branch.
+# Lines with no branch line (detached HEAD) are omitted.
+all_wt_pairs="$(git worktree list --porcelain | awk '
+  /^worktree / { path = $2; branch = "" }
+  /^branch refs\/heads\// { branch = substr($0, 19) }
+  /^$/ { if (path != "" && branch != "") print path "\t" branch; path = ""; branch = "" }
+  END  { if (path != "" && branch != "") print path "\t" branch }
+')"
+
+# Worktrees to remove: non-main paths whose basename matches agent-* or worktree-agent-*.
 worktrees_to_remove=()
-while IFS= read -r line; do
-  path="${line#worktree }"
-  if [[ "$path" != "$main_worktree" ]]; then
+while IFS=$'\t' read -r path branch; do
+  [[ "$path" == "$main_worktree" ]] && continue
+  if [[ "$path" =~ worktrees/(agent-|worktree-agent-) ]]; then
     worktrees_to_remove+=("$path")
   fi
-done < <(git worktree list --porcelain | grep '^worktree ')
+done <<< "$all_wt_pairs"
 
-active_worktree_branches=()
-while IFS= read -r line; do
-  branch="${line#branch refs/heads/}"
-  if [[ "$line" == branch\ * ]]; then
-    active_worktree_branches+=("$branch")
-  fi
-done < <(git worktree list --porcelain)
+# Produce a newline-delimited list of branches checked out by worktrees NOT in
+# the removal set (excluding main worktree).
+other_active_branches_list=""
+while IFS=$'\t' read -r path branch; do
+  [[ "$path" == "$main_worktree" ]] && continue
+  # Skip if this path is in the removal set.
+  in_removal=false
+  for rpath in "${worktrees_to_remove[@]+"${worktrees_to_remove[@]}"}"; do
+    if [[ "$rpath" == "$path" ]]; then
+      in_removal=true
+      break
+    fi
+  done
+  [[ "$in_removal" == true ]] && continue
+  other_active_branches_list+="$branch"$'\n'
+done <<< "$all_wt_pairs"
 
 branches_to_delete=()
 stuck=()
 while IFS= read -r branch; do
   if [[ "$branch" == worktree-agent-* ]]; then
-    is_active=false
-    for active in "${active_worktree_branches[@]+"${active_worktree_branches[@]}"}"; do
-      if [[ "$active" == "$branch" ]]; then
-        is_active=true
-        break
-      fi
-    done
-
-    if [[ "$is_active" == true ]]; then
+    if printf '%s' "$other_active_branches_list" | grep -qxF "$branch"; then
       stuck+=("$branch")
     else
       branches_to_delete+=("$branch")

--- a/plugins/swarmkit/skills/clean-worktrees/scripts/test.sh
+++ b/plugins/swarmkit/skills/clean-worktrees/scripts/test.sh
@@ -117,6 +117,111 @@ assert_json_keys remove.sh "empty-arrays-noop" \
   "removed remove_errors pruned_branches branch_errors caller_branch_restored" \
   --main-worktree "$MAIN_WT" --caller-branch "" --worktrees '[]' --branches '[]'
 
+# gather.sh — path/branch decoupling test.
+# Simulate swarm worktrees where path name (agent-<hex>) differs from branch name
+# (worktree-agent-<n>). Build a scratch git repo with two registered worktrees
+# whose paths and branches are intentionally mismatched, verify gather.sh:
+#   - emits those worktrees in worktrees_to_remove
+#   - emits the checked-out branches in branches_to_delete (not stuck)
+#   - stuck is empty (the only checked-out branches are in the removal set)
+echo "  [gather.sh path-branch-mismatch] setting up scratch repo..."
+SCRATCH_DIR="$(mktemp -d)"
+cleanup_scratch() { rm -rf "$SCRATCH_DIR"; }
+trap cleanup_scratch EXIT
+
+# Main repo.
+MAIN_REPO="$SCRATCH_DIR/main"
+git init -q "$MAIN_REPO"
+git -C "$MAIN_REPO" commit -q --allow-empty -m "init"
+
+# Create the worktree-agent-* branches in the main repo.
+git -C "$MAIN_REPO" branch worktree-agent-694
+git -C "$MAIN_REPO" branch worktree-agent-695
+
+# Create two agent worktrees with hex-style paths but issue-numbered branches.
+WT1="$SCRATCH_DIR/main/.claude/worktrees/agent-a08bdd74112e06062"
+WT2="$SCRATCH_DIR/main/.claude/worktrees/agent-b19cee85223f17173"
+mkdir -p "$(dirname "$WT1")"
+git -C "$MAIN_REPO" worktree add -q "$WT1" worktree-agent-694
+git -C "$MAIN_REPO" worktree add -q "$WT2" worktree-agent-695
+
+# Run gather.sh from within the main repo so git commands resolve correctly.
+GATHER_OUT="$(cd "$MAIN_REPO" && bash "$SCRIPT_DIR/gather.sh" 2>/tmp/gather_stderr)"
+GATHER_RC=$?
+
+if [[ $GATHER_RC -ne 0 ]]; then
+  red   "  FAIL [gather.sh path-branch-mismatch]: gather.sh exited $GATHER_RC"
+  cat /tmp/gather_stderr | sed 's/^/         stderr: /' || true
+  FAIL=$((FAIL + 1))
+else
+  # Verify worktrees_to_remove has 2 entries.
+  WT_COUNT="$(printf '%s' "$GATHER_OUT" | jq '.worktrees_to_remove | length')"
+  # Verify branches_to_delete contains both worktree-agent-694 and worktree-agent-695.
+  B694="$(printf '%s' "$GATHER_OUT" | jq -r '.branches_to_delete[] | select(. == "worktree-agent-694")')"
+  B695="$(printf '%s' "$GATHER_OUT" | jq -r '.branches_to_delete[] | select(. == "worktree-agent-695")')"
+  # Verify stuck is empty.
+  STUCK_COUNT="$(printf '%s' "$GATHER_OUT" | jq '.stuck | length')"
+
+  if [[ "$WT_COUNT" -eq 2 && -n "$B694" && -n "$B695" && "$STUCK_COUNT" -eq 0 ]]; then
+    green "  PASS [gather.sh path-branch-mismatch]: 2 worktrees to remove, branches in delete list, stuck empty"
+    PASS=$((PASS + 1))
+  else
+    red   "  FAIL [gather.sh path-branch-mismatch]: unexpected output"
+    printf '%s\n' "$GATHER_OUT" | jq . | sed 's/^/         /'
+    FAIL=$((FAIL + 1))
+  fi
+fi
+
+# gather.sh — stuck-from-outside test.
+# A worktree at a path that does NOT match worktrees/(agent-|worktree-agent-)
+# checks out a worktree-agent-* branch. That branch must land in stuck[], not
+# branches_to_delete. An agent-path worktree on a different worktree-agent-*
+# branch must land in branches_to_delete and worktrees_to_remove.
+echo "  [gather.sh stuck-from-outside] setting up scratch repo..."
+SCRATCH2_DIR="$(mktemp -d)"
+cleanup_scratch2() { rm -rf "$SCRATCH2_DIR"; }
+trap cleanup_scratch2 EXIT
+
+MAIN2_REPO="$SCRATCH2_DIR/main"
+git init -q "$MAIN2_REPO"
+git -C "$MAIN2_REPO" commit -q --allow-empty -m "init"
+
+git -C "$MAIN2_REPO" branch worktree-agent-700
+git -C "$MAIN2_REPO" branch worktree-agent-701
+
+# Agent-path worktree (will land in worktrees_to_remove + branches_to_delete).
+AGENT_WT="$SCRATCH2_DIR/main/.claude/worktrees/agent-c30dff96334b28284"
+mkdir -p "$(dirname "$AGENT_WT")"
+git -C "$MAIN2_REPO" worktree add -q "$AGENT_WT" worktree-agent-700
+
+# External-path worktree (NOT an agent path — checks out worktree-agent-701).
+EXTERNAL_WT="$SCRATCH2_DIR/main/external-wt"
+git -C "$MAIN2_REPO" worktree add -q "$EXTERNAL_WT" worktree-agent-701
+
+GATHER2_OUT="$(cd "$MAIN2_REPO" && bash "$SCRIPT_DIR/gather.sh" 2>/tmp/gather2_stderr)"
+GATHER2_RC=$?
+
+if [[ $GATHER2_RC -ne 0 ]]; then
+  red   "  FAIL [gather.sh stuck-from-outside]: gather.sh exited $GATHER2_RC"
+  sed 's/^/         stderr: /' /tmp/gather2_stderr || true
+  FAIL=$((FAIL + 1))
+else
+  WT2_COUNT="$(printf '%s' "$GATHER2_OUT" | jq '.worktrees_to_remove | length')"
+  B700="$(printf '%s' "$GATHER2_OUT" | jq -r '.branches_to_delete[] | select(. == "worktree-agent-700")')"
+  B701_IN_DELETE="$(printf '%s' "$GATHER2_OUT" | jq -r '.branches_to_delete[] | select(. == "worktree-agent-701")')"
+  B701_IN_STUCK="$(printf '%s' "$GATHER2_OUT" | jq -r '.stuck[].branch | select(. == "worktree-agent-701")')"
+  STUCK2_COUNT="$(printf '%s' "$GATHER2_OUT" | jq '.stuck | length')"
+
+  if [[ "$WT2_COUNT" -eq 1 && -n "$B700" && -z "$B701_IN_DELETE" && -n "$B701_IN_STUCK" && "$STUCK2_COUNT" -eq 1 ]]; then
+    green "  PASS [gather.sh stuck-from-outside]: agent worktree in remove set, external worktree-agent branch in stuck"
+    PASS=$((PASS + 1))
+  else
+    red   "  FAIL [gather.sh stuck-from-outside]: unexpected output"
+    printf '%s\n' "$GATHER2_OUT" | jq . | sed 's/^/         /'
+    FAIL=$((FAIL + 1))
+  fi
+fi
+
 echo
 echo "clean-worktrees: ${PASS} passed, ${FAIL} failed"
 [[ $FAIL -eq 0 ]] || exit 1

--- a/plugins/swarmkit/skills/swarm-plus/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-plus/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: swarm-plus
-description: Wrap /swarmkit:swarm with an automatic review/fix pass. After each swarm PR opens, dispatch a swarmkit-vendored reviewer; if the reviewer flags blockers or concerns, dispatch a worker to address them and update the PR. Single pass — stop after one reviewer + at-most-one worker per PR.
+description: Wrap /swarmkit:swarm with an automatic review/fix pass. After each swarm PR opens, dispatch a swarmkit-vendored reviewer; if the reviewer flags blockers or concerns, re-engage the original builder via SendMessage to address them and update the PR. Single pass — stop after one reviewer + at-most-one fix round per PR.
 triggers:
   - "swarm plus"
   - "swarm+"
@@ -12,7 +12,21 @@ triggers:
 
 # Swarm Plus
 
-Layer an automatic review/fix pass over `/swarmkit:swarm`. Same arg grammar; same isolation; same final state (open PRs awaiting human merge). The only addition: each PR gets one reviewer, and if the reviewer surfaces blockers or concerns, one worker pushes follow-up commits to the same branch.
+Layer an automatic review/fix pass over `/swarmkit:swarm`. Same arg grammar; same isolation; same final state (open PRs awaiting human merge). The only addition: each PR gets one reviewer, and if the reviewer surfaces blockers or concerns, the original builder is re-engaged via SendMessage to push follow-up commits to the same branch.
+
+### Keep-alive architecture
+
+Builders do not terminate after reporting their PR URL — they enter standby awaiting an orchestrator message. The orchestrator routes the reviewer's verdict back to the original builder via SendMessage:
+
+- **Reviewer clean** → `"Approved. Terminate."` — builder exits cleanly.
+- **Reviewer flagged blockers / concerns / `[recommended]` coverage gaps** → reviewer findings forwarded verbatim with explicit scope. Builder applies, pushes, comments on the PR, terminates.
+- **`--review-only` set** → `"Review-only run. Terminate."` — builder exits without acting on findings.
+
+**Why keep-alive**: the builder already has every relevant file loaded, the design rationale in working memory, and the issue acceptance criteria internalized. Re-engaging it via SendMessage saves an entire spawn-and-orient cycle per PR with non-clean review.
+
+**Cost tradeoff**: peak agent concurrency roughly doubles during the review window — on a 5-PR run, up to 10 alive concurrently (5 builders in standby + 5 reviewers) instead of the baseline of 5 sequential builders followed by 5 sequential reviewers. Acceptable for the latency win.
+
+**Fallback to spawn-fresh-worker**: if the original builder is no longer alive (crashed at PR creation, or `verify_agent.sh` recovered the PR after the builder failed to push), the orchestrator falls back to the legacy spawn-fresh-worker path. `--worker-model` continues to apply on this fallback path only.
 
 ## Input
 
@@ -23,8 +37,8 @@ Identical to `/swarmkit:swarm`:
 - Issue numbers (`12 15 18`, `#12 #15 #18`, range `12-18`) → one-shot mode → `develop`
 - `--model <tier>` (`sonnet`, `opus`) — model override for swarm agents (reviewer + worker have their own defaults; see below)
 - `--base <branch>` — override default base branch
-- `--review-only` — review only; never dispatch worker (useful for triage)
-- `--worker-model <tier>` — override worker model (default: `sonnet`)
+- `--review-only` — review only; never act on findings (useful for triage). Each builder still receives a `"Review-only run. Terminate."` SendMessage so it exits cleanly from standby.
+- `--worker-model <tier>` — override model **for the fallback spawn-fresh-worker path only** (default: `sonnet`). On the default keep-alive path the builder is re-engaged with whatever model `--model` selected; this knob has no effect there. Kept as a knob for the fallback case.
 - `--reviewer-model <tier>` — override reviewer model (default: `sonnet`)
 
 ## Process
@@ -39,17 +53,38 @@ Resolve the project's verify command once and reuse it for every worker prompt. 
 2. **`package.json` `scripts.verify`** — common project-local convention. If present, the verify command is determined by the package manager: `yarn.lock` present → `yarn run verify`; `pnpm-lock.yaml` present → `pnpm run verify`; otherwise → `npm run verify`.
 3. **Fallback** — `npx tsc -b --noEmit` for TS projects. "TS toolchain present" means `tsconfig.json` exists at the repo root. If neither of the above resolves AND `tsconfig.json` is absent, print a warning and instruct the worker to skip the verify step rather than running a command that will obviously fail. **Note:** projects that use `tsc` via a non-standard mechanism (e.g. a wrapper script, a monorepo tool, or a config file named differently) won't be detected by this check — those repos should set `verifyCommand` in `.squadkit/config.json` to opt in explicitly.
 
-Record the resolved command as `<verify_command>` and interpolate it into the worker prompt template in step 4.
+Record the resolved command as `<verify_command>` and interpolate it into the prompts in step 1 (builder standby instruction) and step 4 (fallback worker prompt).
 
 ### 1. Run the swarm phase
 
-Invoke `/swarmkit:swarm` with the same args (excluding `--review-only`, `--worker-model`, and `--reviewer-model` — those are swarm-plus-only flags). Track the agent IDs and the issues each agent owns. Record `(issue, pr_number, head_branch, base_branch)` for each PR as it is produced.
+**Builder prompt construction (swarm-plus constructs prompts directly).** swarm-plus does NOT invoke `/swarmkit:swarm` as a sub-skill. Instead, it follows the spawn pattern documented in `/swarmkit:swarm/SKILL.md` — reading its agent prompt structure, dependency graph logic, and verification steps — but constructs each builder Agent call itself with two modifications:
+
+1. Each builder is spawned with a deterministic, addressable `name:` parameter: `swarm-builder-<issue>`. This is required so the orchestrator can route reviewer findings back via SendMessage.
+2. A STANDBY clause is appended to every builder prompt (see below).
+
+This approach keeps `/swarmkit:swarm` completely unmodified while giving swarm-plus full control over name assignment and prompt injection.
+
+Record `(issue, pr_number, head_branch, base_branch, builder_agent_name)` for each PR as it is produced.
+
+**Standby instruction injection.** swarm-plus appends the following STANDBY clause to the end of every builder prompt it constructs. Plain `/swarmkit:swarm` invocations continue to terminate at step 6 of the swarm prompt — this clause only appears in swarm-plus-constructed prompts.
+
+> **STANDBY (swarm-plus only).** After reporting the PR URL, do NOT terminate. Reply `STANDBY_READY` and then enter standby, awaiting an orchestrator SendMessage. You will receive one of three messages:
+>
+> 1. `"Approved. Terminate."` — exit cleanly.
+> 2. `"Review-only run. Terminate."` — exit cleanly without acting on anything.
+> 3. A `REVIEWER FINDINGS` payload with explicit scope — apply the in-scope items (blockers, concerns, `[recommended]` coverage gaps), skip the out-of-scope items (nits, `[optional]`), run `<verify_command>` and the relevant test scope, commit (conventional-commit format, no Claude mentions, no co-author lines), `git push origin <head_branch>`, and optionally `gh pr comment <pr_number>` summarizing what was addressed and what was deferred. Then terminate.
+>
+> All swarm constraints still apply: never branch off `develop` for the fix round (you are already on the PR's head branch in your worktree), never force-push, never close the issue manually.
 
 Do NOT block on every swarm agent before spawning reviewers. As each swarm agent's task notification arrives:
 
 1. Verify the PR exists: `gh pr view <pr_number> --json url,headRefName,baseRefName,state`
 2. Fetch the original issue body: `gh issue view <issue> --json body --jq '.body'`
-3. Spawn a reviewer for that PR (see step 2). Continue handling other notifications in parallel.
+3. **Determine builder liveness.** The builder emits `STANDBY_READY` in its task notification body immediately before entering standby. If the notification body contains `STANDBY_READY`, set `builder_alive: true`. If it does not (e.g. the builder completed without emitting the sentinel — crashed at PR creation, was recovered by `verify_agent.sh`, or the standby clause was missed/ignored), set `builder_alive: false`.
+
+   Additionally, if `verify_agent.sh` returns `pushed_now: true` OR if `pr_exists: false` (meaning the orchestrator had to create the PR on the builder's behalf), set `builder_alive: false` — in both cases the builder exited before completing its standby setup.
+
+4. Spawn a reviewer for that PR (see step 2). Continue handling other notifications in parallel.
 
 ### 2. Spawn reviewer per PR
 
@@ -69,30 +104,54 @@ The reviewer prompt MUST include:
 
 Track each reviewer's agent ID against the PR it covers.
 
-### 3. Decide whether to spawn a worker
+### 3. Decide what to send the builder
 
-When a reviewer's task notification arrives, parse its result. Apply the **skip-on-clean** rule:
+When a reviewer's task notification arrives, parse its result. Apply the **skip-on-clean** rule.
 
-| Reviewer output | Worker action |
-|-----------------|---------------|
-| Verdict `Approve` AND no blockers AND no concerns AND no `[recommended]` coverage gaps | **Skip worker.** Nits and `[optional]` coverage gaps are not actionable enough to warrant a worker round. |
-| Any blockers | **Spawn worker.** Blockers are mandatory. |
-| Any concerns | **Spawn worker.** Concerns get addressed or explicitly deferred. |
-| Coverage gaps flagged `[recommended]` | **Spawn worker.** Treat recommended coverage gaps as concerns. |
-| `--review-only` flag set | Skip regardless. |
+**If `builder_alive: false`**: skip Step 3 routing entirely and proceed directly to the Step 4 fallback path. The decision table below applies only when `builder_alive: true`.
+
+**If `builder_alive: true`**: the builder is in standby and must always receive a SendMessage so it can exit cleanly. Never abandon a standby builder.
+
+| Reviewer output | Builder message |
+|-----------------|-----------------|
+| Verdict `Approve` AND no blockers AND no concerns AND no `[recommended]` coverage gaps | SendMessage `"Approved. Terminate."` — builder exits. Nits and `[optional]` coverage gaps are not actionable enough to warrant a fix round. |
+| Any blockers | SendMessage with reviewer findings + scope. Blockers are mandatory. |
+| Any concerns | SendMessage with reviewer findings + scope. Concerns get addressed or explicitly deferred. |
+| Coverage gaps flagged `[recommended]` | SendMessage with reviewer findings + scope. Treat recommended coverage gaps as concerns. |
+| `--review-only` flag set | SendMessage `"Review-only run. Terminate."` regardless of reviewer verdict — builder exits without acting on findings. |
 
 Print one line announcing the decision per PR:
 
 ```
-PR #1390: reviewer clean (no blockers/concerns) → skipping worker
-PR #1391: reviewer flagged 1 blocker, 2 concerns → dispatching worker
+PR #1390: reviewer clean (no blockers/concerns) → SendMessage "Approved. Terminate."
+PR #1391: reviewer flagged 1 blocker, 2 concerns → SendMessage findings to swarm-builder-<issue>
+PR #1392: builder no longer alive → falling back to spawn-fresh-worker
 ```
 
-### 4. Spawn worker
+### 4. Re-engage builder (or fallback to spawn worker)
 
-For each PR that needs follow-up work, spawn a `general-purpose` agent with `isolation: worktree`, `mode: bypassPermissions`, `run_in_background: true`. Default model `sonnet`; override via `--worker-model`.
+**Default path: SendMessage to the standby builder.** When `builder_alive: true` for the PR, route the message determined in step 3 directly to the builder by name. The builder's standby instructions (injected in step 1) tell it how to interpret each message.
 
-The worker prompt MUST:
+For the findings-payload case, the SendMessage body MUST include:
+
+- The **PR number** and **head branch** (e.g. `worktree-agent-42`) — the builder is already on this branch in its worktree, but include explicitly so the message is self-contained.
+- The **full reviewer output** verbatim under a `REVIEWER FINDINGS` section.
+- Explicit scope:
+  - **In scope**: blockers (mandatory), concerns (address or explicitly defer with stated reason in a PR comment), reviewer-recommended coverage gaps.
+  - **Out of scope**: nits (skip unless trivially co-located with a fix), `[optional]` coverage gaps, unrelated cleanups, scope creep.
+
+The builder's standby instructions already cover the action steps (verify, commit, push, optional PR comment, terminate) — no need to re-state them in the SendMessage.
+
+**Fallback path: spawn a fresh worker.** Trigger the legacy spawn-fresh-worker path **only** when:
+
+- `builder_alive: false` for this PR (builder crashed at PR creation, or `verify_agent.sh` recovered the PR after the builder failed to push, or the builder somehow exited without emitting `STANDBY_READY`).
+- AND `--review-only` is **not** set (review-only never spawns workers, regardless of liveness).
+
+If `--review-only` is set and `builder_alive: false`, do nothing — the reviewer output stays inline in the final report and no fix round happens.
+
+For the fallback, spawn a `general-purpose` agent with `isolation: worktree`, `mode: bypassPermissions`, `run_in_background: true`. Default model `sonnet`; override via `--worker-model` (this is the only path where `--worker-model` takes effect).
+
+The fallback worker prompt MUST:
 
 - Include the **PR number** and **head branch** (e.g. `worktree-agent-42`).
 - Include the **full reviewer output** verbatim under a `REVIEWER FINDINGS` section.
@@ -116,22 +175,25 @@ The worker prompt MUST:
 - Forbid: branching off `develop`, force-pushing, rewriting prior commits, closing the issue manually.
 - Termination: report the new commit SHAs and confirm `gh pr view <pr_number> --json commits` includes them.
 
-### 5. Wait for all workers
+### 5. Wait for all builders / fallback workers
 
-Continue until every dispatched worker reports completion. Verify each PR's HEAD has advanced:
+Continue until every re-engaged builder and every fallback worker reports completion. For PRs whose builder received `"Approved. Terminate."` or `"Review-only run. Terminate."`, simply confirm the builder's task notification arrived. For PRs that received a findings payload (or that fell back to a fresh worker), verify the PR's HEAD has advanced:
 
 ```bash
 gh pr view <pr_number> --json commits | jq '.commits[-1].oid'
 ```
 
+Note: for review-only runs, no HEAD check is needed — no commits were pushed.
+
 ### 6. Final report
 
 ```
 ── swarm-review complete ─────────────────────
-PRs opened by swarm: #1390 #1391 #1392
-  #1390: reviewed → clean → no worker
-  #1391: reviewed → 2 concerns → worker pushed 2 commits
-  #1392: reviewed → 1 blocker → worker pushed 1 commit
+PRs opened by swarm: #1390 #1391 #1392 #1393
+  #1390: reviewed → clean → builder terminated cleanly
+  #1391: reviewed → 2 concerns → builder pushed 2 commits (re-engaged)
+  #1392: reviewed → 1 blocker → builder pushed 1 commit (re-engaged)
+  #1393: reviewed → 1 blocker → fallback worker pushed 1 commit (builder was no longer alive)
 All PRs ready for human merge.
 ─────────────────────────────────────────────
 ```
@@ -140,20 +202,26 @@ Suggest next step: `/merge-pr` for one PR or `/merge-stack` for two or more.
 
 ## Constraints
 
-- **Single pass** — no reviewer-after-worker re-review. The user can manually trigger another review with `/review <pr>` if desired.
-- **Skip-on-clean** — never dispatch a worker against a clean approval. Manufactured churn is worse than a no-op.
-- **Worker branches off PR head, never off `develop`** — commits must stack on the existing PR.
-- **Reviewer output stays inline, never posted as a PR comment** by the reviewer itself. The worker is the only sub-agent that may comment on the PR (and only with a brief "addressed feedback" summary).
+- **Single pass** — no reviewer-after-fix re-review. The user can manually trigger another review with `/review <pr>` if desired.
+- **Skip-on-clean preserves SendMessage** — even on a clean approval, the orchestrator must SendMessage `"Approved. Terminate."` to the standby builder. Never abandon a builder in standby.
+- **Builder never re-branches** — the re-engaged builder is already on the PR's head branch in its worktree; it must not branch off `develop` or anything else for the fix round. The fallback worker (if triggered) branches off the existing PR head, not `develop`.
+- **`/swarmkit:swarm` default behavior is untouched** — swarm-plus constructs its own Agent calls following swarm's spawn pattern, with `name:` and the STANDBY clause added. Plain `/swarmkit:swarm` invocations still terminate at step 6 of the swarm prompt.
+- **`--worker-model` only applies on the fallback path** — on the default keep-alive path the builder runs under whatever `--model` selected. The flag is kept for the fallback case; do not assume it influences re-engaged builders.
+- **Reviewer output stays inline, never posted as a PR comment** by the reviewer itself. The builder (or fallback worker) is the only sub-agent that may comment on the PR (and only with a brief "addressed feedback" summary).
 - **Never merge** any PR — final state is open PRs awaiting human merge.
 - **Never close issues** — `Closes #N` in PR bodies handles it on merge.
-- **Defer rather than guess** — if the reviewer's findings are ambiguous (e.g. "consider X"), the worker should explicitly defer in a PR comment rather than implement guesses.
+- **Defer rather than guess** — if the reviewer's findings are ambiguous (e.g. "consider X"), the builder should explicitly defer in a PR comment rather than implement guesses.
 - All swarm constraints from `/swarmkit:swarm` apply transitively: worktree isolation, conventional commits, no Claude/co-author mentions, no absolute repo paths in agent prompts, never commit directly to develop or main.
 
 ## Failure modes
 
 | Symptom | Handling |
 |---------|----------|
-| Swarm agent fails to produce a PR | Skip review/worker for that issue; report in final summary |
-| Reviewer crashes or returns no output | Note in final summary; leave PR open without worker pass |
-| Worker push rejected (branch advanced underneath) | Worker re-fetches and rebases (`git fetch origin <head>; git rebase origin/<head>`); if conflicts arise, abort and report to user |
-| Worker introduces new test failures | Worker MUST resolve before push — never push a red build |
+| Swarm agent fails to produce a PR | Skip review/fix round for that issue; report in final summary |
+| Reviewer crashes or returns no output | SendMessage `"Approved. Terminate."` to the standby builder so it exits cleanly; note the missing review in the final summary; leave PR open without a fix pass |
+| Builder unresponsive in standby (SendMessage delivered but no notification within 90 seconds) | Treat as `builder_alive: false` and trigger the fallback spawn-fresh-worker path. Surface a warning in the final summary so the user knows the standby builder may still be holding resources |
+| SendMessage call fails (builder agent ID no longer addressable) | Treat as `builder_alive: false` and trigger the fallback spawn-fresh-worker path |
+| Builder crashed before entering standby (no PR pushed; recovered by `verify_agent.sh`) | `builder_alive: false` from the start; if reviewer flags issues, fallback worker handles the fix round |
+| Builder pushed PR but exited before standby (`STANDBY_READY` not emitted) | `builder_alive: false`; fallback worker handles any fix round |
+| Re-engaged builder push rejected (branch advanced underneath) | Builder re-fetches and rebases (`git fetch origin <head>; git rebase origin/<head>`); if conflicts arise, abort and report to user |
+| Re-engaged builder (or fallback worker) introduces new test failures | Sub-agent MUST resolve before push — never push a red build |


### PR DESCRIPTION
## Summary

Three skill follow-ups from the v2026.5.2 cycle, integrated and tested together on `feature/skill-followups-727`.

## Changes

- **#732** `fix(flowkit:release): match sub-scoped commits in changelog regexes` — `\($PLUGIN[:)]` so `feat(plugin:subscope)` no longer drops out of `### Changes` and `### Release notes`. Mirror inverse on `MEANINGFUL_UNSCOPED`. zsh-safe single-quote concatenation.
- **#733** `fix(swarmkit:clean-worktrees): derive branch names from porcelain output` — read each worktree's checked-out branch from `git worktree list --porcelain` instead of stripping path basenames. Fixes the silent self-stuck false-positive that broke cleanup on every swarm run. Adds `path-branch-mismatch` and `stuck-from-outside` test cases.
- **#734** `feat(swarmkit:swarm-plus): keep builder alive across review pass` — restructure swarm-plus to keep builders in standby and re-engage them via `SendMessage` for reviewer follow-up, with fallback to spawn-fresh-worker when the builder is no longer alive. Includes a `STANDBY_READY` ack-based liveness signal, concrete 90s unresolved-builder timeout, and explicit `verify_agent.sh` → `builder_alive: false` mapping.

## Test plan
- `scripts/test-all-skill-scripts.sh` — 23 tests across 3 skill suites pass.
- This integration was dogfooded by the cycle that produced epic [#723](https://github.com/smallorbit/smallorbit-plugins/issues/723) (PRs [#735](https://github.com/smallorbit/smallorbit-plugins/pull/735), [#736](https://github.com/smallorbit/smallorbit-plugins/pull/736), [#737](https://github.com/smallorbit/smallorbit-plugins/pull/737)) — note that the swarm-plus keep-alive path has not yet been exercised in production (it'll go live the next time `/swarmkit:swarm-plus` runs against a stack that lands a non-clean review).

Closes #724
Closes #727
Closes #731