### PR TITLE
release: 2026-05-02

### DIFF
--- a/docs/reviewkit-tracker.md
+++ b/docs/reviewkit-tracker.md
@@ -1,1 +1,0 @@
-Future work: reviewkit plugin — tracked in https://github.com/smallorbit/smallorbit-plugins/issues/476.

--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship \u2014 with runtime staging detection and a one-command hotfix flow.",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/flowkit/skills/default-branch-prompt/SKILL.md
+++ b/plugins/flowkit/skills/default-branch-prompt/SKILL.md
@@ -5,13 +5,7 @@ description: One-time first-run nudge for /open-pr — detects the GitHub defaul
 
 # default-branch-prompt
 
-A one-time, opt-in nudge surfaced from `/open-pr`'s preflight. Modern Gitflow-on-GitHub repos increasingly set `develop` as the GitHub default branch — that aligns the auto-close lifecycle (`Closes #N` fires on PRs into the default branch) with where features actually land. Repos that keep `main` as default still work fine; flowkit's `/release` and `/hotfix` skills run an explicit `gh issue close` loop after the merge, so the lifecycle completes either way.
-
-This skill exists as its own file (rather than inline in `open-pr/SKILL.md`) because the prompt logic is several distinct steps — detect, gate on a marker, ask, confirm, mutate, persist — and inlining it would crowd open-pr's already long preflight section. Open-pr calls it as the first preflight step; everything else can assume the prompt has either fired (and been answered) or been skipped silently.
-
-## When to invoke
-
-Open-pr's preflight calls this skill before checking the current branch. The skill is a no-op in every case except the narrow first-run-on-`main`-default scenario described below.
+One-time nudge fired by `/open-pr` before checking the current branch. No-op in every case except first-run-on-`main`-default. After returning, `open-pr` continues regardless of outcome.
 
 ## Process
 
@@ -23,7 +17,7 @@ if [ "$(git config --get claude.flowkit.defaultBranchPrompted 2>/dev/null)" = "t
 fi
 ```
 
-The marker is repo-local and persists across sessions. Once set (by any of the three answer paths below), this skill never prompts again in this repo.
+Once set, never prompts again in this repo.
 
 ### 2. Detect the GitHub default branch
 
@@ -31,7 +25,7 @@ The marker is repo-local and persists across sessions. Once set (by any of the t
 DEFAULT_BRANCH=$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || true)
 ```
 
-Treat any non-zero exit, missing `gh` binary, missing auth, or empty result as **skip silently** — do not pester the user when detection fails for environmental reasons. Open-pr's later steps already handle the "no `gh`" case loudly; that's where the user should learn about it, not here.
+On any non-zero exit, missing `gh`, no auth, or empty result: skip silently. `open-pr` already surfaces `gh` errors in its main flow.
 
 ```bash
 if [ -z "$DEFAULT_BRANCH" ]; then
@@ -47,7 +41,7 @@ if [ "$DEFAULT_BRANCH" != "main" ]; then
 fi
 ```
 
-Any other default branch (including `develop`, `master`, or a custom name) means the user has already made a deliberate choice — leave them alone.
+Any other value means the user has already made a deliberate choice — leave them alone.
 
 ### 4. Ask the user
 
@@ -56,10 +50,10 @@ Invoke `AskUserQuestion` with the following shape:
 - **Question**: "Your repo's GitHub default branch is `main`. Flowkit recommends `develop` as the default for new flowkit users — modern Gitflow-on-GitHub convention, and it makes `Closes #N` auto-close fire on the PRs that actually carry the work. The switch is `gh repo edit --default-branch develop`. Existing `main`-as-default setups continue to work; this is a recommendation, not a requirement."
 - **Options** (exactly three):
   1. `Switch to develop` — run `gh repo edit --default-branch develop` after a confirmation step
-  2. `Keep main as default` — semantically: "I considered the recommendation and chose `main`." Sets the marker. The repo is unchanged.
-  3. `Don't ask again` — semantically: "Stop bothering me — I haven't decided yet." Sets the marker. The repo is unchanged.
+  2. `Keep main as default` — "I chose `main` deliberately." Sets the marker. No repo mutation.
+  3. `Don't ask again` — "Not deciding yet." Sets the marker. No repo mutation.
 
-Both `Keep main as default` and `Don't ask again` set the same marker and produce the same observable outcome (no repo change, no future prompts). They are presented as separate options because the distinction matters socially: a user who consciously chose `main` should not have to pretend they're dismissing the prompt out of annoyance, and a user who's not ready to decide should not have to commit to a position they haven't formed yet. Future readers of this skill should preserve both options for that reason.
+Both options 2 and 3 produce the same outcome (marker set, no change, no future prompts) but are presented as distinct choices so a deliberate `main` user and an undecided user each have an honest answer. Preserve both options.
 
 ### 5. Handle the answer
 
@@ -80,15 +74,9 @@ On `Yes`:
 gh repo edit --default-branch develop
 ```
 
-If the command succeeds, set the marker:
+On success, set the marker. On failure, report the error and **do not** set the marker — the next `/open-pr` gives them another chance.
 
-```bash
-git config claude.flowkit.defaultBranchPrompted true
-```
-
-If the command fails (non-zero exit), report the error to the user and **do not** set the marker — that way the next `/open-pr` invocation will give them another chance to retry once they've fixed permissions or auth.
-
-On `Cancel`: do nothing. The marker stays unset, so the next `/open-pr` invocation will surface the original three-option prompt again. (Cancelling the confirmation is not the same as choosing `Don't ask again`.)
+On `Cancel`: marker stays unset; the three-option prompt resurfaces next time.
 
 #### `Keep main as default`
 
@@ -96,7 +84,7 @@ On `Cancel`: do nothing. The marker stays unset, so the next `/open-pr` invocati
 git config claude.flowkit.defaultBranchPrompted true
 ```
 
-No repo mutation. Report a single line: "Keeping `main` as the default branch. Flowkit's release flow handles `Closes #N` issue-close at release time."
+Report: "Keeping `main` as the default branch. Flowkit's release flow handles `Closes #N` issue-close at release time."
 
 #### `Don't ask again`
 
@@ -104,22 +92,10 @@ No repo mutation. Report a single line: "Keeping `main` as the default branch. F
 git config claude.flowkit.defaultBranchPrompted true
 ```
 
-No repo mutation. Report a single line: "OK, won't ask again. Re-run by clearing the marker: `git config --unset claude.flowkit.defaultBranchPrompted`."
+Report: "OK, won't ask again. Re-run by clearing the marker: `git config --unset claude.flowkit.defaultBranchPrompted`."
 
 ## Constraints
 
-- **Never automatic.** Every action that mutates the repo or the marker requires an explicit user answer. This skill does not run `gh repo edit` without the second confirmation, and it does not set the marker without a user choice.
-- **Detection failure is silent.** Missing `gh`, no auth, network errors, or any non-zero exit from `gh repo view` skip the prompt without warning. Open-pr's main flow surfaces gh-related errors on its own.
-- **Marker is repo-local.** `git config` (without `--global`) writes to the repo's `.git/config`, which is the right scope: a user's preference for one repo should not leak to another.
-- **Only `main` triggers the prompt.** Any other default branch is treated as a deliberate choice and left alone.
-- **Never use the legacy `claude.prBase` key.** The marker key is `claude.flowkit.defaultBranchPrompted` and lives under the `claude.flowkit.*` namespace.
-
-## Resetting
-
-To re-surface the prompt (e.g., after migrating between repos or for testing):
-
-```bash
-git config --unset claude.flowkit.defaultBranchPrompted
-```
-
-The next `/open-pr` invocation will run through the detect-and-prompt flow from scratch.
+- Never run `gh repo edit` without the second confirmation; never set the marker without a user choice.
+- Marker key is `claude.flowkit.defaultBranchPrompted` (repo-local `git config`). Never use `claude.prBase`.
+- To reset: `git config --unset claude.flowkit.defaultBranchPrompted`.

--- a/plugins/flowkit/skills/pr-base-scope/SKILL.md
+++ b/plugins/flowkit/skills/pr-base-scope/SKILL.md
@@ -35,24 +35,15 @@ git config --unset claude.flowkit.prBase
 
 ### Read
 
-Resolve the current target branch (used by `/open-pr`). The authoritative five-step resolution order lives in [`open-pr/SKILL.md`](../open-pr/SKILL.md) — step 2. In summary:
+Resolution order (authoritative spec in [`open-pr/SKILL.md`](../open-pr/SKILL.md) step 2):
 
-1. Explicit `--base <branch>` caller arg in `$ARGUMENTS`
-2. `claude.flowkit.prBase` — primary config key
-3. `claude.prBase` — legacy fallback (emits deprecation notice when hit)
-4. `develop` — if the branch exists on the remote
-5. Repo default branch (via `gh repo view`) — with a warning; always assigned so `$BASE` is never empty
+1. `--base <branch>` in `$ARGUMENTS`
+2. `claude.flowkit.prBase`
+3. `claude.prBase` — legacy fallback (emits deprecation notice)
+4. `develop` if it exists on the remote
+5. Repo default branch via `gh repo view` (with warning)
 
-`$BASE` is guaranteed non-empty after resolution; `/open-pr` always passes `--base "$BASE"` to `gh pr create`.
-
-## Usage by Callers
-
-| Caller | Action |
-|--------|--------|
-| `/ship` | Sets `claude.flowkit.prBase develop` before opening PRs, then unsets after the flow completes |
-| `/swarm` loop mode | Sets `claude.flowkit.prBase` to the appropriate integration branch for the loop session |
-| `/cut-epic` | Sets `claude.flowkit.prBase` to the long-lived epic branch so sub-PRs target it; user runs **Unset** when the epic ships |
-| `/open-pr` | Reads the resolved base (explicit arg → new key → legacy key → `develop` → repo default) before creating the PR; `$BASE` is always non-empty |
+`$BASE` is always non-empty after resolution.
 
 ## Constraints
 

--- a/plugins/flowkit/skills/preview-epic-direct/SKILL.md
+++ b/plugins/flowkit/skills/preview-epic-direct/SKILL.md
@@ -48,10 +48,7 @@ If either `$BASE_BRANCH` or `$EPIC_BRANCH` is empty after parsing, stop with:
 
 ### 2. Sync the epic branch locally
 
-There is no synthesis to do — the epic branch already accumulates the squash-merged contributions. Pull it down and check it out so verify runs against the integrated state.
-
 ```bash
-# Preserve any uncommitted state in the working tree.
 STASHED=0
 if ! git diff --quiet HEAD || ! git diff --cached --quiet; then
   git stash push -u -m "preview-epic auto-stash"
@@ -87,7 +84,7 @@ After verify completes, restore the user's pre-skill working state if any was st
 
 ### 3. Resolve verify commands
 
-Read `.squadkit/config.json` for `verify.typecheck`, `verify.test`, `verify.lint`, and `install`:
+Read `.squadkit/config.json` for `verify.typecheck`, `verify.test`, `verify.lint`, `install`:
 
 ```bash
 TYPECHECK=$(jq -r '.verify.typecheck // empty' .squadkit/config.json 2>/dev/null)
@@ -106,7 +103,7 @@ If the user declines any, skip that step. The skill does not hardcode `npm run t
 
 ### 4. Run verify commands
 
-If `$INSTALL` is set and HEAD moved during the fetch/fast-forward, run install first. Then run typecheck, tests, and lint. Capture exit codes — do not abort the skill on failure; the user wants to see all results.
+If `$INSTALL` is set and HEAD moved, run install first. Run typecheck, tests, lint. Capture all exit codes — do not abort on failure.
 
 ```bash
 if [[ -n "$INSTALL" ]]; then
@@ -145,9 +142,3 @@ Print a concise summary tagged with the model:
   - Verify failure → fix on the epic branch (or open a follow-up PR targeting the epic) and re-run.
 
 No cleanup needed — the epic branch is long-lived.
-
-## Constraints
-
-- **Epic branch is fetched, not modified beyond fast-forward.** Diverged remotes abort rather than auto-resolving.
-- **Preserve working state.** Auto-stash uncommitted changes before checking out the epic branch; restore on completion.
-- **Idempotent in spirit.** Re-running simply re-fast-forwards the epic branch rather than clobbering existing local state.

--- a/plugins/flowkit/skills/preview-epic-stacked/SKILL.md
+++ b/plugins/flowkit/skills/preview-epic-stacked/SKILL.md
@@ -130,7 +130,7 @@ Do not proceed to verify commands when sequential merge fails.
 
 ### 6. Resolve verify commands
 
-Read `.squadkit/config.json` for `verify.typecheck`, `verify.test`, `verify.lint`, and `install`:
+Read `.squadkit/config.json` for `verify.typecheck`, `verify.test`, `verify.lint`, `install`:
 
 ```bash
 TYPECHECK=$(jq -r '.verify.typecheck // empty' .squadkit/config.json 2>/dev/null)
@@ -149,7 +149,7 @@ If the user declines any, skip that step. The skill does not hardcode `npm run t
 
 ### 7. Run verify commands
 
-If `$INSTALL` is set, run install first (the working tree just changed). Then run typecheck, tests, and lint. Capture exit codes — do not abort the skill on failure; the user wants to see all results.
+If `$INSTALL` is set, run install first (working tree just changed). Run typecheck, tests, lint. Capture all exit codes — do not abort on failure.
 
 ```bash
 if [[ -n "$INSTALL" ]]; then
@@ -194,9 +194,3 @@ Suggested cleanup:
 git checkout "$BASE_BRANCH"
 git branch -D "$PREVIEW_BRANCH"
 ```
-
-## Constraints
-
-- **Local-only.** Never push the synthesized preview branch; it is a throwaway integration check.
-- **Halt cleanly on conflict.** Sequential merge must `git merge --abort` before reporting, so the working tree is left in a clean state on the preview branch's pre-conflict commit.
-- **Idempotent in spirit.** Re-running with the same root will pick a fresh `preview/...-N` name rather than clobbering existing local state.

--- a/plugins/flowkit/skills/with-clean-workspace/SKILL.md
+++ b/plugins/flowkit/skills/with-clean-workspace/SKILL.md
@@ -50,9 +50,3 @@ fi
 [ "$MERGE_OK" = "false" ] && exit 1
 ```
 
-## Constraints
-
-- Never auto-resolve a stash-pop conflict — leave the stash on the stack and tell the user.
-- Always use `-u` so untracked files (e.g. new hook scripts) are stashed too.
-- Use the literal message `flowkit-auto-stash` so the user can identify the entry in `git stash list`.
-- Only pop the stash if the wrapped command exited 0 — a failed command must not trigger a pop that masks the failure on retry.

--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sessionkit",
   "description": "Session continuity and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, plan through structured interviews, discover reusable skills, and reduce permission noise.",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/sessionkit/skills/handoff/SKILL.md
+++ b/plugins/sessionkit/skills/handoff/SKILL.md
@@ -34,7 +34,7 @@ If `--full` is present, strip it from `$ARGUMENTS` before folding the remaining 
 
 ### 1. Gather context
 
-Run these commands in parallel to collect raw data. Tolerate missing files — the absence of a todo file or uncommitted changes is itself signal.
+Run these commands in parallel:
 
 ```bash
 cat .claude/TODO 2>/dev/null || cat .claude/todos.md 2>/dev/null || echo "No todo file"
@@ -74,7 +74,7 @@ Compare against the fingerprints from step 1a using two **independent** reuse de
 
 If no prior file exists, or the meta header is absent, treat both fingerprints as non-matching and regenerate all sections.
 
-When **both** fingerprints match, all four reusable sections come straight from the prior file. The actual routing decision — including whether to skip the sub-agent — is made in step 1c after this check. Report the reuse outcome in the confirmation (e.g. `reused 4 sections`, `reused 2 sections (git)`, `reused 2 sections (task)`, or `regenerated all sections`).
+When **both** fingerprints match, all four reusable sections come straight from the prior file. The routing decision is made in step 1c.
 
 ### 1c. Delta-mode decision
 
@@ -85,14 +85,9 @@ After step 1b classifies which sections need to be regenerated, decide whether t
 1. A prior `.sessionkit/HANDOFF.md` exists and parsed cleanly in step 1b (meta header found, all six canonical sections present in the documented order, fenced `json` block in `## Task List` parses).
 2. The prior `gitFingerprint`'s HEAD-sha component is an ancestor of the current HEAD — verify with `git merge-base --is-ancestor <prior-head-sha> HEAD` (exit 0 = ancestor). This confirms session continuity rather than a branch swap. (The staged/unstaged drift is already captured by step 1b's fingerprint comparison; this ancestor check only guards against branch-swap or force-push scenarios where the commit graph has diverged.)
 3. At most **two** of the four reusable sections (`Git State`, `Progress`, `Task List`, `Remaining Work`) need regeneration. Goal and Context are always refreshed and don't count toward the threshold.
-4. `$ARGUMENTS` does not contain `--full` and does not look like a structural-rewrite directive (a freeform note longer than ~200 chars or one that explicitly mentions reframing/rewriting the goal/context counts as structural — when in doubt, fall back to full regenerate). The 200-char threshold is a heuristic; `--full` remains the deterministic override when you want a guaranteed full pass regardless of note length.
+4. `$ARGUMENTS` does not contain `--full` and does not look like a structural-rewrite directive (a freeform note longer than ~200 chars or one that explicitly mentions reframing/rewriting the goal/context counts as structural — when in doubt, fall back to full regenerate).
 
-**Otherwise, use the full Haiku regenerate path** (step 2). Specifically, fall back when:
-
-- No prior file, or prior file is missing the meta header / required sections / parseable Task List JSON.
-- Prior `gitFingerprint`'s HEAD is not an ancestor of current HEAD (branch swap, force-push, unrelated session).
-- Three or four reusable sections need regeneration (drift exceeds threshold).
-- `$ARGUMENTS` contains `--full`, or its freeform content suggests a structural rewrite.
+**Otherwise, use the full Haiku regenerate path** (step 2).
 
 Record the chosen mode (`delta` vs `full`) for the step 4 confirmation.
 
@@ -115,7 +110,7 @@ After all Edits land, skip step 2 entirely and proceed to step 3.
 
 ### 2. Synthesize via Haiku sub-agent
 
-Reached only when step 1c picked the `full` path (no prior file, structural divergence, drift over threshold, or `--full`). Delegate markdown synthesis to a sub-agent running on Haiku — the handoff document is structured output and does not need the main model.
+Reached only when step 1c picked the `full` path. Delegate markdown synthesis to a sub-agent running on Haiku — the handoff document is structured output and does not need the main model.
 
 Invoke the `Agent` tool with:
 

--- a/plugins/sessionkit/skills/pickup/SKILL.md
+++ b/plugins/sessionkit/skills/pickup/SKILL.md
@@ -104,7 +104,7 @@ Do not pose this as a plain-text question when `AskUserQuestion` is viable — t
 
 ## Constraints
 
-- Never modify or delete `.sessionkit/HANDOFF.md` — this skill is read-only with respect to the handoff file
+- Never modify `.sessionkit/HANDOFF.md` — this skill is read-only
 - Do not assume the handoff file always exists — always check first and fail gracefully
 - Keep the orientation summary concise — surface the essentials, not everything verbatim
 - Do not automatically re-execute any commands referenced in the handoff — the goal is to orient, not to act

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "5.4.1",
+  "version": "5.4.2",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/swarmkit/skills/clean-worktrees/SKILL.md
+++ b/plugins/swarmkit/skills/clean-worktrees/SKILL.md
@@ -63,20 +63,9 @@ If both `worktrees_to_remove` and `branches_to_delete` are empty arrays, report:
 
 And stop.
 
-### Step 4 — Present plan and confirm
+### Step 4 — Proceed
 
-Summarize what will happen:
-
-```
-Worktrees to remove: <count>
-  - /path/to/worktree-agent-42
-  ...
-Branches to delete: <count>
-  - worktree-agent-42
-  ...
-```
-
-Proceed immediately (no confirmation prompt needed for this automated cleanup step).
+No confirmation prompt needed for this automated cleanup step.
 
 ### Step 5 — Perform removal
 
@@ -122,11 +111,3 @@ If `caller_branch_restored` is `false` and there were no errors, warn:
 
 > `<caller_branch>` was removed as part of cleanup — no branch to restore to.
 
-## Constraints
-
-- Never remove the main working directory — only non-main worktrees
-- Never abort on a single worktree removal failure — always continue and report failures at the end
-- If any orphaned branch is still checked out by an active worktree, stop and report — do not attempt deletion
-- Always run `git worktree prune` both before the removal loop and after removals to clear stale references (handled inside the scripts)
-- Use `git worktree remove <path> -f -f` (double-force) to handle agent-locked worktrees (handled inside remove.sh)
-- Always attempt to restore the caller's branch after cleanup; warn instead of erroring if the branch no longer exists

--- a/plugins/vaultkit/.claude-plugin/plugin.json
+++ b/plugins/vaultkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vaultkit",
   "description": "Obsidian vault skills for Claude Code. Read, search, edit notes, manage projects, capture decisions, and archive conversations — all via the Obsidian CLI.",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/vaultkit/skills/list-projects/SKILL.md
+++ b/plugins/vaultkit/skills/list-projects/SKILL.md
@@ -3,7 +3,7 @@ name: list-projects
 description: List all projects in an Obsidian vault's Projects folder, with status and count summary. Sub-skill used by vaultkit:load-project.
 ---
 
-# vaultkit:list-projects
+# list-projects
 
 Lists all projects in an Obsidian vault's `Projects/` folder, sorted by status, with a count summary.
 


### PR DESCRIPTION
## Summary

Token-efficiency tightening across user-facing sessionkit skills and internal sub-skills, plus a stale-doc sweep. Patch bumps for flowkit, sessionkit, swarmkit, and vaultkit so clients pick up the updated prompts.

## Release summary

**Built from**: `rc/2026-05-02.4`

### Version bumps
- flowkit 3.8.1 → 3.8.2
- sessionkit 1.8.0 → 1.8.1
- swarmkit 5.4.1 → 5.4.2
- vaultkit 1.1.4 → 1.1.5

### Release notes

**flowkit**
- chore(skills): tighten internal sub-skill prompts for token efficiency (#755) — covers git-sync-*, default-branch-prompt, with-clean-workspace, pr-base-scope, preview-epic-direct/stacked.

**sessionkit**
- perf(sessionkit): tighten handoff/pickup skill prompts (#754) — both prompts trimmed without changing observable behavior (delta mode, full-regen, task hydration two-pass).

**swarmkit**
- chore(skills): tighten internal sub-skill prompts for token efficiency (#755) — covers gh-fetch-issues, conventional-commit-message, issue-rank, clean-worktrees.

**vaultkit**
- chore(skills): tighten internal sub-skill prompts for token efficiency (#755) — covers list-projects.

**cross-plugin / docs**
- chore(docs): remove stale reviewkit tracker (#753) — deleted `docs/reviewkit-tracker.md` (issue #476 closed).

### Changes

**flowkit**
- chore(plugins): bump flowkit@3.8.2, sessionkit@1.8.1, swarmkit@5.4.2, vaultkit@1.1.5 (#756)
- chore(skills): tighten sub-skill prompts for token efficiency (#755)

**sessionkit**
- perf(sessionkit): tighten handoff/pickup skill prompts for token efficiency (#754)

**docs**
- chore(docs): remove stale reviewkit tracker (#753)

## Test plan
- [ ] Per-plugin tags pushed for flowkit/sessionkit/swarmkit/vaultkit.
- [ ] Repo-level calver tag created on main HEAD.
- [ ] RC branch deleted, develop synced with main.