### PR TITLE
refactor(site): remove accentColor from kits schema for single-source-of-truth

### DIFF
--- a/site/src/components/landing/KitGrid.astro
+++ b/site/src/components/landing/KitGrid.astro
@@ -44,7 +44,6 @@ const kits = (await getCollection('kits')).sort(
           <article
             class="kit-card"
             data-kit={stripExt(kit.id)}
-            style={`--kit-accent: ${kit.data.accentColor};`}
           >
             <div class="kit-card__head">
               <a class="kit-card__id" href={`${baseHref}kits/${stripExt(kit.id)}/`}>
@@ -134,6 +133,14 @@ const kits = (await getCollection('kits')).sort(
     gap: 1rem;
     transition: transform 0.15s ease, box-shadow 0.15s ease;
   }
+
+  .kit-card[data-kit='speckit'] { --kit-accent: var(--speckit); }
+  .kit-card[data-kit='swarmkit'] { --kit-accent: var(--swarmkit); }
+  .kit-card[data-kit='polishkit'] { --kit-accent: var(--polishkit); }
+  .kit-card[data-kit='flowkit'] { --kit-accent: var(--flowkit); }
+  .kit-card[data-kit='sessionkit'] { --kit-accent: var(--sessionkit); }
+  .kit-card[data-kit='vaultkit'] { --kit-accent: var(--vaultkit); }
+  .kit-card[data-kit='squadkit'] { --kit-accent: var(--squadkit); }
 
   .kit-card:hover {
     transform: translateY(-2px);

--- a/site/src/content/config.ts
+++ b/site/src/content/config.ts
@@ -57,7 +57,6 @@ const kits = defineCollection({
   schema: z.object({
     name: z.string(),
     role: z.string(),
-    accentColor: z.string(),
     oneLiner: z.string(),
     commands: z.array(z.string()).default([]),
     summary: z.string(),

--- a/site/src/content/kits/flowkit.md
+++ b/site/src/content/kits/flowkit.md
@@ -1,7 +1,6 @@
 ---
 name: flowkit
 role: Git workflow automation — branching, PRs, releases, and hotfixes
-accentColor: "var(--flowkit)"
 oneLiner: Ship features faster with opinionated Git flow built for Claude Code.
 commands:
   - /flowkit:create-branch

--- a/site/src/content/kits/hookify.md
+++ b/site/src/content/kits/hookify.md
@@ -1,7 +1,6 @@
 ---
 name: hookify
 role: Guard it — author Claude Code hooks that prevent unwanted behaviors
-accentColor: "var(--color-accent)"
 oneLiner: Create and manage Claude Code hooks from conversation analysis or explicit instructions — list, configure, and write rules.
 commands:
   - /hookify:hookify

--- a/site/src/content/kits/polishkit.md
+++ b/site/src/content/kits/polishkit.md
@@ -1,7 +1,6 @@
 ---
 name: polishkit
 role: Polish it — appraise craft, sweep cruft, polish cross-cutting issues
-accentColor: "var(--polishkit)"
 oneLiner: Codebase quality toolkit — score craft across 5 dimensions, sweep dead code and stale artifacts, polish cross-cutting fixes in one PR.
 commands:
   - /polishkit:appraise

--- a/site/src/content/kits/sessionkit.md
+++ b/site/src/content/kits/sessionkit.md
@@ -1,7 +1,6 @@
 ---
 name: sessionkit
 role: Throughout — session continuity, planning, and meta-learning
-accentColor: "var(--sessionkit)"
 oneLiner: Hand off context, resume seamlessly, plan work-in-flight to "shipped", and capture reusable patterns from your sessions.
 commands:
   - /sessionkit:handoff

--- a/site/src/content/kits/speckit.md
+++ b/site/src/content/kits/speckit.md
@@ -1,7 +1,6 @@
 ---
 name: speckit
 role: Plan it — interview-driven planning and issue capture
-accentColor: "var(--speckit)"
 oneLiner: Define and capture work as GitHub issues — interview a feature into existence, bulk-convert findings, or quickly file a single issue.
 commands:
   - /speckit:interview

--- a/site/src/content/kits/squadkit.md
+++ b/site/src/content/kits/squadkit.md
@@ -1,7 +1,6 @@
 ---
 name: squadkit
 role: Orchestrate it — multi-agent crews with the roles → squads → crews vocabulary
-accentColor: "var(--squadkit)"
 oneLiner: Multi-agent team coordination — spawn role-aware crews for execution or read-only discovery, end to end.
 commands:
   - /squadkit:init

--- a/site/src/content/kits/swarmkit.md
+++ b/site/src/content/kits/swarmkit.md
@@ -1,7 +1,6 @@
 ---
 name: swarmkit
 role: Execute it — parallel worktree agents resolving issues into stacked PRs
-accentColor: "var(--swarmkit)"
 oneLiner: Resolve GitHub issues with parallel agents — pick what to work on, swarm it in isolated worktrees, merge top-down.
 commands:
   - /swarmkit:swarm

--- a/site/src/content/kits/vaultkit.md
+++ b/site/src/content/kits/vaultkit.md
@@ -1,7 +1,6 @@
 ---
 name: vaultkit
 role: Capture it — Obsidian vault skills for notes, projects, and archives
-accentColor: "var(--vaultkit)"
 oneLiner: Read, search, edit, and capture into an Obsidian vault — projects, decisions, and conversation archives, all via the Obsidian CLI.
 commands:
   - /vaultkit:obsidian

--- a/site/src/pages/kits/[...slug].astro
+++ b/site/src/pages/kits/[...slug].astro
@@ -38,7 +38,6 @@ interface Props {
 }
 
 const { kit, posts } = Astro.props;
-const accent = kit.data.accentColor;
 const kitSlug = kit.id.replace(/\.(md|mdx)$/, '');
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
@@ -55,7 +54,7 @@ const slugFor = (id: string): string => id.replace(/\.(md|mdx)$/, '');
   description={kit.data.oneLiner}
   active="kits"
 >
-  <article class="kit-page" style={`--kit-accent: ${accent};`}>
+  <article class="kit-page" data-kit={kitSlug}>
     <header class="kit-page__header">
       <p class="kit-page__eyebrow">the kits</p>
       <h1 class="kit-page__title">{kit.data.name}</h1>
@@ -129,6 +128,14 @@ const slugFor = (id: string): string => id.replace(/\.(md|mdx)$/, '');
     margin: 0 auto;
     padding: 3.5rem 1.25rem 5rem;
   }
+
+  .kit-page[data-kit='speckit'] { --kit-accent: var(--speckit); }
+  .kit-page[data-kit='swarmkit'] { --kit-accent: var(--swarmkit); }
+  .kit-page[data-kit='polishkit'] { --kit-accent: var(--polishkit); }
+  .kit-page[data-kit='flowkit'] { --kit-accent: var(--flowkit); }
+  .kit-page[data-kit='sessionkit'] { --kit-accent: var(--sessionkit); }
+  .kit-page[data-kit='vaultkit'] { --kit-accent: var(--vaultkit); }
+  .kit-page[data-kit='squadkit'] { --kit-accent: var(--squadkit); }
 
   .kit-page__header {
     border-left: 4px solid var(--kit-accent);


### PR DESCRIPTION
## Summary
- Remove `accentColor` field from the `kits` collection schema in `site/src/content/config.ts`.
- Drop `accentColor` from the frontmatter of all 8 kit markdown files under `site/src/content/kits/`.
- Per-kit accents now resolve solely through the `data-kit="<slug>"` attribute + `var(--<kit>)` CSS variable pattern (single-source-of-truth, per blueprint #760's invariant).
- Cross-link with #813: that issue adds a `--hookify` token to BaseLayout. After this PR, #813's frontmatter step is moot; only the token addition + KIT_COLORS map update apply.

## Changes
- `site/src/content/config.ts`: drop `accentColor: z.string()` from kits schema.
- `site/src/content/kits/*.md` (8 files): strip `accentColor` frontmatter line.
- `site/src/components/landing/KitGrid.astro`: remove inline `--kit-accent` style; add `[data-kit='<slug>']` CSS rules mapping each slug to its `var(--<kit>)` token.
- `site/src/pages/kits/[...slug].astro`: replace inline `--kit-accent` style with `data-kit={kitSlug}` attribute and matching CSS rules.
- Hookify falls back to `var(--color-accent)` (no `--hookify` token yet — that's #813's scope).

## Test plan
- `cd site && npx astro check && npm run build` succeeds with 0 errors.
- Built `dist/kits/<kit>/index.html` (verified speckit, squadkit, hookify) carry `data-kit="<slug>"` and the bundled CSS contains `[data-kit='<slug>']{--kit-accent: var(--<kit>)}` rules.
- `grep -r "accentColor" site/` returns no matches.

Closes #816