### PR TITLE
chore(plugins): bump flowkit@3.9.0

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship \u2014 with runtime staging detection and a one-command hotfix flow.",
-  "version": "3.8.2",
+  "version": "3.9.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Bump flowkit to 3.9.0 (minor) — adds the new push-or-pr sub-skill.

## Changes

- flowkit@3.9.0

## Test plan

- [ ] Confirm the per-plugin tag flowkit--v3.9.0 is created after merge.