### PR TITLE
chore(plugins): bump flowkit@3.9.2

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship \u2014 with runtime staging detection and a one-command hotfix flow.",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Bump flowkit plugin version after recent fixes (#799, #800).

## Changes

- flowkit@3.9.2

## Test plan

- [ ] Confirm `plugins/flowkit/.claude-plugin/plugin.json` reflects 3.9.2 after merge.
- [ ] After merge, the flowkit--v3.9.2 tag is created locally and pushed by the release flow.