### PR TITLE
chore(plugins): bump sessionkit@1.7.1, squadkit@0.7.1

### DIFF
--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sessionkit",
   "description": "Session continuity and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, plan through structured interviews, discover reusable skills, and reduce permission noise.",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/squadkit/.claude-plugin/plugin.json
+++ b/plugins/squadkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "squadkit",
   "description": "Multi-agent team coordination for Claude Code. Roles, squads, and crews \u2014 interview-driven setup, no per-stack presets, reusable across any repo.",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary
- Patch-bump sessionkit 1.7.0 → 1.7.1 and squadkit 0.7.0 → 0.7.1 to cover the metadata-only encoding fix in [#742](https://github.com/smallorbit/smallorbit-plugins/pull/742) (literal `á` → UTF-8 `á` in author name).

## Test plan
- `jq -r '.version' plugins/sessionkit/.claude-plugin/plugin.json` returns `1.7.1`
- `jq -r '.version' plugins/squadkit/.claude-plugin/plugin.json` returns `0.7.1`
- Per-plugin tags `sessionkit--v1.7.1` and `squadkit--v0.7.1` to be created post-merge and pushed by `/flowkit:release`.