### PR TITLE
chore(plugins): fix author name encoding in plugin.json files

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -4,6 +4,6 @@
   "version": "3.8.0",
   "license": "MIT",
   "author": {
-    "name": "Rom\u00e1n M. Pacheco"
+    "name": "Román M. Pacheco"
   }
 }

--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -4,6 +4,6 @@
   "version": "1.7.0",
   "license": "MIT",
   "author": {
-    "name": "Rom\u00e1n M. Pacheco"
+    "name": "Román M. Pacheco"
   }
 }

--- a/plugins/squadkit/.claude-plugin/plugin.json
+++ b/plugins/squadkit/.claude-plugin/plugin.json
@@ -4,7 +4,7 @@
   "version": "0.7.0",
   "license": "MIT",
   "author": {
-    "name": "Rom\u00e1n M. Pacheco"
+    "name": "Román M. Pacheco"
   },
   "hooks": {
     "SessionStart": [

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -4,6 +4,6 @@
   "version": "5.4.0",
   "license": "MIT",
   "author": {
-    "name": "Rom\u00e1n M. Pacheco"
+    "name": "Román M. Pacheco"
   }
 }


### PR DESCRIPTION
## Summary
- Replace the literal `á` text bytes in flowkit, sessionkit, squadkit, swarmkit `plugin.json` author names with the proper UTF-8 `á` character
- polishkit, speckit, vaultkit were already correct — no change

## Root cause
Some prior write path serialized the JSON with `ensure_ascii=True` (or equivalent) which emitted `á` as a 6-byte text sequence. A subsequent read-and-rewrite preserved those bytes literally instead of decoding them, so the `á` showed up as a backslash-u-escape across four manifests.

## Test plan
- `for p in plugins/*/.claude-plugin/plugin.json; do grep -o 'Rom[^"]*' "$p"; done` shows `Román M. Pacheco` in all seven (no `á` literal anywhere)
- `jq -r '.author.name' plugins/flowkit/.claude-plugin/plugin.json` returns `Román M. Pacheco`