### PR TITLE
fix(flowkit/merge-pr): retarget child PRs before squash-delete

### DIFF
--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -74,7 +74,25 @@ If `git worktree remove` fails, abort with:
 >
 > Then re-run /merge-pr.
 
-### 5. Squash-merge and delete the remote branch
+### 5. Retarget any child PRs stacked on this PR's head branch
+
+`gh pr merge --delete-branch` deletes the head branch on the remote. GitHub auto-CLOSES (not merges) any open PRs whose `baseRefName` equals the deleted branch, silently abandoning their diffs. Pre-empt this by enumerating those child PRs and retargeting each to the merging PR's base before the squash.
+
+```bash
+BASE_BRANCH=$(gh pr view "$PR_NUM" --json baseRefName --jq '.baseRefName')
+
+gh pr list --base "$HEAD_BRANCH" --state open --json number --jq '.[].number' \
+  | while read CHILD; do
+      [ -z "$CHILD" ] && continue
+      if gh pr edit "$CHILD" --base "$BASE_BRANCH" >/dev/null; then
+        echo "Retargeted PR #$CHILD: base $HEAD_BRANCH → $BASE_BRANCH" >&2
+      else
+        echo "WARNING: Failed to retarget PR #$CHILD from $HEAD_BRANCH to $BASE_BRANCH. It will be auto-closed when $HEAD_BRANCH is deleted." >&2
+      fi
+    done
+```
+
+### 6. Squash-merge and delete the remote branch
 
 `gh pr merge --squash --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. The block below mirrors the stash-guard logic from `flowkit:with-clean-workspace` — auto-stashing dirty state before the merge and restoring it after:
 
@@ -123,7 +141,7 @@ fi
 [ "$MERGE_OK" = "false" ] && exit 1
 ```
 
-### 6. Report
+### 7. Report
 
 Print a summary:
 


### PR DESCRIPTION
## Summary
Auto-retarget any child PRs stacked on a PR's head branch before squash-merging. Without this, `gh pr merge --delete-branch` silently auto-CLOSES (not merges) any open PRs whose `baseRefName` equals the deleted branch, abandoning their diffs without warning.

## Changes
- Add new step 5 to `plugins/flowkit/skills/merge-pr/SKILL.md`: enumerate open PRs with `gh pr list --base $HEAD_BRANCH`, retarget each to the merging PR's `baseRefName` via `gh pr edit --base`, surface success/failure to stderr.
- Renumber subsequent steps (squash-merge → 6, Report → 7).

## Test plan
- [ ] Recreate the v2026.5.3 scenario: open PR A on develop, stack PR B on A's head branch, run `/flowkit:merge-pr` on A, verify PR B was retargeted to develop instead of auto-CLOSED.
- [ ] Single-PR case (no children): verify the loop emits nothing and doesn't disrupt the merge.
- [ ] Verify retarget warning fires correctly when `gh pr edit` fails (e.g. permission denied).

Closes #798