### PR TITLE
refactor(flowkit/merge-pr): extract worktree-finder function, fix prose

### DIFF
--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -48,11 +48,16 @@ HEAD_BRANCH=$(gh pr view "$PR_NUM" --json headRefName --jq '.headRefName')
 `gh pr merge --delete-branch` deletes the local branch after the remote merge. Git refuses to delete a branch that is currently checked out in a worktree, so any worktree (typically a swarmkit `.claude/worktrees/agent-N` produced by `/swarmkit:swarm-plus`) holding `HEAD_BRANCH` must be removed first.
 
 ```bash
-BLOCKING_WORKTREE=$(git worktree list --porcelain \
-  | awk -v target="refs/heads/$HEAD_BRANCH" '
-      /^worktree / { wt = $2 }
-      $0 == "branch " target { print wt }
-    ')
+# Returns the worktree path currently checked out on the given branch, or empty.
+_find_worktree_for_branch() {
+  git worktree list --porcelain \
+    | awk -v target="refs/heads/$1" '
+        /^worktree / { wt = $2 }
+        $0 == "branch " target { print wt }
+      '
+}
+
+BLOCKING_WORKTREE=$(_find_worktree_for_branch "$HEAD_BRANCH")
 
 if [ -n "$BLOCKING_WORKTREE" ]; then
   git worktree remove --force "$BLOCKING_WORKTREE"
@@ -71,7 +76,7 @@ If `git worktree remove` fails, abort with:
 
 ### 5. Squash-merge and delete the remote branch
 
-`gh pr merge --squash --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. Wrap the call with the `flowkit:with-clean-workspace` sub-skill so any dirty state is auto-stashed and restored:
+`gh pr merge --squash --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. The block below mirrors the stash-guard logic from `flowkit:with-clean-workspace` — auto-stashing dirty state before the merge and restoring it after:
 
 ```bash
 DIRTY=false
@@ -110,7 +115,8 @@ fi
 if [ "$LOCAL_DELETE_FAILED" = "true" ]; then
   echo "WARNING: PR #$PR_NUM merged remotely but the local branch \`$HEAD_BRANCH\` could not be deleted." >&2
   echo "To clean up manually:" >&2
-  echo "  git worktree list --porcelain | awk -v t=\"refs/heads/$HEAD_BRANCH\" '/^worktree /{wt=\$2} \$0==\"branch \"t{print wt}' | xargs -r git worktree remove --force" >&2
+  LEFTOVER=$(_find_worktree_for_branch "$HEAD_BRANCH")
+  [ -n "$LEFTOVER" ] && echo "  git worktree remove --force $LEFTOVER" >&2
   echo "  git branch -D $HEAD_BRANCH" >&2
 fi
 


### PR DESCRIPTION
## Summary

Polish pass on `plugins/flowkit/skills/merge-pr/SKILL.md` (stacked on PR #790 / issue #749). Extracts the repeated `awk` worktree-finder one-liner into a named shell function and corrects a prose inaccuracy introduced by the fix.

## Changes

- Extract the `git worktree list --porcelain | awk ...` pattern into `_find_worktree_for_branch()` defined once in step 4; step 5's manual-recovery hint now calls the function instead of emitting an escaped inline awk command.
- Fix step 5 lead-in prose: replaced "Wrap the call with the `flowkit:with-clean-workspace` sub-skill" (which implied sub-skill delegation) with accurate language reflecting that the block inlines equivalent stash-guard logic directly.

## Test plan

- [ ] `scripts/test-all-skill-scripts.sh` passes clean (4 suites, 29 tests — none in merge-pr since it is a docs-only skill).
- [ ] Read through `plugins/flowkit/skills/merge-pr/SKILL.md` and confirm the `_find_worktree_for_branch` function is defined exactly once (step 4) and called in both the pre-clean block and the `LOCAL_DELETE_FAILED` recovery hint.
- [ ] Confirm step 5 prose no longer claims to delegate to `flowkit:with-clean-workspace`.
- [ ] Confirm the manual-recovery commands still produce valid shell: `git worktree remove --force <path>` followed by `git branch -D <branch>`.

## Findings deferred to issues

- `plugins/flowkit/skills/merge-pr/SKILL.md` line 92 (post-fix, step 5): capturing `gh pr merge` stderr to distinguish "remote branch protected" from "worktree still blocking the local branch" would allow a more targeted error message. Not applied — would change error-path behavior.
- The inlined stash-guard logic (step 5) is duplicated verbatim from `flowkit:with-clean-workspace`. Refactoring merge-pr to genuinely invoke the sub-skill rather than inline it would be a behavioral change (sub-skill invocation semantics differ from bash-block execution) and is out of scope for a polish pass.

Stacked on #790