### PR TITLE
refactor(site): extract TopNav component and hide on landing route

### DIFF
--- a/site/src/components/nav/TopNav.astro
+++ b/site/src/components/nav/TopNav.astro
@@ -1,0 +1,89 @@
+---
+interface Props {
+  active?: 'blog' | 'kits' | 'about';
+}
+
+const { active } = Astro.props;
+
+const baseHref = import.meta.env.BASE_URL.endsWith('/')
+  ? import.meta.env.BASE_URL
+  : `${import.meta.env.BASE_URL}/`;
+
+const githubRepoUrl = 'https://github.com/smallorbit/smallorbit-plugins';
+---
+
+<header class="site-header">
+  <div class="site-header__inner">
+    <a class="site-header__wordmark" href={baseHref}>smallorbit-plugins</a>
+    <nav class="site-header__nav" aria-label="Primary">
+      <a href={baseHref}>Home</a>
+      <a
+        href={`${baseHref}blog/`}
+        class:list={[{ 'is-active': active === 'blog' }]}
+        aria-current={active === 'blog' ? 'page' : undefined}
+      >
+        Blog
+      </a>
+      <a
+        href={`${baseHref}about/`}
+        class:list={[{ 'is-active': active === 'about' }]}
+        aria-current={active === 'about' ? 'page' : undefined}
+      >
+        About
+      </a>
+      <a href={githubRepoUrl} rel="noopener noreferrer">GitHub</a>
+    </nav>
+  </div>
+</header>
+
+<style>
+  .site-header {
+    border-bottom: 1px solid var(--border);
+    background: var(--bg-page);
+  }
+
+  .site-header__inner {
+    max-width: 1080px;
+    margin: 0 auto;
+    padding: 1rem 1.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5rem;
+  }
+
+  .site-header__wordmark {
+    font-family: var(--sans);
+    font-weight: 600;
+    font-size: 1rem;
+    color: var(--text-strong);
+    text-decoration: none;
+  }
+
+  .site-header__wordmark:hover {
+    color: var(--text-strong);
+  }
+
+  .site-header__nav {
+    display: flex;
+    gap: 1.25rem;
+    align-items: center;
+    font-size: 0.95rem;
+  }
+
+  .site-header__nav a {
+    color: var(--text);
+    text-decoration: none;
+    padding-bottom: 2px;
+    border-bottom: 2px solid transparent;
+  }
+
+  .site-header__nav a:hover {
+    color: var(--text-strong);
+  }
+
+  .site-header__nav a.is-active {
+    color: var(--text-strong);
+    border-bottom-color: var(--text-strong);
+  }
+</style>

--- a/site/src/layouts/BaseLayout.astro
+++ b/site/src/layouts/BaseLayout.astro
@@ -1,9 +1,13 @@
 ---
+import TopNav from '../components/nav/TopNav.astro';
+
 interface Props {
   title?: string;
   description?: string;
   ogImage?: string;
   ogType?: 'website' | 'article';
+  showTopNav?: boolean;
+  active?: 'blog' | 'kits' | 'about';
 }
 
 const {
@@ -11,6 +15,8 @@ const {
   description = 'Plan, execute, and ship — Claude Code plugin essays and kit deep-dives from smallorbit.',
   ogImage,
   ogType = 'website',
+  showTopNav = true,
+  active,
 } = Astro.props;
 
 const siteOrigin = Astro.site?.toString().replace(/\/$/, '') ?? 'https://smallorbit.github.io';
@@ -165,49 +171,6 @@ const rssUrl = `${siteOrigin}${baseHref}rss.xml`;
         }
       }
 
-      .site-header {
-        border-bottom: 1px solid var(--border);
-        background: var(--bg-page);
-      }
-
-      .site-header__inner {
-        max-width: 1080px;
-        margin: 0 auto;
-        padding: 1rem 1.25rem;
-        display: flex;
-        align-items: center;
-        justify-content: space-between;
-        gap: 1.5rem;
-      }
-
-      .site-header__wordmark {
-        font-family: var(--sans);
-        font-weight: 600;
-        font-size: 1rem;
-        color: var(--text-strong);
-        text-decoration: none;
-      }
-
-      .site-header__wordmark:hover {
-        color: var(--text-strong);
-      }
-
-      .site-header__nav {
-        display: flex;
-        gap: 1.25rem;
-        align-items: center;
-        font-size: 0.95rem;
-      }
-
-      .site-header__nav a {
-        color: var(--text);
-        text-decoration: none;
-      }
-
-      .site-header__nav a:hover {
-        color: var(--text-strong);
-      }
-
       main {
         flex: 1 0 auto;
         width: 100%;
@@ -251,17 +214,7 @@ const rssUrl = `${siteOrigin}${baseHref}rss.xml`;
     <slot name="head" />
   </head>
   <body>
-    <header class="site-header">
-      <div class="site-header__inner">
-        <a class="site-header__wordmark" href={baseHref}>smallorbit-plugins</a>
-        <nav class="site-header__nav" aria-label="Primary">
-          <a href={baseHref}>Home</a>
-          <a href={`${baseHref}blog/`}>Blog</a>
-          <a href={`${baseHref}about/`}>About</a>
-          <a href={githubRepoUrl} rel="noopener noreferrer">GitHub</a>
-        </nav>
-      </div>
-    </header>
+    {showTopNav && <TopNav active={active} />}
 
     <main>
       <slot />

--- a/site/src/layouts/PostLayout.astro
+++ b/site/src/layouts/PostLayout.astro
@@ -25,7 +25,7 @@ const generatedOgImage = `${siteOrigin}${baseHref}og/${postSlug}.png`;
 const resolvedOgImage = ogImage ?? generatedOgImage;
 ---
 
-<BaseLayout title={title} description={description} ogImage={resolvedOgImage} ogType="article">
+<BaseLayout title={title} description={description} ogImage={resolvedOgImage} ogType="article" active="blog">
   <article class="post" style={`--post-accent: ${accentVar};`}>
     <header class="post__header">
       {kit && <p class="post__kit">{kit}</p>}

--- a/site/src/pages/about.astro
+++ b/site/src/pages/about.astro
@@ -9,6 +9,7 @@ const baseHref = import.meta.env.BASE_URL.endsWith('/')
 <BaseLayout
   title="About · smallorbit-plugins"
   description="smallorbit builds Claude Code plugins that turn the AI development lifecycle — plan, execute, polish, ship — into a complete loop with a human in every handoff."
+  active="about"
 >
   <article class="about">
     <header class="about__header">

--- a/site/src/pages/blog/index.astro
+++ b/site/src/pages/blog/index.astro
@@ -31,6 +31,7 @@ const accentFor = (kit: string | undefined): string =>
 <BaseLayout
   title="Blog · smallorbit-plugins"
   description="Essays and kit deep-dives on planning, parallel execution, and shipping with Claude Code."
+  active="blog"
 >
   <section class="blog-index">
     <header class="blog-index__header">

--- a/site/src/pages/index.astro
+++ b/site/src/pages/index.astro
@@ -9,6 +9,7 @@ import InstallSteps from '../components/landing/InstallSteps.astro';
 <BaseLayout
   title="smallorbit-plugins · From idea to release. With you in the loop."
   description="Claude Code plugins for the end-to-end AI development lifecycle, keeping you in the loop at every handoff."
+  showTopNav={false}
 >
   <Hero />
   <LifecycleMap />

--- a/site/src/pages/kits/[...slug].astro
+++ b/site/src/pages/kits/[...slug].astro
@@ -53,6 +53,7 @@ const slugFor = (id: string): string => id.replace(/\.(md|mdx)$/, '');
 <BaseLayout
   title={`${kit.data.name} · smallorbit-plugins`}
   description={kit.data.oneLiner}
+  active="kits"
 >
   <article class="kit-page" style={`--kit-accent: ${accent};`}>
     <header class="kit-page__header">


### PR DESCRIPTION
## Summary
- New `site/src/components/nav/TopNav.astro` with `active?: 'blog' | 'kits' | 'about'` prop and 2px active-link bottom-border indicator.
- `BaseLayout.astro` accepts `showTopNav?: boolean` (default `true`) and `active?: ...`; conditionally renders `<TopNav />`.
- `pages/index.astro` passes `showTopNav={false}` so the landing's hero composition is uncluttered.
- Interior page routes pass `active=...` for the indicator (`PostLayout` forwards `active="blog"`).

## Test plan
- `cd site && npx astro check && npm run build` succeeds.
- Built `dist/index.html` does NOT include the top nav markup.
- Built `dist/blog/index.html`, `dist/about/index.html`, `dist/kits/*/index.html`, and `dist/blog/<slug>/index.html` DO include the top nav with the correct active link styled.

Closes #817