### PR TITLE
release: 2026-05-03

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,8 +36,18 @@ Run it before staging and committing the release.
 
 ## Skill Authoring Conventions
 
+**Before authoring** a new skill, adding a script under `scripts/`, or substantially rewriting a `SKILL.md` under `plugins/`, read the canonical convention docs that apply:
+
+- New script under `plugins/<plugin>/skills/<skill>/scripts/` → [`plugins/_shared/script-authoring.md`](./plugins/_shared/script-authoring.md)
+- Skill or script that opens a PR → [`plugins/_shared/pr-body.md`](./plugins/_shared/pr-body.md)
+- New skill or cross-plugin pattern → both of the above
+
+Skip for typo fixes, renames, and small edits that don't touch convention surfaces.
+
 **Bash loop convention**: Never use `for N in $VAR` to iterate over newline-delimited output — word splitting is unreliable across shell contexts. Always pipe directly: `some-command | while read N; do ... done`.
 
 **PR body standard**: All PRs opened by agents in this repo must follow the canonical three-section shape (`## Summary`, `## Changes`, `## Test plan`) plus an issue-reference footer. The spec lives at [`plugins/_shared/pr-body.md`](./plugins/_shared/pr-body.md) — reference it instead of inventing a local format.
 
 **Skill scripts standard**: Skills that extract deterministic bash work into shell scripts must follow the convention at [`plugins/_shared/script-authoring.md`](./plugins/_shared/script-authoring.md) — folder layout, `$SKILL_DIR` resolution, bare-payload JSON, stderr errors, when to extract, and `.claude/settings.json` allowlist guidance.
+
+**README flag-matrix drift**: Any change to a SKILL.md `## Input` table needs a matching pass on the corresponding plugin README's flag matrix — these drift silently otherwise.

--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship \u2014 with runtime staging detection and a one-command hotfix flow.",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -163,6 +163,24 @@ git config claude.flowkit.prBase main
 git config --unset claude.flowkit.prBase
 ```
 
+### Release scope grouping
+
+`/release` groups `### Release notes` bullets by conventional-commit scope. By default, scopes are auto-detected from the commit range being released — `/release` extracts the `type(scope):` tokens from `git log origin/main..origin/$SOURCE`, normalizes sub-scopes (`flowkit:open-pr` → `flowkit`), and uses the deduplicated set. No configuration needed; it adapts to whatever scopes the repo actually uses.
+
+To pin an explicit scope list (e.g. to enforce naming, exclude noisy one-off scopes, or guarantee a stable rendering order), drop a `.flowkit/scopes.txt` file at the repo root:
+
+```
+# .flowkit/scopes.txt — one scope per line, blank lines and # comments ignored
+cmdk
+cache
+library
+visualizer
+providers
+queue
+```
+
+When the file is present, `/release` uses it verbatim and skips auto-detection. Use the same token you put in commit messages and PR titles.
+
 ### Migrating from `claude.prBase`
 
 The legacy key `claude.prBase` is still read as a fallback so existing setups don't break. When flowkit falls back to the legacy key, it emits a one-line deprecation notice with the exact commands below. Migrate at your convenience:

--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -37,7 +37,39 @@ If `PR_NUM` is empty, abort with:
 
 > No open PR found for branch `$BRANCH`. Run /open-pr first.
 
-### 3. Squash-merge and delete the remote branch
+### 3. Resolve the PR head branch
+
+```bash
+HEAD_BRANCH=$(gh pr view "$PR_NUM" --json headRefName --jq '.headRefName')
+```
+
+### 4. Pre-clean any agent worktrees blocking the head branch
+
+`gh pr merge --delete-branch` deletes the local branch after the remote merge. Git refuses to delete a branch that is currently checked out in a worktree, so any worktree (typically a swarmkit `.claude/worktrees/agent-N` produced by `/swarmkit:swarm-plus`) holding `HEAD_BRANCH` must be removed first.
+
+```bash
+BLOCKING_WORKTREE=$(git worktree list --porcelain \
+  | awk -v target="refs/heads/$HEAD_BRANCH" '
+      /^worktree / { wt = $2 }
+      $0 == "branch " target { print wt }
+    ')
+
+if [ -n "$BLOCKING_WORKTREE" ]; then
+  git worktree remove --force "$BLOCKING_WORKTREE"
+fi
+```
+
+If `git worktree remove` fails, abort with:
+
+> Cannot remove worktree at `$BLOCKING_WORKTREE` that holds `$HEAD_BRANCH`. Remove it manually with:
+>
+> ```
+> git worktree remove --force <path>
+> ```
+>
+> Then re-run /merge-pr.
+
+### 5. Squash-merge and delete the remote branch
 
 `gh pr merge --squash --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. Wrap the call with the `flowkit:with-clean-workspace` sub-skill so any dirty state is auto-stashed and restored:
 
@@ -50,8 +82,20 @@ fi
 
 if gh pr merge "$PR_NUM" --squash --delete-branch; then
   MERGE_OK=true
+  LOCAL_DELETE_FAILED=false
 else
-  MERGE_OK=false
+  # gh pr merge exited non-zero — re-query the PR state. If the remote merge
+  # actually succeeded, only the local branch-delete failed (e.g. another
+  # worktree still held the branch, or a race condition). Treat that as a
+  # recoverable warning, not a hard failure.
+  PR_STATE=$(gh pr view "$PR_NUM" --json state --jq '.state' 2>/dev/null)
+  if [ "$PR_STATE" = "MERGED" ]; then
+    MERGE_OK=true
+    LOCAL_DELETE_FAILED=true
+  else
+    MERGE_OK=false
+    LOCAL_DELETE_FAILED=false
+  fi
 fi
 
 if [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "true" ]; then
@@ -63,10 +107,17 @@ elif [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "false" ]; then
   echo "WARNING: merge failed — stash preserved. Run \`git stash pop\` after resolving the merge error." >&2
 fi
 
+if [ "$LOCAL_DELETE_FAILED" = "true" ]; then
+  echo "WARNING: PR #$PR_NUM merged remotely but the local branch \`$HEAD_BRANCH\` could not be deleted." >&2
+  echo "To clean up manually:" >&2
+  echo "  git worktree list --porcelain | awk -v t=\"refs/heads/$HEAD_BRANCH\" '/^worktree /{wt=\$2} \$0==\"branch \"t{print wt}' | xargs -r git worktree remove --force" >&2
+  echo "  git branch -D $HEAD_BRANCH" >&2
+fi
+
 [ "$MERGE_OK" = "false" ] && exit 1
 ```
 
-### 4. Report
+### 6. Report
 
 Print a summary:
 

--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -48,11 +48,16 @@ HEAD_BRANCH=$(gh pr view "$PR_NUM" --json headRefName --jq '.headRefName')
 `gh pr merge --delete-branch` deletes the local branch after the remote merge. Git refuses to delete a branch that is currently checked out in a worktree, so any worktree (typically a swarmkit `.claude/worktrees/agent-N` produced by `/swarmkit:swarm-plus`) holding `HEAD_BRANCH` must be removed first.
 
 ```bash
-BLOCKING_WORKTREE=$(git worktree list --porcelain \
-  | awk -v target="refs/heads/$HEAD_BRANCH" '
-      /^worktree / { wt = $2 }
-      $0 == "branch " target { print wt }
-    ')
+# Returns the worktree path currently checked out on the given branch, or empty.
+_find_worktree_for_branch() {
+  git worktree list --porcelain \
+    | awk -v target="refs/heads/$1" '
+        /^worktree / { wt = $2 }
+        $0 == "branch " target { print wt }
+      '
+}
+
+BLOCKING_WORKTREE=$(_find_worktree_for_branch "$HEAD_BRANCH")
 
 if [ -n "$BLOCKING_WORKTREE" ]; then
   git worktree remove --force "$BLOCKING_WORKTREE"
@@ -71,7 +76,7 @@ If `git worktree remove` fails, abort with:
 
 ### 5. Squash-merge and delete the remote branch
 
-`gh pr merge --squash --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. Wrap the call with the `flowkit:with-clean-workspace` sub-skill so any dirty state is auto-stashed and restored:
+`gh pr merge --squash --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. The block below mirrors the stash-guard logic from `flowkit:with-clean-workspace` — auto-stashing dirty state before the merge and restoring it after:
 
 ```bash
 DIRTY=false
@@ -110,7 +115,8 @@ fi
 if [ "$LOCAL_DELETE_FAILED" = "true" ]; then
   echo "WARNING: PR #$PR_NUM merged remotely but the local branch \`$HEAD_BRANCH\` could not be deleted." >&2
   echo "To clean up manually:" >&2
-  echo "  git worktree list --porcelain | awk -v t=\"refs/heads/$HEAD_BRANCH\" '/^worktree /{wt=\$2} \$0==\"branch \"t{print wt}' | xargs -r git worktree remove --force" >&2
+  LEFTOVER=$(_find_worktree_for_branch "$HEAD_BRANCH")
+  [ -n "$LEFTOVER" ] && echo "  git worktree remove --force $LEFTOVER" >&2
   echo "  git branch -D $HEAD_BRANCH" >&2
 fi
 

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -137,7 +137,7 @@ If no tags exist yet, `ISSUE_REFS` remains empty and the PR body is unchanged.
 
 ### 5. Build release summary and create a PR from SOURCE → main
 
-Compute the git log range between the source branch and main, then derive version bumps, synthesized release notes, and grouped changes from that range.
+Compute the git log range between the source branch and main, then derive version bumps and synthesized release notes from that range.
 
 ```bash
 RELEASE_DATE=$(date +%Y-%m-%d)
@@ -148,60 +148,29 @@ VERSION_BUMPS=$(git log origin/main..origin/"$SOURCE" --oneline \
   | sed 's/^[a-f0-9]* /- /' \
   || true)
 
-# --- grouped changes by conventional-commit scope ---
-# Collect all commits that are NOT version-bump lines
-ALL_COMMITS=$(git log origin/main..origin/"$SOURCE" --oneline \
-  | grep -ivE "bump|version|plugin\.json" \
-  || true)
-
-# Extract known plugin scopes; extend this list as new plugins are added.
-# Newline-delimited so we can iterate via `while read` — `for X in $VAR` does
-# not word-split unquoted variables in zsh and would silently process the
-# whole list as a single value.
-PLUGINS="flowkit
-speckit
-swarmkit
-sessionkit
-polishkit
-squadkit
-vaultkit"
-
-GROUPED_CHANGES_FILE=$(mktemp)
-printf '%s\n' "$PLUGINS" | while read PLUGIN; do
-  [ -z "$PLUGIN" ] && continue
-  PLUGIN_COMMITS=$(printf '%s\n' "$ALL_COMMITS" \
-    | grep -iE '\('"$PLUGIN"'[:)]' \
-    | sed 's/^[a-f0-9]* /- /' \
+# --- scope list ---
+# Prefer .flowkit/scopes.txt at the repo root if the operator has pinned a
+# canonical list (one scope per line; blank lines and `#` comments ignored).
+# Otherwise auto-detect scopes from the release commit range: extract
+# conventional-commit `type(scope):` tokens, normalize sub-scopes
+# (`flowkit:open-pr` → `flowkit`), and dedupe. The skill adapts to whatever
+# scopes the consumer repo actually uses — no hardcoded list.
+SCOPES_FILE="$(git rev-parse --show-toplevel)/.flowkit/scopes.txt"
+if [ -f "$SCOPES_FILE" ]; then
+  PLUGINS=$(grep -v '^[[:space:]]*#' "$SCOPES_FILE" | grep -v '^[[:space:]]*$' || true)
+else
+  PLUGINS=$(git log origin/main..origin/"$SOURCE" --format=%s \
+    | grep -oE '^[a-z]+\([^)]+\)' \
+    | sed -E 's/^[a-z]+\(([^):]+).*/\1/' \
+    | sort -u \
     || true)
-  if [ -n "$PLUGIN_COMMITS" ]; then
-    printf '\n**%s**\n%s\n' "$PLUGIN" "$PLUGIN_COMMITS" >> "$GROUPED_CHANGES_FILE"
-  fi
-done
-
-# Unscoped commits: filter out mechanical chore/docs entries — they don't
-# belong in release notes and account for nearly all "other" noise. Unscoped
-# commits with feat/fix/refactor/perf type are inlined after the last plugin
-# group without an **other** header; the header adds visual weight without
-# information value and the commits speak for themselves.
-SCOPED_PATTERN=$(printf '%s\n' "$PLUGINS" | tr '\n' '|' | sed 's/|$//')
-MEANINGFUL_UNSCOPED=$(printf '%s\n' "$ALL_COMMITS" \
-  | grep -ivE '\('"$SCOPED_PATTERN"'[:)]' \
-  | grep -iE "^[a-f0-9]+ (feat|fix|refactor|perf)" \
-  | sed 's/^[a-f0-9]* /- /' \
-  || true)
-if [ -n "$MEANINGFUL_UNSCOPED" ]; then
-  printf '\n**cross-plugin**\n%s\n' "$MEANINGFUL_UNSCOPED" >> "$GROUPED_CHANGES_FILE"
 fi
-
-GROUPED_CHANGES=$(cat "$GROUPED_CHANGES_FILE"); rm -f "$GROUPED_CHANGES_FILE"
 
 # --- synthesized release notes ---
 # Fetch merged-PR titles and the first sentence of each PR's ## Summary section
-# since the last release tag. Group per plugin using the same scope list as
-# ### Changes. Render as human-readable bullets — one bullet per PR, phrased
-# from the PR title with the Summary's first sentence appended if it adds
-# context beyond the title. This is the canonical "what shipped" view;
-# ### Changes remains the raw commit log for completeness.
+# since the last release tag. Group per scope using the list above. Render as
+# human-readable bullets — one bullet per PR, phrased from the PR title with
+# the Summary's first sentence appended if it adds context beyond the title.
 RELEASE_NOTES_FILE=$(mktemp)
 if [ -n "$LAST_TAG" ] && [ -n "$TAG_DATE" ]; then
   MERGED_PR_DATA=$(gh pr list --base develop --state merged --limit 200 \
@@ -257,14 +226,14 @@ RELEASE_NOTES=$(cat "$RELEASE_NOTES_FILE"); rm -f "$RELEASE_NOTES_FILE"
 # "Ship swarmkit stacked-merge bugfix alongside flowkit hotfix workflow tidy-up."
 # Do not list individual file paths or repeat the title. Keep it to 3 sentences max.
 NARRATIVE_SUMMARY="<!-- Write 1–3 sentences summarising what this release contains.
-Derive the narrative from the version bumps and grouped changes computed above.
+Derive the narrative from the version bumps and release notes computed above.
 Example: "Ship swarmkit stacked-merge bugfix alongside flowkit hotfix workflow tidy-up." -->"
 
 # --- assemble PR body ---
 # <!-- include: plugins/_shared/pr-body.md -->
 # The body shape below follows the canonical PR body spec defined in
 # plugins/_shared/pr-body.md: Summary → Release summary → Version bumps →
-# Release notes → Changes → issue-reference footer. Keep that order.
+# Release notes → issue-reference footer. Keep that order.
 PR_BODY="## Summary
 
 $NARRATIVE_SUMMARY
@@ -285,13 +254,6 @@ if [ -n "$RELEASE_NOTES" ]; then
 
 ### Release notes
 $RELEASE_NOTES"
-fi
-
-if [ -n "$GROUPED_CHANGES" ]; then
-  PR_BODY="$PR_BODY
-
-### Changes
-$GROUPED_CHANGES"
 fi
 
 [ -n "$ARGUMENTS" ] && PR_BODY="$PR_BODY

--- a/plugins/squadkit/.claude-plugin/plugin.json
+++ b/plugins/squadkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "squadkit",
   "description": "Multi-agent team coordination for Claude Code. Roles, squads, and crews \u2014 interview-driven setup, no per-stack presets, reusable across any repo.",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/squadkit/README.md
+++ b/plugins/squadkit/README.md
@@ -124,6 +124,8 @@ members:
 | `--name <custom>` | auto | Override the team name; skips phonetic auto-naming. |
 | `--epic <slug>` | none | Cut `feature/<slug>-<issue>` from the configured base branch and pin `claude.flowkit.prBase` for the session. If omitted, the skill prompts. |
 | `--issues <range>` | none | Issue numbers / ranges to load as the team's initial backlog (swarmkit grammar: `1319,1329,1331` or `1319-1337`). Resolved via `swarmkit:gh-fetch-issues` and forwarded to the lead's first dispatch prompt as a structured backlog table. Trailing-narrative form (`to tackle issues 1319-1337`) is also accepted. |
+| `--brief <text\|@path>` | none | Mission brief embedded into the architect's spawn prompt. Inline text or `@path` to a file. **Required when the resolved profile has `kind: discovery`.** Optional and otherwise ignored when `kind: execution`. |
+| `--mode <inherit\|auto\|bypass>` | `inherit` | Permission mode for spawned members. `inherit`: no override; harness defaults apply. `auto`: pass `mode: "auto"` to every spawn AND force `model: "opus"` for non-builder roles (sonnet members prompt for permissions in auto mode). `bypass`: pass `mode: "bypassPermissions"`; model stays default. Pass when the orchestrator runs in `auto` or `bypassPermissions` so spawned members inherit the same authority. |
 
 ### Phonetic naming convention
 

--- a/plugins/squadkit/skills/spawn-team/SKILL.md
+++ b/plugins/squadkit/skills/spawn-team/SKILL.md
@@ -30,6 +30,7 @@ Materialize a crew of agents from a profile. The skill picks an unused phonetic 
 | `--epic <slug>` | none | Cut `feature/<slug>-<issue>` from the configured base branch and pin `claude.flowkit.prBase`. If omitted, prompt. **Rejected when the resolved profile has `kind: discovery`.** |
 | `--issues <range>` | none | Issue numbers / ranges to load as the team's initial backlog. Accepts the swarmkit grammar: `1319,1329,1331` or `1319-1337` (inclusive). Resolved (open, non-on-hold) list is forwarded to the lead's first dispatch prompt as a structured backlog table. |
 | `--brief <text\|@path>` | none | Mission brief embedded into the architect's spawn prompt under `## Mission brief`. Accepts inline text (`--brief "the brief"`) or a file reference (`--brief @./path/to/brief.md`). **Required when the resolved profile has `kind: discovery`** (prompt via `AskUserQuestion` if missing). Optional and otherwise ignored when `kind: execution`. |
+| `--mode <inherit\|auto\|bypass>` | `inherit` | Permission mode for spawned members. `inherit`: no `mode` override passed to `Agent` — harness defaults apply. `auto`: pass `mode: "auto"` to every spawn AND force `model: "opus"` for non-builder roles (sonnet members prompt for permissions in auto mode — see Harness constraints). `bypass`: pass `mode: "bypassPermissions"` to every spawn; model stays default per role. Pass this when the orchestrator is in `auto` or `bypassPermissions` so spawned members inherit the same authority. |
 
 ### Narrative-tail parsing
 
@@ -396,6 +397,22 @@ The brief is included verbatim — do not paraphrase, summarize, or re-order its
 
 **Other roles stay mission-agnostic.** Do **not** embed `MISSION_BRIEF` in the spawn prompts for explorer, designer, builder, reviewer, tester, or any other non-architect role. They receive the brief (if at all) only when the team-lead routes a scoped task to them — never via spawn-time injection.
 
+#### Spawn-time mode + model selection
+
+The `--mode` flag controls the permission `mode` passed to each `Agent({mode})` spawn and, in auto mode, forces opus for non-builder roles:
+
+| `--mode` | `Agent({mode})` per spawn | Model override |
+|----------|---------------------------|----------------|
+| `inherit` (default) | not passed — harness defaults apply | none — role frontmatter default |
+| `auto` | `"auto"` | non-builder roles forced to `opus`; builders unchanged |
+| `bypass` | `"bypassPermissions"` | none — role frontmatter default |
+
+**Rationale.** When the orchestrator runs in auto mode, sonnet-tier crew members prompt for permission approval on every tool call, defeating the autonomous-flow benefit of auto. Opus-tier members run cleanly under the same condition (see Harness constraints for the empirical observation). The `--mode auto` shortcut encodes this so teams stay autonomous end-to-end without per-spawn fiddling.
+
+Builders are exempt from the auto-mode opus override because builder workloads benefit less from the larger model and burn budget faster on long-running implementation work. If a builder workload requires opus, override the role default explicitly — `--mode auto` only forces opus for non-builders.
+
+**Mode detection (operator responsibility).** The spawn skill cannot programmatically detect the parent orchestrator's permission mode — there is no `CLAUDE_PERMISSION_MODE` env var or persisted setting that reflects the active session's runtime mode. The operator (or the calling slash command / agent) is responsible for passing `--mode auto` or `--mode bypass` to match the orchestrator's session. Defaulting to `inherit` keeps existing call sites unchanged.
+
 Capture the session UUID returned by each `Agent` spawn — it lands in the harness-managed config automatically; the squadkit-specific sibling file (step 10) only stores the squadkit metadata, not the per-member roster.
 
 ### 8.5 Tool-registry validation probe
@@ -543,6 +560,7 @@ Idle ≠ delivery. The orchestrator reads the latest `(member, task)` line befor
 - Discovery crews (`kind: discovery`) must not provision worktrees, must not cut an epic branch, must not pin `claude.flowkit.prBase`, and must reject `--epic`. They require `--brief`.
 - Reject any `kind:` value other than `execution` or `discovery`. A missing `kind:` defaults to `execution`.
 - The `--brief` payload is embedded verbatim in the architect spawn prompt only — never in explorer, designer, builder, reviewer, or tester spawn prompts.
+- `--mode auto` MUST force `model: "opus"` for every non-builder role at spawn time, even when the role frontmatter declares `model: sonnet`. Sonnet members under auto mode are non-autonomous (they prompt for permissions) and will deadlock the dispatch loop if the orchestrator stops monitoring.
 
 ## Harness constraints
 
@@ -553,6 +571,7 @@ These are observed limitations of the `Agent` and `TeamCreate` primitives at the
 - **`Agent({isolation: "worktree"})` is unreliable when combined with `team_name`.** The auto-isolation does not fire reliably for team-scoped spawns, so the skill always provisions worktrees manually via `git worktree add --detach` (see step 7) and passes the resolved absolute path into each spawned agent.
 - **`git worktree add <path> <branch>` refuses when the main worktree is already on `<branch>`.** Always use `--detach` for per-builder worktrees so the branch ref stays free.
 - **`Agent({model})` rejects 1M-context aliases like `opus[1m]`.** The harness validates the model param against a fixed allowlist of bare names. To put a long-running role (tester, reviewer, architect) on the 1M tier, spawn with the bare alias (e.g. `opus`) and rely on the team-lead's between-wave swap protocol to rotate in a fresh successor before context fills.
+- **Sonnet-tier crew members prompt for permissions in auto mode.** When the orchestrator runs in auto mode and a spawned member is on sonnet, every tool call that would normally proceed silently under auto instead prompts for approval — even though the orchestrator session itself runs autonomously. Opus-tier members do not exhibit this. The `--mode auto` flag (see step 8) forces opus for non-builder roles to work around this; without that flag, autonomous flow breaks the moment a sonnet member needs to call a tool.
 - **Frontmatter `model:` in `.claude/agents/*.md` is ignored on spawn.** Only the explicit `Agent({model})` parameter controls which model the spawned agent runs on. The frontmatter field is informational for human readers; do not expect it to override the spawn-time parameter, and do not let users assume editing frontmatter changes a live team.
 - **Frontmatter `tools:` is overridden by a default allowlist for some roles.** The harness applies its own tool subset on spawn that may strip tools the role contract declared. Always include `Bash` in the explicit spawn `tools` param so an agent missing `Glob`/`Grep`/`LS` can still fall back to `find`/`grep`/`ls` and complete its work.
 


### PR DESCRIPTION
## Summary

Ship flowkit release-flow improvements (auto-detected scope grouping, agent-worktree-aware merge, worktree-finder refactor) alongside squadkit's autonomy-aware `--mode` flag for `spawn-team`. Project-level `CLAUDE.md` absorbs the authoring-conventions discipline so it auto-loads instead of requiring an operator-triggered preflight skill.

## Release summary

**Built from**: `rc/2026-05-03.1`

### Version bumps
- chore(plugins): bump flowkit@3.9.1, squadkit@0.8.0 (#793)

### Release notes

**flowkit**
- fix(flowkit:release): drop ### Changes, auto-detect scope list — Two related fixes to `/release` that make synthesized release PR bodies work for any consumer repo, not just the plugin monorepo. Drops a redundant section and replaces a hardcoded scope list with auto-detection.
- fix(flowkit/merge-pr): handle agent worktrees blocking local branch delete — `/flowkit:merge-pr` failed with a misleading "merge failed" error when a swarmkit agent worktree still held the PR's head branch checked out. Adds a two-layer fix: pre-clean the blocking worktree, and treat a post-merge local-delete failure as a recoverable warning when the PR is already merged remotely.
- refactor(flowkit/merge-pr): extract worktree-finder function, fix prose — Extracts the `git worktree list --porcelain | awk ...` pattern into `_find_worktree_for_branch()` and fixes inaccurate prose claiming sub-skill delegation.

**squadkit**
- feat(squadkit): add --mode flag to spawn-team for autonomy-aware spawning — Adds `--mode <inherit|auto|bypass>` so spawned crew members inherit the orchestrator's permission mode. `--mode auto` forces opus for non-builder roles to keep crews autonomous end-to-end (sonnet members prompt for approval, opus runs cleanly).

**docs**
- docs(claude-md): strengthen authoring conventions section — Encode the authoring-conventions discipline directly into project-level `CLAUDE.md` so it ships with every session's auto-loaded context, removing the need for an operator-triggered `/authoring-preflight` skill.

Closes #738
Closes #749