### PR TITLE
feat(site): migrate landing + add /blog, /kits, /about pages

### DIFF
--- a/site/src/components/landing/Hero.astro
+++ b/site/src/components/landing/Hero.astro
@@ -1,0 +1,135 @@
+---
+---
+
+<section class="hero" aria-labelledby="hero-title">
+  <div class="hero__inner">
+    <span class="hero__prompt">
+      ~/smallorbit-plugins<span class="hero__cursor" aria-hidden="true">▋</span>
+    </span>
+    <h1 id="hero-title" class="hero__title">
+      From idea to release.<br />
+      <span class="hero__title-line-two">With you in the loop.</span>
+    </h1>
+    <p class="hero__sub">
+      Claude Code plugins for plan, execute, and ship —
+      each keeping you at the handoffs that matter.
+    </p>
+    <div class="hero__actions">
+      <a href="#install" class="hero__cta">
+        Get started
+        <span class="hero__cta-glyph" aria-hidden="true">→</span>
+      </a>
+      <span class="hero__secondary">or <a href="#lifecycle">see the flow</a></span>
+    </div>
+  </div>
+</section>
+
+<style>
+  .hero {
+    position: relative;
+    border-bottom: 1px solid var(--border);
+    background:
+      radial-gradient(
+        ellipse at 50% 0%,
+        rgba(79, 70, 229, 0.06) 0%,
+        rgba(79, 70, 229, 0) 60%
+      ),
+      var(--bg-page);
+    overflow: hidden;
+  }
+
+  .hero__inner {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 5rem 1.25rem 4.5rem;
+    text-align: center;
+  }
+
+  .hero__prompt {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 0.85rem;
+    color: var(--text-muted);
+    margin: 0 0 1.5rem;
+    letter-spacing: 0.02em;
+  }
+
+  .hero__cursor {
+    display: inline-block;
+    margin-left: 0.15rem;
+    color: var(--color-accent);
+    animation: hero-blink 1s steps(2, end) infinite;
+  }
+
+  @keyframes hero-blink {
+    50% { opacity: 0; }
+  }
+
+  .hero__title {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: clamp(2.4rem, 6vw, 4.2rem);
+    line-height: 1.05;
+    color: var(--text-strong);
+    margin: 0 0 1.5rem;
+    letter-spacing: -0.015em;
+  }
+
+  .hero__title-line-two {
+    color: var(--color-accent);
+    font-style: italic;
+  }
+
+  .hero__sub {
+    max-width: 56ch;
+    margin: 0 auto 2.25rem;
+    font-size: 1.125rem;
+    line-height: 1.55;
+    color: var(--text);
+  }
+
+  .hero__actions {
+    display: inline-flex;
+    align-items: center;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 1rem;
+    font-size: 0.95rem;
+    color: var(--text-muted);
+  }
+
+  .hero__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.7rem 1.25rem;
+    background: var(--text-strong);
+    color: var(--bg-page);
+    border-radius: var(--r-md);
+    text-decoration: none;
+    font-weight: 600;
+    transition: transform 0.15s ease, background 0.15s ease;
+  }
+
+  .hero__cta:hover {
+    color: var(--bg-page);
+    background: var(--color-accent);
+    transform: translateY(-1px);
+  }
+
+  .hero__cta:visited {
+    color: var(--bg-page);
+  }
+
+  .hero__cta-glyph {
+    transition: transform 0.15s ease;
+  }
+
+  .hero__cta:hover .hero__cta-glyph {
+    transform: translateX(2px);
+  }
+
+  .hero__secondary a {
+    color: var(--link);
+  }
+</style>

--- a/site/src/components/landing/InstallSteps.astro
+++ b/site/src/components/landing/InstallSteps.astro
@@ -1,0 +1,322 @@
+---
+const lifecycleKits = ['speckit', 'swarmkit', 'polishkit', 'flowkit', 'sessionkit', 'squadkit'];
+const utilityKits = ['vaultkit'];
+---
+
+<section id="install" class="install" aria-labelledby="install-title">
+  <div class="install__container">
+    <span class="install__eyebrow">getting started</span>
+    <h2 id="install-title" class="install__title">Install and run.</h2>
+    <p class="install__intro">
+      Add the marketplace, then install the plugins you want. Everything below runs in a Claude Code session.
+    </p>
+
+    <a
+      class="install__teaser"
+      href="https://github.com/smallorbit/smallorbit-plugins#getting-started"
+      rel="noopener noreferrer"
+    >
+      <div class="install__teaser-body">
+        <h3 class="install__teaser-title">New here? Start with the walkthrough.</h3>
+        <p class="install__teaser-pitch">
+          A five-minute tour from <code>/spec</code> to a shipped release — prereqs, install, and your first swarm.
+        </p>
+      </div>
+      <span class="install__teaser-cta">Read it<span aria-hidden="true">↗</span></span>
+    </a>
+
+    <ol class="install__steps">
+      <li class="install__step">
+        <div class="install__step-n">01</div>
+        <div class="install__step-body">
+          <div class="install__step-head">
+            <h3 class="install__step-title">Add the marketplace</h3>
+            <span class="install__step-sub">one-time setup &middot; syncs plugin index</span>
+          </div>
+          <div class="install__commands">
+            <div class="install__cmd" data-copy="/plugin marketplace add smallorbit/smallorbit-plugins">
+              <pre><code>/plugin marketplace add smallorbit/smallorbit-plugins</code></pre>
+              <button type="button" class="install__copy-btn" aria-label="Copy marketplace install command">copy</button>
+            </div>
+          </div>
+        </div>
+      </li>
+
+      <li class="install__step">
+        <div class="install__step-n">02</div>
+        <div class="install__step-body">
+          <div class="install__step-head">
+            <h3 class="install__step-title">Install the plugins</h3>
+            <span class="install__step-sub">pick the suite or just what you need</span>
+          </div>
+          <div class="install__commands">
+            <div class="install__sublabel">Development lifecycle</div>
+            {
+              lifecycleKits.map((kit) => {
+                const cmd = `/plugin install ${kit}@smallorbit-plugins`;
+                return (
+                  <div class="install__cmd" data-copy={cmd}>
+                    <pre><code>{cmd}</code></pre>
+                    <button type="button" class="install__copy-btn" aria-label={`Copy ${kit} install command`}>copy</button>
+                  </div>
+                );
+              })
+            }
+            <div class="install__sublabel">Utilities &amp; productivity</div>
+            {
+              utilityKits.map((kit) => {
+                const cmd = `/plugin install ${kit}@smallorbit-plugins`;
+                return (
+                  <div class="install__cmd" data-copy={cmd}>
+                    <pre><code>{cmd}</code></pre>
+                    <button type="button" class="install__copy-btn" aria-label={`Copy ${kit} install command`}>copy</button>
+                  </div>
+                );
+              })
+            }
+          </div>
+        </div>
+      </li>
+    </ol>
+  </div>
+</section>
+
+<script is:inline>
+  (function () {
+    const setup = () => {
+      document.querySelectorAll('.install__cmd').forEach((wrapper) => {
+        const btn = wrapper.querySelector('.install__copy-btn');
+        if (!btn || btn.dataset.bound === 'true') return;
+        btn.dataset.bound = 'true';
+        btn.addEventListener('click', async () => {
+          const text = wrapper.getAttribute('data-copy') ?? '';
+          try {
+            await navigator.clipboard.writeText(text);
+            btn.textContent = 'copied';
+            btn.dataset.copied = 'true';
+            setTimeout(() => {
+              btn.textContent = 'copy';
+              btn.dataset.copied = 'false';
+            }, 1600);
+          } catch (err) {
+            btn.textContent = 'failed';
+          }
+        });
+      });
+    };
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', setup);
+    } else {
+      setup();
+    }
+  })();
+</script>
+
+<style>
+  .install {
+    background: var(--bg-page);
+  }
+
+  .install__container {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 4.5rem 1.25rem;
+  }
+
+  .install__eyebrow {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-muted);
+    margin: 0 0 1rem;
+  }
+
+  .install__title {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: clamp(1.8rem, 3.5vw, 2.6rem);
+    line-height: 1.15;
+    color: var(--text-strong);
+    margin: 0 0 0.75rem;
+    letter-spacing: -0.01em;
+  }
+
+  .install__intro {
+    color: var(--text-muted);
+    max-width: 60ch;
+    margin: 0 0 2rem;
+    font-size: 1.05rem;
+  }
+
+  .install__teaser {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+    padding: 1.25rem 1.5rem;
+    margin: 0 0 2.5rem;
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    background: var(--bg-raised);
+    text-decoration: none;
+    color: inherit;
+    transition: border-color 0.15s ease, transform 0.15s ease;
+  }
+
+  .install__teaser:hover {
+    border-color: var(--color-accent);
+    transform: translateY(-1px);
+  }
+
+  .install__teaser-title {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: 1.15rem;
+    color: var(--text-strong);
+    margin: 0 0 0.25rem;
+  }
+
+  .install__teaser-pitch {
+    margin: 0;
+    font-size: 0.9rem;
+    color: var(--text-muted);
+  }
+
+  .install__teaser-pitch code {
+    font-family: var(--mono);
+    font-size: 0.85rem;
+    padding: 0.1rem 0.3rem;
+    background: var(--bg-veil);
+    border: 1px solid var(--border);
+    border-radius: var(--r-xs);
+  }
+
+  .install__teaser-cta {
+    flex-shrink: 0;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    color: var(--color-accent);
+    font-weight: 600;
+    font-size: 0.95rem;
+  }
+
+  .install__steps {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+  }
+
+  .install__step {
+    display: grid;
+    grid-template-columns: 64px 1fr;
+    gap: 1.25rem;
+    padding: 1.5rem;
+    border: 1px solid var(--border);
+    border-radius: var(--r-md);
+    background: var(--bg-raised);
+  }
+
+  .install__step-n {
+    font-family: var(--mono);
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--color-accent);
+  }
+
+  .install__step-body {
+    min-width: 0;
+  }
+
+  .install__step-head {
+    margin-bottom: 1rem;
+  }
+
+  .install__step-title {
+    font-family: var(--serif);
+    font-size: 1.25rem;
+    font-weight: 500;
+    color: var(--text-strong);
+    margin: 0 0 0.15rem;
+  }
+
+  .install__step-sub {
+    font-size: 0.85rem;
+    color: var(--text-muted);
+  }
+
+  .install__commands {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6rem;
+  }
+
+  .install__sublabel {
+    margin-top: 0.6rem;
+    font-family: var(--mono);
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-dim);
+  }
+
+  .install__sublabel:first-child {
+    margin-top: 0;
+  }
+
+  .install__cmd {
+    position: relative;
+  }
+
+  .install__cmd pre {
+    margin: 0;
+    padding: 0.75rem 1rem;
+    padding-right: 4rem;
+    background: var(--bg-page);
+    border: 1px solid var(--border);
+    border-radius: var(--r-sm);
+    font-family: var(--mono);
+    font-size: 0.85rem;
+    overflow-x: auto;
+    color: var(--text-strong);
+  }
+
+  .install__cmd code {
+    font-family: inherit;
+  }
+
+  .install__copy-btn {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.5rem;
+    padding: 0.25rem 0.6rem;
+    font-family: var(--mono);
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: var(--r-xs);
+    cursor: pointer;
+    transition: color 0.15s ease, border-color 0.15s ease;
+  }
+
+  .install__copy-btn:hover {
+    color: var(--text-strong);
+    border-color: var(--border-strong);
+  }
+
+  .install__copy-btn[data-copied='true'] {
+    color: var(--swarmkit);
+  }
+
+  @media (max-width: 600px) {
+    .install__step {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>

--- a/site/src/components/landing/InstallSteps.astro
+++ b/site/src/components/landing/InstallSteps.astro
@@ -1,6 +1,6 @@
 ---
 const lifecycleKits = ['speckit', 'swarmkit', 'polishkit', 'flowkit', 'sessionkit', 'squadkit'];
-const utilityKits = ['vaultkit'];
+const utilityKits = ['vaultkit', 'hookify'];
 ---
 
 <section id="install" class="install" aria-labelledby="install-title">

--- a/site/src/components/landing/KitGrid.astro
+++ b/site/src/components/landing/KitGrid.astro
@@ -1,0 +1,213 @@
+---
+import { getCollection, type CollectionEntry } from 'astro:content';
+
+type KitEntry = CollectionEntry<'kits'>;
+
+const baseHref = import.meta.env.BASE_URL.endsWith('/')
+  ? import.meta.env.BASE_URL
+  : `${import.meta.env.BASE_URL}/`;
+
+const KIT_ORDER = [
+  'speckit',
+  'swarmkit',
+  'polishkit',
+  'flowkit',
+  'sessionkit',
+  'squadkit',
+  'vaultkit',
+  'hookify',
+];
+
+const stripExt = (id: string): string => id.replace(/\.(md|mdx)$/, '');
+
+const orderIndex = (id: string): number => {
+  const idx = KIT_ORDER.indexOf(stripExt(id));
+  return idx === -1 ? 999 : idx;
+};
+
+const kits = (await getCollection('kits')).sort(
+  (a: KitEntry, b: KitEntry) => orderIndex(a.id) - orderIndex(b.id)
+);
+---
+
+<section id="plugins" class="kit-grid" aria-labelledby="plugins-title">
+  <div class="kit-grid__container">
+    <span class="kit-grid__eyebrow">the kits</span>
+    <h2 id="plugins-title" class="kit-grid__title">Tools for the whole lifecycle.</h2>
+    <p class="kit-grid__lede">
+      Each kit is built for a specific phase. Pick the suite or just what you need.
+    </p>
+
+    <div class="kit-grid__list">
+      {
+        kits.map((kit) => (
+          <article
+            class="kit-card"
+            data-kit={stripExt(kit.id)}
+            style={`--kit-accent: ${kit.data.accentColor};`}
+          >
+            <div class="kit-card__head">
+              <a class="kit-card__id" href={`${baseHref}kits/${stripExt(kit.id)}/`}>
+                <span class="kit-card__name">{kit.data.name}</span>
+                <span class="kit-card__role">{kit.data.role}</span>
+              </a>
+              <a
+                class="kit-card__readme"
+                href={`https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/${stripExt(kit.id)}`}
+                rel="noopener noreferrer"
+              >
+                README ↗
+              </a>
+            </div>
+            <p class="kit-card__desc">{kit.data.oneLiner}</p>
+            {kit.data.commands.length > 0 && (
+              <ul class="kit-card__commands">
+                {kit.data.commands.slice(0, 5).map((cmd: string) => (
+                  <li>
+                    <code>{cmd}</code>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </article>
+        ))
+      }
+    </div>
+  </div>
+</section>
+
+<style>
+  .kit-grid {
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-page);
+  }
+
+  .kit-grid__container {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 4.5rem 1.25rem;
+  }
+
+  .kit-grid__eyebrow {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-muted);
+    margin: 0 0 1rem;
+  }
+
+  .kit-grid__title {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: clamp(1.8rem, 3.5vw, 2.6rem);
+    line-height: 1.15;
+    color: var(--text-strong);
+    margin: 0 0 0.75rem;
+    letter-spacing: -0.01em;
+  }
+
+  .kit-grid__lede {
+    max-width: 60ch;
+    color: var(--text-muted);
+    margin: 0 0 2.5rem;
+    font-size: 1.05rem;
+  }
+
+  .kit-grid__list {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+    gap: 1.25rem;
+  }
+
+  .kit-card {
+    --kit-accent: var(--color-accent);
+    position: relative;
+    padding: 1.5rem;
+    border: 1px solid var(--border);
+    border-left: 4px solid var(--kit-accent);
+    border-radius: var(--r-md);
+    background: var(--bg-raised);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    transition: transform 0.15s ease, box-shadow 0.15s ease;
+  }
+
+  .kit-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 8px 24px -16px rgba(26, 22, 18, 0.18);
+  }
+
+  .kit-card__head {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .kit-card__id {
+    text-decoration: none;
+    color: inherit;
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .kit-card__id:hover .kit-card__name {
+    color: var(--kit-accent);
+  }
+
+  .kit-card__name {
+    font-family: var(--mono);
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--text-strong);
+    transition: color 0.15s ease;
+  }
+
+  .kit-card__role {
+    font-family: var(--sans);
+    font-size: 0.85rem;
+    color: var(--text-muted);
+  }
+
+  .kit-card__readme {
+    flex-shrink: 0;
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    text-decoration: none;
+  }
+
+  .kit-card__readme:hover {
+    color: var(--kit-accent);
+  }
+
+  .kit-card__desc {
+    margin: 0;
+    font-size: 0.95rem;
+    line-height: 1.55;
+    color: var(--text);
+  }
+
+  .kit-card__commands {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+  }
+
+  .kit-card__commands li code {
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    padding: 0.15rem 0.45rem;
+    background: var(--bg-veil);
+    border: 1px solid var(--border);
+    border-radius: var(--r-xs);
+    color: var(--text-strong);
+  }
+</style>

--- a/site/src/components/landing/LifecycleMap.astro
+++ b/site/src/components/landing/LifecycleMap.astro
@@ -1,0 +1,391 @@
+---
+---
+
+<section id="lifecycle" class="lifecycle" aria-labelledby="lifecycle-title">
+  <div class="lifecycle__container">
+    <span class="lifecycle__eyebrow">end-to-end flow</span>
+    <h2 id="lifecycle-title" class="lifecycle__title">A complete loop, with you at every turn.</h2>
+    <p class="lifecycle__lede">
+      Claude drives each phase; you approve at every handoff. sessionkit keeps context flowing as you go.
+    </p>
+
+    <div class="lifecycle__panel">
+      <div
+        class="lifecycle__svg-wrap"
+        role="img"
+        aria-label="Development lifecycle subway map: speckit, swarmkit, polishkit, and flowkit arranged left to right across the PLAN, EXECUTE, POLISH, and SHIP phases. Below each is a human-in-the-loop decision point. sessionkit runs underneath all phases."
+      >
+        <svg class="lifecycle__svg" viewBox="0 0 1040 430" preserveAspectRatio="xMidYMid meet" aria-hidden="true" focusable="false">
+          <rect class="ls-phase-bar" x="130" y="34" width="60" height="2" fill="var(--speckit)" />
+          <rect class="ls-phase-bar" x="370" y="34" width="60" height="2" fill="var(--swarmkit)" />
+          <rect class="ls-phase-bar" x="610" y="34" width="60" height="2" fill="var(--polishkit)" />
+          <rect class="ls-phase-bar" x="850" y="34" width="60" height="2" fill="var(--flowkit)" />
+
+          <text class="ls-phase-text" x="160" y="22" text-anchor="middle">PLAN</text>
+          <text class="ls-phase-text" x="400" y="22" text-anchor="middle">EXECUTE</text>
+          <text class="ls-phase-text" x="640" y="22" text-anchor="middle">POLISH</text>
+          <text class="ls-phase-text" x="880" y="22" text-anchor="middle">SHIP</text>
+
+          <line class="ls-spine" x1="50" y1="113" x2="990" y2="113" />
+
+          <text class="ls-lane-label" x="20" y="116">AI</text>
+
+          <path class="ls-transfer" data-kit="speckit"   d="M 160,150 C 150,190 170,220 160,252" />
+          <path class="ls-transfer" data-kit="swarmkit"  d="M 400,150 C 390,190 410,220 400,252" />
+          <path class="ls-transfer" data-kit="polishkit" d="M 640,150 C 630,190 650,220 640,252" />
+          <path class="ls-transfer" data-kit="flowkit"   d="M 880,150 C 870,190 890,220 880,252" />
+
+          <g class="ls-station">
+            <rect class="ls-node-rect" data-kit="speckit" x="50"  y="76" width="220" height="74" rx="12" />
+            <text class="ls-node-name" data-kit="speckit" x="160" y="110">speckit</text>
+            <text class="ls-node-role" x="160" y="132">plan it</text>
+            <circle class="ls-star" cx="252" cy="84" r="2" />
+          </g>
+          <g class="ls-station">
+            <rect class="ls-node-rect" data-kit="swarmkit" x="290" y="76" width="220" height="74" rx="12" />
+            <text class="ls-node-name" data-kit="swarmkit" x="400" y="110">swarmkit</text>
+            <text class="ls-node-role" x="400" y="132">execute it</text>
+            <circle class="ls-star" cx="492" cy="84" r="2" />
+          </g>
+          <g class="ls-station">
+            <rect class="ls-node-rect" data-kit="polishkit" x="530" y="76" width="220" height="74" rx="12" />
+            <text class="ls-node-name" data-kit="polishkit" x="640" y="110">polishkit</text>
+            <text class="ls-node-role" x="640" y="132">polish it</text>
+            <circle class="ls-star" cx="732" cy="84" r="2" />
+          </g>
+          <g class="ls-station">
+            <rect class="ls-node-rect" data-kit="flowkit" x="770" y="76" width="220" height="74" rx="12" />
+            <text class="ls-node-name" data-kit="flowkit" x="880" y="110">flowkit</text>
+            <text class="ls-node-role" x="880" y="132">ship it</text>
+            <circle class="ls-star" cx="972" cy="84" r="2" />
+          </g>
+
+          <text class="ls-lane-label" x="20" y="285">YOU</text>
+
+          <line x1="50" y1="282" x2="990" y2="282" stroke="var(--border-strong)" stroke-width="1" stroke-dasharray="2 4" />
+
+          <g class="ls-station">
+            <rect class="ls-you-rect" x="50" y="252" width="220" height="60" rx="10" />
+            <text class="ls-you-action" x="160" y="275">approve spec</text>
+            <text class="ls-you-hint"   x="160" y="294">review issues before swarm</text>
+          </g>
+          <g class="ls-station">
+            <rect class="ls-you-rect" x="290" y="252" width="220" height="60" rx="10" />
+            <text class="ls-you-action" x="400" y="275">review PRs from swarm</text>
+            <text class="ls-you-hint"   x="400" y="294">merge or request changes</text>
+          </g>
+          <g class="ls-station">
+            <rect class="ls-you-rect" x="530" y="252" width="220" height="60" rx="10" />
+            <text class="ls-you-action" x="640" y="275">triage polish findings</text>
+            <text class="ls-you-hint"   x="640" y="294">decide what ships now</text>
+          </g>
+          <g class="ls-station">
+            <rect class="ls-you-rect" x="770" y="252" width="220" height="60" rx="10" />
+            <text class="ls-you-action" x="880" y="275">approve release</text>
+            <text class="ls-you-hint"   x="880" y="294">tag and ship to users</text>
+          </g>
+
+          <line class="ls-session-bar" x1="50" y1="370" x2="340" y2="370" />
+          <line class="ls-session-bar" x1="700" y1="370" x2="990" y2="370" />
+          <text class="ls-session-label" x="520" y="374" text-anchor="middle">sessionkit · throughout all phases</text>
+          <text class="ls-session-handoff" x="520" y="395" text-anchor="middle">/handoff    /pickup</text>
+        </svg>
+      </div>
+
+      <ol class="lifecycle__mobile" aria-label="Development lifecycle, vertical view">
+        <li class="lcm-phase-label">PLAN</li>
+        <li class="lcm-row">
+          <div class="lcm-ai"><span class="lcm-ai-name" data-kit="speckit">speckit</span><span class="lcm-ai-role">plan it</span></div>
+          <div class="lcm-you"><span class="lcm-you-action">approve spec</span><span class="lcm-you-hint">review issues before swarm</span></div>
+        </li>
+        <li class="lcm-phase-label">EXECUTE</li>
+        <li class="lcm-row">
+          <div class="lcm-ai"><span class="lcm-ai-name" data-kit="swarmkit">swarmkit</span><span class="lcm-ai-role">execute it</span></div>
+          <div class="lcm-you"><span class="lcm-you-action">review PRs</span><span class="lcm-you-hint">merge or request changes</span></div>
+        </li>
+        <li class="lcm-phase-label">POLISH</li>
+        <li class="lcm-row">
+          <div class="lcm-ai"><span class="lcm-ai-name" data-kit="polishkit">polishkit</span><span class="lcm-ai-role">polish it</span></div>
+          <div class="lcm-you"><span class="lcm-you-action">triage findings</span><span class="lcm-you-hint">decide what ships now</span></div>
+        </li>
+        <li class="lcm-phase-label">SHIP</li>
+        <li class="lcm-row">
+          <div class="lcm-ai"><span class="lcm-ai-name" data-kit="flowkit">flowkit</span><span class="lcm-ai-role">ship it</span></div>
+          <div class="lcm-you"><span class="lcm-you-action">approve release</span><span class="lcm-you-hint">tag and ship to users</span></div>
+        </li>
+        <li class="lcm-session">sessionkit · throughout all phases · /handoff · /pickup</li>
+      </ol>
+
+      <div class="lifecycle__legend">
+        <span class="lifecycle__legend-item"><span class="lifecycle__legend-dot ai"></span>AI agent (plugin-driven)</span>
+        <span class="lifecycle__legend-item"><span class="lifecycle__legend-dot you"></span>Human checkpoint</span>
+        <span class="lifecycle__legend-item"><span class="lifecycle__legend-dot session"></span>sessionkit — throughout</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<style>
+  .lifecycle {
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-page);
+  }
+
+  .lifecycle__container {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 4.5rem 1.25rem;
+  }
+
+  .lifecycle__eyebrow {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-muted);
+    margin: 0 0 1rem;
+  }
+
+  .lifecycle__title {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: clamp(1.8rem, 3.5vw, 2.6rem);
+    line-height: 1.15;
+    color: var(--text-strong);
+    margin: 0 0 0.75rem;
+    letter-spacing: -0.01em;
+  }
+
+  .lifecycle__lede {
+    max-width: 60ch;
+    color: var(--text-muted);
+    margin: 0 0 2.5rem;
+    font-size: 1.05rem;
+  }
+
+  .lifecycle__panel {
+    background: var(--bg-raised);
+    border: 1px solid var(--border);
+    border-radius: var(--r-lg);
+    padding: 2rem 1.5rem;
+  }
+
+  .lifecycle__svg-wrap {
+    display: block;
+  }
+
+  .lifecycle__svg {
+    width: 100%;
+    height: auto;
+  }
+
+  .ls-phase-text {
+    font-family: var(--mono);
+    font-size: 11px;
+    fill: var(--text-muted);
+    letter-spacing: 0.12em;
+  }
+
+  .ls-spine {
+    stroke: var(--border-strong);
+    stroke-width: 1.5;
+  }
+
+  .ls-lane-label {
+    font-family: var(--mono);
+    font-size: 10px;
+    fill: var(--text-dim);
+    letter-spacing: 0.12em;
+  }
+
+  .ls-transfer {
+    fill: none;
+    stroke-width: 1.25;
+    stroke-dasharray: 3 3;
+    opacity: 0.6;
+  }
+
+  .ls-transfer[data-kit="speckit"]   { stroke: var(--speckit); }
+  .ls-transfer[data-kit="swarmkit"]  { stroke: var(--swarmkit); }
+  .ls-transfer[data-kit="polishkit"] { stroke: var(--polishkit); }
+  .ls-transfer[data-kit="flowkit"]   { stroke: var(--flowkit); }
+
+  .ls-node-rect {
+    fill: var(--bg-veil);
+    stroke-width: 2;
+  }
+
+  .ls-node-rect[data-kit="speckit"]   { stroke: var(--speckit); }
+  .ls-node-rect[data-kit="swarmkit"]  { stroke: var(--swarmkit); }
+  .ls-node-rect[data-kit="polishkit"] { stroke: var(--polishkit); }
+  .ls-node-rect[data-kit="flowkit"]   { stroke: var(--flowkit); }
+
+  .ls-node-name {
+    font-family: var(--mono);
+    font-size: 16px;
+    font-weight: 600;
+    text-anchor: middle;
+  }
+
+  .ls-node-name[data-kit="speckit"]   { fill: var(--speckit); }
+  .ls-node-name[data-kit="swarmkit"]  { fill: var(--swarmkit); }
+  .ls-node-name[data-kit="polishkit"] { fill: var(--polishkit); }
+  .ls-node-name[data-kit="flowkit"]   { fill: var(--flowkit); }
+
+  .ls-node-role {
+    font-family: var(--sans);
+    font-size: 12px;
+    fill: var(--text-muted);
+    text-anchor: middle;
+  }
+
+  .ls-star {
+    fill: var(--text-dim);
+  }
+
+  .ls-you-rect {
+    fill: var(--bg-page);
+    stroke: var(--border);
+    stroke-width: 1;
+    stroke-dasharray: 4 3;
+  }
+
+  .ls-you-action {
+    font-family: var(--sans);
+    font-size: 13px;
+    font-weight: 600;
+    fill: var(--text-strong);
+    text-anchor: middle;
+  }
+
+  .ls-you-hint {
+    font-family: var(--sans);
+    font-size: 11px;
+    fill: var(--text-muted);
+    text-anchor: middle;
+  }
+
+  .ls-session-bar {
+    stroke: var(--sessionkit);
+    stroke-width: 2;
+    opacity: 0.45;
+  }
+
+  .ls-session-label {
+    font-family: var(--mono);
+    font-size: 11px;
+    fill: var(--sessionkit);
+    letter-spacing: 0.06em;
+  }
+
+  .ls-session-handoff {
+    font-family: var(--mono);
+    font-size: 10px;
+    fill: var(--text-dim);
+    letter-spacing: 0.05em;
+  }
+
+  .lifecycle__mobile {
+    display: none;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+  }
+
+  @media (max-width: 720px) {
+    .lifecycle__svg-wrap {
+      display: none;
+    }
+
+    .lifecycle__mobile {
+      display: block;
+    }
+  }
+
+  .lcm-phase-label {
+    font-family: var(--mono);
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-muted);
+    margin: 1.25rem 0 0.5rem;
+  }
+
+  .lcm-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+    padding: 0.75rem 0;
+    border-top: 1px solid var(--border);
+  }
+
+  .lcm-ai,
+  .lcm-you {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+  }
+
+  .lcm-ai-name {
+    font-family: var(--mono);
+    font-weight: 600;
+    font-size: 0.95rem;
+  }
+
+  .lcm-ai-name[data-kit="speckit"]   { color: var(--speckit); }
+  .lcm-ai-name[data-kit="swarmkit"]  { color: var(--swarmkit); }
+  .lcm-ai-name[data-kit="polishkit"] { color: var(--polishkit); }
+  .lcm-ai-name[data-kit="flowkit"]   { color: var(--flowkit); }
+
+  .lcm-ai-role,
+  .lcm-you-hint {
+    font-size: 0.8rem;
+    color: var(--text-muted);
+  }
+
+  .lcm-you-action {
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: var(--text-strong);
+  }
+
+  .lcm-session {
+    margin-top: 1rem;
+    padding: 0.75rem;
+    border-radius: var(--r-sm);
+    background: var(--bg-veil);
+    color: var(--sessionkit);
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    text-align: center;
+  }
+
+  .lifecycle__legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    margin-top: 1.5rem;
+    padding-top: 1.25rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.82rem;
+    color: var(--text-muted);
+  }
+
+  .lifecycle__legend-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .lifecycle__legend-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    display: inline-block;
+  }
+
+  .lifecycle__legend-dot.ai      { background: var(--swarmkit); }
+  .lifecycle__legend-dot.you     { background: var(--text-muted); }
+  .lifecycle__legend-dot.session { background: var(--sessionkit); }
+</style>

--- a/site/src/content/kits/hookify.md
+++ b/site/src/content/kits/hookify.md
@@ -1,0 +1,19 @@
+---
+name: hookify
+role: Guard it — author Claude Code hooks that prevent unwanted behaviors
+accentColor: "var(--color-accent)"
+oneLiner: Create and manage Claude Code hooks from conversation analysis or explicit instructions — list, configure, and write rules.
+commands:
+  - /hookify:hookify
+  - /hookify:list
+  - /hookify:configure
+  - /hookify:writing-rules
+  - /hookify:help
+summary: >
+  hookify turns observed friction into enforced guardrails. /hookify writes a
+  new rule from conversation analysis or explicit intent. /list and /configure
+  inspect and toggle the active rule set. /writing-rules captures the rule
+  syntax canon, and /help is a thin entry point for newcomers.
+---
+
+hookify is the guardrails kit — codify "never do this again" the moment it surfaces.

--- a/site/src/content/kits/polishkit.md
+++ b/site/src/content/kits/polishkit.md
@@ -1,0 +1,18 @@
+---
+name: polishkit
+role: Polish it — appraise craft, sweep cruft, polish cross-cutting issues
+accentColor: "var(--polishkit)"
+oneLiner: Codebase quality toolkit — score craft across 5 dimensions, sweep dead code and stale artifacts, polish cross-cutting fixes in one PR.
+commands:
+  - /polishkit:appraise
+  - /polishkit:sweep
+  - /polishkit:polish
+summary: >
+  polishkit is the quality gate between swarm and release. /appraise scores a
+  scope across elegance, architecture, and craft. /sweep clears unused exports,
+  imports, dead branches, and stale build artifacts in a single confirmed pass.
+  /polish fixes cross-cutting reuse / quality / efficiency issues across a
+  themed scope in an isolated worktree, gated on your project's verify commands.
+---
+
+polishkit sits between execution and release — sharpen what the swarm just built.

--- a/site/src/content/kits/sessionkit.md
+++ b/site/src/content/kits/sessionkit.md
@@ -1,0 +1,22 @@
+---
+name: sessionkit
+role: Throughout — session continuity, planning, and meta-learning
+accentColor: "var(--sessionkit)"
+oneLiner: Hand off context, resume seamlessly, plan work-in-flight to "shipped", and capture reusable patterns from your sessions.
+commands:
+  - /sessionkit:handoff
+  - /sessionkit:pickup
+  - /sessionkit:roadmap
+  - /sessionkit:drive
+  - /sessionkit:skillit
+  - /sessionkit:retro
+  - /sessionkit:suggest-permissions
+summary: >
+  sessionkit is the connective tissue across phases. /handoff and /pickup
+  preserve state across context windows. /roadmap surveys your work-in-flight
+  and produces an approved task chain; /drive executes that chain autonomously.
+  /skillit and /retro mine the session for reusable patterns, while
+  /suggest-permissions trims approval friction over time.
+---
+
+sessionkit runs underneath everything — keep the loop intact across sessions.

--- a/site/src/content/kits/speckit.md
+++ b/site/src/content/kits/speckit.md
@@ -1,0 +1,18 @@
+---
+name: speckit
+role: Plan it — interview-driven planning and issue capture
+accentColor: "var(--speckit)"
+oneLiner: Define and capture work as GitHub issues — interview a feature into existence, bulk-convert findings, or quickly file a single issue.
+commands:
+  - /speckit:interview
+  - /speckit:spec
+  - /speckit:catalog
+  - /speckit:issue
+summary: >
+  speckit is the planning kit. Use /interview to clarify scope, /spec to drive a
+  full requirements interview that files an epic plus child issues, /catalog to
+  bulk-convert review findings into prioritized issues, and /issue to file a
+  single ticket fast — all with duplicate detection and label hygiene built in.
+---
+
+speckit shapes raw intent into well-formed GitHub issues you can hand to a swarm.

--- a/site/src/content/kits/squadkit.md
+++ b/site/src/content/kits/squadkit.md
@@ -1,0 +1,18 @@
+---
+name: squadkit
+role: Orchestrate it — multi-agent crews with the roles → squads → crews vocabulary
+accentColor: "var(--squadkit)"
+oneLiner: Multi-agent team coordination — spawn role-aware crews for execution or read-only discovery, end to end.
+commands:
+  - /squadkit:init
+  - /squadkit:spawn-team
+  - /squadkit:agent-team-retro
+summary: >
+  squadkit introduces a small coordination model — a role is one agent with a
+  fixed contract, a squad is a role-cohesive group, a crew is a team-lead
+  driving one or more squads. Spawn execution crews on a feature branch or
+  discovery crews that produce blueprint comments on issues, with init and a
+  SessionStart hook keeping role context alive across resumes.
+---
+
+squadkit is the team-shaped sibling to swarmkit's parallel agents.

--- a/site/src/content/kits/swarmkit.md
+++ b/site/src/content/kits/swarmkit.md
@@ -1,0 +1,20 @@
+---
+name: swarmkit
+role: Execute it — parallel worktree agents resolving issues into stacked PRs
+accentColor: "var(--swarmkit)"
+oneLiner: Resolve GitHub issues with parallel agents — pick what to work on, swarm it in isolated worktrees, merge top-down.
+commands:
+  - /swarmkit:swarm
+  - /swarmkit:swarm-plus
+  - /swarmkit:next-issue
+  - /swarmkit:merge-stack
+  - /swarmkit:clean-worktrees
+  - /swarmkit:clean-remote-worktrees
+summary: >
+  swarmkit dispatches one isolated-worktree agent per issue, opens stacked PRs
+  in dependency order, and lets you merge them bottom-up with a single command.
+  An optional /swarm-plus layer adds an automatic reviewer plus one fix-up pass
+  per PR. Read METHODOLOGY.md for the full stacked-agent / stacked-PR design.
+---
+
+swarmkit is the parallel-execution engine — issues in, stacked PRs out.

--- a/site/src/content/kits/vaultkit.md
+++ b/site/src/content/kits/vaultkit.md
@@ -1,0 +1,19 @@
+---
+name: vaultkit
+role: Capture it — Obsidian vault skills for notes, projects, and archives
+accentColor: "var(--vaultkit)"
+oneLiner: Read, search, edit, and capture into an Obsidian vault — projects, decisions, and conversation archives, all via the Obsidian CLI.
+commands:
+  - /vaultkit:obsidian
+  - /vaultkit:jot
+  - /vaultkit:archive-export
+  - /vaultkit:project
+summary: >
+  vaultkit is the personal-capture utility. /obsidian wraps the Obsidian CLI
+  for reading, searching, tagging, and editing notes. /jot drops decisions into
+  the active project. /archive-export files an exported conversation into the
+  project's Conversations folder. /project loads, initializes, and updates a
+  Projects/ second-brain structure inside any vault.
+---
+
+vaultkit lives outside the dev loop — it's the capture utility that keeps your second brain in sync with the work.

--- a/site/src/content/posts/swarmkit-stacked-prs.md
+++ b/site/src/content/posts/swarmkit-stacked-prs.md
@@ -1,0 +1,33 @@
+---
+title: "Stacked PRs without the headache"
+subtitle: "How swarmkit dispatches isolated agents and merges their work top-down"
+kit: swarmkit
+date: 2026-04-22
+author: smallorbit
+readTime: 8
+draft: false
+tags: ["swarmkit", "workflow", "stacked-prs"]
+---
+
+A swarm produces a stack of dependent pull requests. Merging that stack without
+breaking the dependency order is the difference between a clean release and a
+weekend of cherry-picks.
+
+## The shape of the stack
+
+When you dispatch `/swarm` against a list of issues, swarmkit picks a root issue,
+opens a branch off `develop`, and stacks the rest of the PRs on top — each one
+targeting the branch above it. The dependency graph is encoded directly in the
+GitHub PR base-branch field, so reviewers can see what depends on what.
+
+## Merging top-down
+
+`/merge-stack` walks the stack leaf-first, retargets every non-root PR to the
+base branch in one batch, and squash-merges with `--delete-branch`. The result:
+one squash commit per issue on `develop`, no merge bubbles, and no orphaned
+remote branches.
+
+## Where this draft picks up
+
+This post will become a long-form walkthrough. For now it exists as a fixture
+that demonstrates the kit-aggregation page at `/kits/swarmkit/`.

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -257,6 +257,7 @@ const rssUrl = `${siteOrigin}${baseHref}rss.xml`;
         <nav class="site-header__nav" aria-label="Primary">
           <a href={baseHref}>Home</a>
           <a href={`${baseHref}blog/`}>Blog</a>
+          <a href={`${baseHref}about/`}>About</a>
           <a href={githubRepoUrl} rel="noopener noreferrer">GitHub</a>
         </nav>
       </div>

--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -1,0 +1,223 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+
+const baseHref = import.meta.env.BASE_URL.endsWith('/')
+  ? import.meta.env.BASE_URL
+  : `${import.meta.env.BASE_URL}/`;
+---
+
+<BaseLayout
+  title="About · smallorbit-plugins"
+  description="smallorbit builds Claude Code plugins that turn the AI development lifecycle — plan, execute, polish, ship — into a complete loop with a human in every handoff."
+>
+  <article class="about">
+    <header class="about__header">
+      <p class="about__eyebrow">about smallorbit</p>
+      <h1 class="about__title">
+        From idea to release.<br />
+        <span class="about__title-italic">With you in the loop.</span>
+      </h1>
+      <p class="about__lede">
+        smallorbit builds Claude Code plugins that turn the AI development lifecycle
+        into a complete loop — plan, execute, polish, ship — with a human checkpoint
+        at every handoff.
+      </p>
+    </header>
+
+    <section class="about__section">
+      <h2>Why these kits exist</h2>
+      <p>
+        AI-assisted development is fast, but speed without a loop is just chaos.
+        Each kit in the smallorbit family handles one phase of the cycle, hands
+        off cleanly to the next, and pauses where a human decision belongs:
+        approving a spec, reviewing a stack of PRs, triaging polish findings,
+        signing off on a release.
+      </p>
+      <p>
+        Together they make the loop legible. You always know which phase you're
+        in, what the agent just did, and where you have to weigh in.
+      </p>
+    </section>
+
+    <section class="about__section">
+      <h2>The kit ecosystem</h2>
+      <ul class="about__kit-list">
+        <li>
+          <a href={`${baseHref}kits/speckit/`}><strong>speckit</strong></a>
+          — plan it. Interview a feature into existence and file an epic plus
+          child issues, all from a slash command.
+        </li>
+        <li>
+          <a href={`${baseHref}kits/swarmkit/`}><strong>swarmkit</strong></a>
+          — execute it. Spawn isolated worktree agents in parallel, open a
+          stacked PR per issue, merge bottom-up.
+        </li>
+        <li>
+          <a href={`${baseHref}kits/squadkit/`}><strong>squadkit</strong></a>
+          — orchestrate it. Multi-agent crews built from a small
+          roles → squads → crews vocabulary, for execution or read-only discovery.
+        </li>
+        <li>
+          <a href={`${baseHref}kits/polishkit/`}><strong>polishkit</strong></a>
+          — polish it. Appraise craft, sweep dead code and stale artifacts, and
+          polish cross-cutting issues in one pass.
+        </li>
+        <li>
+          <a href={`${baseHref}kits/flowkit/`}><strong>flowkit</strong></a>
+          — ship it. Branch, commit, PR, merge, cut releases, and tag — the full
+          develop → main lifecycle behind one set of slash commands.
+        </li>
+        <li>
+          <a href={`${baseHref}kits/sessionkit/`}><strong>sessionkit</strong></a>
+          — throughout. Hand off context, resume seamlessly, plan work in flight,
+          and capture reusable patterns from every session.
+        </li>
+        <li>
+          <a href={`${baseHref}kits/vaultkit/`}><strong>vaultkit</strong></a>
+          — capture it. Read, search, edit, and capture into an Obsidian vault,
+          all via the Obsidian CLI.
+        </li>
+        <li>
+          <a href={`${baseHref}kits/hookify/`}><strong>hookify</strong></a>
+          — guard it. Turn observed friction into Claude Code hooks that prevent
+          the same mistake twice.
+        </li>
+      </ul>
+    </section>
+
+    <section class="about__section">
+      <h2>How they compose</h2>
+      <p>
+        The development-lifecycle kits form a complete loop:
+        <code>/spec</code> plans, <code>/swarm</code> executes,
+        <code>/appraise</code> and <code>/sweep</code> polish, and
+        <code>/release</code> ships. <code>/handoff</code> and
+        <code>/pickup</code> sit underneath all of them so context survives
+        between sessions.
+      </p>
+      <p>
+        You can adopt them piecemeal — most teams start with speckit and
+        swarmkit, then layer flowkit on top once they want a proper release
+        pipeline. The kits are designed to be useful on their own and stronger
+        together.
+      </p>
+    </section>
+
+    <section class="about__section">
+      <h2>The principle</h2>
+      <p>
+        We don't believe in autonomous AI that ships code at you while you
+        watch. We believe in AI that does the legwork at every phase and stops
+        for the decisions only you can make. That's what "with you in the loop"
+        means — the loop is yours, the kits just keep it spinning.
+      </p>
+    </section>
+
+    <section class="about__section">
+      <h2>Stay in touch</h2>
+      <p>
+        The full source — plugins, skills, and this site — lives on
+        <a href="https://github.com/smallorbit/smallorbit-plugins" rel="noopener noreferrer">
+          GitHub</a>. New kits and essays land in the
+        <a href={`${baseHref}blog/`}>blog</a>.
+      </p>
+    </section>
+  </article>
+</BaseLayout>
+
+<style>
+  .about {
+    max-width: var(--measure);
+    margin: 0 auto;
+    padding: 3rem 1.25rem 5rem;
+  }
+
+  .about__header {
+    margin-bottom: 3rem;
+  }
+
+  .about__eyebrow {
+    font-family: var(--mono);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-muted);
+    margin: 0 0 1rem;
+  }
+
+  .about__title {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: clamp(2.2rem, 5vw, 3.6rem);
+    line-height: 1.1;
+    color: var(--text-strong);
+    margin: 0 0 1.5rem;
+    letter-spacing: -0.015em;
+  }
+
+  .about__title-italic {
+    color: var(--color-accent);
+    font-style: italic;
+  }
+
+  .about__lede {
+    font-size: 1.15rem;
+    line-height: 1.6;
+    color: var(--text-muted);
+    margin: 0;
+  }
+
+  .about__section {
+    margin-bottom: 2.5rem;
+  }
+
+  .about__section h2 {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: 1.6rem;
+    color: var(--text-strong);
+    margin: 0 0 1rem;
+    letter-spacing: -0.005em;
+  }
+
+  .about__section p {
+    font-size: 1.0625rem;
+    line-height: 1.7;
+    color: var(--text);
+    margin: 0 0 1.25rem;
+  }
+
+  .about__section code {
+    font-family: var(--mono);
+    font-size: 0.92em;
+    padding: 0.1rem 0.35rem;
+    background: var(--bg-veil);
+    border: 1px solid var(--border);
+    border-radius: var(--r-xs);
+    color: var(--text-strong);
+  }
+
+  .about__kit-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.85rem;
+  }
+
+  .about__kit-list li {
+    padding-left: 1rem;
+    border-left: 2px solid var(--border);
+    line-height: 1.55;
+    color: var(--text);
+  }
+
+  .about__kit-list a {
+    color: var(--text-strong);
+  }
+
+  .about__kit-list a:hover {
+    color: var(--color-accent);
+  }
+</style>

--- a/site/src/pages/blog/index.astro
+++ b/site/src/pages/blog/index.astro
@@ -1,0 +1,220 @@
+---
+import { getCollection, type CollectionEntry } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+type PostEntry = CollectionEntry<'posts'>;
+
+const baseHref = import.meta.env.BASE_URL.endsWith('/')
+  ? import.meta.env.BASE_URL
+  : `${import.meta.env.BASE_URL}/`;
+
+const allPosts = await getCollection('posts', ({ data }: PostEntry) => {
+  return !data.draft || import.meta.env.DEV;
+});
+
+const posts = allPosts.sort(
+  (a: PostEntry, b: PostEntry) => b.data.date.valueOf() - a.data.date.valueOf()
+);
+
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+});
+
+const slugFor = (id: string): string => id.replace(/\.(md|mdx)$/, '');
+
+const accentFor = (kit: string | undefined): string =>
+  kit ? `var(--${kit}, var(--color-accent))` : 'var(--color-accent)';
+---
+
+<BaseLayout
+  title="Blog · smallorbit-plugins"
+  description="Essays and kit deep-dives on planning, parallel execution, and shipping with Claude Code."
+>
+  <section class="blog-index">
+    <header class="blog-index__header">
+      <span class="blog-index__eyebrow">the blog</span>
+      <h1 class="blog-index__title">From the lab.</h1>
+      <p class="blog-index__lede">
+        Essays on plan, execute, and ship — and the kits that make the loop work.
+      </p>
+    </header>
+
+    {
+      posts.length === 0 ? (
+        <p class="blog-index__empty">No posts yet. Check back soon.</p>
+      ) : (
+        <ul class="blog-index__list">
+          {posts.map((post) => (
+            <li
+              class="post-card"
+              style={`--post-accent: ${accentFor(post.data.kit)};`}
+            >
+              <a class="post-card__link" href={`${baseHref}blog/${slugFor(post.id)}/`}>
+                <div class="post-card__meta">
+                  <time datetime={post.data.date.toISOString()}>
+                    {dateFormatter.format(post.data.date)}
+                  </time>
+                  {post.data.kit && (
+                    <span class="post-card__kit">{post.data.kit}</span>
+                  )}
+                  {post.data.draft && (
+                    <span class="post-card__draft">Draft</span>
+                  )}
+                </div>
+                <h2 class="post-card__title">{post.data.title}</h2>
+                {post.data.subtitle && (
+                  <p class="post-card__subtitle">{post.data.subtitle}</p>
+                )}
+                {post.data.readTime && (
+                  <p class="post-card__readtime">{post.data.readTime} min read</p>
+                )}
+              </a>
+            </li>
+          ))}
+        </ul>
+      )
+    }
+  </section>
+</BaseLayout>
+
+<style>
+  .blog-index {
+    max-width: 900px;
+    margin: 0 auto;
+    padding: 4rem 1.25rem 5rem;
+  }
+
+  .blog-index__header {
+    margin-bottom: 3rem;
+  }
+
+  .blog-index__eyebrow {
+    display: inline-block;
+    font-family: var(--mono);
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-muted);
+    margin: 0 0 1rem;
+  }
+
+  .blog-index__title {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: clamp(2.4rem, 5vw, 3.8rem);
+    line-height: 1.1;
+    color: var(--text-strong);
+    margin: 0 0 1rem;
+    letter-spacing: -0.015em;
+  }
+
+  .blog-index__lede {
+    color: var(--text-muted);
+    max-width: 60ch;
+    font-size: 1.1rem;
+    margin: 0;
+  }
+
+  .blog-index__empty {
+    color: var(--text-muted);
+    font-style: italic;
+  }
+
+  .blog-index__list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .post-card {
+    --post-accent: var(--color-accent);
+    border-top: 1px solid var(--border);
+  }
+
+  .post-card:last-child {
+    border-bottom: 1px solid var(--border);
+  }
+
+  .post-card__link {
+    display: block;
+    padding: 2rem 0;
+    text-decoration: none;
+    color: inherit;
+    transition: padding-left 0.15s ease;
+    border-left: 0 solid var(--post-accent);
+  }
+
+  .post-card__link:visited {
+    color: inherit;
+  }
+
+  .post-card__link:hover {
+    padding-left: 1rem;
+    border-left-width: 3px;
+  }
+
+  .post-card__link:hover .post-card__title {
+    color: var(--post-accent);
+  }
+
+  .post-card__meta {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin: 0 0 0.75rem;
+    font-family: var(--mono);
+    font-size: 0.8rem;
+    color: var(--text-muted);
+  }
+
+  .post-card__kit {
+    padding: 0.1rem 0.5rem;
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--post-accent);
+    border-radius: var(--r-xs);
+    background: var(--bg-veil);
+    text-transform: lowercase;
+    color: var(--text-strong);
+  }
+
+  .post-card__draft {
+    padding: 0.1rem 0.5rem;
+    border: 1px dashed var(--border-strong);
+    border-radius: var(--r-xs);
+    color: var(--polishkit);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    font-size: 0.7rem;
+  }
+
+  .post-card__title {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: clamp(1.5rem, 3vw, 2rem);
+    line-height: 1.2;
+    color: var(--text-strong);
+    margin: 0 0 0.5rem;
+    letter-spacing: -0.005em;
+    transition: color 0.15s ease;
+  }
+
+  .post-card__subtitle {
+    font-family: var(--serif);
+    font-style: italic;
+    color: var(--text-muted);
+    font-size: 1.05rem;
+    margin: 0 0 0.5rem;
+  }
+
+  .post-card__readtime {
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    color: var(--text-dim);
+    margin: 0;
+  }
+</style>

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -1,67 +1,17 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-
-const baseHref = import.meta.env.BASE_URL.endsWith('/')
-  ? import.meta.env.BASE_URL
-  : `${import.meta.env.BASE_URL}/`;
+import Hero from '../components/landing/Hero.astro';
+import LifecycleMap from '../components/landing/LifecycleMap.astro';
+import KitGrid from '../components/landing/KitGrid.astro';
+import InstallSteps from '../components/landing/InstallSteps.astro';
 ---
 
 <BaseLayout
-  title="smallorbit-plugins"
-  description="Plan, execute, and ship — Claude Code plugin essays and kit deep-dives from smallorbit."
+  title="smallorbit-plugins · From idea to release. With you in the loop."
+  description="Claude Code plugins for the end-to-end AI development lifecycle, keeping you in the loop at every handoff."
 >
-  <section class="placeholder">
-    <p class="placeholder__eyebrow">smallorbit-plugins</p>
-    <h1 class="placeholder__title">Plan, execute, and ship.</h1>
-    <p class="placeholder__lede">
-      A new home for the smallorbit Claude Code plugin family. The full landing
-      and blog are en route.
-    </p>
-    <p class="placeholder__cta">
-      <a href={`${baseHref}blog/`}>Read the blog</a>
-      <span aria-hidden="true">&middot;</span>
-      <a href="https://github.com/smallorbit/smallorbit-plugins" rel="noopener noreferrer">View on GitHub</a>
-    </p>
-  </section>
+  <Hero />
+  <LifecycleMap />
+  <KitGrid />
+  <InstallSteps />
 </BaseLayout>
-
-<style>
-  .placeholder {
-    max-width: 70ch;
-    margin: 0 auto;
-    padding: 6rem 1.25rem 4rem;
-  }
-
-  .placeholder__eyebrow {
-    font-family: var(--mono);
-    font-size: 0.85rem;
-    color: var(--text-muted);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    margin: 0 0 1.25rem;
-  }
-
-  .placeholder__title {
-    font-family: var(--serif);
-    font-weight: 500;
-    font-size: clamp(2.4rem, 5vw, 3.8rem);
-    line-height: 1.1;
-    color: var(--text-strong);
-    margin: 0 0 1.5rem;
-  }
-
-  .placeholder__lede {
-    font-size: 1.125rem;
-    color: var(--text);
-    margin: 0 0 2rem;
-  }
-
-  .placeholder__cta {
-    display: flex;
-    gap: 0.75rem;
-    align-items: center;
-    flex-wrap: wrap;
-    color: var(--text-muted);
-    font-size: 0.95rem;
-  }
-</style>

--- a/site/src/pages/kits/[...slug].astro
+++ b/site/src/pages/kits/[...slug].astro
@@ -1,0 +1,320 @@
+---
+import { getCollection, type CollectionEntry } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+type KitEntry = CollectionEntry<'kits'>;
+type PostEntry = CollectionEntry<'posts'>;
+
+const baseHref = import.meta.env.BASE_URL.endsWith('/')
+  ? import.meta.env.BASE_URL
+  : `${import.meta.env.BASE_URL}/`;
+
+export async function getStaticPaths() {
+  const kits = await getCollection('kits');
+  const allPosts = await getCollection('posts', ({ data }: PostEntry) => {
+    return !data.draft || import.meta.env.DEV;
+  });
+
+  const stripExt = (id: string): string => id.replace(/\.(md|mdx)$/, '');
+
+  return kits.map((kit: KitEntry) => {
+    const kitSlug = stripExt(kit.id);
+    const posts = allPosts
+      .filter((post: PostEntry) => post.data.kit === kitSlug)
+      .sort(
+        (a: PostEntry, b: PostEntry) => b.data.date.valueOf() - a.data.date.valueOf()
+      );
+
+    return {
+      params: { slug: kitSlug },
+      props: { kit, posts },
+    };
+  });
+}
+
+interface Props {
+  kit: KitEntry;
+  posts: PostEntry[];
+}
+
+const { kit, posts } = Astro.props;
+const accent = kit.data.accentColor;
+const kitSlug = kit.id.replace(/\.(md|mdx)$/, '');
+
+const dateFormatter = new Intl.DateTimeFormat('en-US', {
+  year: 'numeric',
+  month: 'short',
+  day: 'numeric',
+});
+
+const slugFor = (id: string): string => id.replace(/\.(md|mdx)$/, '');
+---
+
+<BaseLayout
+  title={`${kit.data.name} · smallorbit-plugins`}
+  description={kit.data.oneLiner}
+>
+  <article class="kit-page" style={`--kit-accent: ${accent};`}>
+    <header class="kit-page__header">
+      <p class="kit-page__eyebrow">the kits</p>
+      <h1 class="kit-page__title">{kit.data.name}</h1>
+      <p class="kit-page__role">{kit.data.role}</p>
+      <p class="kit-page__lede">{kit.data.oneLiner}</p>
+
+      <div class="kit-page__cta">
+        <a
+          class="kit-page__readme"
+          href={`https://github.com/smallorbit/smallorbit-plugins/tree/main/plugins/${kitSlug}`}
+          rel="noopener noreferrer"
+        >
+          Read the README ↗
+        </a>
+        <code class="kit-page__install">/plugin install {kitSlug}@smallorbit-plugins</code>
+      </div>
+    </header>
+
+    <section class="kit-page__summary">
+      <h2 class="kit-page__h2">What it does</h2>
+      <p>{kit.data.summary}</p>
+    </section>
+
+    {
+      kit.data.commands.length > 0 && (
+        <section class="kit-page__commands">
+          <h2 class="kit-page__h2">Commands</h2>
+          <ul>
+            {kit.data.commands.map((cmd: string) => (
+              <li>
+                <code>{cmd}</code>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )
+    }
+
+    <section class="kit-page__posts">
+      <h2 class="kit-page__h2">From the blog</h2>
+      {
+        posts.length === 0 ? (
+          <p class="kit-page__empty">
+            No posts tagged <code>{kitSlug}</code> yet. Check the
+            <a href={`${baseHref}blog/`}> blog index</a> for the latest writing.
+          </p>
+        ) : (
+          <ul class="kit-page__post-list">
+            {posts.map((post) => (
+              <li class="kit-post">
+                <a class="kit-post__link" href={`${baseHref}blog/${slugFor(post.id)}/`}>
+                  <span class="kit-post__date">
+                    {dateFormatter.format(post.data.date)}
+                  </span>
+                  <span class="kit-post__title">{post.data.title}</span>
+                  {post.data.draft && <span class="kit-post__draft">Draft</span>}
+                </a>
+              </li>
+            ))}
+          </ul>
+        )
+      }
+    </section>
+  </article>
+</BaseLayout>
+
+<style>
+  .kit-page {
+    --kit-accent: var(--color-accent);
+    max-width: 780px;
+    margin: 0 auto;
+    padding: 3.5rem 1.25rem 5rem;
+  }
+
+  .kit-page__header {
+    border-left: 4px solid var(--kit-accent);
+    padding-left: 1.25rem;
+    margin-bottom: 3rem;
+  }
+
+  .kit-page__eyebrow {
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--text-muted);
+    margin: 0 0 0.75rem;
+  }
+
+  .kit-page__title {
+    font-family: var(--mono);
+    font-weight: 600;
+    font-size: clamp(2.2rem, 4.5vw, 3.2rem);
+    line-height: 1.1;
+    color: var(--kit-accent);
+    margin: 0 0 0.5rem;
+  }
+
+  .kit-page__role {
+    font-family: var(--serif);
+    font-style: italic;
+    font-size: 1.2rem;
+    color: var(--text-muted);
+    margin: 0 0 1.25rem;
+  }
+
+  .kit-page__lede {
+    font-size: 1.1rem;
+    line-height: 1.6;
+    color: var(--text);
+    margin: 0 0 1.5rem;
+  }
+
+  .kit-page__cta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+  }
+
+  .kit-page__readme {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.55rem 1rem;
+    border: 1px solid var(--kit-accent);
+    border-radius: var(--r-md);
+    color: var(--kit-accent);
+    text-decoration: none;
+    font-weight: 600;
+    font-size: 0.95rem;
+    transition: background 0.15s ease, color 0.15s ease;
+  }
+
+  .kit-page__readme:hover {
+    background: var(--kit-accent);
+    color: var(--bg-page);
+  }
+
+  .kit-page__install {
+    font-family: var(--mono);
+    font-size: 0.85rem;
+    padding: 0.4rem 0.75rem;
+    background: var(--bg-veil);
+    border: 1px solid var(--border);
+    border-radius: var(--r-xs);
+    color: var(--text-strong);
+  }
+
+  .kit-page__h2 {
+    font-family: var(--serif);
+    font-weight: 500;
+    font-size: 1.5rem;
+    color: var(--text-strong);
+    margin: 0 0 1rem;
+  }
+
+  .kit-page__summary,
+  .kit-page__commands,
+  .kit-page__posts {
+    margin-bottom: 2.5rem;
+  }
+
+  .kit-page__summary p {
+    font-size: 1.05rem;
+    line-height: 1.7;
+    color: var(--text);
+    margin: 0;
+  }
+
+  .kit-page__commands ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .kit-page__commands code {
+    font-family: var(--mono);
+    font-size: 0.85rem;
+    padding: 0.3rem 0.6rem;
+    background: var(--bg-veil);
+    border: 1px solid var(--border);
+    border-left: 3px solid var(--kit-accent);
+    border-radius: var(--r-xs);
+    color: var(--text-strong);
+  }
+
+  .kit-page__empty {
+    color: var(--text-muted);
+  }
+
+  .kit-page__empty code {
+    font-family: var(--mono);
+    font-size: 0.9em;
+    padding: 0.1rem 0.3rem;
+    background: var(--bg-veil);
+    border: 1px solid var(--border);
+    border-radius: var(--r-xs);
+  }
+
+  .kit-page__post-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .kit-post {
+    border-top: 1px solid var(--border);
+  }
+
+  .kit-post:last-child {
+    border-bottom: 1px solid var(--border);
+  }
+
+  .kit-post__link {
+    display: flex;
+    align-items: baseline;
+    gap: 1rem;
+    padding: 1rem 0;
+    text-decoration: none;
+    color: inherit;
+    transition: color 0.15s ease;
+  }
+
+  .kit-post__link:hover {
+    color: var(--kit-accent);
+  }
+
+  .kit-post__date {
+    flex-shrink: 0;
+    font-family: var(--mono);
+    font-size: 0.78rem;
+    color: var(--text-muted);
+    min-width: 7rem;
+  }
+
+  .kit-post__title {
+    font-family: var(--serif);
+    font-size: 1.1rem;
+    color: var(--text-strong);
+  }
+
+  .kit-post__link:hover .kit-post__title {
+    color: var(--kit-accent);
+  }
+
+  .kit-post__draft {
+    font-family: var(--mono);
+    font-size: 0.7rem;
+    color: var(--polishkit);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    border: 1px dashed var(--border-strong);
+    border-radius: var(--r-xs);
+    padding: 0.05rem 0.4rem;
+  }
+</style>


### PR DESCRIPTION
## Summary

- Port the existing static landing (hero, lifecycle subway-map, kit grid, install steps) from `docs/index.html` into Astro components under `site/src/components/landing/`, composed in `site/src/pages/index.astro` under the existing light theme.
- Add three new routes: `/blog/` (date-desc index, drafts hidden in prod, kit-color tags), `/kits/<kit>/` (one route per `getCollection('kits')` entry, with kit metadata and a filtered list of posts where `data.kit === kitSlug`), and `/about/` (smallorbit + kit ecosystem narrative).
- Expand the kits collection beyond the seed `flowkit` entry: add `speckit`, `swarmkit`, `polishkit`, `sessionkit`, `squadkit`, `vaultkit`, and `hookify` using the sealed schema fields exactly. Seed one non-draft post tagged `kit: swarmkit` so `/kits/swarmkit/` demonstrates real aggregation.
- Extend `BaseLayout`'s primary nav with `/about` (the only structural change permitted by the BaseLayout contract); the lifecycle SVG retains its topology and station layout, only swapping colors onto the light-theme tokens.

## Test plan

- [ ] `cd site && npx astro check` reports zero errors
- [ ] `cd site && npm run build` succeeds
- [ ] `dist/index.html`, `dist/blog/index.html`, `dist/about/index.html`, and at least one `dist/kits/<kit>/index.html` exist
- [ ] Lifecycle subway-map SVG renders under the light palette without distortion
- [ ] No changes outside `site/` (docs/ explicitly preserved)

## Follow-up

The issue's "Once verified, remove `docs/`" step is intentionally NOT done in this PR. It is gated on the manual GitHub Pages source flip from `main` (`/docs`) to `gh-pages` (`/(root)`), which can only happen after the integration PR merges to `develop` and the deploy workflow creates the `gh-pages` branch. A separate cleanup PR should retire `docs/` after operations confirms the cutover succeeded.

Closes #765