### PR TITLE
fix(flowkit/release): normalize slash sub-scopes in auto-detect

### DIFF
--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -161,7 +161,7 @@ if [ -f "$SCOPES_FILE" ]; then
 else
   PLUGINS=$(git log origin/main..origin/"$SOURCE" --format=%s \
     | grep -oE '^[a-z]+\([^)]+\)' \
-    | sed -E 's/^[a-z]+\(([^):]+).*/\1/' \
+    | sed -E 's/^[a-z]+\(([^):/]+).*/\1/' \
     | sort -u \
     || true)
 fi
@@ -185,7 +185,7 @@ if [ -n "$LAST_TAG" ] && [ -n "$TAG_DATE" ]; then
   printf '%s\n' "$PLUGINS" | while read PLUGIN; do
     [ -z "$PLUGIN" ] && continue
     PLUGIN_NOTES=$(printf '%s\n' "$MERGED_PR_DATA" \
-      | grep -iE '\('"$PLUGIN"'[:)]' \
+      | grep -iE '\('"$PLUGIN"'[:/)]' \
       | while IFS=$(printf '\t') read TITLE SUMMARY; do
           if [ -n "$SUMMARY" ] && [ "$SUMMARY" != "$TITLE" ]; then
             printf '- %s — %s\n' "$TITLE" "$SUMMARY"


### PR DESCRIPTION
## Summary
The scope auto-detect in `flowkit:release` step 5 normalizes colon sub-scopes (`flowkit:release` → `flowkit`) but leaves slash sub-scopes (`flowkit/merge-pr`) split. The release-notes synthesis grep then can't group them under their plugin, producing duplicate `**flowkit**` and `**flowkit/merge-pr**` sections in the rendered notes. Observed manually in v2026.5.3.

## Changes
- Extend the sed character class on the scope-extraction line from `[^):]` to `[^):/]` so `flowkit/merge-pr` normalizes to `flowkit`.
- Extend the release-notes synthesis grep from `[:)]` to `[:/)]` so commits scoped `(flowkit/merge-pr)` match the `flowkit` group.

## Test plan
- [ ] Mock a release range with both `fix(flowkit:release):` and `fix(flowkit/merge-pr):` commits and verify the synthesized notes produce a single `**flowkit**` group.
- [ ] Verify single-component scopes (e.g. `chore(plugins):`) still normalize correctly.

Closes #797