### PR TITLE
feat(polishkit): add /buff skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "polishkit",
       "source": "./plugins/polishkit",
-      "description": "Codebase quality toolkit. Assess code craft with /critique, sweep for cruft with /tidy-codebase, and eliminate unused code with /dead-code."
+      "description": "Codebase quality toolkit. Assess code craft with /critique, sweep for cruft with /tidy-codebase, eliminate unused code with /dead-code, and apply cross-cutting fixes with /simplify-scope."
     },
     {
       "name": "vaultkit",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "polishkit",
       "source": "./plugins/polishkit",
-      "description": "Codebase quality toolkit. Assess code craft with /critique, sweep for cruft with /tidy-codebase, eliminate unused code with /dead-code, and apply cross-cutting fixes with /simplify-scope."
+      "description": "Codebase quality toolkit. Assess code craft with /critique, sweep for cruft with /tidy-codebase, eliminate unused code with /dead-code, and buff out cross-cutting code-quality issues with /buff."
     },
     {
       "name": "vaultkit",

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The development-lifecycle plugins form a complete loop from idea to release:
 
 **swarmkit** runs a built-in `simplify-loop` after each agent finishes — iterative `/simplify` passes that tighten the code before opening the PR. This is a lightweight pre-PR sanity check, not a code review.
 
-**polishkit** sits between `/swarm` and `/release` as a quality gate: use `/critique` to assess elegance and craft, `/tidy-codebase` to sweep for stale files and cruft, `/dead-code` to eliminate unused exports, and `/simplify-scope` to apply cross-cutting code-quality fixes (reuse, quality, efficiency) across a path or themed scope before shipping.
+**polishkit** sits between `/swarm` and `/release` as a quality gate: use `/critique` to assess elegance and craft, `/tidy-codebase` to sweep for stale files and cruft, `/dead-code` to eliminate unused exports, and `/buff` to buff out cross-cutting code-quality issues (reuse, quality, efficiency) across a path or themed scope before shipping.
 
 **sessionkit** acts as connective tissue throughout: use `/handoff` to preserve state across agent context limits, `/skillit` to capture reusable patterns after a swarm, and `/suggest-permissions` to reduce approval friction over time.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Claude Code plugins for plan, execute, and ship — each keeping you at the hand
 | **[speckit](./plugins/speckit/)** | `/plugin install speckit@smallorbit-plugins` | Define and capture work through interviews and issue filing |
 | **[swarmkit](./plugins/swarmkit/)** | `/plugin install swarmkit@smallorbit-plugins` | Resolve GitHub issues with parallel worktree agents. Optional automatic review/fix layer via `/swarm-plus`. _Recommends elevated session permissions — see the plugin's [Permissions](./plugins/swarmkit/README.md#permissions) section._ See [METHODOLOGY.md](./plugins/swarmkit/METHODOLOGY.md) for the stacked agent/PR workflow in depth. |
 | **[squadkit](./plugins/squadkit/)** | `/plugin install squadkit@smallorbit-plugins` | Multi-agent team coordination with the `roles → squads → crews` vocabulary. Spawn role-aware crews (team-lead, architect, builder, reviewer, tester, explorer, designer) — `kind: execution` for code on a `feature/<slug>-<issue>` branch, or `kind: discovery` for read-only research producing issue blueprint comments. |
-| **[polishkit](./plugins/polishkit/)** | `/plugin install polishkit@smallorbit-plugins` | Critique code quality, sweep for cruft, and eliminate dead code |
+| **[polishkit](./plugins/polishkit/)** | `/plugin install polishkit@smallorbit-plugins` | Critique code quality, sweep for cruft, eliminate dead code, and apply cross-cutting fixes |
 | **[flowkit](./plugins/flowkit/)** | `/plugin install flowkit@smallorbit-plugins` | Manage the full git lifecycle from branch to release |
 | **[sessionkit](./plugins/sessionkit/)** | `/plugin install sessionkit@smallorbit-plugins` | Session continuity, context handoffs, and meta-learning |
 
@@ -139,7 +139,7 @@ The development-lifecycle plugins form a complete loop from idea to release:
 
 **swarmkit** runs a built-in `simplify-loop` after each agent finishes — iterative `/simplify` passes that tighten the code before opening the PR. This is a lightweight pre-PR sanity check, not a code review.
 
-**polishkit** sits between `/swarm` and `/release` as a quality gate: use `/critique` to assess elegance and craft, `/tidy-codebase` to sweep for stale files and cruft, and `/dead-code` to eliminate unused exports before shipping.
+**polishkit** sits between `/swarm` and `/release` as a quality gate: use `/critique` to assess elegance and craft, `/tidy-codebase` to sweep for stale files and cruft, `/dead-code` to eliminate unused exports, and `/simplify-scope` to apply cross-cutting code-quality fixes (reuse, quality, efficiency) across a path or themed scope before shipping.
 
 **sessionkit** acts as connective tissue throughout: use `/handoff` to preserve state across agent context limits, `/skillit` to capture reusable patterns after a swarm, and `/suggest-permissions` to reduce approval friction over time.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -279,7 +279,7 @@
               <li><code>/critique</code> — scored quality assessment across 5 dimensions</li>
               <li><code>/tidy-codebase</code> — hygiene sweep: stale files, artifacts, merged branches</li>
               <li><code>/dead-code</code> — find and remove unused exports, imports, and variables</li>
-              <li><code>/simplify-scope</code> — cross-cutting reuse / quality / efficiency fixes in one PR</li>
+              <li><code>/buff</code> — buff out cross-cutting reuse / quality / efficiency issues in one PR</li>
             </ul>
             <div class="transcript" role="group" aria-label="polishkit example session">
 <span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/tidy-codebase</span></span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -274,11 +274,12 @@
                 <a class="plugin-readme" href="https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/polishkit" target="_blank" rel="noopener">README ↗</a>
               </div>
             </div>
-            <p class="plugin-desc">Codebase quality toolkit. Assess code craft with a connoisseur's eye, sweep for cruft and hygiene issues, and eliminate dead code.</p>
+            <p class="plugin-desc">Codebase quality toolkit. Assess code craft with a connoisseur's eye, sweep for cruft and hygiene issues, eliminate dead code, and apply cross-cutting code-quality fixes.</p>
             <ul class="skill-list">
               <li><code>/critique</code> — scored quality assessment across 5 dimensions</li>
               <li><code>/tidy-codebase</code> — hygiene sweep: stale files, artifacts, merged branches</li>
               <li><code>/dead-code</code> — find and remove unused exports, imports, and variables</li>
+              <li><code>/simplify-scope</code> — cross-cutting reuse / quality / efficiency fixes in one PR</li>
             </ul>
             <div class="transcript" role="group" aria-label="polishkit example session">
 <span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/tidy-codebase</span></span>

--- a/plugins/polishkit/.claude-plugin/plugin.json
+++ b/plugins/polishkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polishkit",
-  "description": "Codebase quality toolkit. Assess code craft with a connoisseur's eye, sweep for cruft and hygiene issues, and eliminate dead code — three focused skills for improving what you've already built.",
-  "version": "1.0.2",
+  "description": "Codebase quality toolkit. Assess code craft with a connoisseur's eye, sweep for cruft and hygiene issues, eliminate dead code, and apply cross-cutting code-quality fixes — four focused skills for improving what you've already built.",
+  "version": "1.1.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/polishkit/README.md
+++ b/plugins/polishkit/README.md
@@ -1,6 +1,6 @@
 # Polishkit
 
-A Claude Code plugin for improving what you've already built. Assess code craft with a connoisseur's eye, sweep for accumulated cruft, and eliminate dead code — three focused skills for codebase quality.
+A Claude Code plugin for improving what you've already built. Assess code craft with a connoisseur's eye, sweep for accumulated cruft, eliminate dead code, and apply cross-cutting code-quality fixes — four focused skills for codebase quality.
 
 ## Installation
 
@@ -28,6 +28,7 @@ claude --plugin-dir /path/to/polishkit
 | **critique** | `/critique` | Assesses code for elegance, architecture, and craft across 5 weighted dimensions. Produces a scored report with beauty highlights and violation flags. Works on single files, modules, or full repos. |
 | **tidy-codebase** | `/tidy-codebase` | Codebase hygiene sweep — finds and cleans up stale files, outdated documentation, build artifacts, and accumulated cruft. Confirms each action before executing. |
 | **dead-code** | `/dead-code` | Scans for unused exports, unreachable branches, dead variables, and obsolete imports. Runs language-appropriate static analysis, presents findings with file:line references, and removes after confirmation. |
+| **simplify-scope** | `/simplify-scope <scope>` | Applies cross-cutting code-quality fixes (reuse, quality, efficiency) across a path, glob, or themed scope. Runs in an isolated worktree, gates on your project's verify commands, and opens one PR. |
 
 ## Typical Workflows
 
@@ -57,6 +58,13 @@ claude --plugin-dir /path/to/polishkit
 /critique                       # Get an honest assessment before submitting
 ```
 
+### Apply cross-cutting cleanup as a single PR
+
+```
+/simplify-scope src/hooks/                        # Path scope
+/simplify-scope error handling in src/providers/  # Cross-cutting theme + boundary
+```
+
 ## How critique Works
 
 `/critique` surveys the codebase structure, identifies the language(s) in use, and scores across five weighted dimensions: Architecture & Separation of Concerns (30%), Naming & Readability (25%), Algorithmic Elegance (20%), Testability & Test Design (15%), and Idiomatic Consistency (10%). It always leads with beauty highlights before discussing flaws, and flags critical violations (god classes, magic numbers, functions over 30 lines) in a dedicated section.
@@ -68,6 +76,10 @@ claude --plugin-dir /path/to/polishkit
 ## How dead-code Works
 
 `/dead-code` detects the project language and available static analysis tools, then runs all applicable checks in parallel: unused exports, unused imports, dead variables, and commented-out code blocks. Findings are grouped by severity, shown with file:line references, and confirmed in batches before removal. After cleanup, it verifies the codebase still compiles.
+
+## How simplify-scope Works
+
+`/simplify-scope` takes a scope (path, glob, or cross-cutting concern + scope hint), resolves the file list, sniffs the project's typecheck/test commands, and dispatches a single subagent in an isolated worktree. The agent applies semantic fixes across three categories — reuse (extract duplication, use existing helpers), quality (naming, error handling, type hygiene), and efficiency (avoidable recomputation, quadratic loops) — under a soft cap on files touched. It must keep public surfaces compatible, gate on every verify command, and open one PR with deferred findings called out for follow-up.
 
 ## Pairing with Other Plugins
 

--- a/plugins/polishkit/README.md
+++ b/plugins/polishkit/README.md
@@ -28,7 +28,7 @@ claude --plugin-dir /path/to/polishkit
 | **critique** | `/critique` | Assesses code for elegance, architecture, and craft across 5 weighted dimensions. Produces a scored report with beauty highlights and violation flags. Works on single files, modules, or full repos. |
 | **tidy-codebase** | `/tidy-codebase` | Codebase hygiene sweep — finds and cleans up stale files, outdated documentation, build artifacts, and accumulated cruft. Confirms each action before executing. |
 | **dead-code** | `/dead-code` | Scans for unused exports, unreachable branches, dead variables, and obsolete imports. Runs language-appropriate static analysis, presents findings with file:line references, and removes after confirmation. |
-| **simplify-scope** | `/simplify-scope <scope>` | Applies cross-cutting code-quality fixes (reuse, quality, efficiency) across a path, glob, or themed scope. Runs in an isolated worktree, gates on your project's verify commands, and opens one PR. |
+| **buff** | `/buff <scope>` | Buffs out cross-cutting code-quality issues (reuse, quality, efficiency) across a path, glob, or themed scope. Runs in an isolated worktree, gates on your project's verify commands, and opens one PR. |
 
 ## Typical Workflows
 
@@ -61,8 +61,8 @@ claude --plugin-dir /path/to/polishkit
 ### Apply cross-cutting cleanup as a single PR
 
 ```
-/simplify-scope src/hooks/                        # Path scope
-/simplify-scope error handling in src/providers/  # Cross-cutting theme + boundary
+/buff src/hooks/                        # Path scope
+/buff error handling in src/providers/  # Cross-cutting theme + boundary
 ```
 
 ## How critique Works
@@ -77,9 +77,9 @@ claude --plugin-dir /path/to/polishkit
 
 `/dead-code` detects the project language and available static analysis tools, then runs all applicable checks in parallel: unused exports, unused imports, dead variables, and commented-out code blocks. Findings are grouped by severity, shown with file:line references, and confirmed in batches before removal. After cleanup, it verifies the codebase still compiles.
 
-## How simplify-scope Works
+## How buff Works
 
-`/simplify-scope` takes a scope (path, glob, or cross-cutting concern + scope hint), resolves the file list, sniffs the project's typecheck/test commands, and dispatches a single subagent in an isolated worktree. The agent applies semantic fixes across three categories — reuse (extract duplication, use existing helpers), quality (naming, error handling, type hygiene), and efficiency (avoidable recomputation, quadratic loops) — under a soft cap on files touched. It must keep public surfaces compatible, gate on every verify command, and open one PR with deferred findings called out for follow-up.
+`/buff` takes a scope (path, glob, or cross-cutting concern + scope hint), resolves the file list, sniffs the project's typecheck/test commands, and dispatches a single subagent in an isolated worktree. The agent applies semantic fixes across three categories — reuse (extract duplication, use existing helpers), quality (naming, error handling, type hygiene), and efficiency (avoidable recomputation, quadratic loops) — under a soft cap on files touched. It must keep public surfaces compatible, gate on every verify command, and open one PR with deferred findings called out for follow-up.
 
 ## Pairing with Other Plugins
 

--- a/plugins/polishkit/skills/buff/SKILL.md
+++ b/plugins/polishkit/skills/buff/SKILL.md
@@ -1,24 +1,25 @@
 ---
-name: simplify-scope
-description: Apply code-quality fixes (reuse, quality, efficiency) across a scope (path, glob, or cross-cutting concern) in an isolated worktree and open one PR. Lightweight, fast, single-pass — meant for cross-cutting cleanup like naming consistency, error handling patterns, or type hygiene across modules.
+name: buff
+description: Buff out cross-cutting code-quality issues (reuse, quality, efficiency) across a scope (path, glob, or themed concern) in an isolated worktree and open one PR. Lightweight, fast, single-pass — for cleanup like naming consistency, error handling patterns, or type hygiene across modules.
 triggers:
-  - "simplify scope"
-  - "simplify across"
-  - "simplify the X concern"
+  - "buff"
+  - "buff scope"
+  - "buff across"
+  - "buff the X concern"
   - "lightweight polish"
   - "cross-cutting cleanup"
 ---
 
-# Simplify Scope
+# Buff
 
-Apply code-quality fixes over a scope you specify — a path, glob, or cross-cutting concern — in an isolated worktree, and open one PR. Single pass, single agent, single PR.
+Buff out the rough edges across a scope you specify — a path, glob, or cross-cutting concern — in an isolated worktree, and open one PR. Single pass, single agent, single PR.
 
 Lightweight sibling to polishkit's other skills:
 
 - `polishkit:critique` — score code quality without changing anything.
 - `polishkit:dead-code` — remove unused exports/imports/variables.
 - `polishkit:tidy-codebase` — sweep stale files and accumulated cruft.
-- `polishkit:simplify-scope` (this skill) — apply semantic code-quality fixes (reuse, quality, efficiency) across a scope.
+- `polishkit:buff` (this skill) — apply semantic code-quality fixes (reuse, quality, efficiency) across a scope.
 
 Use this when you want quick, targeted cleanup applied across a cross-cutting concern, not a full assessment or hygiene sweep.
 
@@ -39,7 +40,7 @@ Optional flags:
 
 If `<scope>` is empty:
 
-> What scope should I simplify? (path, glob, or cross-cutting concern + scope hint)
+> What scope should I buff? (path, glob, or cross-cutting concern + scope hint)
 
 ## Process
 
@@ -55,7 +56,7 @@ Derive a kebab-case slug from the scope. Examples:
 - `error handling in src/providers/` → `providers-error-handling`
 - `naming consistency in hooks` → `hooks-naming`
 
-Branch name: `simplify/<slug>`.
+Branch name: `buff/<slug>`.
 
 ### 2. Detect the project's verify commands
 
@@ -106,11 +107,11 @@ For a cross-cutting theme, prioritize fixes matching that theme; deprioritize ev
    ```
    BASE=$(git ls-remote --exit-code --heads origin develop >/dev/null 2>&1 && echo develop || echo main)
    git fetch origin "$BASE"
-   git checkout -B simplify/<slug> "origin/$BASE"
+   git checkout -B buff/<slug> "origin/$BASE"
    [[ "$PWD" != *"worktrees"* ]] && echo "ERROR: not in worktree" && exit 1
    ```
 2. First pass: read every file in scope and build a findings list grouped by category (reuse / quality / efficiency / deferred). Apply the cross-cutting theme filter if one was given.
-3. Apply edits. Surgical changes; don't bundle unrelated fixes into a single "simplify" commit. Group commits by category or by file (conventional-commit format).
+3. Apply edits. Surgical changes; don't bundle unrelated fixes into a single "buff" commit. Group commits by category or by file (conventional-commit format).
 4. Verify by running every command in `VERIFY_COMMANDS` (passed by the orchestrator). All MUST pass before push. If any fails, iterate until green or revert the breaking edit and list it as deferred.
 5. Push and open the PR (see PR BODY SHAPE below).
 6. Report the PR URL. That is the only acceptable termination condition.
@@ -134,13 +135,13 @@ If `--dry-run` is set, the agent skips the apply/commit/push phase and instead r
 
 Print one line confirming dispatch (scope, slug, branch, agent type, model, max-files, verify commands). Don't wait synchronously — the harness notifies on completion. When notified:
 
-- Verify branch is pushed: `git ls-remote --exit-code origin simplify/<slug>`
-- Verify the PR exists: `gh pr list --head simplify/<slug>`
+- Verify branch is pushed: `git ls-remote --exit-code origin buff/<slug>`
+- Verify the PR exists: `gh pr list --head buff/<slug>`
 - Report the PR URL.
 
 ## Constraints
 
-- One agent per invocation, one PR per agent. Never fan out multiple simplify agents on the same scope.
+- One agent per invocation, one PR per agent. Never fan out multiple buff agents on the same scope.
 - Lightweight by default — if scope is so large the agent wants to touch >50 files, it should narrow to the highest-impact subset and defer the rest. The skill is for cross-cutting cleanup, not whole-codebase rewrites.
 - Always pass relative paths to the agent. Never include absolute repo paths in the prompt.
 - Always run in an isolated worktree. Never edit the scope directly from the orchestrator.

--- a/plugins/polishkit/skills/simplify-scope/SKILL.md
+++ b/plugins/polishkit/skills/simplify-scope/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: simplify-scope
+description: Apply code-quality fixes (reuse, quality, efficiency) across a scope (path, glob, or cross-cutting concern) in an isolated worktree and open one PR. Lightweight, fast, single-pass — meant for cross-cutting cleanup like naming consistency, error handling patterns, or type hygiene across modules.
+triggers:
+  - "simplify scope"
+  - "simplify across"
+  - "simplify the X concern"
+  - "lightweight polish"
+  - "cross-cutting cleanup"
+---
+
+# Simplify Scope
+
+Apply code-quality fixes over a scope you specify — a path, glob, or cross-cutting concern — in an isolated worktree, and open one PR. Single pass, single agent, single PR.
+
+Lightweight sibling to polishkit's other skills:
+
+- `polishkit:critique` — score code quality without changing anything.
+- `polishkit:dead-code` — remove unused exports/imports/variables.
+- `polishkit:tidy-codebase` — sweep stale files and accumulated cruft.
+- `polishkit:simplify-scope` (this skill) — apply semantic code-quality fixes (reuse, quality, efficiency) across a scope.
+
+Use this when you want quick, targeted cleanup applied across a cross-cutting concern, not a full assessment or hygiene sweep.
+
+## Input
+
+`<scope>` — required. One of:
+
+- **Path** — `src/hooks/`, `src/components/PlayerContent/`, `src/services/spotify/auth.ts`
+- **Glob** — `src/**/use*.ts`, `src/components/**/*.test.tsx`
+- **Cross-cutting concern** — a natural-language description plus a scope hint, e.g. `error handling in src/providers/`, `naming consistency in hooks`, `type hygiene across services/`
+
+Optional flags:
+
+- `--model <tier>` — `sonnet` (default) or `opus` for harder cross-cutting passes
+- `--agent <type>` — subagent type override (default: `general-purpose`). The skill prompt embeds the review heuristics inline, so a dedicated `code-simplifier` agent is not required.
+- `--max-files <N>` — soft cap on files the subagent should touch in one PR (default: 15). Lightweight stays lightweight.
+- `--dry-run` — review and report findings without applying fixes; useful as a pre-flight before committing to a PR
+
+If `<scope>` is empty:
+
+> What scope should I simplify? (path, glob, or cross-cutting concern + scope hint)
+
+## Process
+
+### 1. Resolve scope
+
+For a path/glob, list files that match. For a cross-cutting concern, treat the description as the agent's *theme* and the path/glob hint as the *file boundary* — pass both to the agent.
+
+Confirm at least one matching file exists. Pass the resolved file list to the agent verbatim so it doesn't re-discover scope.
+
+Derive a kebab-case slug from the scope. Examples:
+- `src/hooks/` → `hooks`
+- `src/services/spotify/auth.ts` → `services-spotify-auth`
+- `error handling in src/providers/` → `providers-error-handling`
+- `naming consistency in hooks` → `hooks-naming`
+
+Branch name: `simplify/<slug>`.
+
+### 2. Detect the project's verify commands
+
+Before dispatching the agent, sniff the repo for the canonical typecheck and test commands. The agent runs them as the green-build gate.
+
+Detection order:
+
+1. `CLAUDE.md` or `.claude/rules/*.md` — if a `## Verify` (or similar) section names commands, use those verbatim.
+2. `package.json` `scripts` — prefer (in order) `typecheck`, `test:run`, `test`, `lint`. Skip watch-mode scripts.
+3. `Makefile` targets — `make test`, `make check`.
+4. Language defaults — `tsc --noEmit` (TS), `pytest` (Python), `go test ./...` (Go), `cargo test` (Rust).
+
+If nothing matches, ask the user for the verify command before dispatching. Never invent a command the repo doesn't expose.
+
+Pass the resolved verify commands to the agent prompt as `VERIFY_COMMANDS`.
+
+### 3. Dispatch the subagent
+
+Spawn one agent with:
+
+- `subagent_type`: `general-purpose` (overridable via `--agent`).
+- `model`: `sonnet` (overridable via `--model`)
+- `isolation`: `worktree`
+- `mode`: `bypassPermissions`
+- `run_in_background`: `true`
+
+The agent prompt MUST include each section, in order:
+
+**CONTEXT** — describe the scope in natural language, list every file in scope verbatim, and (if a cross-cutting concern was given) state the theme. Note CWD is the repo root of an isolated worktree and the agent must use **relative paths only**.
+
+**TASK** — apply these review heuristics to the listed files:
+
+1. **Reuse** — duplicated logic that should be extracted; existing helpers that should be used instead of inlined alternatives.
+2. **Quality** — unclear naming, dead code, weak error handling, leaky abstractions, magic numbers, type hygiene gaps.
+3. **Efficiency** — quadratic loops where linear is trivially possible, redundant async waits, unnecessary re-renders / recomputations in hooks (apply `react-useeffect` heuristics where applicable).
+
+For a cross-cutting theme, prioritize fixes matching that theme; deprioritize everything else (mention as deferred findings, don't fix).
+
+**RESPECT BEHAVIOR** — keep public surfaces compatible. If a fix would change a public contract, leave it untouched and surface in the PR's `## Findings deferred to issues` section with file:line refs.
+
+**CONSTRAINTS** — read `CLAUDE.md` and `.claude/rules/` before editing. Honor every hard contract found there. No new dependencies. No type-error suppression (e.g. `as any`, `@ts-ignore`, `# type: ignore` without justification). Follow the project's commit message and authorship conventions.
+
+**SOFT CAP** — touch at most `--max-files` files (default 15). If the scope clearly exceeds the cap, fix the highest-impact subset and list the rest under deferred findings. Lightweight passes stay lightweight.
+
+**WORKFLOW**:
+
+1. Branch from the repo's base branch (`develop` if it exists, otherwise `main`):
+   ```
+   BASE=$(git ls-remote --exit-code --heads origin develop >/dev/null 2>&1 && echo develop || echo main)
+   git fetch origin "$BASE"
+   git checkout -B simplify/<slug> "origin/$BASE"
+   [[ "$PWD" != *"worktrees"* ]] && echo "ERROR: not in worktree" && exit 1
+   ```
+2. First pass: read every file in scope and build a findings list grouped by category (reuse / quality / efficiency / deferred). Apply the cross-cutting theme filter if one was given.
+3. Apply edits. Surgical changes; don't bundle unrelated fixes into a single "simplify" commit. Group commits by category or by file (conventional-commit format).
+4. Verify by running every command in `VERIFY_COMMANDS` (passed by the orchestrator). All MUST pass before push. If any fails, iterate until green or revert the breaking edit and list it as deferred.
+5. Push and open the PR (see PR BODY SHAPE below).
+6. Report the PR URL. That is the only acceptable termination condition.
+
+**PR BODY SHAPE** — follow the canonical spec at `plugins/_shared/pr-body.md` (`## Summary` / `## Changes` / `## Test plan` plus issue-reference footer). Append one extra section after `## Test plan`:
+
+```
+## Findings deferred to issues
+<list of fixes intentionally not applied (cap exceeded, behavior change, theme mismatch) with file:line refs>
+```
+
+The `## Test plan` checklist must include each command from `VERIFY_COMMANDS` as a `- [ ]` item.
+
+**NO-OP IS LEGITIMATE** — if the pass finds nothing actionable in the scope, open the PR anyway with `## Summary` stating `no actionable simplifications found` and a `## Findings deferred to issues` section listing what was considered. Manufactured churn is worse than a no-op PR.
+
+### 4. Dry-run mode
+
+If `--dry-run` is set, the agent skips the apply/commit/push phase and instead returns a structured findings report inline (not as a PR). Useful as a pre-flight before committing to a full pass.
+
+### 5. Report
+
+Print one line confirming dispatch (scope, slug, branch, agent type, model, max-files, verify commands). Don't wait synchronously — the harness notifies on completion. When notified:
+
+- Verify branch is pushed: `git ls-remote --exit-code origin simplify/<slug>`
+- Verify the PR exists: `gh pr list --head simplify/<slug>`
+- Report the PR URL.
+
+## Constraints
+
+- One agent per invocation, one PR per agent. Never fan out multiple simplify agents on the same scope.
+- Lightweight by default — if scope is so large the agent wants to touch >50 files, it should narrow to the highest-impact subset and defer the rest. The skill is for cross-cutting cleanup, not whole-codebase rewrites.
+- Always pass relative paths to the agent. Never include absolute repo paths in the prompt.
+- Always run in an isolated worktree. Never edit the scope directly from the orchestrator.
+- Verify must be green before push. Red builds are never acceptable, even for "lightweight" passes.
+- No-op PR is legitimate — never invent edits to justify the run.
+- Defer behavior-changing fixes to follow-up issues; this skill is for safe, fast cleanup only.


### PR DESCRIPTION
## Summary

Adds a fourth skill to polishkit — `/buff` — that buffs out cross-cutting code-quality issues (reuse, quality, efficiency) across a path, glob, or themed scope inside an isolated worktree, gated on the project's typecheck and test commands, and opens one PR. Bumps polishkit to 1.1.0 and propagates the new skill through the marketplace, root README, and landing-page catalogs.

> **Naming note:** initially landed as `simplify-scope`; renamed to `buff` before publishing because the original name buried the verb in a generic noun. `buff` fits polishkit's polish theme and reads naturally as `/buff src/hooks/`.

## Changes

- Add `plugins/polishkit/skills/buff/SKILL.md` — sniffs verify commands (CLAUDE.md → package.json scripts → Makefile → language defaults), branches off `develop` or `main`, applies semantic fixes under a soft file cap, and uses the canonical PR body shape from `plugins/_shared/pr-body.md` plus a `## Findings deferred to issues` section.
- Bump `plugins/polishkit/.claude-plugin/plugin.json` to 1.1.0 with an updated four-skill description.
- Update `plugins/polishkit/README.md` skill table, workflow examples, and "How buff Works" section.
- Update `.claude-plugin/marketplace.json` polishkit description.
- Update root `README.md` catalog row and "polishkit sits between" paragraph.
- Update `docs/index.html` polishkit plugin card to list `/buff`.

## Test plan

- [ ] Reload plugins and confirm `polishkit:buff` is discoverable as a skill.
- [ ] Run `/buff src/<some-path>` in a project with `package.json` typecheck/test scripts and confirm the orchestrator detects them and dispatches a worktree-isolated agent.
- [ ] Run `/buff --dry-run` and confirm a structured findings report is returned without applying fixes or opening a PR.
- [ ] Confirm the agent's PR body follows the canonical three-section shape plus `## Findings deferred to issues`, with each detected verify command appearing as a `- [ ]` Test plan item.
- [ ] Confirm the landing page renders the four-skill polishkit card with `/buff` listed.