### PR TITLE
fix(flowkit:release): drop ### Changes, auto-detect scope list

### DIFF
--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -163,6 +163,24 @@ git config claude.flowkit.prBase main
 git config --unset claude.flowkit.prBase
 ```
 
+### Release scope grouping
+
+`/release` groups `### Release notes` bullets by conventional-commit scope. By default, scopes are auto-detected from the commit range being released — `/release` extracts the `type(scope):` tokens from `git log origin/main..origin/$SOURCE`, normalizes sub-scopes (`flowkit:open-pr` → `flowkit`), and uses the deduplicated set. No configuration needed; it adapts to whatever scopes the repo actually uses.
+
+To pin an explicit scope list (e.g. to enforce naming, exclude noisy one-off scopes, or guarantee a stable rendering order), drop a `.flowkit/scopes.txt` file at the repo root:
+
+```
+# .flowkit/scopes.txt — one scope per line, blank lines and # comments ignored
+cmdk
+cache
+library
+visualizer
+providers
+queue
+```
+
+When the file is present, `/release` uses it verbatim and skips auto-detection. Use the same token you put in commit messages and PR titles.
+
 ### Migrating from `claude.prBase`
 
 The legacy key `claude.prBase` is still read as a fallback so existing setups don't break. When flowkit falls back to the legacy key, it emits a one-line deprecation notice with the exact commands below. Migrate at your convenience:

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -137,7 +137,7 @@ If no tags exist yet, `ISSUE_REFS` remains empty and the PR body is unchanged.
 
 ### 5. Build release summary and create a PR from SOURCE → main
 
-Compute the git log range between the source branch and main, then derive version bumps, synthesized release notes, and grouped changes from that range.
+Compute the git log range between the source branch and main, then derive version bumps and synthesized release notes from that range.
 
 ```bash
 RELEASE_DATE=$(date +%Y-%m-%d)
@@ -148,12 +148,7 @@ VERSION_BUMPS=$(git log origin/main..origin/"$SOURCE" --oneline \
   | sed 's/^[a-f0-9]* /- /' \
   || true)
 
-# --- grouped changes by conventional-commit scope ---
-# Collect all commits that are NOT version-bump lines
-ALL_COMMITS=$(git log origin/main..origin/"$SOURCE" --oneline \
-  | grep -ivE "bump|version|plugin\.json" \
-  || true)
-
+# --- scope list ---
 # Extract known plugin scopes; extend this list as new plugins are added.
 # Newline-delimited so we can iterate via `while read` — `for X in $VAR` does
 # not word-split unquoted variables in zsh and would silently process the
@@ -166,42 +161,11 @@ polishkit
 squadkit
 vaultkit"
 
-GROUPED_CHANGES_FILE=$(mktemp)
-printf '%s\n' "$PLUGINS" | while read PLUGIN; do
-  [ -z "$PLUGIN" ] && continue
-  PLUGIN_COMMITS=$(printf '%s\n' "$ALL_COMMITS" \
-    | grep -iE '\('"$PLUGIN"'[:)]' \
-    | sed 's/^[a-f0-9]* /- /' \
-    || true)
-  if [ -n "$PLUGIN_COMMITS" ]; then
-    printf '\n**%s**\n%s\n' "$PLUGIN" "$PLUGIN_COMMITS" >> "$GROUPED_CHANGES_FILE"
-  fi
-done
-
-# Unscoped commits: filter out mechanical chore/docs entries — they don't
-# belong in release notes and account for nearly all "other" noise. Unscoped
-# commits with feat/fix/refactor/perf type are inlined after the last plugin
-# group without an **other** header; the header adds visual weight without
-# information value and the commits speak for themselves.
-SCOPED_PATTERN=$(printf '%s\n' "$PLUGINS" | tr '\n' '|' | sed 's/|$//')
-MEANINGFUL_UNSCOPED=$(printf '%s\n' "$ALL_COMMITS" \
-  | grep -ivE '\('"$SCOPED_PATTERN"'[:)]' \
-  | grep -iE "^[a-f0-9]+ (feat|fix|refactor|perf)" \
-  | sed 's/^[a-f0-9]* /- /' \
-  || true)
-if [ -n "$MEANINGFUL_UNSCOPED" ]; then
-  printf '\n**cross-plugin**\n%s\n' "$MEANINGFUL_UNSCOPED" >> "$GROUPED_CHANGES_FILE"
-fi
-
-GROUPED_CHANGES=$(cat "$GROUPED_CHANGES_FILE"); rm -f "$GROUPED_CHANGES_FILE"
-
 # --- synthesized release notes ---
 # Fetch merged-PR titles and the first sentence of each PR's ## Summary section
-# since the last release tag. Group per plugin using the same scope list as
-# ### Changes. Render as human-readable bullets — one bullet per PR, phrased
-# from the PR title with the Summary's first sentence appended if it adds
-# context beyond the title. This is the canonical "what shipped" view;
-# ### Changes remains the raw commit log for completeness.
+# since the last release tag. Group per scope using the list above. Render as
+# human-readable bullets — one bullet per PR, phrased from the PR title with
+# the Summary's first sentence appended if it adds context beyond the title.
 RELEASE_NOTES_FILE=$(mktemp)
 if [ -n "$LAST_TAG" ] && [ -n "$TAG_DATE" ]; then
   MERGED_PR_DATA=$(gh pr list --base develop --state merged --limit 200 \
@@ -257,14 +221,14 @@ RELEASE_NOTES=$(cat "$RELEASE_NOTES_FILE"); rm -f "$RELEASE_NOTES_FILE"
 # "Ship swarmkit stacked-merge bugfix alongside flowkit hotfix workflow tidy-up."
 # Do not list individual file paths or repeat the title. Keep it to 3 sentences max.
 NARRATIVE_SUMMARY="<!-- Write 1–3 sentences summarising what this release contains.
-Derive the narrative from the version bumps and grouped changes computed above.
+Derive the narrative from the version bumps and release notes computed above.
 Example: "Ship swarmkit stacked-merge bugfix alongside flowkit hotfix workflow tidy-up." -->"
 
 # --- assemble PR body ---
 # <!-- include: plugins/_shared/pr-body.md -->
 # The body shape below follows the canonical PR body spec defined in
 # plugins/_shared/pr-body.md: Summary → Release summary → Version bumps →
-# Release notes → Changes → issue-reference footer. Keep that order.
+# Release notes → issue-reference footer. Keep that order.
 PR_BODY="## Summary
 
 $NARRATIVE_SUMMARY
@@ -285,13 +249,6 @@ if [ -n "$RELEASE_NOTES" ]; then
 
 ### Release notes
 $RELEASE_NOTES"
-fi
-
-if [ -n "$GROUPED_CHANGES" ]; then
-  PR_BODY="$PR_BODY
-
-### Changes
-$GROUPED_CHANGES"
 fi
 
 [ -n "$ARGUMENTS" ] && PR_BODY="$PR_BODY

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -149,17 +149,22 @@ VERSION_BUMPS=$(git log origin/main..origin/"$SOURCE" --oneline \
   || true)
 
 # --- scope list ---
-# Extract known plugin scopes; extend this list as new plugins are added.
-# Newline-delimited so we can iterate via `while read` — `for X in $VAR` does
-# not word-split unquoted variables in zsh and would silently process the
-# whole list as a single value.
-PLUGINS="flowkit
-speckit
-swarmkit
-sessionkit
-polishkit
-squadkit
-vaultkit"
+# Prefer .flowkit/scopes.txt at the repo root if the operator has pinned a
+# canonical list (one scope per line; blank lines and `#` comments ignored).
+# Otherwise auto-detect scopes from the release commit range: extract
+# conventional-commit `type(scope):` tokens, normalize sub-scopes
+# (`flowkit:open-pr` → `flowkit`), and dedupe. The skill adapts to whatever
+# scopes the consumer repo actually uses — no hardcoded list.
+SCOPES_FILE="$(git rev-parse --show-toplevel)/.flowkit/scopes.txt"
+if [ -f "$SCOPES_FILE" ]; then
+  PLUGINS=$(grep -v '^[[:space:]]*#' "$SCOPES_FILE" | grep -v '^[[:space:]]*$' || true)
+else
+  PLUGINS=$(git log origin/main..origin/"$SOURCE" --format=%s \
+    | grep -oE '^[a-z]+\([^)]+\)' \
+    | sed -E 's/^[a-z]+\(([^):]+).*/\1/' \
+    | sort -u \
+    || true)
+fi
 
 # --- synthesized release notes ---
 # Fetch merged-PR titles and the first sentence of each PR's ## Summary section


### PR DESCRIPTION
## Summary

Two related fixes to `/release` that make synthesized release PR bodies work for any consumer repo, not just the plugin monorepo. Drops a redundant section and replaces a hardcoded scope list with auto-detection.

## Changes

- Remove the `### Changes` section and its `GROUPED_CHANGES` accumulator (`ALL_COMMITS`, `SCOPED_PATTERN`, `MEANINGFUL_UNSCOPED`, the per-scope grep loop). `### Release notes` already covers what shipped — each bullet links back to the source PR — so the raw commit list duplicated information and invited operators to skim it instead of synthesizing notes.
- Replace the hardcoded `PLUGINS=flowkit\nspeckit\n…` list with auto-detection: `/release` now extracts conventional-commit `type(scope):` tokens from `git log origin/main..origin/$SOURCE`, normalizes sub-scopes (`flowkit:open-pr` → `flowkit`), and dedupes. `.flowkit/scopes.txt` at the repo root acts as an optional override for repos that want to pin a canonical ordered list.
- Update the body-shape comment in `plugins/flowkit/skills/release/SKILL.md` to drop `→ Changes →` and refresh the surrounding prose so it no longer references "grouped changes".
- Document the new scope-grouping behaviour and the `.flowkit/scopes.txt` override in `plugins/flowkit/README.md` under Configuration.

## Test plan

- [ ] Run `/flowkit:release` on the plugin monorepo and confirm the PR body has `## Summary` + `### Release notes` + `### Version bumps` + `Closes #N` footer, no `### Changes` section.
- [ ] Confirm `### Release notes` still groups bullets per plugin (`**flowkit**`, `**swarmkit**`, …) under auto-detection.
- [ ] Run `/flowkit:release` (or smoke-test the synthesis block) on a non-plugin consumer repo and confirm scopes are picked up from the actual commit range, not silently empty.
- [ ] Drop a `.flowkit/scopes.txt` with a custom list and verify the loop iterates that list verbatim.
- [ ] Verify the `(Closes|Fixes|Resolves) #N #M` lint still aborts when a malformed footer is present.

Closes #738