### PR TITLE
chore(plugins): bump flowkit@3.9.1, squadkit@0.8.0

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship \u2014 with runtime staging detection and a one-command hotfix flow.",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/squadkit/.claude-plugin/plugin.json
+++ b/plugins/squadkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "squadkit",
   "description": "Multi-agent team coordination for Claude Code. Roles, squads, and crews \u2014 interview-driven setup, no per-stack presets, reusable across any repo.",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Bump plugin.json versions for plugins changed since their last release.

## Changes

- flowkit@3.9.1
- squadkit@0.8.0

## Test plan

- [ ] Confirm each `plugin.json` version bump matches the per-plugin tag that will be created after merge.