### PR TITLE
feat(polishkit)!: rename /buff to /polish

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -32,7 +32,7 @@
     {
       "name": "polishkit",
       "source": "./plugins/polishkit",
-      "description": "Codebase quality toolkit. Appraise code craft with /appraise, sweep dead code and cruft with /sweep, and buff out cross-cutting code-quality issues with /buff."
+      "description": "Codebase quality toolkit. Appraise code craft with /appraise, sweep dead code and cruft with /sweep, and polish cross-cutting code-quality issues with /polish."
     },
     {
       "name": "vaultkit",

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The development-lifecycle plugins form a complete loop from idea to release:
 
 **swarmkit** runs a built-in `simplify-loop` after each agent finishes — iterative `/simplify` passes that tighten the code before opening the PR. This is a lightweight pre-PR sanity check, not a code review.
 
-**polishkit** sits between `/swarm` and `/release` as a quality gate: use `/appraise` to assess elegance and craft, `/sweep` to remove dead code and accumulated cruft (unused exports, stale files, build artifacts) in one pass, and `/buff` to buff out cross-cutting code-quality issues (reuse, quality, efficiency) across a path or themed scope before shipping.
+**polishkit** sits between `/swarm` and `/release` as a quality gate: use `/appraise` to assess elegance and craft, `/sweep` to remove dead code and accumulated cruft (unused exports, stale files, build artifacts) in one pass, and `/polish` to polish cross-cutting code-quality issues (reuse, quality, efficiency) across a path or themed scope before shipping.
 
 **sessionkit** acts as connective tissue throughout: use `/handoff` to preserve state across agent context limits, `/skillit` to capture reusable patterns after a swarm, and `/suggest-permissions` to reduce approval friction over time.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -278,7 +278,7 @@
             <ul class="skill-list">
               <li><code>/appraise</code> — scored quality assessment across 5 dimensions</li>
               <li><code>/sweep</code> — dead code + cruft in one pass: unused exports, stale files, merged branches</li>
-              <li><code>/buff</code> — buff out cross-cutting reuse / quality / efficiency issues in one PR</li>
+              <li><code>/polish</code> — polish cross-cutting reuse / quality / efficiency issues in one PR</li>
             </ul>
             <div class="transcript" role="group" aria-label="polishkit example session">
 <span class="transcript-line"><span class="transcript-prompt">$</span> <span class="transcript-cmd">/sweep</span></span>

--- a/plugins/polishkit/.claude-plugin/plugin.json
+++ b/plugins/polishkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polishkit",
-  "description": "Codebase quality toolkit. Appraise code craft with a connoisseur's eye, sweep dead code and cruft in one pass, and buff out cross-cutting code-quality issues — three focused skills for improving what you've already built.",
-  "version": "2.0.0",
+  "description": "Codebase quality toolkit. Appraise code craft with a connoisseur's eye, sweep dead code and cruft in one pass, and polish cross-cutting code-quality issues — three focused skills for improving what you've already built.",
+  "version": "3.0.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/polishkit/README.md
+++ b/plugins/polishkit/README.md
@@ -27,7 +27,7 @@ claude --plugin-dir /path/to/polishkit
 |-------|--------|--------------|
 | **appraise** | `/appraise` | Appraises code for elegance, architecture, and craft across 5 weighted dimensions. Produces a scored report with beauty highlights and violation flags. Works on single files, modules, or full repos. |
 | **sweep** | `/sweep` | Sweeps the codebase in two phases: dead code (unused exports, imports, variables, unreachable branches) and cruft (stale docs, build artifacts, duplicate content, merged branches). Confirms each action before executing. |
-| **buff** | `/buff <scope>` | Buffs out cross-cutting code-quality issues (reuse, quality, efficiency) across a path, glob, or themed scope. Runs in an isolated worktree, gates on your project's verify commands, and opens one PR. |
+| **polish** | `/polish <scope>` | Polishes cross-cutting code-quality issues (reuse, quality, efficiency) across a path, glob, or themed scope. Runs in an isolated worktree, gates on your project's verify commands, and opens one PR. |
 
 ## Typical Workflows
 
@@ -59,8 +59,8 @@ claude --plugin-dir /path/to/polishkit
 ### Apply cross-cutting cleanup as a single PR
 
 ```
-/buff src/hooks/                        # Path scope
-/buff error handling in src/providers/  # Cross-cutting theme + boundary
+/polish src/hooks/                        # Path scope
+/polish error handling in src/providers/  # Cross-cutting theme + boundary
 ```
 
 ## How appraise Works
@@ -71,9 +71,9 @@ claude --plugin-dir /path/to/polishkit
 
 `/sweep` runs in two phases. **Phase 1 — dead code**: detects the project language and available static analysis tools (`tsc --noEmit`, `pyflakes`, `vulture`, `staticcheck`, etc.), then scans for unused exports, unused imports, dead variables, unreachable branches, and commented-out code blocks. **Phase 2 — cruft**: parallel checks for stale docs, build artifacts, documentation gaps, duplicate content, and git hygiene (merged branches, stale worktrees, orphaned remotes). Findings from both phases are merged into a single Remove / Update / Keep summary and confirmed via `AskUserQuestion` before any changes are made.
 
-## How buff Works
+## How polish Works
 
-`/buff` takes a scope (path, glob, or cross-cutting concern + scope hint), resolves the file list, sniffs the project's typecheck/test commands, and dispatches a single subagent in an isolated worktree. The agent applies semantic fixes across three categories — reuse (extract duplication, use existing helpers), quality (naming, error handling, type hygiene), and efficiency (avoidable recomputation, quadratic loops) — under a soft cap on files touched. It must keep public surfaces compatible, gate on every verify command, and open one PR with deferred findings called out for follow-up.
+`/polish` takes a scope (path, glob, or cross-cutting concern + scope hint), resolves the file list, sniffs the project's typecheck/test commands, and dispatches a single subagent in an isolated worktree. The agent applies semantic fixes across three categories — reuse (extract duplication, use existing helpers), quality (naming, error handling, type hygiene), and efficiency (avoidable recomputation, quadratic loops) — under a soft cap on files touched. It must keep public surfaces compatible, gate on every verify command, and open one PR with deferred findings called out for follow-up.
 
 ## Pairing with Other Plugins
 

--- a/plugins/polishkit/skills/polish/SKILL.md
+++ b/plugins/polishkit/skills/polish/SKILL.md
@@ -1,24 +1,24 @@
 ---
-name: buff
-description: Buff out cross-cutting code-quality issues (reuse, quality, efficiency) across a scope (path, glob, or themed concern) in an isolated worktree and open one PR. Lightweight, fast, single-pass — for cleanup like naming consistency, error handling patterns, or type hygiene across modules.
+name: polish
+description: Polish cross-cutting code-quality issues (reuse, quality, efficiency) across a scope (path, glob, or themed concern) in an isolated worktree and open one PR. Lightweight, fast, single-pass — for cleanup like naming consistency, error handling patterns, or type hygiene across modules.
 triggers:
-  - "buff"
-  - "buff scope"
-  - "buff across"
-  - "buff the X concern"
-  - "lightweight polish"
+  - "polish"
+  - "polish scope"
+  - "polish across"
+  - "polish the X concern"
+  - "lightweight cleanup"
   - "cross-cutting cleanup"
 ---
 
-# Buff
+# Polish
 
-Buff out the rough edges across a scope you specify — a path, glob, or cross-cutting concern — in an isolated worktree, and open one PR. Single pass, single agent, single PR.
+Polish the rough edges across a scope you specify — a path, glob, or cross-cutting concern — in an isolated worktree, and open one PR. Single pass, single agent, single PR.
 
 Lightweight sibling to polishkit's other skills:
 
 - `polishkit:appraise` — score code quality without changing anything.
 - `polishkit:sweep` — remove dead code and accumulated cruft (unused exports/imports/variables, stale files, build artifacts).
-- `polishkit:buff` (this skill) — apply semantic code-quality fixes (reuse, quality, efficiency) across a scope.
+- `polishkit:polish` (this skill) — apply semantic code-quality fixes (reuse, quality, efficiency) across a scope.
 
 Use this when you want quick, targeted cleanup applied across a cross-cutting concern, not a full assessment or hygiene sweep.
 
@@ -39,7 +39,7 @@ Optional flags:
 
 If `<scope>` is empty:
 
-> What scope should I buff? (path, glob, or cross-cutting concern + scope hint)
+> What scope should I polish? (path, glob, or cross-cutting concern + scope hint)
 
 ## Process
 
@@ -55,7 +55,7 @@ Derive a kebab-case slug from the scope. Examples:
 - `error handling in src/providers/` → `providers-error-handling`
 - `naming consistency in hooks` → `hooks-naming`
 
-Branch name: `buff/<slug>`.
+Branch name: `polish/<slug>`.
 
 ### 2. Detect the project's verify commands
 
@@ -106,11 +106,11 @@ For a cross-cutting theme, prioritize fixes matching that theme; deprioritize ev
    ```
    BASE=$(git ls-remote --exit-code --heads origin develop >/dev/null 2>&1 && echo develop || echo main)
    git fetch origin "$BASE"
-   git checkout -B buff/<slug> "origin/$BASE"
+   git checkout -B polish/<slug> "origin/$BASE"
    [[ "$PWD" != *"worktrees"* ]] && echo "ERROR: not in worktree" && exit 1
    ```
 2. First pass: read every file in scope and build a findings list grouped by category (reuse / quality / efficiency / deferred). Apply the cross-cutting theme filter if one was given.
-3. Apply edits. Surgical changes; don't bundle unrelated fixes into a single "buff" commit. Group commits by category or by file (conventional-commit format).
+3. Apply edits. Surgical changes; don't bundle unrelated fixes into a single "polish" commit. Group commits by category or by file (conventional-commit format).
 4. Verify by running every command in `VERIFY_COMMANDS` (passed by the orchestrator). All MUST pass before push. If any fails, iterate until green or revert the breaking edit and list it as deferred.
 5. Push and open the PR (see PR BODY SHAPE below).
 6. Report the PR URL. That is the only acceptable termination condition.
@@ -134,13 +134,13 @@ If `--dry-run` is set, the agent skips the apply/commit/push phase and instead r
 
 Print one line confirming dispatch (scope, slug, branch, agent type, model, max-files, verify commands). Don't wait synchronously — the harness notifies on completion. When notified:
 
-- Verify branch is pushed: `git ls-remote --exit-code origin buff/<slug>`
-- Verify the PR exists: `gh pr list --head buff/<slug>`
+- Verify branch is pushed: `git ls-remote --exit-code origin polish/<slug>`
+- Verify the PR exists: `gh pr list --head polish/<slug>`
 - Report the PR URL.
 
 ## Constraints
 
-- One agent per invocation, one PR per agent. Never fan out multiple buff agents on the same scope.
+- One agent per invocation, one PR per agent. Never fan out multiple polish agents on the same scope.
 - Lightweight by default — if scope is so large the agent wants to touch >50 files, it should narrow to the highest-impact subset and defer the rest. The skill is for cross-cutting cleanup, not whole-codebase rewrites.
 - Always pass relative paths to the agent. Never include absolute repo paths in the prompt.
 - Always run in an isolated worktree. Never edit the scope directly from the orchestrator.


### PR DESCRIPTION
## Summary
Folds polishkit's lightweight cross-cutting cleanup skill under the more intuitive `/polish` name. Breaking rename — bumps polishkit to 3.0.0. Also reclaims the `/polish` namespace from the now-broken global command (which referenced the removed `/critique` skill from the polishkit 2.0 rename).

## Changes
- `mv plugins/polishkit/skills/buff` → `plugins/polishkit/skills/polish`
- Frontmatter `name: buff` → `name: polish`; triggers updated; branch prefix `buff/<slug>` → `polish/<slug>`
- Propagated `/buff` → `/polish` across polishkit README (skill table, workflows, "How X Works"), root README plugin narrative, `marketplace.json`, `docs/index.html`
- polishkit 2.0.0 → 3.0.0 (breaking rename)

## Test plan
- [ ] `grep -rn '/buff\b\|polishkit:buff\|name: buff' plugins/ docs/ README.md` returns no matches.
- [ ] `/polish <scope>` invocation resolves to the renamed skill after install.
- [ ] Per-plugin tag `polishkit--v3.0.0` created on the merge commit.