### PR TITLE
perf(sessionkit): tighten handoff/pickup skill prompts

### DIFF
--- a/plugins/sessionkit/skills/handoff/SKILL.md
+++ b/plugins/sessionkit/skills/handoff/SKILL.md
@@ -34,7 +34,7 @@ If `--full` is present, strip it from `$ARGUMENTS` before folding the remaining 
 
 ### 1. Gather context
 
-Run these commands in parallel to collect raw data. Tolerate missing files — the absence of a todo file or uncommitted changes is itself signal.
+Run these commands in parallel:
 
 ```bash
 cat .claude/TODO 2>/dev/null || cat .claude/todos.md 2>/dev/null || echo "No todo file"
@@ -74,7 +74,7 @@ Compare against the fingerprints from step 1a using two **independent** reuse de
 
 If no prior file exists, or the meta header is absent, treat both fingerprints as non-matching and regenerate all sections.
 
-When **both** fingerprints match, all four reusable sections come straight from the prior file. The actual routing decision — including whether to skip the sub-agent — is made in step 1c after this check. Report the reuse outcome in the confirmation (e.g. `reused 4 sections`, `reused 2 sections (git)`, `reused 2 sections (task)`, or `regenerated all sections`).
+When **both** fingerprints match, all four reusable sections come straight from the prior file. The routing decision is made in step 1c.
 
 ### 1c. Delta-mode decision
 
@@ -85,14 +85,9 @@ After step 1b classifies which sections need to be regenerated, decide whether t
 1. A prior `.sessionkit/HANDOFF.md` exists and parsed cleanly in step 1b (meta header found, all six canonical sections present in the documented order, fenced `json` block in `## Task List` parses).
 2. The prior `gitFingerprint`'s HEAD-sha component is an ancestor of the current HEAD — verify with `git merge-base --is-ancestor <prior-head-sha> HEAD` (exit 0 = ancestor). This confirms session continuity rather than a branch swap. (The staged/unstaged drift is already captured by step 1b's fingerprint comparison; this ancestor check only guards against branch-swap or force-push scenarios where the commit graph has diverged.)
 3. At most **two** of the four reusable sections (`Git State`, `Progress`, `Task List`, `Remaining Work`) need regeneration. Goal and Context are always refreshed and don't count toward the threshold.
-4. `$ARGUMENTS` does not contain `--full` and does not look like a structural-rewrite directive (a freeform note longer than ~200 chars or one that explicitly mentions reframing/rewriting the goal/context counts as structural — when in doubt, fall back to full regenerate). The 200-char threshold is a heuristic; `--full` remains the deterministic override when you want a guaranteed full pass regardless of note length.
+4. `$ARGUMENTS` does not contain `--full` and does not look like a structural-rewrite directive (a freeform note longer than ~200 chars or one that explicitly mentions reframing/rewriting the goal/context counts as structural — when in doubt, fall back to full regenerate).
 
-**Otherwise, use the full Haiku regenerate path** (step 2). Specifically, fall back when:
-
-- No prior file, or prior file is missing the meta header / required sections / parseable Task List JSON.
-- Prior `gitFingerprint`'s HEAD is not an ancestor of current HEAD (branch swap, force-push, unrelated session).
-- Three or four reusable sections need regeneration (drift exceeds threshold).
-- `$ARGUMENTS` contains `--full`, or its freeform content suggests a structural rewrite.
+**Otherwise, use the full Haiku regenerate path** (step 2).
 
 Record the chosen mode (`delta` vs `full`) for the step 4 confirmation.
 
@@ -115,7 +110,7 @@ After all Edits land, skip step 2 entirely and proceed to step 3.
 
 ### 2. Synthesize via Haiku sub-agent
 
-Reached only when step 1c picked the `full` path (no prior file, structural divergence, drift over threshold, or `--full`). Delegate markdown synthesis to a sub-agent running on Haiku — the handoff document is structured output and does not need the main model.
+Reached only when step 1c picked the `full` path. Delegate markdown synthesis to a sub-agent running on Haiku — the handoff document is structured output and does not need the main model.
 
 Invoke the `Agent` tool with:
 

--- a/plugins/sessionkit/skills/pickup/SKILL.md
+++ b/plugins/sessionkit/skills/pickup/SKILL.md
@@ -104,7 +104,7 @@ Do not pose this as a plain-text question when `AskUserQuestion` is viable — t
 
 ## Constraints
 
-- Never modify or delete `.sessionkit/HANDOFF.md` — this skill is read-only with respect to the handoff file
+- Never modify `.sessionkit/HANDOFF.md` — this skill is read-only
 - Do not assume the handoff file always exists — always check first and fail gracefully
 - Keep the orientation summary concise — surface the essentials, not everything verbatim
 - Do not automatically re-execute any commands referenced in the handoff — the goal is to orient, not to act


### PR DESCRIPTION
## Summary

Surgical token cuts to the `/handoff` and `/pickup` skill prompts. Net removal of ~200 tokens from handoff (primarily by eliminating a verbatim inversion of step 1c's positive conditions and a restated fallback parenthetical) plus one constraint tightening in pickup. All observable behaviors preserved.

## Changes

- Remove the "Fall back when:" list in handoff step 1c — it fully inverts the "Pick delta mode when ALL of these hold:" conditions immediately above it, adding nothing
- Trim handoff step 2 intro parenthetical that restated step 1c's fallback conditions verbatim
- Drop "Tolerate missing files" sentence in step 1 — the `2>/dev/null` guards in the bash block convey this without prose
- Collapse the step 1b routing-decision sentence from two sentences to one (removed redundant reuse-outcome examples already listed in step 4's Confirm)
- Remove redundant trailing sentence from step 1c condition 4 (`--full` behavior is already documented in the Input section)
- Tighten pickup Constraints: "Never modify or delete … — this skill is read-only with respect to the handoff file" → "Never modify … — this skill is read-only"

## Test plan

- [ ] `bash scripts/test-all-skill-scripts.sh` passes
- [ ] Re-read edited handoff SKILL — delta-mode fast path (intro + step 1c) still detectable on first read; `--full` flag still documented; step 1c positive conditions are still complete and unambiguous
- [ ] Re-read edited pickup SKILL — task hydration two-pass (Pass 1 / Pass 2) and AskUserQuestion termination with plain-text fallback still clearly expressed
- [ ] Word count delta meaningful: handoff −~200 tokens, pickup −~10 tokens

## Findings deferred

- `plugins/sessionkit/skills/handoff/SKILL.md:86` — condition 2's parenthetical explaining the ancestor-check scope is verbose but load-bearing agent guidance; left intact
- `plugins/sessionkit/skills/handoff/SKILL.md:190-198` — inference rules block partially duplicates template bullet comments; kept because each rule names a concrete source (`todo file`, `branch name`) not visible from the template placeholders alone
- `plugins/sessionkit/skills/pickup/SKILL.md:108` — "Do not assume the handoff file always exists" restates step 1 but serves as a cross-cutting reminder in Constraints; kept