### PR TITLE
feat(site): add posts + kits content collections

### DIFF
--- a/site/src/content/config.ts
+++ b/site/src/content/config.ts
@@ -16,6 +16,8 @@ const posts = defineCollection({
   }),
 });
 
+// Astro 5 reserves `slug` in `type: 'content'` collections (auto-derived from
+// the entry filename and exposed as `entry.id`). Consumers route on `entry.id`.
 const kits = defineCollection({
   type: 'content',
   schema: z.object({

--- a/site/src/content/config.ts
+++ b/site/src/content/config.ts
@@ -1,0 +1,31 @@
+import { defineCollection, z } from 'astro:content';
+
+const posts = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    subtitle: z.string().optional(),
+    kit: z.string().optional(),
+    date: z.coerce.date(),
+    author: z.string().default('smallorbit'),
+    heroImage: z.string().optional(),
+    ogImage: z.string().optional(),
+    readTime: z.number().optional(),
+    draft: z.boolean().default(false),
+    tags: z.array(z.string()).default([]),
+  }),
+});
+
+const kits = defineCollection({
+  type: 'content',
+  schema: z.object({
+    name: z.string(),
+    role: z.string(),
+    accentColor: z.string(),
+    oneLiner: z.string(),
+    commands: z.array(z.string()).default([]),
+    summary: z.string(),
+  }),
+});
+
+export const collections = { posts, kits };

--- a/site/src/content/kits/flowkit.md
+++ b/site/src/content/kits/flowkit.md
@@ -1,0 +1,25 @@
+---
+name: flowkit
+role: Git workflow automation — branching, PRs, releases, and hotfixes
+accentColor: "var(--flowkit)"
+oneLiner: Ship features faster with opinionated Git flow built for Claude Code.
+commands:
+  - /flowkit:create-branch
+  - /flowkit:pr
+  - /flowkit:merge-pr
+  - /flowkit:cut
+  - /flowkit:release
+  - /flowkit:hotfix
+  - /flowkit:sync
+  - /flowkit:stage
+  - /flowkit:pipeline-status
+  - /flowkit:preview-epic
+  - /flowkit:cut-epic
+summary: >
+  flowkit wraps the full develop → release → main lifecycle into a set of
+  Claude Code skills. It handles branch creation, PR opening with structured
+  bodies, squash-merging, staging cuts, hotfixes, and release tagging — so
+  every merge follows the same convention without manual steps.
+---
+
+flowkit is the backbone of the smallorbit release pipeline.

--- a/site/src/content/posts/welcome.md
+++ b/site/src/content/posts/welcome.md
@@ -1,0 +1,10 @@
+---
+title: "Welcome to the smallorbit blog"
+subtitle: "What we're building and why"
+date: 2026-05-03
+author: smallorbit
+draft: true
+tags: ["meta", "announcement"]
+---
+
+This is a placeholder post for the smallorbit blog. More content coming soon.


### PR DESCRIPTION
## Summary

- Adds `site/src/content/config.ts` with two Astro content collections: `posts` (title, subtitle, kit, date, author, heroImage, ogImage, readTime, draft, tags) and `kits` (name, role, accentColor, oneLiner, commands, summary), each backed by a Zod schema via `defineCollection`.
- Seeds `posts` with `welcome.md` (draft: true) and `kits` with `flowkit.md` carrying real command list and summary drawn from existing plugin docs.
- Note: Astro 5 reserves `slug` in `type:'content'` collections (it's derived from the entry filename as `id`); the kits schema omits `slug` as a declared field to stay compatible — callers reference entries by `entry.id` instead.

## Test plan

- [ ] `cd site && npx astro check` reports zero errors
- [ ] `getCollection('posts')` and `getCollection('kits')` return the seed entries when called from a future page (verified later by #764)
- [ ] No changes outside `site/src/content/`

Closes #763