### PR TITLE
feat(site): add PostLayout with Shiki and reading components

### DIFF
--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -5,4 +5,10 @@ export default defineConfig({
   base: '/smallorbit-plugins',
   output: 'static',
   trailingSlash: 'always',
+  markdown: {
+    shikiConfig: {
+      theme: 'github-light',
+      wrap: false,
+    },
+  },
 });

--- a/site/src/components/post/AudioPlayer.astro
+++ b/site/src/components/post/AudioPlayer.astro
@@ -1,0 +1,82 @@
+---
+interface Props {
+  src?: string;
+  duration?: string;
+}
+
+const { src, duration } = Astro.props;
+---
+
+<details class="audio-player">
+  <summary class="audio-player__summary">
+    <span class="audio-player__icon" aria-hidden="true">&#9658;</span>
+    <span class="audio-player__label">Audio version</span>
+    {duration && <span class="audio-player__duration">{duration}</span>}
+  </summary>
+  <div class="audio-player__body">
+    {src ? (
+      <audio controls preload="none" src={src}>
+        Your browser does not support the audio element.
+      </audio>
+    ) : (
+      <p class="audio-player__placeholder">
+        Audio voiceover coming soon.
+      </p>
+    )}
+  </div>
+</details>
+
+<style>
+  .audio-player {
+    margin: 1.5rem 0 2rem;
+    padding: 0.875rem 1rem;
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+  }
+
+  .audio-player__summary {
+    display: flex;
+    align-items: center;
+    gap: 0.625rem;
+    cursor: pointer;
+    list-style: none;
+    color: var(--text-strong);
+    font-weight: 500;
+    font-size: 0.95rem;
+  }
+
+  .audio-player__summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .audio-player__icon {
+    color: var(--color-accent);
+    font-size: 0.85rem;
+  }
+
+  .audio-player__label {
+    flex: 1;
+  }
+
+  .audio-player__duration {
+    color: var(--text-muted);
+    font-family: var(--mono);
+    font-size: 0.825rem;
+  }
+
+  .audio-player__body {
+    margin-top: 0.875rem;
+  }
+
+  .audio-player__body audio {
+    width: 100%;
+  }
+
+  .audio-player__placeholder {
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    font-style: italic;
+  }
+</style>

--- a/site/src/components/post/Byline.astro
+++ b/site/src/components/post/Byline.astro
@@ -1,0 +1,85 @@
+---
+interface Props {
+  author: string;
+  date: Date;
+  readTime?: number;
+}
+
+const { author, date, readTime } = Astro.props;
+
+const formattedDate = date.toLocaleDateString('en-US', {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+});
+
+const initial = author.trim().charAt(0).toUpperCase() || 'S';
+---
+
+<div class="byline">
+  <div class="byline__avatar" aria-hidden="true">{initial}</div>
+  <div class="byline__meta">
+    <div class="byline__author">{author}</div>
+    <div class="byline__details">
+      <time datetime={date.toISOString()}>{formattedDate}</time>
+      {readTime !== undefined && (
+        <>
+          <span class="byline__sep" aria-hidden="true">&middot;</span>
+          <span>{readTime} min read</span>
+        </>
+      )}
+    </div>
+  </div>
+</div>
+
+<style>
+  .byline {
+    display: flex;
+    align-items: center;
+    gap: 0.875rem;
+    margin: 1.5rem 0 2.5rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .byline__avatar {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    background: var(--bg-veil);
+    color: var(--text-strong);
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: 1.1rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    border: 1px solid var(--border);
+  }
+
+  .byline__meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    line-height: 1.3;
+  }
+
+  .byline__author {
+    font-weight: 600;
+    color: var(--text-strong);
+    font-size: 0.95rem;
+  }
+
+  .byline__details {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: var(--text-muted);
+    font-size: 0.875rem;
+  }
+
+  .byline__sep {
+    color: var(--text-dim);
+  }
+</style>

--- a/site/src/components/post/Callout.astro
+++ b/site/src/components/post/Callout.astro
@@ -1,0 +1,50 @@
+---
+interface Props {
+  kit?: string;
+  cite?: string;
+}
+
+const { kit, cite } = Astro.props;
+const accent = kit ? `var(--${kit}, var(--color-accent))` : 'var(--color-accent)';
+---
+
+<aside class="callout" style={`--callout-accent: ${accent};`}>
+  <div class="callout__body">
+    <slot />
+    {cite && <footer class="callout__cite">&mdash; {cite}</footer>}
+  </div>
+</aside>
+
+<style>
+  .callout {
+    margin: 2rem 0;
+    padding: 1.25rem 1.5rem;
+    border-left: 4px solid var(--callout-accent);
+    background: var(--bg-raised);
+    border-radius: 0 var(--r-md) var(--r-md) 0;
+    color: var(--text-strong);
+  }
+
+  .callout__body {
+    font-family: var(--serif);
+    font-size: 1.15rem;
+    line-height: 1.55;
+    font-weight: 400;
+  }
+
+  .callout__body :global(p) {
+    margin: 0;
+  }
+
+  .callout__body :global(p + p) {
+    margin-top: 0.75rem;
+  }
+
+  .callout__cite {
+    margin-top: 0.75rem;
+    font-family: var(--sans);
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    font-style: normal;
+  }
+</style>

--- a/site/src/components/post/CodeBlock.astro
+++ b/site/src/components/post/CodeBlock.astro
@@ -1,0 +1,69 @@
+---
+interface Props {
+  filename?: string;
+  lineNumbers?: boolean;
+}
+
+const { filename, lineNumbers = false } = Astro.props;
+---
+
+<figure class={`code-block${lineNumbers ? ' code-block--numbered' : ''}`}>
+  {filename && <figcaption class="code-block__filename">{filename}</figcaption>}
+  <div class="code-block__body">
+    <slot />
+  </div>
+</figure>
+
+<style is:global>
+  .code-block {
+    margin: 2rem 0;
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    background: var(--bg-raised);
+    overflow: hidden;
+  }
+
+  .code-block__filename {
+    padding: 0.5rem 1rem;
+    border-bottom: 1px solid var(--border);
+    font-family: var(--mono);
+    font-size: 0.825rem;
+    color: var(--text-muted);
+    background: var(--bg-veil);
+  }
+
+  .code-block__body {
+    position: relative;
+  }
+
+  .code-block__body pre {
+    margin: 0 !important;
+    border-radius: 0 !important;
+    border: none !important;
+  }
+
+  .code-block--numbered .code-block__body pre {
+    padding-left: 0 !important;
+  }
+
+  .code-block--numbered .code-block__body pre code {
+    counter-reset: line;
+  }
+
+  .code-block--numbered .code-block__body pre code .line {
+    counter-increment: line;
+    padding-left: 3rem;
+    position: relative;
+  }
+
+  .code-block--numbered .code-block__body pre code .line::before {
+    content: counter(line);
+    position: absolute;
+    left: 0;
+    width: 2.25rem;
+    text-align: right;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+    user-select: none;
+  }
+</style>

--- a/site/src/components/post/Figure.astro
+++ b/site/src/components/post/Figure.astro
@@ -1,0 +1,38 @@
+---
+interface Props {
+  src: string;
+  alt: string;
+  caption?: string;
+  width?: number;
+  height?: number;
+}
+
+const { src, alt, caption, width, height } = Astro.props;
+---
+
+<figure class="figure">
+  <img src={src} alt={alt} width={width} height={height} loading="lazy" decoding="async" />
+  {caption && <figcaption class="figure__caption">{caption}</figcaption>}
+</figure>
+
+<style>
+  .figure {
+    margin: 2.5rem 0;
+  }
+
+  .figure img {
+    width: 100%;
+    border-radius: var(--r-md);
+    border: 1px solid var(--border);
+    background: var(--bg-veil);
+  }
+
+  .figure__caption {
+    margin-top: 0.75rem;
+    font-size: 0.875rem;
+    color: var(--text-muted);
+    text-align: center;
+    font-style: italic;
+    line-height: 1.5;
+  }
+</style>

--- a/site/src/components/post/InlineSubscribe.astro
+++ b/site/src/components/post/InlineSubscribe.astro
@@ -1,0 +1,104 @@
+---
+interface Props {
+  heading?: string;
+  blurb?: string;
+}
+
+const {
+  heading = 'Subscribe to smallorbit',
+  blurb = 'New posts on Claude Code plugins and shipping discipline, straight to your inbox.',
+} = Astro.props;
+---
+
+<aside class="inline-subscribe" data-todo="integrations-issue">
+  <div class="inline-subscribe__copy">
+    <h3 class="inline-subscribe__heading">{heading}</h3>
+    <p class="inline-subscribe__blurb">{blurb}</p>
+  </div>
+  <form
+    class="inline-subscribe__form"
+    aria-label="Subscribe (placeholder until newsletter integration ships)"
+  >
+    <label class="inline-subscribe__label" for="inline-subscribe-email">Email</label>
+    <input
+      id="inline-subscribe-email"
+      type="email"
+      placeholder="you@example.com"
+      autocomplete="email"
+      disabled
+    />
+    <button type="submit" disabled>Subscribe</button>
+  </form>
+  <p class="inline-subscribe__note">
+    Placeholder &mdash; wired up once the newsletter integration ships.
+  </p>
+</aside>
+
+<style>
+  .inline-subscribe {
+    margin: 3rem 0;
+    padding: 1.75rem;
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+  }
+
+  .inline-subscribe__heading {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: 1.4rem;
+    color: var(--text-strong);
+    margin: 0 0 0.5rem;
+  }
+
+  .inline-subscribe__blurb {
+    margin: 0 0 1.25rem;
+    color: var(--text);
+    font-size: 1rem;
+  }
+
+  .inline-subscribe__form {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+  }
+
+  .inline-subscribe__label {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+  }
+
+  .inline-subscribe__form input {
+    flex: 1 1 220px;
+    padding: 0.625rem 0.875rem;
+    border: 1px solid var(--border-strong);
+    border-radius: var(--r-sm);
+    font-family: var(--sans);
+    font-size: 0.95rem;
+    background: var(--bg-page);
+    color: var(--text);
+  }
+
+  .inline-subscribe__form button {
+    padding: 0.625rem 1.25rem;
+    border: 1px solid var(--color-accent);
+    background: var(--color-accent);
+    color: #fff;
+    font-family: var(--sans);
+    font-weight: 500;
+    font-size: 0.95rem;
+    border-radius: var(--r-sm);
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  .inline-subscribe__note {
+    margin: 0.75rem 0 0;
+    font-size: 0.8rem;
+    color: var(--text-dim);
+    font-family: var(--mono);
+  }
+</style>

--- a/site/src/components/post/TocTicks.astro
+++ b/site/src/components/post/TocTicks.astro
@@ -1,0 +1,198 @@
+---
+interface Props {
+  contentSelector?: string;
+  headingSelector?: string;
+}
+
+const { contentSelector = '.post__body', headingSelector = 'h2, h3' } = Astro.props;
+---
+
+<aside class="toc-ticks" aria-label="On this page">
+  <div class="toc-ticks__inner">
+    <p class="toc-ticks__label">On this page</p>
+    <ul
+      class="toc-ticks__list"
+      data-content-selector={contentSelector}
+      data-heading-selector={headingSelector}
+    ></ul>
+  </div>
+</aside>
+
+<style>
+  .toc-ticks {
+    display: none;
+  }
+
+  @media (min-width: 1100px) {
+    .toc-ticks {
+      display: block;
+      position: fixed;
+      top: 50%;
+      right: 1.5rem;
+      transform: translateY(-50%);
+      max-height: 70vh;
+      overflow-y: auto;
+      z-index: 5;
+    }
+
+    .toc-ticks__inner {
+      padding: 0.75rem 1rem;
+    }
+
+    .toc-ticks__label {
+      margin: 0 0 0.625rem;
+      font-family: var(--mono);
+      font-size: 0.7rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--text-dim);
+    }
+
+    .toc-ticks__list {
+      list-style: none;
+      padding: 0;
+      margin: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 0.25rem;
+    }
+
+    .toc-ticks__list :global(li) {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .toc-ticks__list :global(.toc-ticks__tick) {
+      width: 18px;
+      height: 2px;
+      background: var(--border);
+      border-radius: 2px;
+      transition: background 0.2s ease, width 0.2s ease;
+      flex-shrink: 0;
+    }
+
+    .toc-ticks__list :global(li[data-level='3'] .toc-ticks__tick) {
+      width: 12px;
+    }
+
+    .toc-ticks__list :global(li.is-visible .toc-ticks__tick) {
+      background: var(--text-muted);
+    }
+
+    .toc-ticks__list :global(li.is-active .toc-ticks__tick) {
+      background: var(--color-accent);
+      width: 24px;
+    }
+
+    .toc-ticks__list :global(a) {
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      text-decoration: none;
+      line-height: 1.3;
+      max-width: 16ch;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+
+    .toc-ticks__list :global(li.is-active a) {
+      color: var(--text-strong);
+      font-weight: 500;
+    }
+  }
+</style>
+
+<script is:inline>
+  (function () {
+    const list = document.querySelector('.toc-ticks__list');
+    if (!list) return;
+
+    const contentSelector = list.getAttribute('data-content-selector') || '.post__body';
+    const headingSelector = list.getAttribute('data-heading-selector') || 'h2, h3';
+    const root = document.querySelector(contentSelector);
+    if (!root) return;
+
+    const headings = Array.from(root.querySelectorAll(headingSelector));
+    if (headings.length === 0) return;
+
+    const slugify = (text) =>
+      text
+        .toLowerCase()
+        .replace(/[^a-z0-9\s-]/g, '')
+        .trim()
+        .replace(/\s+/g, '-');
+
+    const itemMap = new Map();
+
+    headings.forEach((heading) => {
+      if (!heading.id) {
+        heading.id = slugify(heading.textContent || '');
+      }
+      const li = document.createElement('li');
+      li.setAttribute('data-level', heading.tagName.charAt(1));
+      li.setAttribute('data-target', heading.id);
+
+      const tick = document.createElement('span');
+      tick.className = 'toc-ticks__tick';
+      tick.setAttribute('aria-hidden', 'true');
+
+      const link = document.createElement('a');
+      link.href = '#' + heading.id;
+      link.textContent = heading.textContent || '';
+
+      li.appendChild(tick);
+      li.appendChild(link);
+      list.appendChild(li);
+      itemMap.set(heading.id, li);
+    });
+
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    const visible = new Set();
+
+    const updateActive = () => {
+      itemMap.forEach((li, id) => {
+        if (visible.has(id)) {
+          li.classList.add('is-visible');
+        } else {
+          li.classList.remove('is-visible');
+        }
+        li.classList.remove('is-active');
+      });
+      const visibleIds = Array.from(visible);
+      if (visibleIds.length > 0) {
+        const firstId = visibleIds[0];
+        const firstLi = itemMap.get(firstId);
+        if (firstLi) firstLi.classList.add('is-active');
+      }
+    };
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            visible.add(entry.target.id);
+          } else {
+            visible.delete(entry.target.id);
+          }
+        });
+        updateActive();
+      },
+      { rootMargin: '0px 0px -60% 0px', threshold: 0 }
+    );
+
+    headings.forEach((heading) => observer.observe(heading));
+
+    if (reduceMotion) {
+      list.querySelectorAll('a').forEach((a) => {
+        a.addEventListener('click', (e) => {
+          e.preventDefault();
+          const id = a.getAttribute('href')?.slice(1);
+          if (!id) return;
+          const target = document.getElementById(id);
+          if (target) target.scrollIntoView({ behavior: 'auto' });
+        });
+      });
+    }
+  })();
+</script>

--- a/site/src/components/post/TocTicks.astro
+++ b/site/src/components/post/TocTicks.astro
@@ -107,6 +107,7 @@ const { contentSelector = '.post__body', headingSelector = 'h2, h3' } = Astro.pr
   (function () {
     const list = document.querySelector('.toc-ticks__list');
     if (!list) return;
+    if (list.childElementCount > 0) return;
 
     const contentSelector = list.getAttribute('data-content-selector') || '.post__body';
     const headingSelector = list.getAttribute('data-heading-selector') || 'h2, h3';

--- a/site/src/content/posts/welcome.md
+++ b/site/src/content/posts/welcome.md
@@ -1,10 +1,99 @@
 ---
 title: "Welcome to the smallorbit blog"
-subtitle: "What we're building and why"
+subtitle: "What we're building, why it matters, and how the kits fit together"
+kit: flowkit
 date: 2026-05-03
 author: smallorbit
-draft: true
+readTime: 6
+draft: false
 tags: ["meta", "announcement"]
 ---
 
-This is a placeholder post for the smallorbit blog. More content coming soon.
+This is the seed post for the smallorbit blog &mdash; equal parts welcome mat and
+typography test. It walks through every component the reading layout supports so
+the design can be verified against a real piece of writing.
+
+## Why a blog?
+
+We ship Claude Code plugins that sit at the intersection of planning, parallel
+execution, and release discipline. The kits make sense in motion, not in a feature
+matrix &mdash; so we needed somewhere to show the work. That's what this lives for.
+
+The reading experience is intentionally Substack-flavored: a generous measure, a
+serif title, and a body that gets out of the way.
+
+<aside class="callout" style="--callout-accent: var(--flowkit, var(--color-accent));">
+  <div class="callout__body">
+    <p>The reading layout is the visible payoff of Phase 0 design work. If it lands
+    flat, the whole content effort lands flat.</p>
+  </div>
+</aside>
+
+## Code blocks
+
+Fenced code blocks are highlighted with the `github-light` Shiki theme so they
+sit comfortably against the warm-paper background. Inline `code` fragments use a
+chip with a subtle border.
+
+```ts
+import { defineCollection, z } from 'astro:content';
+
+const posts = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    date: z.coerce.date(),
+    readTime: z.number().optional(),
+    draft: z.boolean().default(false),
+  }),
+});
+
+export const collections = { posts };
+```
+
+```bash
+# Create a feature branch and start a swarm
+flowkit cut-epic blog 775
+swarmkit swarm --epic blog-775
+```
+
+### Inline code
+
+Try a sentence with a few inline references &mdash; for instance, calling
+`getCollection('posts')` and then awaiting `entry.render()` to get a renderable
+`<Content />` component.
+
+## Captioned images
+
+<figure class="figure">
+  <img
+    src="https://placehold.co/1200x600/ede9e3/737069/png?text=smallorbit"
+    alt="Placeholder hero illustration for the smallorbit blog"
+    loading="lazy"
+    decoding="async"
+  />
+  <figcaption class="figure__caption">
+    A captioned image &mdash; the workhorse of any essay format.
+  </figcaption>
+</figure>
+
+## Pull quotes
+
+> The kits make sense in motion, not in a feature matrix.
+
+The default markdown blockquote inherits the post's accent color via
+`--post-accent`, so a pillar post tagged `kit: flowkit` gets a flowkit-blue
+left border without any per-post styling.
+
+## Audio voiceover
+
+The audio voiceover slot lives at the top of every post, just under the byline.
+When a post has no recorded audio yet, the slot stays collapsed with a placeholder
+&mdash; no missing-asset clutter. We will wire up real audio sources once the
+production pipeline is ready.
+
+## Wrap
+
+That's the seed. Subsequent posts can lean on the same components without thinking
+about layout: drop the markdown in, fill in `kit:` and `readTime:` in the
+frontmatter, and the rest follows.

--- a/site/src/layouts/PostLayout.astro
+++ b/site/src/layouts/PostLayout.astro
@@ -1,0 +1,298 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import BaseLayout from './BaseLayout.astro';
+import Byline from '../components/post/Byline.astro';
+import AudioPlayer from '../components/post/AudioPlayer.astro';
+import InlineSubscribe from '../components/post/InlineSubscribe.astro';
+import TocTicks from '../components/post/TocTicks.astro';
+
+interface Props {
+  entry: CollectionEntry<'posts'>;
+}
+
+const { entry } = Astro.props;
+const { title, subtitle, kit, date, author, readTime, ogImage, draft } = entry.data;
+
+const description = subtitle ?? title;
+const accentVar = kit ? `var(--${kit}, var(--color-accent))` : 'var(--color-accent)';
+---
+
+<BaseLayout title={title} description={description} ogImage={ogImage} ogType="article">
+  <article class="post" style={`--post-accent: ${accentVar};`}>
+    <header class="post__header">
+      {kit && <p class="post__kit">{kit}</p>}
+      <h1 class="post__title">{title}</h1>
+      {subtitle && <p class="post__subtitle">{subtitle}</p>}
+      {draft && <p class="post__draft" aria-label="Draft post">Draft</p>}
+
+      <Byline author={author} date={date} readTime={readTime} />
+      <AudioPlayer />
+    </header>
+
+    <div class="post__body">
+      <slot />
+    </div>
+
+    <footer class="post__footer">
+      <InlineSubscribe />
+    </footer>
+  </article>
+
+  <TocTicks contentSelector=".post__body" headingSelector="h2, h3" />
+</BaseLayout>
+
+<script is:inline>
+  (function () {
+    const setup = () => {
+      document.querySelectorAll('.post__body pre').forEach((pre) => {
+        if (pre.querySelector('.code-copy-btn')) return;
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'code-copy-btn';
+        btn.textContent = 'Copy';
+        btn.setAttribute('aria-label', 'Copy code to clipboard');
+        btn.addEventListener('click', async () => {
+          const code = pre.querySelector('code');
+          if (!code) return;
+          const text = code.innerText;
+          try {
+            await navigator.clipboard.writeText(text);
+            btn.textContent = 'Copied';
+            btn.dataset.copied = 'true';
+            setTimeout(() => {
+              btn.textContent = 'Copy';
+              btn.dataset.copied = 'false';
+            }, 1600);
+          } catch (err) {
+            btn.textContent = 'Failed';
+          }
+        });
+        pre.appendChild(btn);
+      });
+    };
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', setup);
+    } else {
+      setup();
+    }
+  })();
+</script>
+
+<style is:global>
+  .post {
+    max-width: var(--measure);
+    margin: 0 auto;
+    padding: 3rem 1.25rem 4rem;
+  }
+
+  .post__kit {
+    display: inline-block;
+    margin: 0 0 1rem;
+    padding: 0.2rem 0.625rem;
+    font-family: var(--mono);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-strong);
+    background: var(--bg-veil);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--post-accent);
+    border-radius: var(--r-xs);
+  }
+
+  .post__title {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: clamp(2rem, 4.5vw, 3.2rem);
+    line-height: 1.15;
+    color: var(--text-strong);
+    margin: 0 0 0.75rem;
+    letter-spacing: -0.01em;
+  }
+
+  .post__subtitle {
+    font-family: var(--serif);
+    font-weight: 400;
+    font-style: italic;
+    font-size: 1.25rem;
+    line-height: 1.45;
+    color: var(--text-muted);
+    margin: 0 0 1.25rem;
+  }
+
+  .post__draft {
+    display: inline-block;
+    margin: 0 0 1rem;
+    padding: 0.15rem 0.5rem;
+    font-family: var(--mono);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--polishkit, var(--text-muted));
+    background: transparent;
+    border: 1px dashed var(--border-strong);
+    border-radius: var(--r-xs);
+  }
+
+  .post__body {
+    font-family: var(--sans);
+    font-size: 1.0625rem;
+    line-height: 1.75;
+    color: var(--text);
+  }
+
+  .post__body > * {
+    margin-top: 0;
+    margin-bottom: 1.25rem;
+  }
+
+  .post__body h2 {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: 1.75rem;
+    line-height: 1.25;
+    color: var(--text-strong);
+    margin: 2.75rem 0 1rem;
+    letter-spacing: -0.005em;
+  }
+
+  .post__body h3 {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: 1.35rem;
+    line-height: 1.3;
+    color: var(--text-strong);
+    margin: 2rem 0 0.75rem;
+  }
+
+  .post__body p {
+    margin: 0 0 1.25rem;
+  }
+
+  .post__body ul,
+  .post__body ol {
+    padding-left: 1.5rem;
+    margin: 0 0 1.25rem;
+  }
+
+  .post__body li {
+    margin: 0.25rem 0;
+  }
+
+  .post__body blockquote {
+    margin: 2rem 0;
+    padding: 0.5rem 0 0.5rem 1.25rem;
+    border-left: 3px solid var(--post-accent);
+    color: var(--text-strong);
+    font-family: var(--serif);
+    font-size: 1.15rem;
+    font-style: italic;
+    line-height: 1.55;
+  }
+
+  .post__body blockquote p {
+    margin: 0 0 0.5rem;
+  }
+
+  .post__body hr {
+    border: 0;
+    border-top: 1px solid var(--border);
+    margin: 2.5rem 0;
+  }
+
+  .post__body a {
+    color: var(--link);
+  }
+
+  .post__footer {
+    margin-top: 3rem;
+    padding-top: 2rem;
+    border-top: 1px solid var(--border);
+  }
+
+  .post__body pre.astro-code,
+  .post__body pre {
+    position: relative;
+    margin: 2rem 0;
+    padding: 1rem 1.25rem;
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    background: #ffffff !important;
+    font-family: var(--mono);
+    font-size: 0.875rem;
+    line-height: 1.6;
+    overflow-x: auto;
+  }
+
+  .post__body pre code {
+    font-family: inherit;
+    font-size: inherit;
+    background: none;
+    padding: 0;
+    counter-reset: line;
+  }
+
+  .post__body pre code .line {
+    display: block;
+    padding-left: 0.25rem;
+  }
+
+  .post__body pre.line-numbers code .line,
+  .post__body pre[data-line-numbers] code .line {
+    counter-increment: line;
+    padding-left: 3rem;
+    position: relative;
+  }
+
+  .post__body pre.line-numbers code .line::before,
+  .post__body pre[data-line-numbers] code .line::before {
+    content: counter(line);
+    position: absolute;
+    left: 0;
+    width: 2.25rem;
+    text-align: right;
+    color: var(--text-dim);
+    font-variant-numeric: tabular-nums;
+    user-select: none;
+  }
+
+  .code-copy-btn {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    padding: 0.25rem 0.625rem;
+    font-family: var(--mono);
+    font-size: 0.75rem;
+    color: var(--text-muted);
+    background: var(--bg-page);
+    border: 1px solid var(--border);
+    border-radius: var(--r-xs);
+    cursor: pointer;
+    opacity: 0;
+    transition: opacity 0.15s ease, color 0.15s ease;
+  }
+
+  .post__body pre:hover .code-copy-btn,
+  .code-copy-btn:focus-visible {
+    opacity: 1;
+  }
+
+  .code-copy-btn:hover {
+    color: var(--text-strong);
+    border-color: var(--border-strong);
+  }
+
+  .code-copy-btn[data-copied='true'] {
+    color: var(--swarmkit, var(--color-accent));
+  }
+
+  .post__body :not(pre) > code {
+    font-family: var(--mono);
+    font-size: 0.9em;
+    padding: 0.1rem 0.35rem;
+    background: var(--bg-veil);
+    border: 1px solid var(--border);
+    border-radius: var(--r-xs);
+    color: var(--text-strong);
+  }
+</style>

--- a/site/src/pages/blog/[...slug].astro
+++ b/site/src/pages/blog/[...slug].astro
@@ -1,0 +1,26 @@
+---
+import { getCollection, type CollectionEntry } from 'astro:content';
+import PostLayout from '../../layouts/PostLayout.astro';
+
+export async function getStaticPaths() {
+  const entries = await getCollection('posts', ({ data }: CollectionEntry<'posts'>) => {
+    return !data.draft || import.meta.env.DEV;
+  });
+
+  return entries.map((entry: CollectionEntry<'posts'>) => ({
+    params: { slug: entry.id.replace(/\.(md|mdx)$/, '') },
+    props: { entry },
+  }));
+}
+
+interface Props {
+  entry: CollectionEntry<'posts'>;
+}
+
+const { entry } = Astro.props;
+const { Content } = await entry.render();
+---
+
+<PostLayout entry={entry}>
+  <Content />
+</PostLayout>


### PR DESCRIPTION
## Summary

- Adds `PostLayout.astro` that wraps `BaseLayout`, forwards frontmatter (title/description/ogImage), and renders the byline strip, audio voiceover slot, inline subscribe placeholder, scroll-position TOC, and a copy button on every fenced code block.
- Adds reading components under `site/src/components/post/`: `Byline`, `Callout`, `Figure`, `InlineSubscribe`, `AudioPlayer`, `TocTicks`, and an opt-in `CodeBlock` wrapper for filename headers and line numbers.
- Configures Shiki with the `github-light` theme (no new deps) so fenced code blocks render in light mode.
- Adds the `/blog/[...slug]/` dynamic route powered by `getStaticPaths` over the `posts` collection (drafts filtered out in production builds), and updates the `welcome` seed post to exercise every reading component at `/blog/welcome/`.

## Changes

- `site/astro.config.mjs` &mdash; add `markdown.shikiConfig` (`theme: 'github-light'`, `wrap: false`).
- `site/src/layouts/PostLayout.astro` &mdash; new layout consuming `CollectionEntry<'posts'>`.
- `site/src/components/post/*.astro` &mdash; seven new reading components.
- `site/src/pages/blog/[...slug].astro` &mdash; dynamic post route with draft filtering.
- `site/src/content/posts/welcome.md` &mdash; expanded seed post that exercises byline, callout, figure, code blocks, blockquote, and inline code.

`BaseLayout.astro` is untouched (extended via slots/props only). `site/src/content/config.ts` is untouched (schema sealed by #763).

## Test plan

- [x] `cd site && npx astro check` reports zero errors (also zero warnings / hints).
- [x] `cd site && npm run build` succeeds and produces `dist/blog/welcome/index.html`.
- [x] `dist/blog/welcome/index.html` includes the byline, callout, figure, and Shiki-highlighted code blocks (`astro-code` + `github-light` markers present).
- [x] No changes outside `site/`.

Closes #764