### PR TITLE
feat(sessionkit): add /roadmap + /drive skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,7 +17,7 @@
     {
       "name": "sessionkit",
       "source": "./plugins/sessionkit",
-      "description": "Session continuity and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, plan through structured interviews, discover reusable skills, and reduce permission noise."
+      "description": "Session continuity, planning, and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, map work-in-flight into an approved task chain and drive it to completion, discover reusable skills, and reduce permission noise."
     },
     {
       "name": "speckit",

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Claude Code plugins for plan, execute, and ship — each keeping you at the hand
 | **[squadkit](./plugins/squadkit/)** | `/plugin install squadkit@smallorbit-plugins` | Multi-agent team coordination with the `roles → squads → crews` vocabulary. Spawn role-aware crews (team-lead, architect, builder, reviewer, tester, explorer, designer) — `kind: execution` for code on a `feature/<slug>-<issue>` branch, or `kind: discovery` for read-only research producing issue blueprint comments. |
 | **[polishkit](./plugins/polishkit/)** | `/plugin install polishkit@smallorbit-plugins` | Appraise code quality, sweep dead code and cruft, and apply cross-cutting fixes |
 | **[flowkit](./plugins/flowkit/)** | `/plugin install flowkit@smallorbit-plugins` | Manage the full git lifecycle from branch to release |
-| **[sessionkit](./plugins/sessionkit/)** | `/plugin install sessionkit@smallorbit-plugins` | Session continuity, context handoffs, and meta-learning |
+| **[sessionkit](./plugins/sessionkit/)** | `/plugin install sessionkit@smallorbit-plugins` | Session continuity, context handoffs, planning, and meta-learning. Map work-in-flight into an approved task chain with `/roadmap` and drive it to completion with `/drive`. |
 
 ### Utilities & Productivity
 

--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "sessionkit",
-  "description": "Session continuity and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, plan through structured interviews, discover reusable skills, and reduce permission noise.",
+  "description": "Session continuity, planning, and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, map work-in-flight into an approved task chain and drive it to completion, discover reusable skills, and reduce permission noise.",
   "version": "1.8.1",
   "license": "MIT",
   "author": {

--- a/plugins/sessionkit/README.md
+++ b/plugins/sessionkit/README.md
@@ -29,6 +29,8 @@ claude --plugin-dir /path/to/sessionkit
 |-------|--------|--------------|
 | **handoff** | `/handoff` | Captures session goal, progress, git state, remaining work, and active tasks into `.sessionkit/HANDOFF.md`. Use when context is running low or when switching agents. |
 | **pickup** | `/pickup` | Loads `.sessionkit/HANDOFF.md` at the start of a new session, orients the agent, and hydrates pending/in-progress tasks back into the task system. |
+| **roadmap** | `/roadmap` | Surveys the current work-in-flight and produces an approved task chain that takes it all the way to "shipped". On approval, optionally hands off to `/drive` for autonomous execution. |
+| **drive** | `/drive` | Executes an approved task chain autonomously — marks each task in_progress before starting and completed immediately after, surfaces only for blockers or executive decisions. Pairs with `/roadmap`; standalone-invokable when a task list is already prepared. |
 | **skillit** | `/skillit` | Reflects on the current session to identify patterns worth encoding as reusable skills. Checks for existing overlap before proposing anything new. |
 | **suggest-permissions** | `/suggest-permissions` | Scans recent session history for repeatedly approved permissions and proposes additions to `.claude/settings.json` to reduce future prompts. |
 | **retro** | `/retro` | Runs a session retrospective — scans conversation transcript, task list, git activity, and hook/tool-denial events, then surfaces what went well and what didn't, and presents a one-keystroke action menu that delegates to the right downstream skill. |
@@ -41,6 +43,19 @@ claude --plugin-dir /path/to/sessionkit
 /handoff                          # Capture current state before context runs out
                                   # — start a new Claude Code session —
 /pickup                           # Restore context and resume work
+```
+
+### Planning the path to "done", then driving it
+
+```
+/roadmap                          # Survey work-in-flight, propose a task chain to ship,
+                                  # ask for approval
+
+# On approval, either:
+/drive                            # Hand the chain to Claude — it executes autonomously
+                                  # and only surfaces for blockers or executive decisions
+
+# …or work the task list manually if you'd rather drive it yourself.
 ```
 
 ### Growing your skill library
@@ -105,6 +120,28 @@ Handoff files written by sessionkit ≤ 1.5.0 may contain a legacy squad-coordin
 | **Context** | Gotchas, constraints, or non-obvious state the next agent must know |
 
 You can manually edit `.sessionkit/HANDOFF.md` between sessions — `/pickup` reads whatever is there.
+
+## How Roadmap / Drive Works
+
+`/roadmap` surveys the current work-in-flight — uncommitted state, current branch's role (feature / epic / RC / develop), open PRs targeting common bases, peer PRs in a stack, in-flight worktrees, RC branches awaiting release, the latest release tag, and the existing task list. It classifies the state, picks the matching sub-chain from a step library (commit → push → PR → review → merge → bump → cut → release), and materializes it as a linear task chain with `blockedBy` edges wired between steps.
+
+After the plan is built, `/roadmap` presents a compact summary and asks for approval via `AskUserQuestion`:
+
+- **Drive it for me** — hands the chain to `/drive` for autonomous execution.
+- **I'll drive** — exits; you work the task list manually.
+- **Modify** — describe a change, plan is regenerated.
+- **Cancel** — the provisional tasks created during planning are deleted.
+
+`/drive` picks up an approved task chain and executes it end-to-end. It marks each task `in_progress` *before* starting work and `completed` *immediately after* — never batched. While driving, it stays silent: the task list itself is the progress feed. It surfaces only for:
+
+- **Blockers** — a tool failed in a way it can't recover from.
+- **Executive decisions** — a real fork in approach not covered by the task description; a scope change.
+- **Risky/destructive actions** — anything that would delete data, force-push, or modify shared state.
+- **Completion** — final report.
+
+`/drive` is standalone-invokable. If you've populated a task list any other way (manually, via `/pickup`, via another planning workflow), you can just run `/drive` and it picks up the chain.
+
+The driving contract lives entirely inside the `/drive` skill — it does **not** depend on any rule in your global or project `CLAUDE.md`. Installs of sessionkit get the autonomous-execution semantics out of the box.
 
 ## How Skillit Works
 

--- a/plugins/sessionkit/skills/drive/SKILL.md
+++ b/plugins/sessionkit/skills/drive/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: drive
+description: Execute an approved task chain autonomously from start to finish. Mark each task in_progress before starting and completed immediately after. Surface to the user only for blockers, executive decisions (scope changes, forking choices), or completion. Use after a plan has been approved — typically dispatched by `/sessionkit:roadmap`, but can be invoked standalone when a task list is already prepared.
+triggers:
+  - "/drive"
+  - "drive the plan"
+  - "drive the task list"
+  - "execute the roadmap"
+  - "you're driving"
+  - "drive it"
+allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TaskList, TaskGet, TaskCreate, TaskUpdate, AskUserQuestion, Skill, Agent
+---
+
+# Drive
+
+Take an approved task chain and run it to completion. You are now responsible for getting the plan done end-to-end. The user has signed off on the roadmap; your job is to execute it without further narration of routine steps.
+
+## When to invoke
+
+- After `/sessionkit:roadmap` produces an approved plan and the user picks "drive it for me".
+- Standalone, when the task list is already populated by other means and the user says "drive it" / "you're driving" / "execute the plan".
+
+## Process
+
+### 1. Confirm there's a chain to drive
+
+Call `TaskList`. If the result has no `pending` or `in_progress` tasks, stop with:
+
+> Nothing to drive — the task list is empty or fully completed. Add tasks (or run `/sessionkit:roadmap`) before invoking `/drive`.
+
+If there are tasks but they all have unresolved `blockedBy` edges pointing at non-existent IDs, report the broken state and stop. Do not silently start work on a corrupted graph.
+
+### 2. State the driving contract (one preamble, then silence)
+
+Before the first tool call of the chain, output exactly one short preamble so the user knows you've taken over:
+
+> Driving from task #N. I'll work the chain top-down, mark tasks completed as I go, and only surface for blockers or executive decisions. Press Esc to interrupt at any time.
+
+Do not narrate again until you finish, hit a blocker, or need a decision. The task list itself is the progress signal — every `TaskUpdate` is visible to the user without prose.
+
+### 3. Drive loop
+
+Repeat until the chain is empty:
+
+1. **Pick the next task.** `TaskList` → take the lowest-ID task whose `status` is `pending` and whose `blockedBy` array is empty (or whose blockers are already `completed`). Ties broken by ID. If multiple `in_progress` tasks exist, finish them before picking a new one.
+2. **Mark `in_progress`.** Call `TaskUpdate` with `status: in_progress` *before* doing any work for the task. One task in_progress at a time.
+3. **Execute the task.** Read the task's `description` (use `TaskGet` if needed). Three execution shapes:
+   - **Named skill** — description references a skill (e.g. "Run `/flowkit:merge-pr`", "Use `flowkit:cut`"): invoke it via the `Skill` tool. Pass arguments mentioned in the description verbatim.
+   - **Explicit command** — description gives a shell command or sequence: run via `Bash`.
+   - **Open-ended work** — description describes an outcome (e.g. "Self-review the diff and confirm X"): perform the work using whatever tools fit. Read, edit, search — whatever the description implies.
+4. **Mark `completed`.** Immediately after the task's outcome is achieved, `TaskUpdate` with `status: completed`. Never batch — completing two tasks before updating either is a contract violation.
+5. **Loop.** Go back to step 1.
+
+### 4. Surface conditions (when to break the silence)
+
+Surface to the user **only** when one of these is true. Otherwise, keep driving silently.
+
+| Condition | What it means | How to surface |
+|-----------|---------------|----------------|
+| **Blocker** | A tool failed in a way you cannot recover from (auth missing, network down, dependency missing, hook rejected without an obvious fix, irreversible-state needed). | Plain text: state what failed, what you tried, what's needed. Leave the task `in_progress`. Stop. |
+| **Executive decision** | A genuine fork in approach not covered by the task description; a scope change emerges; two valid paths with materially different consequences. | `AskUserQuestion` with 2–4 options and your recommendation labeled `(Recommended)`. Resume on answer. |
+| **Risky/destructive action** | The next step would delete data, rewrite shared history, force-push, mass-modify external systems, or send messages on the user's behalf. | Plain text confirmation prompt — describe the action and ask permission. Do not bury it inside an `AskUserQuestion`. |
+| **Completion** | All tasks completed. | Final report (see step 5). |
+
+What does **not** count as a surface condition:
+- Routine tool failures with obvious remediation (try again, fix the typo, adjust the path).
+- Each task starting/finishing — the task list updates carry that signal.
+- Cosmetic choices with no downstream impact (commit message wording, branch naming when no convention is given).
+- "Just to confirm" moments. If you're confident, proceed. If you're not, that's an executive decision — surface.
+
+### 5. Final report
+
+When the chain is fully completed (no pending or in_progress tasks remain), output a tight report:
+
+```
+Driven to completion: <N> tasks, <T> minutes.
+
+Highlights:
+- <one-line summary per task that produced an artifact: PR opened, tag created, file modified, etc.>
+
+Outstanding:
+- <anything the user should know about — created follow-ups, deferred work, surfaced findings>
+```
+
+Keep it short. The task list itself records the steps; the report adds anything the list can't carry (URLs, IDs, things created).
+
+## Constraints
+
+- **One task `in_progress` at a time.** Mark `in_progress` before starting, `completed` immediately after, never batch.
+- **No narration.** No "starting task #5", "moving on to #6", "now I'll do X". The task list is the progress feed.
+- **No silent destructive actions.** Even when driving, ask before deleting data, force-pushing, or modifying shared/production state.
+- **No silent scope expansion.** If a task turns out to need a sub-task that wasn't in the plan, add it via `TaskCreate` (with appropriate `blockedBy`) so it's visible — don't smuggle work into an unrelated task.
+- **Blocker etiquette.** Leave the failing task in `in_progress` so the next session/agent can resume it. Don't mark it `completed` if you didn't complete it.
+- **Read tasks fresh.** Use `TaskGet` between steps if a description might have been edited — don't cache stale state.
+- **Never modify task subjects/descriptions to make them easier.** If a task is wrong, surface it as an executive decision.

--- a/plugins/sessionkit/skills/roadmap/SKILL.md
+++ b/plugins/sessionkit/skills/roadmap/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: roadmap
+description: Survey the current work-in-flight (uncommitted state, branch role, open PRs, peer PRs, RCs, in-flight worktrees, existing tasks) and produce an approved task chain that takes the work all the way to "shipped". Read-only during planning. Presents the chain for approval and, on approval, optionally hands off to `/sessionkit:drive` for autonomous execution.
+triggers:
+  - "/roadmap"
+  - "plan the rest"
+  - "what's left to ship"
+  - "map out the remaining steps"
+  - "task out the path to done"
+  - "wrap up current work"
+allowed-tools: Bash, Read, Grep, Glob, TaskList, TaskGet, TaskCreate, TaskUpdate, AskUserQuestion, Skill
+---
+
+# Roadmap
+
+Map the route from "where we are now" to "fully shipped" — or whatever the natural completion state is for the current work — and materialize it as an approved task chain. After approval, hand off to `/sessionkit:drive` for autonomous execution, or hand the chain back to the user to drive manually.
+
+Companion to `/sessionkit:drive`:
+
+- `/sessionkit:roadmap` (this skill) — surveys + plans + approves.
+- `/sessionkit:drive` — executes an approved chain.
+
+## Process
+
+### 1. Survey current work-in-flight
+
+Read-only. Run these in parallel:
+
+```bash
+# Uncommitted state
+git status --porcelain
+
+# Current branch
+git branch --show-current
+
+# Branch's relationship to remote
+git log @{u}..HEAD --oneline 2>/dev/null   # local commits not pushed
+git log HEAD..@{u} --oneline 2>/dev/null   # remote commits not pulled
+git rev-parse --abbrev-ref @{u} 2>/dev/null # tracked upstream
+
+# Base branch + epic mode
+git config claude.flowkit.prBase           # epic base if set
+git ls-remote --heads origin develop main  # which long-lived branches exist
+
+# Open PRs targeting common bases
+gh pr list --base develop --state open --json number,title,headRefName,reviewDecision,mergeStateStatus,isDraft 2>/dev/null
+gh pr list --base main    --state open --json number,title,headRefName,reviewDecision,mergeStateStatus,isDraft 2>/dev/null
+gh pr list --head "$(git branch --show-current)" --state open --json number,title,baseRefName,reviewDecision,mergeStateStatus 2>/dev/null
+
+# Pipeline state (RC branches, latest tag)
+git ls-remote --heads origin "rc/*" | awk '{print $2}' | sed 's|refs/heads/||'
+git ls-remote --tags  origin "v[0-9]*" | awk '{print $2}' | sed 's|refs/tags/||' | sort -V | tail -1
+
+# In-flight worktrees (isolated agents)
+git worktree list
+
+# Existing task list
+```
+
+Then call `TaskList` to see what's already tracked.
+
+If `flowkit:pipeline-status` is available in this repo, prefer invoking it once via the `Skill` tool for the canonical pipeline view — it summarizes the data above into a single block.
+
+### 2. Classify the state
+
+Identify every state signal that applies (composable, not exclusive). Map each to the entry point of a sub-chain:
+
+| Signal | Sub-chain entry |
+|--------|-----------------|
+| Uncommitted local changes (`git status` non-empty) | Commit → push → PR → review → merge → … |
+| Local commits ahead of upstream | Push → PR → review → merge → … |
+| Branch pushed, no PR open | Open PR → review → merge → … |
+| Open PR for current branch | Self-review → merge → … |
+| Peer PRs on same base (stack) | Preview-epic → merge-stack → … |
+| Epic mode set (`claude.flowkit.prBase` non-empty) | Same as stack, then preview epic → integration PR to base |
+| `develop` ahead of `main` (release awaiting cut) | Bump versions → cut → release |
+| RC branch exists on origin | Release (RC → main) |
+| Latest release shipped, develop in sync | "Nothing to ship" — surface and offer alternatives |
+
+### 3. Synthesize the linear/DAG plan
+
+Compose the entry sub-chains into a single ordered chain. Standard step library — pick from these and stitch:
+
+| Step | Skill / command |
+|------|-----------------|
+| Commit local changes | `/flowkit:commit` |
+| Open PR for current branch | `/flowkit:open-pr` |
+| Stage + commit + open PR in one shot | `/flowkit:pr` |
+| Self-review the PR diff | `/review` (or manual read-through) |
+| Merge a single PR | `/flowkit:merge-pr` |
+| Merge a stacked PR set | `/swarmkit:merge-stack` |
+| Preview an epic before integration | `/flowkit:preview-epic` |
+| Sync local develop with origin | `/flowkit:sync` |
+| Bump per-plugin versions + tags | `/bump-versions` |
+| Cut a release candidate | `/flowkit:cut` |
+| Promote RC → main, tag, close issues | `/flowkit:release` |
+| Verify post-release pipeline state | `/flowkit:pipeline-status` |
+
+For each step in the chain, write a task with:
+
+- **subject** — imperative title (e.g. `Merge PR #777 to develop`).
+- **description** — exact skill invocation (e.g. `Run /flowkit:merge-pr.`) or, for non-skill work, the concrete outcome (e.g. `Self-review the final diff. Confirm: bug fix is correct, no flowkit dependencies remain, PR body matches plugins/_shared/pr-body.md.`). Drive parses the description, so be unambiguous.
+- **activeForm** — present-continuous form for the spinner.
+
+Wire `blockedBy` so each step is unblocked only after its predecessor completes. Linear chains are the common case; only branch when the work genuinely forks.
+
+### 4. Present the plan + ask approval
+
+After all tasks are created, output a compact summary:
+
+```
+── Roadmap ────────────────────────────────────────
+Goal: <one-sentence statement of what "done" means here>
+
+Plan (<N> steps):
+  1. <subject>            (skill: <skill or "manual">)
+  2. <subject>            (...)
+  ...
+
+Estimated path: <ordered list of skill names that will run>
+───────────────────────────────────────────────────
+```
+
+Then ask via `AskUserQuestion`:
+
+- **question**: `Approve this roadmap?`
+- **header**: `Roadmap`
+- **options**:
+  1. `Drive it for me` — invokes `/sessionkit:drive` immediately. Recommended.
+  2. `I'll drive` — exits; user works the task list manually.
+  3. `Modify` — user describes changes; regenerate the plan from step 3.
+  4. `Cancel` — delete the created tasks and exit.
+
+If only one step exists, fall back to plain text — the structured prompt is overkill for a single-action plan.
+
+### 5. Act on the answer
+
+- **Drive it for me** → invoke `Skill("sessionkit:drive")`. The drive skill picks up the just-created task list and executes it. Roadmap's job ends here.
+- **I'll drive** → print the task IDs and a one-line reminder (`Run /sessionkit:drive when ready, or work the list manually.`) and exit.
+- **Modify** → prompt the user for what to change. Update the task list (TaskUpdate to edit/delete, TaskCreate to add). Re-present from step 4.
+- **Cancel** → for every task created in this invocation, `TaskUpdate` with `status: deleted`. Confirm and exit.
+
+## Constraints
+
+- **Read-only during steps 1–3.** Never mutate the repo, branches, tags, or PRs while planning. The plan is a proposal until the user approves.
+- **Tasks created before approval are provisional.** If the user picks "Cancel", delete every task this invocation created.
+- **Don't invent steps the project doesn't have.** Only reference skills and commands that exist in this repo / installed plugins. If the natural step is missing (no `/flowkit:cut` because flowkit isn't installed), surface that as a gap rather than silently stepping over it.
+- **Never assume universal driving rules.** The driving contract lives in `/sessionkit:drive`'s SKILL.md and in this skill — do not assume the user has any global directive in `CLAUDE.md`. The skill must work for any installer.
+- **One chain per invocation.** If the survey turns up two unrelated work threads (e.g. an in-flight PR *and* a separate untracked feature branch), ask which one to plan rather than producing a fork. The user can run roadmap again for the other thread.
+- **Use named skills, not raw commands, where possible.** A task description that says "Run `/flowkit:cut`" is unambiguous to drive; a description that pastes the cut script is brittle.


### PR DESCRIPTION
## Summary

Adds two new sessionkit skills that pair to take the user from "where is my work-in-flight" to "shipped" with one approval step.

- `/sessionkit:roadmap` — surveys the current work, classifies the state, materializes a complete task chain (commit → push → PR → review → merge → bump → cut → release, or whatever subset applies), and presents it for approval. On approval, optionally hands off to `/drive` for autonomous execution.
- `/sessionkit:drive` — executes an approved task chain end-to-end. Marks each task `in_progress` before starting and `completed` immediately after, never batched. Surfaces only for blockers, executive decisions, risky/destructive actions, or completion. Standalone-invokable on any prepared task list.

## Changes

- `plugins/sessionkit/skills/drive/SKILL.md` — new sub-skill that owns the autonomous-execution contract (preamble, drive loop, surface conditions, final report, constraints).
- `plugins/sessionkit/skills/roadmap/SKILL.md` — new skill that surveys → classifies → synthesizes → presents → hands off. Read-only during planning; created tasks are provisional and deleted on cancel.
- `plugins/sessionkit/README.md` — adds roadmap + drive to the user-facing skill table, a new "Planning the path to 'done', then driving it" workflow, and a "How Roadmap / Drive Works" deep-dive.
- `plugins/sessionkit/.claude-plugin/plugin.json` — refreshes the description to mention planning and driving.
- `.claude-plugin/marketplace.json` — same description refresh for the marketplace catalog.
- `README.md` — extends the sessionkit catalog row to mention `/roadmap` + `/drive`.

## Decoupling note

The driving contract (mark in_progress before/completed after, only surface for blockers or executive decisions, never batch) lives entirely inside `/sessionkit:drive`'s SKILL.md. Sessionkit does **not** depend on the user having a personal "driving mode" directive in their global or project `CLAUDE.md`. Any installer gets the autonomous-execution semantics out of the box.

## Test plan

- [ ] In a session with no global "driving mode" directive present, run `/sessionkit:roadmap` while a piece of work is in flight (e.g. an open PR awaiting review). Confirm the survey identifies the work, classifies it, and produces a complete task chain ending in `/release` or equivalent.
- [ ] Approve the plan via the "Drive it for me" option. Confirm `/drive` starts, prints the one-line preamble, marks the first task `in_progress`, and proceeds through the chain.
- [ ] Confirm `/drive` surfaces only for blockers / executive decisions, not for routine task transitions.
- [ ] Run `/sessionkit:drive` standalone on a hand-built task list. Confirm it picks up the existing chain without a roadmap step.
- [ ] Run `/sessionkit:roadmap` and pick "Cancel". Confirm every task created during planning is deleted (status `deleted`).
- [ ] Run `/sessionkit:roadmap` when there's no work-in-flight. Confirm the skill says "nothing to ship" gracefully and offers alternatives.

## Context

The motivation: the user wants a single skill that maps "what's left to ship from where we are right now" into an approved chain, then either drives it autonomously or hands it back to the user. The split between planning (`/roadmap`) and execution (`/drive`) keeps each skill focused and lets `/drive` be reused on any task list, not just one built by `/roadmap`.