### PR TITLE
release: 2026-05-02

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,7 +23,9 @@
       "Bash($SKILL_DIR/scripts/remove.sh:*)",
       "Bash($SKILL_DIR/scripts/classify.sh:*)",
       "Bash($SKILL_DIR/scripts/delete.sh:*)",
-      "Bash($SKILL_DIR/scripts/detect_changed.sh:*)"
+      "Bash($SKILL_DIR/scripts/detect_changed.sh:*)",
+      "Bash(plugins/flowkit/skills/push-or-pr/scripts/push_or_pr.sh:*)",
+      "Bash(*/plugins/flowkit/skills/push-or-pr/scripts/push_or_pr.sh:*)"
     ]
   }
 }

--- a/.claude/skills/bump-versions/SKILL.md
+++ b/.claude/skills/bump-versions/SKILL.md
@@ -93,22 +93,54 @@ Fall through to free-form prompting (asking the user to type patch/minor/major i
 
 For each plugin being bumped, read the current `plugin.json`, increment the version field, and write it back.
 
-### Step 4 — Commit plugin.json changes
+### Step 4 — Commit and publish plugin.json changes
 
-Stage and commit all updated `plugin.json` files to the current branch, then push:
+Stage and commit all updated `plugin.json` files to the current branch:
 
 ```bash
+BUMPED_LIST="<comma-separated list of plugin@new-version>"
 git add plugins/*/.claude-plugin/plugin.json
-git commit -m "chore(plugins): bump <list of plugin@version>"
-git push origin HEAD
+git commit -m "chore(plugins): bump $BUMPED_LIST"
 ```
 
 Use a single commit message listing all bumped plugins, e.g.:
 `chore(plugins): bump swarmkit@2.0.0, flowkit@1.3.0`
 
+Then publish the commit via the [`flowkit:push-or-pr`](../../../plugins/flowkit/skills/push-or-pr/SKILL.md) sub-skill so the bump lands on the protected branch even when direct pushes are rejected:
+
+```bash
+PR_BODY="## Summary
+
+Bump plugin.json versions for plugins changed since their last release.
+
+## Changes
+
+$(printf '%s\n' "$BUMPED_LIST" | tr ',' '\n' | sed 's/^[[:space:]]*/- /')
+
+## Test plan
+
+- [ ] Confirm each \`plugin.json\` version bump matches the per-plugin tag that will be created after merge."
+
+RESULT=$(bash plugins/flowkit/skills/push-or-pr/scripts/push_or_pr.sh \
+  --prefix "chore/bump-plugins" \
+  --title "chore(plugins): bump $BUMPED_LIST" \
+  --body "$PR_BODY" \
+  --base "develop")
+
+PUSH_RESULT=$(printf '%s' "$RESULT" | jq -r '.push_result')
+NEW_BRANCH=$(printf '%s' "$RESULT" | jq -r '.new_branch // empty')
+PR_URL=$(printf '%s' "$RESULT" | jq -r '.pr_url // empty')
+```
+
+Branch on `$PUSH_RESULT`:
+
+- `direct` — the bump commit is on origin's protected branch. Continue to Step 5.
+- `pr` — push-or-pr opened `$PR_URL`. Self-review the PR, then merge it (`/flowkit:merge-pr` from `$NEW_BRANCH`). Once merged, switch to the protected branch and pull (`git checkout <branch> && git pull origin <branch>`), then continue to Step 5 — tags now point at the squash-merged commit, not the original feature-branch commit.
+- `noop` — nothing changed. Stop and report.
+
 ### Step 5 — Create git tags
 
-After the commit is pushed, create a tag for each bumped plugin pointing at that commit:
+After the bump commit is on origin's protected branch (either via direct push or via merged PR), create a tag for each bumped plugin pointing at the current branch tip:
 
 ```bash
 git tag {plugin-name}--v{new-version}

--- a/plugins/_shared/script-authoring.md
+++ b/plugins/_shared/script-authoring.md
@@ -38,6 +38,25 @@ export SKILL_DIR="<absolute path from the 'Base directory for this skill:' heade
 
 Use `"$SKILL_DIR/scripts/<name>.sh"` for every invocation. Never hardcode `plugins/<plugin>/...` — that path only resolves in repos that vendor the plugin directly.
 
+### Cross-skill invocation
+
+The default expectation is that a script is invoked **only by its owner skill**, where `$SKILL_DIR` aligns and the standard `"$SKILL_DIR/scripts/<name>.sh"` form works. Some sub-skills (e.g. `flowkit:push-or-pr`) are intentionally shared across multiple callers; those callers cannot use their own `$SKILL_DIR` to address the script. Two resolution patterns cover the cases that come up in this repo:
+
+- **Sibling-skill caller** (caller and target are in the same plugin) — derive the target's `SKILL_DIR` from the caller's:
+
+  ```bash
+  TARGET_SKILL_DIR="$(dirname "$SKILL_DIR")/<target-skill>"
+  bash "$TARGET_SKILL_DIR/scripts/<name>.sh" ...
+  ```
+
+- **Project-local caller** (e.g. a skill under `.claude/skills/` reaching into a vendored `plugins/<plugin>/skills/<skill>/`) — hardcode the repo-relative path. This is the one case where the "never hardcode `plugins/<plugin>/...`" rule does not apply, because project-local skills only ever run in repos that vendor the target plugin:
+
+  ```bash
+  bash plugins/<plugin>/skills/<target-skill>/scripts/<name>.sh ...
+  ```
+
+Either way, document the cross-skill dependency in the target's SKILL.md so callers know how to invoke it. The allowlist implications are addressed under [`.claude/settings.json` allowlist](#claudesettingsjson-allowlist) below.
+
 ## JSON output convention
 
 On success a script exits 0 and emits a **bare payload** JSON object on stdout. No envelope wrapper — the payload is the output:
@@ -123,3 +142,25 @@ The harness requires explicit permission before executing each script path. Add 
 ```
 
 Because `$SKILL_DIR` resolves at runtime, use the literal token `$SKILL_DIR` in the allowlist string — Claude Code expands environment variables in permission patterns. Add one entry per script, in the same PR that introduces the script. Do not batch allowlist entries ahead of the scripts they cover.
+
+### Allowlist for cross-skill scripts
+
+The harness expands `$SKILL_DIR` in allowlist patterns against the **calling skill's** runtime `$SKILL_DIR`. That means `Bash($SKILL_DIR/scripts/<name>.sh:*)` only matches when the script is invoked by its owner — for cross-skill scripts (see [Cross-skill invocation](#cross-skill-invocation) above), that pattern silently fails to match every external caller.
+
+Use these two matchers instead:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(plugins/<plugin>/skills/<target-skill>/scripts/<name>.sh:*)",
+      "Bash(*/plugins/<plugin>/skills/<target-skill>/scripts/<name>.sh:*)"
+    ]
+  }
+}
+```
+
+- The first matches project-local callers that invoke via the repo-relative path.
+- The second is a leading-glob suffix matcher that catches callers from other plugins' skills, where the script is invoked via an absolute path that varies by install location (plugin marketplace cache, vendored copy, etc.).
+
+Both are additions on top of the standard `$SKILL_DIR` form; if the script is also invoked by its owner, keep that entry too. The path itself acts as the discriminator — the script's plugin-namespaced location is distinctive enough that the suffix glob does not over-match.

--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship \u2014 with runtime staging detection and a one-command hotfix flow.",
-  "version": "3.8.2",
+  "version": "3.9.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/flowkit/skills/hotfix/SKILL.md
+++ b/plugins/flowkit/skills/hotfix/SKILL.md
@@ -125,15 +125,43 @@ If a hotfix is targeting a repo where `main` is the GitHub default, the auto-clo
 
 ### 12. Back-merge main into develop
 
-Keep `develop` in sync with the hotfix:
+Keep `develop` in sync with the hotfix. Merge locally first:
 
 ```bash
 git fetch origin
 git checkout develop
-git pull origin develop
+git pull --ff-only origin develop
 git merge --no-ff origin/main -m "chore(develop): back-merge hotfix from main"
-git push origin develop
 ```
+
+Then publish via the [`flowkit:push-or-pr`](../push-or-pr/SKILL.md) sub-skill so the back-merge lands on develop whether or not develop is push-protected:
+
+```bash
+PUSH_OR_PR_DIR="$(dirname "$SKILL_DIR")/push-or-pr"
+PR_BODY="## Summary
+
+Back-merge hotfix \`$TAG\` from main into develop.
+
+## Test plan
+
+- [ ] Confirm \`git log origin/main..origin/develop\` is empty after merge."
+
+RESULT=$(bash "$PUSH_OR_PR_DIR/scripts/push_or_pr.sh" \
+  --prefix "chore/sync-develop" \
+  --title "chore(develop): back-merge hotfix from main" \
+  --body "$PR_BODY" \
+  --base "develop")
+
+PUSH_RESULT=$(printf '%s' "$RESULT" | jq -r '.push_result')
+NEW_BRANCH=$(printf '%s' "$RESULT" | jq -r '.new_branch // empty')
+PR_URL=$(printf '%s' "$RESULT" | jq -r '.pr_url // empty')
+```
+
+Branch on `$PUSH_RESULT`:
+
+- `direct` — develop now matches main on origin.
+- `pr` — push-or-pr opened `$PR_URL` on `$NEW_BRANCH`. Merge it with `gh pr merge "$PR_URL" --merge --delete-branch` (use `--merge`, not `--squash`, to preserve the hotfix merge history).
+- `noop` — develop is already at or ahead of main on origin.
 
 ### 13. Sync develop
 

--- a/plugins/flowkit/skills/push-or-pr/SKILL.md
+++ b/plugins/flowkit/skills/push-or-pr/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: push-or-pr
+description: Publish pending commits on the current branch by pushing directly when allowed, or by creating a feature branch and opening a PR when the target is branch-protected. Sub-skill used by /bump-versions, /flowkit:release, and /flowkit:hotfix.
+---
+
+# push-or-pr
+
+Publish pending commits on the current branch to origin. Optimistically attempts a direct push; if origin rejects the push because the branch is protected, saves HEAD, resets the local branch to its upstream, creates a feature branch carrying the saved commit(s), pushes it, and opens a PR. Skills that legitimately operate on `develop` (or any branch that may or may not be push-protected depending on repo policy) call this sub-skill so they work uniformly across protected and unprotected setups.
+
+The skill is push-only. Tag creation, post-merge sync, and merging the resulting PR remain caller responsibilities — those vary per caller (squash vs. merge strategy, post-sync requirements, tag placement).
+
+## Invocation
+
+The bash work lives in [`scripts/push_or_pr.sh`](./scripts/push_or_pr.sh). Callers invoke it directly:
+
+```bash
+RESULT=$(bash "$SKILL_DIR/scripts/push_or_pr.sh" \
+  --prefix "$PREFIX" \
+  --title "$PR_TITLE" \
+  --body "$PR_BODY" \
+  --base "${BASE:-develop}")
+```
+
+`$SKILL_DIR` is the absolute path of the *push-or-pr* skill on disk. Callers resolve it as follows:
+
+- **Sibling skills inside flowkit** (`release`, `hotfix`): `SKILL_DIR="$(dirname "$CALLER_SKILL_DIR")/push-or-pr"`, where `$CALLER_SKILL_DIR` is the caller's own `Base directory for this skill` value.
+- **Repo-local skills** (e.g. `.claude/skills/bump-versions/`): hardcode `SKILL_DIR="plugins/flowkit/skills/push-or-pr"` relative to the repo root. The skill is project-local so it always knows where flowkit lives.
+
+## Arguments
+
+| Flag | Required | Default | Purpose |
+|------|----------|---------|---------|
+| `--prefix` | when fallback engages | — | Branch-name prefix for the auto-created feature branch (e.g. `chore/bump-plugins`, `chore/sync-develop`). The script appends `-YYYY-MM-DD` and a numeric suffix on collision. |
+| `--title` | when fallback engages | — | Title for the fallback PR. |
+| `--body` | when fallback engages | — | Body for the fallback PR. Caller assembles per [`plugins/_shared/pr-body.md`](../../../_shared/pr-body.md). Multi-line strings are fine — the caller quotes the value. |
+| `--base` | always optional | `develop` | Base branch for the fallback PR. |
+
+If the direct push succeeds, the fallback args are unused and may be omitted. If the push is rejected by branch protection but the fallback args are missing, the script exits non-zero with exit code 2.
+
+## Output
+
+On success the script emits a single bare JSON object on stdout (per [`plugins/_shared/script-authoring.md`](../../../_shared/script-authoring.md)):
+
+| Key | Type | Present when | Meaning |
+|-----|------|--------------|---------|
+| `push_result` | string | always | `"direct"` \| `"pr"` \| `"noop"` |
+| `branch` | string | always | The current branch at invocation time. |
+| `pending_count` | integer | always | Commits ahead of upstream at invocation. |
+| `new_branch` | string | `push_result == "pr"` | Auto-created feature branch carrying the saved commits. |
+| `pr_url` | string | `push_result == "pr"` | URL of the PR opened against `--base`. |
+
+On failure the script exits non-zero with stderr describing the failure and stdout empty.
+
+## Caller follow-up
+
+Branch on `push_result`:
+
+- **`direct`** — commits are on origin's protected branch. Caller continues with whatever post-publish work it has (tag creation, sync, etc.).
+- **`pr`** — PR is open at `pr_url`; commits live on `new_branch`; the local protected branch was reset to its upstream so it no longer holds the unpublished commit. Caller self-reviews and merges (`gh pr merge --squash --delete-branch` or `--merge --delete-branch` depending on whether history needs preserving), then switches back to the protected branch and pulls before continuing post-publish work.
+- **`noop`** — no pending commits. Nothing was pushed; nothing to clean up.
+
+When the fallback engages, the working tree is left on `new_branch`. Callers that need to return to the protected branch must explicitly `git checkout <branch> && git pull origin <branch>` after the PR merges.
+
+## Branch-protection detection
+
+The script classifies push failures as protection-related when stderr contains any of:
+
+- `protected branch` (case-insensitive)
+- `GH006` — GitHub's branch-protection error code
+- `push declined due to repository rule violations` — repository rulesets
+- `protected branch hook declined` — the underlying refspec rejection
+
+Any other push failure (auth, network, divergence) exits non-zero with the captured stderr surfaced.
+
+## Constraints
+
+- Never force-push. The script assumes the protected branch's upstream is the canonical state and resets the local copy to it before creating the feature branch.
+- Never engage the fallback for non-protection-related push failures.
+- The script does not push tags. Tag creation belongs to the caller and must run after the fallback PR (if any) is merged so tags point at the post-merge commit.
+- The script checks out `new_branch` before resetting the protected branch — `git branch -f` refuses to update the currently-checked-out branch, so the order matters.

--- a/plugins/flowkit/skills/push-or-pr/scripts/push_or_pr.sh
+++ b/plugins/flowkit/skills/push-or-pr/scripts/push_or_pr.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# push_or_pr.sh — publish pending commits on the current branch by pushing
+# directly when allowed, or by creating a feature branch and opening a PR
+# when origin rejects the push because the target branch is protected.
+#
+# Usage:
+#   push_or_pr.sh --prefix <name> --title <title> --body <body> [--base <branch>]
+#
+# Args:
+#   --prefix <name>    Branch-name prefix for the auto-created feature branch
+#                      when the fallback engages (e.g. "chore/bump-plugins").
+#                      The script appends "-YYYY-MM-DD" and a numeric suffix
+#                      on collision.
+#   --title <title>    Title for the fallback PR.
+#   --body <body>      Body for the fallback PR. Multi-line strings are fine
+#                      (caller quotes the value).
+#   --base <branch>    Base branch for the fallback PR. Default: develop.
+#
+# Behavior:
+#   1. Compares HEAD against origin/<current-branch>. If no pending commits,
+#      emits {"push_result":"noop"} and exits 0.
+#   2. Otherwise attempts `git push origin HEAD:<current-branch>`.
+#   3. On success, emits {"push_result":"direct", ...} and exits 0.
+#   4. On failure, classifies stderr. If the message matches a branch-
+#      protection rejection (GH006 / repository rule violations / protected
+#      branch hook declined), engages the fallback:
+#      a. Saves HEAD as $SAVED.
+#      b. Picks a non-colliding feature-branch name from $PREFIX + date.
+#      c. Checks out the new branch at $SAVED, then resets the original
+#         branch's local ref to its upstream (so the protected branch no
+#         longer holds the unpublished commit). Order matters — `git branch
+#         -f` refuses to update the currently-checked-out branch.
+#      d. Pushes the new branch and opens a PR via `gh pr create`.
+#      e. Emits {"push_result":"pr", ...} and exits 0.
+#   5. Any other push failure (auth, network, divergence) exits non-zero with
+#      the captured stderr surfaced to the caller.
+#
+# Output (success): a single bare JSON object on stdout with keys:
+#   push_result    — "direct" | "pr" | "noop"
+#   branch         — current branch at invocation time
+#   new_branch     — fallback feature branch (only when push_result=pr)
+#   pr_url         — fallback PR URL (only when push_result=pr)
+#   pending_count  — number of commits ahead of upstream at invocation
+#
+# Output (failure): exit non-zero, stdout empty, human-readable stderr.
+
+PREFIX=""
+PR_TITLE=""
+PR_BODY=""
+BASE="develop"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --prefix)
+      [[ $# -ge 2 ]] || { echo "push_or_pr: --prefix requires a value" >&2; exit 2; }
+      PREFIX="$2"
+      shift 2
+      ;;
+    --title)
+      [[ $# -ge 2 ]] || { echo "push_or_pr: --title requires a value" >&2; exit 2; }
+      PR_TITLE="$2"
+      shift 2
+      ;;
+    --body)
+      [[ $# -ge 2 ]] || { echo "push_or_pr: --body requires a value" >&2; exit 2; }
+      PR_BODY="$2"
+      shift 2
+      ;;
+    --base)
+      [[ $# -ge 2 ]] || { echo "push_or_pr: --base requires a value" >&2; exit 2; }
+      BASE="$2"
+      shift 2
+      ;;
+    *)
+      echo "push_or_pr: unknown argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+for cmd in jq git gh; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "push_or_pr: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+if [[ -z "$BRANCH" || "$BRANCH" == "HEAD" ]]; then
+  echo "push_or_pr: not on a branch (detached HEAD?) — refusing to publish" >&2
+  exit 1
+fi
+
+UPSTREAM_REF="origin/$BRANCH"
+if ! git rev-parse --verify --quiet "$UPSTREAM_REF" >/dev/null; then
+  echo "push_or_pr: $UPSTREAM_REF does not exist locally — run 'git fetch origin' before invoking" >&2
+  exit 1
+fi
+
+PENDING=$(git rev-list --count "$UPSTREAM_REF..HEAD")
+
+if [[ "$PENDING" -eq 0 ]]; then
+  jq -n \
+    --arg push_result "noop" \
+    --arg branch "$BRANCH" \
+    --argjson pending_count 0 \
+    '{push_result: $push_result, branch: $branch, pending_count: $pending_count}'
+  exit 0
+fi
+
+PUSH_LOG=$(mktemp)
+trap 'rm -f "$PUSH_LOG"' EXIT
+
+if git push origin "HEAD:$BRANCH" >"$PUSH_LOG" 2>&1; then
+  jq -n \
+    --arg push_result "direct" \
+    --arg branch "$BRANCH" \
+    --argjson pending_count "$PENDING" \
+    '{push_result: $push_result, branch: $branch, pending_count: $pending_count}'
+  exit 0
+fi
+
+PUSH_OUTPUT=$(cat "$PUSH_LOG")
+if ! printf '%s' "$PUSH_OUTPUT" | grep -qiE "(protected branch|GH006|push declined due to repository rule|protected branch hook declined)"; then
+  echo "push_or_pr: push to $BRANCH failed for a reason other than branch protection:" >&2
+  printf '%s\n' "$PUSH_OUTPUT" >&2
+  exit 1
+fi
+
+if [[ -z "$PREFIX" || -z "$PR_TITLE" || -z "$PR_BODY" ]]; then
+  echo "push_or_pr: branch protection rejected the push, but --prefix / --title / --body are required to engage the fallback" >&2
+  exit 2
+fi
+
+echo "push_or_pr: direct push to $BRANCH rejected by branch protection — falling back to feature branch + PR." >&2
+
+SAVED=$(git rev-parse HEAD)
+DATE=$(date +%Y-%m-%d)
+NEW_BRANCH="${PREFIX}-${DATE}"
+N=1
+while git ls-remote --exit-code origin "refs/heads/$NEW_BRANCH" >/dev/null 2>&1 \
+   || git rev-parse --verify --quiet "refs/heads/$NEW_BRANCH" >/dev/null; do
+  N=$((N + 1))
+  NEW_BRANCH="${PREFIX}-${DATE}-${N}"
+done
+
+git checkout -b "$NEW_BRANCH" "$SAVED" >/dev/null 2>&1
+git branch -f "$BRANCH" "$UPSTREAM_REF" >/dev/null 2>&1
+
+if ! git push -u origin "$NEW_BRANCH" >/dev/null 2>&1; then
+  echo "push_or_pr: failed to push fallback branch '$NEW_BRANCH'" >&2
+  exit 1
+fi
+
+PR_URL=$(gh pr create \
+  --base "$BASE" \
+  --head "$NEW_BRANCH" \
+  --title "$PR_TITLE" \
+  --body "$PR_BODY")
+
+if [[ -z "$PR_URL" ]]; then
+  echo "push_or_pr: 'gh pr create' returned empty URL" >&2
+  exit 1
+fi
+
+jq -n \
+  --arg push_result "pr" \
+  --arg branch "$BRANCH" \
+  --arg new_branch "$NEW_BRANCH" \
+  --arg pr_url "$PR_URL" \
+  --argjson pending_count "$PENDING" \
+  '{push_result: $push_result, branch: $branch, new_branch: $new_branch, pr_url: $pr_url, pending_count: $pending_count}'

--- a/plugins/flowkit/skills/push-or-pr/scripts/test.sh
+++ b/plugins/flowkit/skills/push-or-pr/scripts/test.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# test.sh — smoke tests for flowkit:push-or-pr scripts.
+#
+# Per the convention in plugins/_shared/script-authoring.md:
+# - Successful invocations exit 0 and emit a parseable JSON object on stdout.
+# - Invalid-argument invocations exit non-zero and emit nothing on stdout.
+#
+# Happy paths for push_or_pr.sh require a live git remote, branch-protection
+# rules, and `gh` auth. They cannot run from a smoke harness, so this file
+# covers the deterministic argument-validation surface only. End-to-end
+# behavior is exercised by the calling skills (bump-versions, release,
+# hotfix) when they run against the live repo.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PASS=0
+FAIL=0
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+assert_invalid_args() {
+  local script="$1"; shift
+  local label="$1"; shift
+  local stdout stderr rc
+  local tmp_out tmp_err
+  tmp_out="$(mktemp)"
+  tmp_err="$(mktemp)"
+  set +e
+  "$SCRIPT_DIR/$script" "$@" >"$tmp_out" 2>"$tmp_err"
+  rc=$?
+  set -e
+  stdout="$(cat "$tmp_out")"
+  stderr="$(cat "$tmp_err")"
+  rm -f "$tmp_out" "$tmp_err"
+
+  if [[ $rc -eq 0 ]]; then
+    red   "  FAIL [$script $label]: expected non-zero exit, got 0"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -n "$stdout" ]]; then
+    red   "  FAIL [$script $label]: expected empty stdout on invalid args, got:"
+    printf '%s\n' "$stdout" | sed 's/^/         /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -z "$stderr" ]]; then
+    red   "  FAIL [$script $label]: expected non-empty stderr message"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  green "  PASS [$script $label]: exit=$rc, stdout empty, stderr non-empty"
+  PASS=$((PASS + 1))
+}
+
+echo "push-or-pr: smoke-testing argument validation contracts"
+echo
+
+# push_or_pr.sh — accepts --prefix, --title, --body, --base, all with values.
+assert_invalid_args push_or_pr.sh "unknown-flag"          --not-a-flag
+assert_invalid_args push_or_pr.sh "missing-prefix-value"  --prefix
+assert_invalid_args push_or_pr.sh "missing-title-value"   --title
+assert_invalid_args push_or_pr.sh "missing-body-value"    --body
+assert_invalid_args push_or_pr.sh "missing-base-value"    --base
+assert_invalid_args push_or_pr.sh "extra-positional"      positional-not-allowed
+
+echo
+echo "push-or-pr: ${PASS} passed, ${FAIL} failed"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -417,9 +417,45 @@ git ls-remote --heads origin "rc/$TODAY*" \
     done
 ```
 
-### 11. Sync develop
+### 11. Back-merge main into develop
 
-Follow the `git-sync-develop` sub-skill. Because the release PR was merged with a merge commit (not squashed), `git merge origin/main` on develop will correctly resolve without divergence — no force-push is needed.
+Bring develop's tip up to main so the next release cycle starts from parity. Use a real merge commit (not a fast-forward / squash) so the release merge from step 6 stays visible in develop's history.
+
+```bash
+git fetch origin
+git checkout develop
+git pull --ff-only origin develop
+git merge --no-ff -m "chore(develop): back-merge release $TAG from main" origin/main
+```
+
+Publish the back-merge via the [`flowkit:push-or-pr`](../../push-or-pr/SKILL.md) sub-skill — direct pushes succeed when develop is unprotected and fall through to a merge-strategy back-merge PR when it isn't:
+
+```bash
+PUSH_OR_PR_DIR="$(dirname "$SKILL_DIR")/push-or-pr"
+PR_BODY="## Summary
+
+Back-merge release \`$TAG\` from main into develop.
+
+## Test plan
+
+- [ ] Confirm \`git log origin/main..origin/develop\` is empty after merge."
+
+RESULT=$(bash "$PUSH_OR_PR_DIR/scripts/push_or_pr.sh" \
+  --prefix "chore/sync-develop" \
+  --title "chore(develop): back-merge release $TAG from main" \
+  --body "$PR_BODY" \
+  --base "develop")
+
+PUSH_RESULT=$(printf '%s' "$RESULT" | jq -r '.push_result')
+NEW_BRANCH=$(printf '%s' "$RESULT" | jq -r '.new_branch // empty')
+PR_URL=$(printf '%s' "$RESULT" | jq -r '.pr_url // empty')
+```
+
+Branch on `$PUSH_RESULT`:
+
+- `direct` — develop now matches main on origin. Done.
+- `pr` — push-or-pr opened `$PR_URL` on `$NEW_BRANCH`. Merge it with `gh pr merge "$PR_URL" --merge --delete-branch` (use `--merge`, not `--squash`, to preserve the release merge commit's history). The local working tree is left on `$NEW_BRANCH` — switch back to develop and pull after the merge.
+- `noop` — develop is already at or ahead of main on origin. Skip the publish and continue.
 
 ### 12. Report
 


### PR DESCRIPTION
## Summary

Ship flowkit's new `push-or-pr` sub-skill — a shared protected-branch-aware publish primitive used by `/bump-versions`, `/flowkit:release`, and `/flowkit:hotfix`. Eliminates the recurring "direct push to develop rejected" friction every release cycle hit, and validates the new convention for cross-skill scripts in `plugins/_shared/script-authoring.md`.

## Release summary

**Built from**: `rc/2026-05-02.7`

### Version bumps
- chore(plugins): bump flowkit@3.9.0 (#785)

### Release notes

**flowkit**
- feat(flowkit): add push-or-pr sub-skill for protected-develop publishes — Adds a shared sub-skill that publishes pending commits via direct push when the target branch is unprotected, and falls through to a feature-branch + PR cycle when origin rejects the push because the branch is protected.

### Changes

**flowkit**
- feat(flowkit): add push-or-pr sub-skill for protected-develop publishes (#784)

Closes #782
Closes #783