### PR TITLE
docs(plugins): clarify pairing sections are opt-in

### DIFF
--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -242,6 +242,8 @@ The nudge is **never automatic** — every default-branch change requires explic
 
 ## Pairing with Other Plugins
 
+Flowkit works on its own. The companion plugins referenced below are siblings in the [smallorbit-plugins](../../README.md#available-plugins) marketplace — install them separately to use the composed workflows.
+
 Flowkit handles the shipping half of the development loop. Use it with speckit and swarmkit for the full planning-to-production cycle:
 
 ```

--- a/plugins/polishkit/README.md
+++ b/plugins/polishkit/README.md
@@ -71,6 +71,8 @@ claude --plugin-dir /path/to/polishkit
 
 ## Pairing with Other Plugins
 
+Polishkit works on its own. The companion plugins referenced below are siblings in the [smallorbit-plugins](../../README.md#available-plugins) marketplace — install them separately to use the composed workflows.
+
 Polishkit improves quality; [speckit](../speckit) defines the next work; [swarmkit](../swarmkit) executes it:
 
 ```

--- a/plugins/sessionkit/README.md
+++ b/plugins/sessionkit/README.md
@@ -121,7 +121,9 @@ It scans your existing skill library for overlap before proposing anything new, 
 
 ## Pairing with Other Plugins
 
-Sessionkit works alongside every plugin in the suite:
+Sessionkit works on its own. The companion plugins referenced below are siblings in the [smallorbit-plugins](../../README.md#available-plugins) marketplace — install them separately to use the composed workflows.
+
+Sessionkit works alongside every other plugin in the suite:
 
 **With [swarmkit](../swarmkit)**
 - Use `/skillit` after a swarm run to capture reusable patterns that emerged

--- a/plugins/speckit/README.md
+++ b/plugins/speckit/README.md
@@ -219,6 +219,8 @@ All five issues share the `epic:dark-mode-support` label. Filtering by that labe
 
 ## Pairing with Other Plugins
 
+Speckit works on its own. The companion plugins referenced below are siblings in the [smallorbit-plugins](../../README.md#available-plugins) marketplace — install them separately to use the composed workflows.
+
 Speckit defines the work; [swarmkit](../swarmkit) executes it:
 
 ```

--- a/plugins/squadkit/README.md
+++ b/plugins/squadkit/README.md
@@ -214,6 +214,8 @@ Future role contracts and crew profiles will reference these values rather than 
 
 ## Pairing with Other Plugins
 
+Squadkit works on its own. The companion plugins referenced below are siblings in the [smallorbit-plugins](../../README.md#available-plugins) marketplace — install them separately to use the composed workflows.
+
 Squadkit complements the rest of the suite:
 
 - **[swarmkit](../swarmkit)** — `/swarm` spawns one agent per GitHub issue. Squadkit is the longer-running, role-aware sibling for crew workflows.

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -172,6 +172,8 @@ Swarmkit **never closes issues** — that's intentional. Closing is left to the 
 
 ## Pairing with Other Plugins
 
+Swarmkit works on its own. The companion plugins referenced below are siblings in the [smallorbit-plugins](../../README.md#available-plugins) marketplace — install them separately to use the composed workflows.
+
 Swarmkit executes work; [speckit](../speckit) defines it. Use them together for the full planning-to-execution loop:
 
 ```

--- a/plugins/vaultkit/README.md
+++ b/plugins/vaultkit/README.md
@@ -95,6 +95,8 @@ Editing flows through `vaultkit:file-edit` to preserve birth time — important 
 
 ## Pairing with Other Plugins
 
+Vaultkit works on its own. The companion plugins referenced below are siblings in the [smallorbit-plugins](../../README.md#available-plugins) marketplace — install them separately to use the composed workflows.
+
 Vaultkit captures what happens during and after a session into a durable Obsidian second brain.
 
 **With [sessionkit](../sessionkit)**


### PR DESCRIPTION
## Summary

Each plugin's "Pairing with Other Plugins" section previously read as if the user had every sibling installed. For someone who installed (say) just polishkit standalone, the workflows under that heading reference plugins they don't have, with no acknowledgement that they're optional. Add a one-sentence preface to all seven plugin READMEs that names the marketplace, links back to the root README's catalog anchor, and clarifies the plugin works on its own.

## Changes

- Prepend the same standalone-friendly preface to the "Pairing with Other Plugins" section in `plugins/{polishkit,sessionkit,flowkit,swarmkit,speckit,vaultkit,squadkit}/README.md`.
- Existing pairing prose, code blocks, and bulleted workflows stay intact below the preface.
- Tweak `sessionkit/README.md`'s opening sentence from "every plugin in the suite" to "every other plugin in the suite" to read naturally after the new preface.

## Test plan

- [ ] Render each plugin README on GitHub and confirm the preface appears at the top of "Pairing with Other Plugins".
- [ ] Click the `[smallorbit-plugins](../../README.md#available-plugins)` link from any plugin README and confirm it lands on the catalog section of the root README.
- [ ] Read each plugin README cold (imagine fresh user) and confirm the section now reads as describing optional composition, not required prerequisites.