### PR TITLE
epic: align flowkit issue-close lifecycle and default-branch handling (#723)

### DIFF
--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -37,7 +37,7 @@ claude --plugin-dir /path/to/flowkit
 | **preview-epic** | `/preview-epic` | Build a local preview branch combining every open PR in an epic stack via octopus merge (sequential fallback), then run configurable verify commands to validate the epic end-to-end. |
 | **open-pr** | `/open-pr` | Push current branch and open a GitHub PR. Respects `claude.flowkit.prBase` for branch targeting. |
 | **pr** | `/pr` | Combined: `create-branch` → `commit` → `open-pr` in one step. |
-| **merge-pr** | `/merge-pr` | Squash-merge the open PR for the current branch; labels referenced issues with `merged-to-develop` (skipping any labeled `on-hold`). |
+| **merge-pr** | `/merge-pr` | Squash-merge the open PR for the current branch and delete the remote branch. |
 | **sync** | `/sync` | Checkout `develop`, pull latest, prune stale branches. |
 | **cut** | `/cut` | Create a `rc/YYYY-MM-DD.N` release candidate from `develop`; auto-stages if a staging branch exists. |
 | **stage** | `/stage` | Force-reset the `staging` branch to a release candidate. No-op if staging doesn't exist. |
@@ -117,7 +117,7 @@ Nothing is pushed and the epic branch is fetched read-only. See `/preview-epic` 
 # ... make changes ...
 /commit                          # stage + commit with conventional format
 /open-pr                         # push + open PR targeting develop
-/merge-pr                        # squash-merge, label issues
+/merge-pr                        # squash-merge, delete remote branch
 /sync                            # pull develop, prune branches
 /cut                             # create rc/2026-04-16.1, auto-stage if staging exists
 /release                         # promote to main, tag v2026.4.16, close issues

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -186,7 +186,7 @@ Flowkit is opinionated. Understanding these assumptions upfront will save you fr
 
 Feature work merges into `develop`. Release candidates are cut from `develop`. Staging (if present) is an intermediate promotion gate. `main` always reflects what's in production.
 
-### Default Branch
+### Default Branch (Current Assumption)
 
 Flowkit assumes `main` is the GitHub default branch for the repo. GitHub's `Closes #N` auto-close keywords only fire when a PR merges into the default branch — so the staging→`main` (or RC→`main`) merge that `/release` performs is what closes the issues referenced in PRs that landed on `develop` during the cycle. Likewise, `/hotfix` relies on the merge into `main` to close hotfix-referenced issues.
 
@@ -221,6 +221,24 @@ Common types: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`.
 ### Issue Lifecycle
 
 `/merge-pr` never closes issues — that's intentional. Issues are closed by `/release` (or `/hotfix`) when work actually ships to `main`. This keeps them visible on the board until the feature is in production.
+
+### Default Branch (Recommendation for New Users)
+
+While the `main`-as-default configuration described above is fully supported, for new flowkit adopters we recommend setting **`develop` as the GitHub default branch** instead. This aligns with the modern Gitflow-on-GitHub convention and ensures GitHub's `Closes #N` auto-close keywords fire on the per-feature PRs that actually carry the work — not just at release time.
+
+The first time you run `/open-pr` in a repo whose default branch is `main`, flowkit will surface a one-time prompt offering to switch the default to `develop` (via `gh repo edit --default-branch develop`). The prompt has three options:
+
+- **Switch to develop** — runs `gh repo edit --default-branch develop` after a second confirmation.
+- **Keep main as default** — keeps the current configuration; the prompt won't reappear. Flowkit's `/release` and `/hotfix` skills already run an explicit `gh issue close` loop, so the issue lifecycle still completes on either configuration.
+- **Don't ask again** — silences the prompt without recording a deliberate choice.
+
+The choice is persisted via `git config claude.flowkit.defaultBranchPrompted=true`, so subsequent `/open-pr` invocations stay silent. To re-surface the prompt (e.g., after revisiting the question), unset the marker:
+
+```bash
+git config --unset claude.flowkit.defaultBranchPrompted
+```
+
+The nudge is **never automatic** — every default-branch change requires explicit user confirmation, and existing `main`-as-default setups continue to work without modification.
 
 ## Pairing with Other Plugins
 

--- a/plugins/flowkit/skills/default-branch-prompt/SKILL.md
+++ b/plugins/flowkit/skills/default-branch-prompt/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: default-branch-prompt
+description: One-time first-run nudge for /open-pr — detects the GitHub default branch and, if it's `main`, prompts the user (via AskUserQuestion) to switch to `develop`. Persists the user's choice via `claude.flowkit.defaultBranchPrompted` so subsequent invocations stay silent. Sub-skill used by open-pr's preflight.
+---
+
+# default-branch-prompt
+
+A one-time, opt-in nudge surfaced from `/open-pr`'s preflight. Modern Gitflow-on-GitHub repos increasingly set `develop` as the GitHub default branch — that aligns the auto-close lifecycle (`Closes #N` fires on PRs into the default branch) with where features actually land. Repos that keep `main` as default still work fine; flowkit's `/release` and `/hotfix` skills run an explicit `gh issue close` loop after the merge, so the lifecycle completes either way.
+
+This skill exists as its own file (rather than inline in `open-pr/SKILL.md`) because the prompt logic is several distinct steps — detect, gate on a marker, ask, confirm, mutate, persist — and inlining it would crowd open-pr's already long preflight section. Open-pr calls it as the first preflight step; everything else can assume the prompt has either fired (and been answered) or been skipped silently.
+
+## When to invoke
+
+Open-pr's preflight calls this skill before checking the current branch. The skill is a no-op in every case except the narrow first-run-on-`main`-default scenario described below.
+
+## Process
+
+### 1. Skip if the marker is set
+
+```bash
+if [ "$(git config --get claude.flowkit.defaultBranchPrompted 2>/dev/null)" = "true" ]; then
+  exit 0
+fi
+```
+
+The marker is repo-local and persists across sessions. Once set (by any of the three answer paths below), this skill never prompts again in this repo.
+
+### 2. Detect the GitHub default branch
+
+```bash
+DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || true)
+```
+
+Treat any non-zero exit, missing `gh` binary, missing auth, or empty result as **skip silently** — do not pester the user when detection fails for environmental reasons. Open-pr's later steps already handle the "no `gh`" case loudly; that's where the user should learn about it, not here.
+
+```bash
+if [ -z "$DEFAULT_BRANCH" ]; then
+  exit 0
+fi
+```
+
+### 3. Only prompt when the default is exactly `main`
+
+```bash
+if [ "$DEFAULT_BRANCH" != "main" ]; then
+  exit 0
+fi
+```
+
+Any other default branch (including `develop`, `master`, or a custom name) means the user has already made a deliberate choice — leave them alone.
+
+### 4. Ask the user
+
+Invoke `AskUserQuestion` with the following shape:
+
+- **Question**: "Your repo's GitHub default branch is `main`. Flowkit recommends `develop` as the default for new flowkit users — modern Gitflow-on-GitHub convention, and it makes `Closes #N` auto-close fire on the PRs that actually carry the work. The switch is `gh repo edit --default-branch develop`. Existing `main`-as-default setups continue to work; this is a recommendation, not a requirement."
+- **Options** (exactly three):
+  1. `Switch to develop` — run `gh repo edit --default-branch develop` after a confirmation step
+  2. `Keep main as default` — semantically: "I considered the recommendation and chose `main`." Sets the marker. The repo is unchanged.
+  3. `Don't ask again` — semantically: "Stop bothering me — I haven't decided yet." Sets the marker. The repo is unchanged.
+
+Both `Keep main as default` and `Don't ask again` set the same marker and produce the same observable outcome (no repo change, no future prompts). They are presented as separate options because the distinction matters socially: a user who consciously chose `main` should not have to pretend they're dismissing the prompt out of annoyance, and a user who's not ready to decide should not have to commit to a position they haven't formed yet. Future readers of this skill should preserve both options for that reason.
+
+### 5. Handle the answer
+
+#### `Switch to develop`
+
+Surface a **second** `AskUserQuestion` confirming the destructive-ish change before running it. The confirmation question wording:
+
+> About to run `gh repo edit --default-branch develop`. This changes the GitHub repository's default branch — visible to all collaborators and tooling that reads the default. Confirm?
+
+Options:
+
+- `Yes, change the default branch to develop`
+- `Cancel`
+
+On `Yes`:
+
+```bash
+gh repo edit --default-branch develop
+```
+
+If the command succeeds, set the marker:
+
+```bash
+git config claude.flowkit.defaultBranchPrompted true
+```
+
+If the command fails (non-zero exit), report the error to the user and **do not** set the marker — that way the next `/open-pr` invocation will give them another chance to retry once they've fixed permissions or auth.
+
+On `Cancel`: do nothing. The marker stays unset, so the next `/open-pr` invocation will surface the original three-option prompt again. (Cancelling the confirmation is not the same as choosing `Don't ask again`.)
+
+#### `Keep main as default`
+
+```bash
+git config claude.flowkit.defaultBranchPrompted true
+```
+
+No repo mutation. Report a single line: "Keeping `main` as the default branch. Flowkit's release flow handles `Closes #N` issue-close at release time."
+
+#### `Don't ask again`
+
+```bash
+git config claude.flowkit.defaultBranchPrompted true
+```
+
+No repo mutation. Report a single line: "OK, won't ask again. Re-run by clearing the marker: `git config --unset claude.flowkit.defaultBranchPrompted`."
+
+## Constraints
+
+- **Never automatic.** Every action that mutates the repo or the marker requires an explicit user answer. This skill does not run `gh repo edit` without the second confirmation, and it does not set the marker without a user choice.
+- **Detection failure is silent.** Missing `gh`, no auth, network errors, or any non-zero exit from `gh repo view` skip the prompt without warning. Open-pr's main flow surfaces gh-related errors on its own.
+- **Marker is repo-local.** `git config` (without `--global`) writes to the repo's `.git/config`, which is the right scope: a user's preference for one repo should not leak to another.
+- **Only `main` triggers the prompt.** Any other default branch is treated as a deliberate choice and left alone.
+- **Never use the legacy `claude.prBase` key.** The marker key is `claude.flowkit.defaultBranchPrompted` and lives under the `claude.flowkit.*` namespace.
+
+## Resetting
+
+To re-surface the prompt (e.g., after migrating between repos or for testing):
+
+```bash
+git config --unset claude.flowkit.defaultBranchPrompted
+```
+
+The next `/open-pr` invocation will run through the detect-and-prompt flow from scratch.

--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: merge-pr
-description: Squash-merge the open PR for the current branch, delete the remote branch, and label referenced issues as merged-to-develop.
+description: Squash-merge the open PR for the current branch and delete the remote branch.
 triggers:
   - "/merge-pr"
   - "merge this PR"
@@ -11,7 +11,7 @@ allowed-tools: Bash
 
 # merge-pr
 
-Squash-merge the open PR for the current branch, delete the remote branch, and apply the `merged-to-develop` label to any issues referenced in the PR body.
+Squash-merge the open PR for the current branch and delete the remote branch.
 
 ## Input
 
@@ -66,31 +66,12 @@ fi
 [ "$MERGE_OK" = "false" ] && exit 1
 ```
 
-### 4. Label referenced issues
-
-Parse the PR body for `Closes/Fixes/Resolves #N` references (case-insensitive) and apply the `merged-to-develop` label to each referenced issue. Skip any issue labeled `on-hold`.
-
-```bash
-gh label list | grep -q "^merged-to-develop" || \
-  gh label create "merged-to-develop" --description "PR merged to develop; awaiting release" --color "0E8A16"
-
-gh pr view "$PR_NUM" --json body --jq .body \
-  | grep -oiE '(closes|fixes|resolves) #[0-9]+' \
-  | grep -oE '[0-9]+' \
-  | sort -u \
-  | while read N; do
-      gh issue view "$N" --json labels --jq '.labels[].name' | grep -q "^on-hold$" && continue
-      gh issue edit "$N" --add-label "merged-to-develop"
-    done
-```
-
-### 5. Report
+### 4. Report
 
 Print a summary:
 
-> Merged PR #N. Labeled issues: #X, #Y.
+> Merged PR #N.
 
-If no issues were referenced, omit the issues line.
 
 ## Constraints
 

--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -20,6 +20,16 @@ Push the current branch to origin and open a GitHub pull request against the bas
 
 ## Process
 
+### 0. First-run default-branch nudge
+
+Before any other preflight, invoke the [`default-branch-prompt`](../default-branch-prompt/SKILL.md) sub-skill. It is a no-op in every case except the narrow first-run-on-`main`-default scenario:
+
+- If `git config --get claude.flowkit.defaultBranchPrompted` is `true`, the sub-skill exits silently.
+- If `gh repo view --json defaultBranchRef -q '.defaultBranchRef.name'` fails, returns empty, or returns anything other than `main`, the sub-skill exits silently.
+- Only when the GitHub default branch is exactly `main` does the sub-skill surface an `AskUserQuestion` offering `Switch to develop` / `Keep main as default` / `Don't ask again`. Each definitive answer (`Switch` success, `Keep main as default`, `Don't ask again`) sets `claude.flowkit.defaultBranchPrompted=true`; `Cancel` at the second confirmation leaves the marker unset so the prompt resurfaces next time. `Switch` additionally runs `gh repo edit --default-branch develop` after a second confirmation.
+
+This nudge is fire-and-forget — open-pr does not branch on its outcome. After the sub-skill returns, continue with step 1 regardless of which path the user took (or whether the prompt fired at all).
+
 ### 1. Check current branch
 
 ```bash

--- a/plugins/swarmkit/skills/swarm/scripts/preflight.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/preflight.sh
@@ -48,12 +48,14 @@ base_existed=true
 base_created=false
 if ! git rev-parse --verify --quiet "refs/remotes/origin/$BASE" >/dev/null; then
   base_existed=false
-  if ! git rev-parse --verify --quiet refs/remotes/origin/main >/dev/null; then
-    echo "preflight: base '$BASE' is missing on origin and 'main' does not exist to seed it from" >&2
+  DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || echo "main")
+  DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
+  if ! git rev-parse --verify --quiet "refs/remotes/origin/$DEFAULT_BRANCH" >/dev/null; then
+    echo "preflight: base '$BASE' is missing on origin and '$DEFAULT_BRANCH' does not exist to seed it from" >&2
     exit 1
   fi
-  if ! git push origin "refs/remotes/origin/main:refs/heads/$BASE" >/dev/null 2>&1; then
-    echo "preflight: failed to create '$BASE' on origin from 'main'" >&2
+  if ! git push origin "refs/remotes/origin/$DEFAULT_BRANCH:refs/heads/$BASE" >/dev/null 2>&1; then
+    echo "preflight: failed to create '$BASE' on origin from '$DEFAULT_BRANCH'" >&2
     exit 1
   fi
   base_created=true

--- a/plugins/swarmkit/skills/swarm/scripts/test.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/test.sh
@@ -78,6 +78,73 @@ assert_invalid_args gather_issues.sh "no-args"
 assert_invalid_args gather_issues.sh "non-integer"  abc
 assert_invalid_args gather_issues.sh "mixed-bad"    1 abc
 
+echo "swarm: DEFAULT_BRANCH empty-string guard"
+echo
+
+# preflight.sh: gh returns empty defaultBranchRef → guard falls back to "main"
+# Stubs: gh returns empty string (exit 0); git fetch succeeds; rev-parse fails
+# for the custom base branch but succeeds for "main"; jq and git push are not
+# reached because the test asserts on the error path.
+(
+  stub_dir="$(mktemp -d)"
+  trap 'rm -rf "$stub_dir"' EXIT
+
+  cat >"$stub_dir/gh" <<'STUB'
+#!/usr/bin/env bash
+# Simulate: gh repo view returns empty defaultBranchRef; auth check fails so
+# the authenticated block is skipped; "gh repo view" for nameWithOwner is also
+# not exercised on this path.
+if [[ "$*" == *"defaultBranchRef"* ]]; then
+  printf ''
+  exit 0
+fi
+# auth status — report unauthenticated so the gh_authenticated block is skipped
+exit 1
+STUB
+  chmod +x "$stub_dir/gh"
+
+  cat >"$stub_dir/git" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" == "fetch" ]]; then exit 0; fi
+if [[ "$1" == "rev-parse" ]]; then
+  # Fail for "refs/remotes/origin/nonexistent-base" (the custom --base value),
+  # succeed for "refs/remotes/origin/main" (the guard fallback).
+  if [[ "$*" == *"nonexistent-base"* ]]; then exit 1; fi
+  if [[ "$*" == *"refs/remotes/origin/main"* ]]; then exit 1; fi
+  exit 1
+fi
+if [[ "$1" == "config" ]]; then exit 0; fi
+exec /usr/bin/git "$@"
+STUB
+  chmod +x "$stub_dir/git"
+
+  # jq must be real; only gh and git are stubbed
+  PATH="$stub_dir:$PATH" \
+    tmp_out="$(mktemp)" tmp_err="$(mktemp)" rc=0
+  set +e
+  PATH="$stub_dir:$PATH" "$SCRIPT_DIR/preflight.sh" --base nonexistent-base \
+    >"$tmp_out" 2>"$tmp_err"
+  rc=$?
+  set -e
+  stderr_out="$(cat "$tmp_err")"
+  stdout_out="$(cat "$tmp_out")"
+  rm -f "$tmp_out" "$tmp_err"
+
+  if [[ $rc -eq 0 ]]; then
+    red   "  FAIL [preflight.sh empty-gh-result]: expected non-zero exit, got 0"
+    FAIL=$((FAIL + 1))
+  elif [[ -n "$stdout_out" ]]; then
+    red   "  FAIL [preflight.sh empty-gh-result]: expected empty stdout, got: $stdout_out"
+    FAIL=$((FAIL + 1))
+  elif [[ "$stderr_out" == *"''"* ]] || [[ "$stderr_out" != *"main"* ]]; then
+    red   "  FAIL [preflight.sh empty-gh-result]: error message should reference 'main', got: $stderr_out"
+    FAIL=$((FAIL + 1))
+  else
+    green "  PASS [preflight.sh empty-gh-result]: exit=$rc, stderr references 'main'"
+    PASS=$((PASS + 1))
+  fi
+)
+
 echo
 echo "swarm: ${PASS} passed, ${FAIL} failed"
 [[ $FAIL -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Closes out epic [#723](https://github.com/smallorbit/smallorbit-plugins/issues/723) — three child issues integrated and tested together on `feature/flowkit-default-branch-723`.

## Changes

- **#735 / #722** `refactor(swarmkit:swarm): detect default branch instead of hardcoding main` — replace the hardcoded `main` fallback in swarmkit preflight with `gh repo view`-based default-branch detection. Empty-result guard via `${DEFAULT_BRANCH:-main}` plus a unit test that stubs `gh` to return empty.
- **#736 / #720** `refactor(flowkit): drop merged-to-develop label flow` — remove the label-application block from `/merge-pr`. `grep -rn 'merged-to-develop' plugins/flowkit/skills/ plugins/flowkit/README.md` returns zero hits.
- **#737 / #721** `feat(flowkit:open-pr): detect and nudge default branch toward develop` — new `default-branch-prompt` sub-skill called from `/open-pr` step 0. Detects via `gh repo view`, prompts via `AskUserQuestion` when default is `main`, persists choice via `claude.flowkit.defaultBranchPrompted`. Cancel-at-confirmation correctly leaves the marker unset.

## Test plan
- `scripts/test-all-skill-scripts.sh` — 22 tests across 3 skill suites pass.
- Manual flows from the three child PRs apply transitively (default-branch detection in swarmkit; first-run prompt + persistence in flowkit; absence of `merged-to-develop` labelling in merge-pr).

Closes #720
Closes #721
Closes #722
Closes #723