### PR TITLE
chore(plugins): bump flowkit@3.8.0, swarmkit@5.4.0

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship \u2014 with runtime staging detection and a one-command hotfix flow.",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "license": "MIT",
   "author": {
     "name": "Rom\u00e1n M. Pacheco"

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "license": "MIT",
   "author": {
     "name": "Rom\u00e1n M. Pacheco"


### PR DESCRIPTION
## Summary
- Bump flowkit 3.7.0 → 3.8.0 (new `default-branch-prompt` sub-skill + `/open-pr` step 0)
- Bump swarmkit 5.3.0 → 5.4.0 (`feat(swarmkit:swarm-plus)` keep-builder-alive across review pass; clean-worktrees fix; preflight default-branch detection)

## Test plan
- Per-plugin tags `flowkit--v3.8.0` and `swarmkit--v5.4.0` to be created locally after merge and pushed by `/flowkit:release`.