### PR TITLE
chore(plugins): bump flowkit@3.8.2, sessionkit@1.8.1, swarmkit@5.4.2, vaultkit@1.1.5

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship \u2014 with runtime staging detection and a one-command hotfix flow.",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sessionkit",
   "description": "Session continuity and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, plan through structured interviews, discover reusable skills, and reduce permission noise.",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/vaultkit/.claude-plugin/plugin.json
+++ b/plugins/vaultkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vaultkit",
   "description": "Obsidian vault skills for Claude Code. Read, search, edit notes, manage projects, capture decisions, and archive conversations — all via the Obsidian CLI.",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary
Patch bumps for the four plugins touched by recent token-efficiency tightening (PRs #754, #755) so clients pick up the updated skill prompts.

## Changes
- flowkit 3.8.1 → 3.8.2
- sessionkit 1.8.0 → 1.8.1
- swarmkit 5.4.1 → 5.4.2
- vaultkit 1.1.4 → 1.1.5

## Test plan
- [ ] Per-plugin tags created locally after merge.
- [ ] `/cut` succeeds (no remaining bumps blocking).