### PR TITLE
chore(plugins): bump polishkit@3.0.1, sessionkit@1.9.0

### DIFF
--- a/plugins/polishkit/.claude-plugin/plugin.json
+++ b/plugins/polishkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polishkit",
   "description": "Codebase quality toolkit. Appraise code craft with a connoisseur's eye, sweep dead code and cruft in one pass, and polish cross-cutting code-quality issues — three focused skills for improving what you've already built.",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sessionkit",
   "description": "Session continuity, planning, and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, map work-in-flight into an approved task chain and drive it to completion, discover reusable skills, and reduce permission noise.",
-  "version": "1.8.1",
+  "version": "1.9.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Pre-release version bumps for the v2026.5.2.5 release candidate.

## Changes

- `plugins/polishkit/.claude-plugin/plugin.json`: 3.0.0 → 3.0.1 (patch — picks up the standalone PR-base resolution fix from #777).
- `plugins/sessionkit/.claude-plugin/plugin.json`: 1.8.1 → 1.9.0 (minor — adds the new `/roadmap` and `/drive` skills from #778).

## Test plan

- [ ] CI passes on the bump commit.
- [ ] After merge, /bump-versions detects no changed plugins (commit_count == 0 for both polishkit and sessionkit).