### PR TITLE
docs(claude-md): strengthen authoring conventions section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,18 @@ Run it before staging and committing the release.
 
 ## Skill Authoring Conventions
 
+**Before authoring** a new skill, adding a script under `scripts/`, or substantially rewriting a `SKILL.md` under `plugins/`, read the canonical convention docs that apply:
+
+- New script under `plugins/<plugin>/skills/<skill>/scripts/` → [`plugins/_shared/script-authoring.md`](./plugins/_shared/script-authoring.md)
+- Skill or script that opens a PR → [`plugins/_shared/pr-body.md`](./plugins/_shared/pr-body.md)
+- New skill or cross-plugin pattern → both of the above
+
+Skip for typo fixes, renames, and small edits that don't touch convention surfaces.
+
 **Bash loop convention**: Never use `for N in $VAR` to iterate over newline-delimited output — word splitting is unreliable across shell contexts. Always pipe directly: `some-command | while read N; do ... done`.
 
 **PR body standard**: All PRs opened by agents in this repo must follow the canonical three-section shape (`## Summary`, `## Changes`, `## Test plan`) plus an issue-reference footer. The spec lives at [`plugins/_shared/pr-body.md`](./plugins/_shared/pr-body.md) — reference it instead of inventing a local format.
 
 **Skill scripts standard**: Skills that extract deterministic bash work into shell scripts must follow the convention at [`plugins/_shared/script-authoring.md`](./plugins/_shared/script-authoring.md) — folder layout, `$SKILL_DIR` resolution, bare-payload JSON, stderr errors, when to extract, and `.claude/settings.json` allowlist guidance.
+
+**README flag-matrix drift**: Any change to a SKILL.md `## Input` table needs a matching pass on the corresponding plugin README's flag matrix — these drift silently otherwise.


### PR DESCRIPTION
## Summary

Encode the authoring-conventions discipline directly into the project-level `CLAUDE.md` so it ships with every session's auto-loaded context, removing the need for an operator-triggered `/authoring-preflight` skill that was sitting untracked since the last session's retro.

## Changes

- Add a "Before authoring" trigger block to the `## Skill Authoring Conventions` section that maps work types (new script / PR-emitting / new skill / cross-plugin pattern) to the canonical `plugins/_shared/*.md` docs that apply.
- Capture the README flag-matrix drift convention from last session's lesson — changes to a SKILL.md `## Input` table need a matching pass on the plugin README's flag matrix.
- Delete the untracked `.claude/skills/authoring-preflight/` skill (never committed) — redundant now that the discipline lives in always-loaded context.

## Test plan

- [ ] Confirm the new "Before authoring" block reads cleanly when CLAUDE.md is auto-loaded at session start.
- [ ] Confirm both `plugins/_shared/pr-body.md` and `plugins/_shared/script-authoring.md` links resolve from the repo root.
- [ ] Confirm `.claude/skills/authoring-preflight/` no longer exists locally and was never committed (no rm needed in the diff).