### PR TITLE
fix(flowkit/merge-pr): handle agent worktrees blocking local branch delete

### DIFF
--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -37,7 +37,39 @@ If `PR_NUM` is empty, abort with:
 
 > No open PR found for branch `$BRANCH`. Run /open-pr first.
 
-### 3. Squash-merge and delete the remote branch
+### 3. Resolve the PR head branch
+
+```bash
+HEAD_BRANCH=$(gh pr view "$PR_NUM" --json headRefName --jq '.headRefName')
+```
+
+### 4. Pre-clean any agent worktrees blocking the head branch
+
+`gh pr merge --delete-branch` deletes the local branch after the remote merge. Git refuses to delete a branch that is currently checked out in a worktree, so any worktree (typically a swarmkit `.claude/worktrees/agent-N` produced by `/swarmkit:swarm-plus`) holding `HEAD_BRANCH` must be removed first.
+
+```bash
+BLOCKING_WORKTREE=$(git worktree list --porcelain \
+  | awk -v target="refs/heads/$HEAD_BRANCH" '
+      /^worktree / { wt = $2 }
+      $0 == "branch " target { print wt }
+    ')
+
+if [ -n "$BLOCKING_WORKTREE" ]; then
+  git worktree remove --force "$BLOCKING_WORKTREE"
+fi
+```
+
+If `git worktree remove` fails, abort with:
+
+> Cannot remove worktree at `$BLOCKING_WORKTREE` that holds `$HEAD_BRANCH`. Remove it manually with:
+>
+> ```
+> git worktree remove --force <path>
+> ```
+>
+> Then re-run /merge-pr.
+
+### 5. Squash-merge and delete the remote branch
 
 `gh pr merge --squash --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. Wrap the call with the `flowkit:with-clean-workspace` sub-skill so any dirty state is auto-stashed and restored:
 
@@ -50,8 +82,20 @@ fi
 
 if gh pr merge "$PR_NUM" --squash --delete-branch; then
   MERGE_OK=true
+  LOCAL_DELETE_FAILED=false
 else
-  MERGE_OK=false
+  # gh pr merge exited non-zero — re-query the PR state. If the remote merge
+  # actually succeeded, only the local branch-delete failed (e.g. another
+  # worktree still held the branch, or a race condition). Treat that as a
+  # recoverable warning, not a hard failure.
+  PR_STATE=$(gh pr view "$PR_NUM" --json state --jq '.state' 2>/dev/null)
+  if [ "$PR_STATE" = "MERGED" ]; then
+    MERGE_OK=true
+    LOCAL_DELETE_FAILED=true
+  else
+    MERGE_OK=false
+    LOCAL_DELETE_FAILED=false
+  fi
 fi
 
 if [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "true" ]; then
@@ -63,10 +107,17 @@ elif [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "false" ]; then
   echo "WARNING: merge failed — stash preserved. Run \`git stash pop\` after resolving the merge error." >&2
 fi
 
+if [ "$LOCAL_DELETE_FAILED" = "true" ]; then
+  echo "WARNING: PR #$PR_NUM merged remotely but the local branch \`$HEAD_BRANCH\` could not be deleted." >&2
+  echo "To clean up manually:" >&2
+  echo "  git worktree list --porcelain | awk -v t=\"refs/heads/$HEAD_BRANCH\" '/^worktree /{wt=\$2} \$0==\"branch \"t{print wt}' | xargs -r git worktree remove --force" >&2
+  echo "  git branch -D $HEAD_BRANCH" >&2
+fi
+
 [ "$MERGE_OK" = "false" ] && exit 1
 ```
 
-### 4. Report
+### 6. Report
 
 Print a summary:
 


### PR DESCRIPTION
## Summary

- `/flowkit:merge-pr` failed with a misleading "merge failed" error when a swarmkit agent worktree (e.g. produced by `/swarmkit:swarm-plus`) still held the PR's head branch checked out — the PR merged remotely but `gh pr merge --delete-branch` couldn't delete the local branch and the wrapper exited 1 with an unnecessary stash preserved.
- Adds a two-layer fix to the skill: (a) pre-clean the blocking worktree before the merge call, and (b) treat a post-merge local-delete failure as a recoverable warning when the PR is already merged remotely.

## Changes

- `plugins/flowkit/skills/merge-pr/SKILL.md`:
  - New step 3 resolves the PR head branch via `gh pr view --json headRefName`.
  - New step 4 scans `git worktree list --porcelain` for any worktree on the head branch and runs `git worktree remove --force` before the merge.
  - Step 5 wraps `gh pr merge` so that a non-zero exit triggers a `gh pr view --json state` re-query — if the PR is `MERGED`, the merge is treated as successful and only the local-delete failure is surfaced as a `WARNING` with the exact recovery commands.

## Test plan

- [ ] Repro: `/swarmkit:swarm-plus <issue>` to leave a `.claude/worktrees/agent-N` worktree on `worktree-agent-N`, then `/flowkit:merge-pr <PR>` — verify the worktree is auto-removed before merge and the skill exits 0.
- [ ] Regression: run `/flowkit:merge-pr` on a PR with no agent worktree — verify behavior is unchanged.
- [ ] Safety net: simulate a stale lingering worktree (or any other reason `--delete-branch` fails) and verify the warning + recovery commands print and the skill exits 0 (not 1) when the PR state is `MERGED`.
- [ ] Failure path: simulate a real merge failure (e.g. branch-protection violation) — verify the skill still exits 1 and preserves the auto-stash.

Closes #749