### PR TITLE
chore(plugins): bump 6 plugin versions

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship \u2014 with runtime staging detection and a one-command hotfix flow.",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sessionkit",
   "description": "Session continuity and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, plan through structured interviews, discover reusable skills, and reduce permission noise.",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/speckit/.claude-plugin/plugin.json
+++ b/plugins/speckit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "speckit",
   "description": "Define and capture work as GitHub issues. Interview a feature into existence with /spec, bulk-convert findings with /catalog, or quickly file a single issue with /issue.",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/squadkit/.claude-plugin/plugin.json
+++ b/plugins/squadkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "squadkit",
   "description": "Multi-agent team coordination for Claude Code. Roles, squads, and crews \u2014 interview-driven setup, no per-stack presets, reusable across any repo.",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "5.4.0",
+  "version": "5.4.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/vaultkit/.claude-plugin/plugin.json
+++ b/plugins/vaultkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vaultkit",
   "description": "Obsidian vault skills for Claude Code. Read, search, edit notes, manage projects, capture decisions, and archive conversations — all via the Obsidian CLI.",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary
- Pre-release version bumps for plugins changed since their last per-plugin tag.

## Changes
- flowkit: 3.8.0 → 3.8.1 (patch — docs only)
- sessionkit: 1.7.1 → 1.8.0 (minor — adds `/retro` skill)
- speckit: 1.6.0 → 1.6.1 (patch — docs only)
- squadkit: 0.7.1 → 0.7.2 (patch — docs only)
- swarmkit: 5.4.0 → 5.4.1 (patch — docs only)
- vaultkit: 1.1.3 → 1.1.4 (patch — docs only)

polishkit was bumped to 2.0.0 in #750; tag will be created at release time.

## Test plan
- [ ] After merge, run /ship-plugins to tag and cut RC.