### PR TITLE
refactor(site): harden content schema with KIT_SLUGS and TAG_VOCAB enums

### DIFF
--- a/site/src/content/config.ts
+++ b/site/src/content/config.ts
@@ -1,18 +1,52 @@
 import { defineCollection, z } from 'astro:content';
 
+export const KIT_SLUGS = [
+  'speckit',
+  'swarmkit',
+  'squadkit',
+  'polishkit',
+  'flowkit',
+  'sessionkit',
+  'vaultkit',
+  'hookify',
+  'general',
+] as const;
+
+export const KIT_ONLY_SLUGS = [
+  'speckit',
+  'swarmkit',
+  'squadkit',
+  'polishkit',
+  'flowkit',
+  'sessionkit',
+  'vaultkit',
+  'hookify',
+] as const;
+
+export const TAG_VOCAB = [
+  'how-to',
+  'tutorial',
+  'workflow',
+  'deep-dive',
+  'release',
+  'announcement',
+  'tips',
+  'case-study',
+] as const;
+
 const posts = defineCollection({
   type: 'content',
   schema: z.object({
     title: z.string(),
     subtitle: z.string().optional(),
-    kit: z.string().optional(),
+    kit: z.enum(KIT_SLUGS).optional(),
     date: z.coerce.date(),
     author: z.string().default('smallorbit'),
     heroImage: z.string().optional(),
     ogImage: z.string().optional(),
     readTime: z.number().optional(),
     draft: z.boolean().default(false),
-    tags: z.array(z.string()).default([]),
+    tags: z.array(z.enum(TAG_VOCAB)).max(5).default([]),
   }),
 });
 

--- a/site/src/content/posts/swarmkit-stacked-prs.md
+++ b/site/src/content/posts/swarmkit-stacked-prs.md
@@ -6,7 +6,7 @@ date: 2026-04-22
 author: smallorbit
 readTime: 8
 draft: false
-tags: ["swarmkit", "workflow", "stacked-prs"]
+tags: ["workflow", "deep-dive"]
 ---
 
 A swarm produces a stack of dependent pull requests. Merging that stack without

--- a/site/src/content/posts/welcome.md
+++ b/site/src/content/posts/welcome.md
@@ -6,7 +6,7 @@ date: 2026-05-03
 author: smallorbit
 readTime: 6
 draft: false
-tags: ["meta", "announcement"]
+tags: ["announcement"]
 ---
 
 This is the seed post for the smallorbit blog &mdash; equal parts welcome mat and


### PR DESCRIPTION
## Summary
- Add exported `KIT_SLUGS`, `KIT_ONLY_SLUGS`, and `TAG_VOCAB` constants to `site/src/content/config.ts` (per blueprint #760).
- Migrate `posts.kit` to `z.enum(KIT_SLUGS)` (kept `.optional()` to preserve existing behavior) and `posts.tags` to `z.array(z.enum(TAG_VOCAB)).max(5).default([])`.
- Update existing post frontmatter to fit the controlled vocabularies: `welcome.md` drops `meta`; `swarmkit-stacked-prs.md` aligns to `["workflow", "deep-dive"]`.
- Note: `kits.slug` was not narrowed because the current `kits` schema does not declare a `slug` field — Astro 5 derives slugs from filenames in `type: 'content'` collections (see existing comment at `config.ts:46`). `KIT_ONLY_SLUGS` is exported for future consumers (e.g. filename validation) without altering the schema. The `kits.accentColor` field is intentionally untouched (deferred to #816).

## Test plan
- [x] `cd site && npx astro check` returns 0 errors / 0 warnings / 0 hints.
- [x] `cd site && npm run build` succeeds and re-validates both shipped posts under the new strict schema (13 pages built).
- [x] A typo such as `kit: speckti` would now be rejected by the schema (vs. silently accepted before).

Closes #815