### PR TITLE
fix(polishkit/polish): resolve PR base via flowkit chain

### DIFF
--- a/plugins/polishkit/skills/polish/SKILL.md
+++ b/plugins/polishkit/skills/polish/SKILL.md
@@ -35,6 +35,7 @@ Optional flags:
 - `--model <tier>` — `sonnet` (default) or `opus` for harder cross-cutting passes
 - `--agent <type>` — subagent type override (default: `general-purpose`). The skill prompt embeds the review heuristics inline, so a dedicated `code-simplifier` agent is not required.
 - `--max-files <N>` — soft cap on files the subagent should touch in one PR (default: 15). Lightweight stays lightweight.
+- `--base <branch>` — override the resolved PR base branch (see Process step 3). When set, short-circuits `claude.flowkit.prBase` / `develop` / repo-default resolution.
 - `--dry-run` — review and report findings without applying fixes; useful as a pre-flight before committing to a PR
 
 If `<scope>` is empty:
@@ -72,7 +73,53 @@ If nothing matches, ask the user for the verify command before dispatching. Neve
 
 Pass the resolved verify commands to the agent prompt as `VERIFY_COMMANDS`.
 
-### 3. Dispatch the subagent
+### 3. Resolve the PR base branch
+
+The agent's branch must be cut from the project's PR base, and `gh pr create` must explicitly target the same branch (otherwise it falls through to the GitHub default — usually `main` — which silently produces wrong-base PRs against repos that develop on a non-default branch).
+
+Resolve `BASE` in this order, mirroring `flowkit:open-pr`:
+
+```bash
+# 1. Explicit caller arg
+BASE=""
+if echo "$ARGUMENTS" | grep -qE '(^|[[:space:]])\-\-base[= ]'; then
+  BASE=$(echo "$ARGUMENTS" | grep -oE '(^|[[:space:]])\-\-base[= ][^ ]+' | head -1 | sed 's/.*--base[= ]//')
+fi
+
+# 2. claude.flowkit.prBase (per-session config set by swarm loop / cut-epic / pr-base-scope)
+if [ -z "$BASE" ]; then
+  BASE=$(git config claude.flowkit.prBase 2>/dev/null)
+fi
+
+# 3. Legacy claude.prBase (deprecated, with migration notice)
+if [ -z "$BASE" ]; then
+  LEGACY=$(git config claude.prBase 2>/dev/null)
+  if [ -n "$LEGACY" ]; then
+    BASE="$LEGACY"
+    echo "note: claude.prBase is deprecated. Migrate with:" >&2
+    echo "  git config --unset claude.prBase" >&2
+    echo "  git config claude.flowkit.prBase $LEGACY" >&2
+  fi
+fi
+
+# 4. develop if it exists on the remote
+if [ -z "$BASE" ]; then
+  if git ls-remote --heads origin develop | grep -q 'refs/heads/develop'; then
+    BASE="develop"
+  fi
+fi
+
+# 5. Fallback — use the repo default and warn
+if [ -z "$BASE" ]; then
+  REPO_DEFAULT=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
+  echo "warning: no base branch configured and 'develop' not found on remote; falling back to repo default ($REPO_DEFAULT)" >&2
+  BASE="$REPO_DEFAULT"
+fi
+```
+
+Pass the resolved `BASE` to the agent prompt as `BASE_BRANCH`. The agent must use it for both the branch cut **and** the `gh pr create --base` argument.
+
+### 4. Dispatch the subagent
 
 Spawn one agent with:
 
@@ -102,17 +149,16 @@ For a cross-cutting theme, prioritize fixes matching that theme; deprioritize ev
 
 **WORKFLOW**:
 
-1. Branch from the repo's base branch (`develop` if it exists, otherwise `main`):
+1. Branch from `BASE_BRANCH` (provided by the orchestrator — never re-derive):
    ```
-   BASE=$(git ls-remote --exit-code --heads origin develop >/dev/null 2>&1 && echo develop || echo main)
-   git fetch origin "$BASE"
-   git checkout -B polish/<slug> "origin/$BASE"
+   git fetch origin "$BASE_BRANCH"
+   git checkout -B polish/<slug> "origin/$BASE_BRANCH"
    [[ "$PWD" != *"worktrees"* ]] && echo "ERROR: not in worktree" && exit 1
    ```
 2. First pass: read every file in scope and build a findings list grouped by category (reuse / quality / efficiency / deferred). Apply the cross-cutting theme filter if one was given.
 3. Apply edits. Surgical changes; don't bundle unrelated fixes into a single "polish" commit. Group commits by category or by file (conventional-commit format).
 4. Verify by running every command in `VERIFY_COMMANDS` (passed by the orchestrator). All MUST pass before push. If any fails, iterate until green or revert the breaking edit and list it as deferred.
-5. Push and open the PR (see PR BODY SHAPE below).
+5. Push and open the PR with `--base "$BASE_BRANCH"` explicitly (see PR BODY SHAPE below). **Never** call `gh pr create` without `--base` — without it, gh falls through to the GitHub default branch (often `main`), which silently produces wrong-base PRs.
 6. Report the PR URL. That is the only acceptable termination condition.
 
 **PR BODY SHAPE** — follow the canonical spec at `plugins/_shared/pr-body.md` (`## Summary` / `## Changes` / `## Test plan` plus issue-reference footer). Append one extra section after `## Test plan`:
@@ -126,16 +172,16 @@ The `## Test plan` checklist must include each command from `VERIFY_COMMANDS` as
 
 **NO-OP IS LEGITIMATE** — if the pass finds nothing actionable in the scope, open the PR anyway with `## Summary` stating `no actionable simplifications found` and a `## Findings deferred to issues` section listing what was considered. Manufactured churn is worse than a no-op PR.
 
-### 4. Dry-run mode
+### 5. Dry-run mode
 
 If `--dry-run` is set, the agent skips the apply/commit/push phase and instead returns a structured findings report inline (not as a PR). Useful as a pre-flight before committing to a full pass.
 
-### 5. Report
+### 6. Report
 
-Print one line confirming dispatch (scope, slug, branch, agent type, model, max-files, verify commands). Don't wait synchronously — the harness notifies on completion. When notified:
+Print one line confirming dispatch (scope, slug, branch, base branch, agent type, model, max-files, verify commands). Don't wait synchronously — the harness notifies on completion. When notified:
 
 - Verify branch is pushed: `git ls-remote --exit-code origin polish/<slug>`
-- Verify the PR exists: `gh pr list --head polish/<slug>`
+- Verify the PR exists and targets the resolved base: `gh pr list --head polish/<slug> --json baseRefName,url`
 - Report the PR URL.
 
 ## Constraints

--- a/plugins/polishkit/skills/polish/SKILL.md
+++ b/plugins/polishkit/skills/polish/SKILL.md
@@ -35,7 +35,7 @@ Optional flags:
 - `--model <tier>` — `sonnet` (default) or `opus` for harder cross-cutting passes
 - `--agent <type>` — subagent type override (default: `general-purpose`). The skill prompt embeds the review heuristics inline, so a dedicated `code-simplifier` agent is not required.
 - `--max-files <N>` — soft cap on files the subagent should touch in one PR (default: 15). Lightweight stays lightweight.
-- `--base <branch>` — override the resolved PR base branch (see Process step 3). When set, short-circuits `claude.flowkit.prBase` / `develop` / repo-default resolution.
+- `--base <branch>` — override the resolved PR base branch (see Process step 3). When set, short-circuits config / `develop` / repo-default resolution.
 - `--dry-run` — review and report findings without applying fixes; useful as a pre-flight before committing to a PR
 
 If `<scope>` is empty:
@@ -77,7 +77,9 @@ Pass the resolved verify commands to the agent prompt as `VERIFY_COMMANDS`.
 
 The agent's branch must be cut from the project's PR base, and `gh pr create` must explicitly target the same branch (otherwise it falls through to the GitHub default — usually `main` — which silently produces wrong-base PRs against repos that develop on a non-default branch).
 
-Resolve `BASE` in this order, mirroring `flowkit:open-pr`:
+Polishkit resolves the base standalone — no other plugin is required. If flowkit is also installed and has set its own per-session base, polishkit silently honors it as a courtesy, but never depends on it.
+
+Resolve `BASE` in this order:
 
 ```bash
 # 1. Explicit caller arg
@@ -86,20 +88,14 @@ if echo "$ARGUMENTS" | grep -qE '(^|[[:space:]])\-\-base[= ]'; then
   BASE=$(echo "$ARGUMENTS" | grep -oE '(^|[[:space:]])\-\-base[= ][^ ]+' | head -1 | sed 's/.*--base[= ]//')
 fi
 
-# 2. claude.flowkit.prBase (per-session config set by swarm loop / cut-epic / pr-base-scope)
+# 2. Polishkit's own config
 if [ -z "$BASE" ]; then
-  BASE=$(git config claude.flowkit.prBase 2>/dev/null)
+  BASE=$(git config claude.polishkit.prBase 2>/dev/null)
 fi
 
-# 3. Legacy claude.prBase (deprecated, with migration notice)
+# 3. Optional flowkit interop — honored if flowkit set it, but not required
 if [ -z "$BASE" ]; then
-  LEGACY=$(git config claude.prBase 2>/dev/null)
-  if [ -n "$LEGACY" ]; then
-    BASE="$LEGACY"
-    echo "note: claude.prBase is deprecated. Migrate with:" >&2
-    echo "  git config --unset claude.prBase" >&2
-    echo "  git config claude.flowkit.prBase $LEGACY" >&2
-  fi
+  BASE=$(git config claude.flowkit.prBase 2>/dev/null)
 fi
 
 # 4. develop if it exists on the remote
@@ -118,6 +114,8 @@ fi
 ```
 
 Pass the resolved `BASE` to the agent prompt as `BASE_BRANCH`. The agent must use it for both the branch cut **and** the `gh pr create --base` argument.
+
+To pin a base for the current repo, run `git config claude.polishkit.prBase <branch>` (e.g. `develop`). The flowkit read at step 3 is best-effort interop only — polishkit works without flowkit installed.
 
 ### 4. Dispatch the subagent
 


### PR DESCRIPTION
## Summary

The `polishkit:polish` skill (and its predecessor `buff`) never passed `--base` to `gh pr create`, so PRs silently landed against the GitHub default branch — usually `main` — regardless of where the project actually develops. Repos that develop on a non-default branch (`develop`, in our case) got wrong-base PRs that diff-bombed against `main`.

This patches the skill to resolve the base standalone (no flowkit dependency) and threads the resolved base through to the spawned agent so `gh pr create --base "\$BASE_BRANCH"` is always explicit.

## Changes

- Add a new `## 3. Resolve the PR base branch` Process step that resolves `BASE` via: explicit `--base` flag → `claude.polishkit.prBase` (polishkit's own namespace) → `claude.flowkit.prBase` (best-effort interop, honored if flowkit set it but never required) → `develop` on remote → repo default + warning.
- Renumber subsequent Process steps (Dispatch → 4, Dry-run → 5, Report → 6).
- Document the new `--base <branch>` flag in the input contract.
- Rewrite the agent's WORKFLOW step 1 to consume the orchestrator-provided `BASE_BRANCH` instead of re-deriving with the simple `develop || main` heuristic.
- Tighten WORKFLOW step 5: agent must call `gh pr create --base "\$BASE_BRANCH"` explicitly, with a hard warning that omitting `--base` is the bug being fixed.
- Update the Report step's verification command to surface `baseRefName` so a wrong-base PR is caught immediately.

## Decoupling note

Polishkit must remain usable without flowkit installed. The base-resolution chain therefore prefers polishkit's own config key (`claude.polishkit.prBase`) and only falls back to `claude.flowkit.prBase` as a silent courtesy when flowkit happens to be present. No deprecation framing for `claude.prBase` (that's flowkit's migration story, not polishkit's). No references to flowkit primitives like swarm loop / cut-epic / pr-base-scope.

## Test plan

- [ ] Run `/polishkit:polish <scope>` in a repo with `claude.polishkit.prBase=develop` set — verify the resulting PR targets `develop`.
- [ ] Run `/polishkit:polish <scope>` in a repo with only `claude.flowkit.prBase=develop` set (no polishkit key) — verify interop still resolves to `develop`.
- [ ] Run `/polishkit:polish <scope> --base feature/some-epic` — verify `--base` overrides everything else and the PR targets the named branch.
- [ ] Run `/polishkit:polish <scope>` in a repo with no config and no `develop` branch on origin — verify the warning fires and the PR targets the repo default.
- [ ] Confirm the agent's commits still cut the work branch from `origin/\$BASE_BRANCH` (not from local `develop`, which may be stale).

## Context

Real-world incident: three polish (then-`buff`) PRs opened against \`vorbis-player\` today (#1417, #1418, #1426) all silently landed on \`main\` and had to be hand-retargeted to \`develop\` after the fact. The diffs initially looked huge (~+60/-1100 each) because they were comparing against \`main\`, which is far behind \`develop\`.