### PR TITLE
chore(docs): remove stale reviewkit tracker

### DIFF
--- a/docs/reviewkit-tracker.md
+++ b/docs/reviewkit-tracker.md
@@ -1,1 +1,0 @@
-Future work: reviewkit plugin — tracked in https://github.com/smallorbit/smallorbit-plugins/issues/476.


### PR DESCRIPTION
## Summary
Sweep removes `docs/reviewkit-tracker.md` — a one-line tracker pointing at issue #476, which is now closed. No other doc references the file.

## Changes
- Delete `docs/reviewkit-tracker.md`.

## Test plan
- [ ] `grep -rn reviewkit docs/ plugins/ README.md` returns no matches.
- [ ] No broken links surface in CI link-checks (if configured).