### PR TITLE
docs(blog): add execution kits deep-dives

### DIFF
--- a/site/src/content/posts/flowkit-deep-dive.mdx
+++ b/site/src/content/posts/flowkit-deep-dive.mdx
@@ -1,0 +1,278 @@
+---
+title: "flowkit: runtime staging detection, two preview-epic models, and CalVer with a .N hotfix suffix"
+subtitle: "Three small opinions doing most of the load-bearing work in the kit that ships your code."
+kit: flowkit
+date: 2026-05-03
+author: "smallorbit"
+readTime: 13
+tags: ["deep-dive", "release"]
+---
+
+flowkit ships your code. That sounds like the boring half of a development loop until you've spent a Friday afternoon trying to back out a release because your config file said "staging" and your branches said otherwise, or trying to reason about which `v1.4.7` is the one in production after three back-to-back hotfixes.
+
+This deep-dive walks the three opinions that do most of the load-bearing work inside flowkit: the kit detects staging by probing branches at runtime instead of reading config; `/preview-epic` ships two distinct verify models because there are two distinct ways to assemble an epic; and the version scheme is CalVer with a `.N` hotfix suffix, deliberately, for a plugin marketplace where SemVer's promises don't apply.
+
+## Runtime staging detection: branch presence is the only signal
+
+The skill that exposes this most cleanly is `/cut`. From the SKILL:
+
+```bash
+git ls-remote --exit-code origin staging &>/dev/null && STAGING_EXISTS=true || STAGING_EXISTS=false
+```
+
+That single probe is the entire staging-detection mechanism. No config file. No environment variable. No setup wizard. The branch's presence on `origin` is the sole signal.
+
+The same probe runs in five different skills — `/cut`, `/stage`, `/release`, `/pipeline-status`, and `/hotfix` — and each one branches on the result the same way:
+
+- **Staging exists** → `/cut` pushes the RC to `staging` (via `/stage`); `/release` merges `staging` → `main`.
+- **Staging absent** → the RC merges directly to `main`. The intermediate hop simply doesn't happen.
+
+To add a staging environment to a project, you create the branch:
+
+```bash
+git checkout -b staging main && git push -u origin staging
+```
+
+From that moment on, every flowkit release skill picks it up automatically. To remove staging, delete the branch. There is no other knob. The `/stage` skill is explicit about handling the absent case as a non-error:
+
+```bash
+git ls-remote --exit-code origin staging &>/dev/null || {
+  echo "No staging branch on origin — skipping."
+  exit 0
+}
+```
+
+It's a graceful no-op, not an error. Repos without a staging branch use `rc → main` directly.
+
+**Takeaway:** Configuration that lives in the repo's actual state — does this branch exist? — is harder to forget, easier to migrate, and impossible to have in two minds about.
+
+The alternative would be a config file (`.flowkit/staging.json` or similar) saying `"useStaging": true`. That alternative has three failure modes that probing branches doesn't:
+
+- The config can drift from reality (file says yes, branch doesn't exist; file says no, branch exists and people are deploying to it).
+- The config has to be set up in every new repo before flowkit works.
+- The config has to be migrated when the convention changes — and "the convention changes" is the thing that happens, every time.
+
+Probing avoids all three. The only way the probe can be wrong is if `origin/staging` is in a state nobody intends, and that's a problem you want to surface immediately, not paper over.
+
+There's a small follow-on: because the probe is the contract, *any* tool downstream of flowkit can apply the same rule and stay consistent. CI, deploy scripts, dashboards. The shared signal is `origin/staging exists?` — not `which version of which config file does each surface have access to?`.
+
+**Takeaway:** Five skills, one probe, one branch. If you want staging, you create the branch. If you don't, you don't. Everything else follows from that.
+
+## /preview-epic: Model A vs Model B
+
+`/preview-epic` is the lifeline for multi-PR features. Each child PR's CI is green against its own base, but the union may not compile or pass tests. `/preview-epic` answers "does the integrated state actually work?" before you find out the hard way at merge time.
+
+The interesting design choice is that the kit ships *two* preview models, and the dispatcher picks between them based on what it sees on the remote. Both models share an entry point (`/preview-epic`); both produce the same shape of output (typecheck / test / lint outcomes plus a stack composition). They differ in how the integrated state is assembled.
+
+### Model A — stacked PRs (octopus merge into a throwaway preview)
+
+Model A is for epics where every contribution is still an *open* PR, with each PR's `baseRefName` pointing at the previous PR's `headRefName`, ultimately rooting at the base branch. This is the swarmkit shape — `/swarm` produces a stack of open PRs that haven't merged yet.
+
+The integrated state has to be synthesized locally. From `flowkit:preview-epic-stacked`:
+
+```bash
+git fetch origin
+git checkout -b "$PREVIEW_BRANCH" "origin/$BASE_BRANCH"
+
+# Try octopus first — combines every head in one commit
+HEADS=$(printf 'origin/%s ' "${STACK_HEADS[@]}")
+if git merge --no-ff -m "preview: epic ${PREVIEW_BRANCH}" $HEADS; then
+  STRATEGY="octopus"
+else
+  git merge --abort
+  STRATEGY="sequential"
+fi
+```
+
+Octopus merge succeeds only if every branch merges cleanly together. When it fails, the sub-skill falls back to a sequential merge — one head at a time in stack order, root to leaf, halting on the first conflict and reporting which PR introduced it.
+
+The preview branch is local-only. Nothing is pushed. The branch name (`preview/<root-num>-<root-slug>`) is collision-checked against any existing local branch and disambiguated with `-2`, `-3`, etc. After the merge succeeds, the verify commands resolved from `.squadkit/config.json` (or, for any missing command, asked of the user via `AskUserQuestion`) run against the synthesized tree:
+
+```bash
+[[ -n "$INSTALL"   ]] && eval "$INSTALL"
+[[ -n "$TYPECHECK" ]] && eval "$TYPECHECK"
+[[ -n "$TEST"      ]] && eval "$TEST"
+[[ -n "$LINT"      ]] && eval "$LINT"
+```
+
+When all green, the suggested next step is `swarmkit:merge-stack`. When the merge or verify fails, the report names the offending PR and stops.
+
+**Takeaway:** Model A synthesizes. The integrated state doesn't exist anywhere on the remote — you build it locally to ask the question.
+
+### Model B — direct-merge-to-epic (verify on the epic HEAD)
+
+Model B is for epics where a long-lived `feature/<slug>-<issue>` branch exists, and child PRs squash-merge *into the epic branch* and close. The epic HEAD already *is* the integrated state. Nothing to synthesize. Just fetch and verify:
+
+```bash
+git fetch origin "$EPIC_BRANCH":"refs/remotes/origin/$EPIC_BRANCH"
+
+if git show-ref --verify --quiet "refs/heads/$EPIC_BRANCH"; then
+  git checkout "$EPIC_BRANCH"
+  git pull --ff-only origin "$EPIC_BRANCH"
+else
+  git checkout -b "$EPIC_BRANCH" "origin/$EPIC_BRANCH"
+fi
+```
+
+Then run the same verify commands. When all green, the suggested next step is `gh pr create --base "$BASE_BRANCH" --head "$EPIC_BRANCH"` — the final epic-to-base PR.
+
+**Takeaway:** Model B doesn't synthesize. The integrated state already exists on the long-lived feature branch — you just fetch it and run verify against the HEAD.
+
+### How the dispatcher picks
+
+`/preview-epic` itself is a dispatcher. From `flowkit:preview-epic`:
+
+```bash
+OPEN_AGAINST_EPIC=$(gh pr list --state open --base "$EPIC_BRANCH" --limit 200 --json number --jq 'length')
+
+if [[ "$OPEN_AGAINST_EPIC" -gt 0 ]]; then
+  MODEL="A"
+elif git ls-remote --exit-code origin "$EPIC_BRANCH" >/dev/null 2>&1; then
+  MODEL="B"
+else
+  MODEL="none"
+fi
+```
+
+The decision is purely structural. If there are open PRs targeting the epic branch, Model A applies — there's a stack to synthesize. If there are zero open PRs but the epic branch exists on `origin` (typically with squash-merged contributions accumulated), Model B applies. If neither, there's nothing to preview and the dispatcher stops.
+
+The dispatcher then invokes the matching sub-skill via the `Skill` tool, passing structured arguments:
+
+```text
+Skill("flowkit:preview-epic-stacked", "--base develop --epic feature/payments-42 123")
+Skill("flowkit:preview-epic-direct",  "--base develop --epic feature/payments-42")
+```
+
+**Takeaway:** Two models, one dispatcher, structural detection. You never have to remember which model your epic uses — the kit looks at the remote and picks.
+
+A small but important detail: the dispatcher never edits PR metadata. It inspects, classifies, dispatches. PR retargeting is `swarmkit:merge-stack`'s job, and there's no overlap. From the SKILL: "No PR retargeting. This skill inspects PR metadata but never edits it. Use `swarmkit:merge-stack` for retargeting."
+
+## CalVer plus the `.N` hotfix suffix
+
+flowkit uses CalVer — releases tag as `vYYYY.M.D`. From the README:
+
+> Production releases are tagged with a calendar-versioned tag (e.g., `v2026.4.16`). Multiple releases on the same day append a counter (e.g., `v2026.4.16-2`).
+
+The hotfix story extends the same shape:
+
+> First hotfix on 2026-04-16: tag `v2026.4.16` + companion `hotfix/v2026.4.16`. A second hotfix the same day: `v2026.4.16.1` + companion `hotfix/v2026.4.16.1`.
+
+Two design decisions are stacked here. Each one is small. Together they avoid the common SemVer-on-a-marketplace failure modes.
+
+### Why CalVer instead of SemVer
+
+CalVer reads as time. `v2026.4.16` says "this is what shipped on April 16th, 2026." That's what the version is *for* on a plugin marketplace.
+
+SemVer reads as a contract. `v1.4.7` says "1.4.x is API-compatible with 1.4.6 and 1.5.0 may break things." That contract is load-bearing when downstream consumers rely on the API surface and need to know whether a bump is safe to apply automatically. It is *not* load-bearing for a marketplace where:
+
+- Each kit is independent — bumping `swarmkit` doesn't compose with bumping `flowkit`.
+- Users update them on their own cadence — there's no `npm install --save-exact` story to protect.
+- There's no semantic-break promise to keep — the kit's interface to its user is slash commands, and slash commands evolve in ways that don't fit "MAJOR / MINOR / PATCH."
+
+CalVer encodes the only information the marketplace consumer actually needs from the version string: when did this ship, and is it newer than the version I have. SemVer would encode information that doesn't apply — and worse, would imply a contract the marketplace cannot enforce.
+
+**Takeaway:** Use SemVer when you have a contract. Use CalVer when you have a release calendar.
+
+### Why the `.N` hotfix suffix
+
+A naive hotfix scheme would either reuse the day's tag (which loses history) or jump to the next day (which lies about when the fix shipped). The `.N` suffix avoids both:
+
+```text
+v2026.4.16        # planned release on April 16
+v2026.4.16-2      # second planned release the same day
+v2026.4.16.1      # first hotfix on top of v2026.4.16
+v2026.4.16.2      # second hotfix
+```
+
+The `.N` suffix sorts naturally alongside scheduled releases in the tag history. `git tag --list 'v2026.4.16*'` returns every tag from that day in lexical order, hotfixes interleaved with planned releases. That's the order they shipped in, and the order you want to see them in when you're tracing what was deployed when.
+
+The companion `hotfix/` tag does a different job. From `/hotfix`:
+
+```bash
+COMPANION="hotfix/$TAG"
+git tag "$COMPANION" "$TAG"
+git push origin "$COMPANION"
+```
+
+The companion tag points to the same commit as the canonical version tag, but lives in a different namespace. `git tag --list 'hotfix/*'` returns every hotfix in the repo's history without you having to remember which date carried one. The version namespace stays clean (no naming pollution from emergency releases); the hotfix namespace stays discoverable.
+
+The `/hotfix` skill itself encodes the rest of the emergency-release flow. From the SKILL:
+
+```bash
+# 1. Sync main
+# 2. Create the hotfix branch from origin/main
+git checkout -b "hotfix/$(date +%Y-%m-%d)-<slug>" origin/main
+
+# 3. Wait for the user to apply the fix
+# 4. Commit
+# 5. Detect staging (so the back-merge knows what to do)
+# 6. Scope the PR base to main (claude.flowkit.prBase = main)
+# 7. Open the PR targeting main
+# 8. Merge the PR into main
+# 9. Unset the PR base scope
+# 10. Tag — increment-on-collision, plus companion hotfix/ tag
+# 11. Close referenced issues explicitly (idempotent)
+# 12. Back-merge main into develop (preserves the merge commit's history)
+# 13. Sync develop
+```
+
+Two steps deserve a closer look. Step 10 picks the next available `.N` automatically:
+
+```bash
+BASE_TAG="v$(date +%Y.%-m.%-d)"
+N=1
+TAG="$BASE_TAG"
+while git ls-remote --exit-code origin "refs/tags/$TAG" &>/dev/null; do
+  TAG="$BASE_TAG.$N"
+  N=$((N + 1))
+done
+```
+
+You don't think about the version string. You ship the fix; the version string takes care of itself. The first hotfix on April 16 is `v2026.4.16.1` if `v2026.4.16` already exists, or `v2026.4.16` if it doesn't (in which case the planned release of the day takes the next slot when it cuts).
+
+Step 12 uses `git merge --no-ff` — a real merge commit, not a fast-forward — so the release merge history stays visible in `develop` after the back-merge:
+
+```bash
+git merge --no-ff -m "chore(develop): back-merge hotfix from main" origin/main
+```
+
+A fast-forward back-merge would produce a clean linear history, but at the cost of erasing the fact that *this commit was a hotfix*. The `--no-ff` is deliberate — the history is the audit trail.
+
+**Takeaway:** The `.N` suffix lets hotfixes coexist with planned releases in the same namespace, in the right order. The companion `hotfix/` tag keeps the fixes discoverable without polluting the version namespace. Neither piece is automatic in plain `git`; both are baked into the kit so you don't have to remember.
+
+## Putting it together
+
+The shape of a flowkit release, end to end:
+
+```bash
+# After a swarm:
+/ship                            # merge-stack → cut → release, in one command
+
+# Standard release without a swarm:
+/cut                             # rc/YYYY-MM-DD.N from develop;
+                                 # auto-stages if origin/staging exists
+/release                         # detect staging at runtime,
+                                 # merge to main, tag vYYYY.M.D,
+                                 # close issues, clean up RC branches
+
+# Emergency:
+/hotfix "fix login crash"        # off main, fix, PR, tag (.N if needed),
+                                 # back-merge into develop
+
+# Multi-PR feature in flight:
+/cut-epic <issue>                # long-lived feature/<slug>-<issue> branch
+/preview-epic                    # auto-detect Model A or Model B,
+                                 # run verify against the integrated state
+```
+
+Three opinions are doing the load-bearing work:
+
+- **Runtime staging detection.** A single `git ls-remote` probe replaces a config file, an env var, and a setup wizard. Branch presence is the only signal.
+- **Two preview-epic models, one dispatcher.** Stacked PRs synthesize an integrated state via octopus merge; long-lived epic branches verify directly on HEAD. Structural detection picks between them.
+- **CalVer with a `.N` hotfix suffix.** Time, not contract. Hotfixes interleave with planned releases in the same namespace, with a companion `hotfix/` tag in a separate namespace for discoverability.
+
+What flowkit is *not*: a thin wrapper over `git`. There are 22 skills in the kit and most of them are sub-skills the user-facing ones compose on. The opinions are the surface; the wiring is the depth.
+
+**Takeaway:** flowkit is opinionated about staging, preview, and version strings, and the opinions are load-bearing. They look small individually. They add up to a release flow you can actually trust on a Friday.
+
+For the swarm that produces the work flowkit ships, see the [swarmkit deep-dive](/blog/swarmkit-deep-dive). For the quality gate that sits between merge and ship, see the [polishkit deep-dive](/blog/polishkit-deep-dive).

--- a/site/src/content/posts/polishkit-deep-dive.mdx
+++ b/site/src/content/posts/polishkit-deep-dive.mdx
@@ -1,0 +1,198 @@
+---
+title: "polishkit: weighted taste, two-phase sweep, and a soft cap on cross-cutting cleanups"
+subtitle: "What the appraise rubric's weights actually say about taste, and why /sweep and /polish stop where they do."
+kit: polishkit
+date: 2026-05-03
+author: "smallorbit"
+readTime: 11
+tags: ["deep-dive", "tips"]
+---
+
+"This code is good" is a sentence you should distrust. It collapses five different questions into one number and then asks you to argue with the number instead of the questions. polishkit is built around the opposite move: split the question, weight the parts, and let the weights say what the kit thinks "good" actually means.
+
+This deep-dive walks the three design choices that show up most clearly when you actually use the kit. Each one is a small, deliberate constraint. Together they're the difference between a quality pass that improves a codebase and a quality pass that produces an unreviewable 800-line PR.
+
+## What the appraise weights say about taste
+
+`/appraise` scores code across five weighted dimensions and produces a report with beauty highlights, per-dimension breakdowns, and flagged violations. The weights, copied verbatim from `plugins/polishkit/skills/appraise/SKILL.md`:
+
+- **Architecture & Separation of Concerns — 30%**
+- **Naming & Readability — 25%**
+- **Algorithmic Elegance — 20%**
+- **Testability & Test Design — 15%**
+- **Idiomatic Consistency — 10%**
+
+The overall score is the weighted sum of the five dimensions, each scored 1–10, rounded to one decimal place:
+
+```text
+Overall Score = (Architecture × 0.30)
+             + (Naming × 0.25)
+             + (Algorithmic Elegance × 0.20)
+             + (Testability × 0.15)
+             + (Idiomatic Consistency × 0.10)
+```
+
+Read past the weights and they're a worldview, not arithmetic.
+
+**Takeaway:** Architecture beats naming. Naming beats algorithm. Algorithm beats testability. Testability beats idiomatic consistency. Each `>` is doing real work.
+
+### Why architecture at 30%
+
+The dimension is described as "the most important dimension. Beautiful code has a clear, intentional structure." The score anchors are unambiguous about what counts:
+
+- **9–10**: "Architectural intent is immediately legible. Boundaries are crisp. You could swap infrastructure without touching domain logic."
+- **1–2**: "No discernible architectural intent. Everything depends on everything."
+
+The weight encodes a bet: a codebase with clean architecture and average naming will be cheaper to live with over five years than a codebase with poetic naming and tangled boundaries. You can rename a function with grep. You cannot rename a tangled dependency graph with grep.
+
+### Why naming at 25% — but not 30%
+
+The second-most-weighted dimension is naming, scored against "names reveal intent — you rarely need to read the body to understand what a function does." It is huge, but it sits below architecture for a deliberate reason: a beautifully-named function inside a god class is still inside a god class. Naming makes individual files readable; architecture makes the seams between files defensible. polishkit's view is that the seams come first.
+
+### Why algorithmic elegance at 20%
+
+Algorithmic elegance is scored against the principle "solutions feel inevitable — 'of course it should be done this way.'" It earns 20% because it's where genuine over-engineering shows up — the Rube Goldberg pipeline that does in seven steps what one well-chosen data structure would do in zero. But it sits below naming because most production code is not algorithmically interesting; it's CRUD, glue, and event handlers, and the cheaper win is making those readable than making them clever.
+
+### Why testability at 15%
+
+Testability is the structural support for confidence — "tests serve as living documentation. Test structure mirrors the domain." It's not 30% because tests are downstream: a well-architected, well-named codebase is *already* easy to test. The 15% catches the cases where the code is structured to resist testing (hard-wired dependencies, mocked-too-aggressively boundaries, fragile assertions on implementation details) without giving testing more weight than the architecture that enables it.
+
+### Why idiomatic consistency at only 10%
+
+The smallest weight. The principle: "a native speaker of this language would nod in approval at every file." Idiomatic consistency is real — using LINQ in C#, comprehensions in Python, hooks-and-composition in React — but it sits at 10% because a polished idiom in a tangled architecture is still a tangled architecture. You can teach idioms; you can't teach a redesign.
+
+**Takeaway:** The weights are the kit's argument with you about what "good" means. If you appraise a codebase and it scores high on naming but low on architecture, the report tells you: this code reads well one file at a time but the seams are wrong. That's a different problem than "the variables are unclear", and `/appraise` refuses to flatten them into one number.
+
+The report shape is also pinned. From the SKILL:
+
+```text
+Executive Summary (always first)
+Beauty Highlights (lead with what works)
+Dimension Breakdown (per-dimension score, justification, best example)
+Violations (always-flag list: god classes, magic numbers, functions > 30 lines, files > 300 lines, comments that restate code)
+Closing Note (the single highest-leverage action)
+```
+
+Two details are worth flagging. First: the report leads with beauty. The persona is explicit — "appreciative first. Always lead with what is done well. Genuine beauty deserves recognition before any flaw is discussed." Reviews that open with the worst thing first train the reader to skim past everything else; reviews that open with what works train the reader to read the criticism with the same attention. Second: the report has a hard 500-line cap. "Brevity is itself a form of elegance."
+
+## /sweep as a two-phase pass
+
+`/sweep` does cleanup, but it splits cleanup into two phases that look superficially similar and are actually different jobs.
+
+### Phase 1: dead code
+
+Phase 1 is at the language level. From the SKILL:
+
+> Detects the project language and available static analysis tools (`tsc --noEmit`, `pyflakes`, `vulture`, `staticcheck`, etc.) and finds genuine dead code: unused exports, unused imports, dead variables, unreachable branches, and commented-out code blocks.
+
+Tool detection is conditional on what's in the repo:
+
+```bash
+# TypeScript / JavaScript
+ls tsconfig.json 2>/dev/null && echo "TypeScript project"
+
+# Python
+which pyflakes vulture ruff 2>/dev/null
+
+# Go
+which staticcheck 2>/dev/null
+```
+
+The skill skips findings inside `node_modules/`, `dist/`, `build/`, generated files (`*.generated.ts`, `*.d.ts`), and test files (where dead code can be intentional fixtures). Findings are grouped by category and severity:
+
+```text
+| Category              | Count | Severity |
+|-----------------------|-------|----------|
+| Unused exports        | N     | Medium   |
+| Unused imports        | N     | Low      |
+| Dead variables        | N     | Low      |
+| Unreachable branches  | N     | High     |
+| Commented-out code    | N     | Low      |
+```
+
+### Phase 2: stale artifacts
+
+Phase 2 is at the file/repo level. It runs in parallel with phase 1 and looks at things a typecheck would never catch:
+
+- **Stale documentation** — WIP/tracking files that reference completed work, PRDs and task files for features that shipped months ago, handoff or planning docs for work that's long finished.
+- **Build artifacts & dead directories** — empty directories, leftover build output not in `.gitignore`, generated files committed by accident (`.DS_Store`, logs, temp files), unused config files.
+- **Documentation gaps** — README sections that don't reflect current features, keyboard shortcuts or env vars that were added but not documented, stale screenshots.
+- **Duplicate content** — root-level files that duplicate content already in `docs/`, repeated information across `CLAUDE.md`, `AGENTS.md`, `README.md`.
+- **Git hygiene** — local branches whose upstream has been merged, stale worktrees where the branch no longer exists, orphaned remote-tracking branches.
+
+**Takeaway:** Phase 1 asks "is this code reachable?" Phase 2 asks "does this artifact still describe something true?" They share a verb but they're separate disciplines.
+
+The findings from both phases are merged into a single Remove / Update / Keep summary, and nothing is written without confirmation. From the SKILL:
+
+> Use `AskUserQuestion` to confirm each proposed action, batched in groups of at most 4 questions per call.
+
+A scoped sweep restricts both phases to the matching subtree:
+
+```bash
+/sweep                  # full sweep — dead code + cruft, repo-wide
+/sweep src/components   # scoped to one directory, both phases
+/sweep dead-code-only   # category hint — runs just phase 1
+/sweep cruft-only       # runs just phase 2
+/sweep git-only         # branch / worktree / remote pruning only
+```
+
+The two phases are independent — a category hint runs just the matching phase. After approval, the skill applies removals and edits, verifies the result still parses (`tsc --noEmit` or the language equivalent), re-runs the project's verify command if one is exposed, and commits with `chore: sweep codebase`.
+
+**Takeaway:** Phase 1 needs a static analyzer. Phase 2 needs a careful read of what the project says about itself. Bundling them into one pass is a UX win; treating them as the same kind of cleanup is a category error.
+
+## /polish and the soft cap on files
+
+`/polish` is the cross-cutting cleanup pass. You give it a scope — a path, a glob, or a themed concern with a scope hint — and it dispatches one subagent in an isolated worktree. The agent applies semantic fixes across three categories: reuse (extract duplication, use existing helpers), quality (naming, error handling, type hygiene, magic numbers), and efficiency (avoidable recomputation, quadratic loops where linear is trivially possible).
+
+The scope grammar handles three shapes:
+
+```bash
+/polish src/hooks/                          # path
+/polish "src/**/use*.ts"                    # glob
+/polish error handling in src/providers/    # cross-cutting concern + scope hint
+```
+
+For a cross-cutting theme, the description becomes the agent's *theme* and the path/glob hint becomes the *file boundary*. Both are passed to the agent verbatim so it doesn't re-discover scope.
+
+### The soft cap
+
+This is the single most polishkit-flavored design choice in the kit. From the SKILL:
+
+> **SOFT CAP** — touch at most `--max-files` files (default 15). If the scope clearly exceeds the cap, fix the highest-impact subset and list the rest under deferred findings. Lightweight passes stay lightweight.
+
+Fifteen is not arbitrary. It's the rough boundary at which a cross-cutting cleanup PR stops being reviewable in one sitting. Below 15 files, a reviewer can hold the diff in their head, judge it as a unit, and either approve or push back. Above 15 files, the reviewer either rubber-stamps it (which defeats the point) or breaks it into chunks themselves (which defeats the point in a different way).
+
+The cap is *soft* because some cleanups genuinely need to touch more — you can pass `--max-files 30` if you mean it. But the default forces a deliberate decision: if the agent finds 40 files that need the same fix, it picks the 15 highest-impact ones, applies them, and surfaces the other 25 as deferred findings in the PR body's `## Findings deferred to issues` section, with file:line refs. You then choose whether to file the rest as follow-up issues, run another `/polish` pass with a tighter scope, or accept that the deferred findings document a known shape of debt.
+
+**Takeaway:** The cap is what keeps `/polish` a *cleanup* skill instead of a *refactor* skill. Refactors get their own PRs, their own reviews, and their own scoped epics — they don't ride along inside a "lightweight" pass.
+
+### What else is bounded
+
+A few other constraints, copied straight from the SKILL, are doing similar work:
+
+- **One agent per invocation, one PR per agent.** Never fan out multiple polish agents on the same scope.
+- **Verify must be green before push.** Red builds are never acceptable, even for "lightweight" passes.
+- **Defer behavior-changing fixes.** "If a fix would change a public contract, leave it untouched and surface in the PR's `## Findings deferred to issues` section."
+- **No new dependencies.** Polish is reorganizing what's there, not adding new third-party surface.
+- **No type-error suppression** — no `as any`, no `@ts-ignore`, no `# type: ignore` without justification.
+- **No-op PR is legitimate.** "If the pass finds nothing actionable in the scope, open the PR anyway with `## Summary` stating `no actionable simplifications found`. Manufactured churn is worse than a no-op PR."
+
+That last one is the same discipline that shows up in `/swarm-plus`'s single-pass rule: don't dispatch a fix round to justify the run. If there's nothing to fix, the right output is a tiny PR (or no PR) that documents what was considered and why nothing changed.
+
+## Where polishkit fits
+
+The natural ordering in a development cycle:
+
+```bash
+/sweep              # cleanest moment is right after /merge-stack
+                    # — phase 1 sees the union of all merged branches
+/appraise           # before /cut, so the score reflects what's about to ship
+/polish <scope>     # between them, targeted at any specific dimension
+                    # that scored low in the appraise report
+```
+
+`/sweep` removes; `/appraise` measures; `/polish` improves. They share a kit because they share a discipline — "improve what you've already built" — but they don't share a workflow. Each one solves a problem the others can't.
+
+**Takeaway:** polishkit is the quality gate between the swarm finishing and the ship starting. It's not a refactoring suite. It's not a linter. It's three skills with three jobs and a hard line on what each one does *not* do.
+
+For the swarm that produces the work polishkit cleans up, see the [swarmkit deep-dive](/blog/swarmkit-deep-dive). For the shipping flow that turns the polished develop into a tagged release, see the [flowkit deep-dive](/blog/flowkit-deep-dive).

--- a/site/src/content/posts/swarmkit-deep-dive.mdx
+++ b/site/src/content/posts/swarmkit-deep-dive.mdx
@@ -1,0 +1,173 @@
+---
+title: "swarmkit: stacked PRs, up-front retargeting, and a reviewer that knows when to stop"
+subtitle: "What it actually takes to run parallel agents on one repo without the merge step turning into a second job."
+kit: swarmkit
+date: 2026-05-03
+author: "smallorbit"
+readTime: 12
+tags: ["deep-dive", "workflow"]
+---
+
+"Spawn parallel agents" is the easy part. The hard part is the merge. swarmkit's design is mostly a list of unflattering things you discover the second you try to merge a stack the obvious way: GitHub auto-closes downstream PRs the moment a non-default base disappears, two agents touching the same file produce a `CONFLICTING` graph that nobody wants to debug at 6pm, and a generic "do another pass" reviewer agent will happily review the same PR forever if you let it.
+
+This post walks the three design decisions that came out of working those problems back. Each one is small. Together they're the difference between a swarm that ships and a swarm that you stop trusting after the second time it eats a Friday.
+
+## Up-front retargeting and the auto-close cascade
+
+If you've never hit it, the cascade looks like a platform bug. You have a clean three-PR stack. Root targets `develop`. The middle PR's base is the root's head branch. The leaf's base is the middle PR's head branch. You merge the root. GitHub deletes the root's branch. The middle PR's base branch no longer exists, GitHub interprets that as abandonment, and auto-closes it. The leaf, in turn, depended on the middle PR's branch — so it auto-closes too. You now have two closed PRs that were perfectly healthy thirty seconds ago, and the only way to recover is to re-open them, re-target, and re-push.
+
+**Takeaway:** Bottom-up merging is not the bug. The bug is doing it without telling GitHub first.
+
+`/swarmkit:merge-stack` does the obvious fix in a non-obvious place. *Before* the first merge runs, every non-root PR in a multi-PR chain is retargeted to the base branch:
+
+```bash
+gh pr edit <N> --base $BASE
+```
+
+Once a child's base is `develop` (or whatever `$BASE` is), deleting its predecessor's branch on merge no longer looks like abandonment. The auto-close cascade simply does not fire. From the merge-stack source:
+
+> Before any merge runs, every non-root PR in a multi-PR chain is retargeted to `$BASE`. This neutralizes GitHub's auto-close cascade: once a child's base is `$BASE`, deleting a predecessor's branch on merge no longer looks like abandonment.
+
+The same direction is used by Graphite, git-spice, Sapling, and Phabricator. It's the boring right answer that nobody reaches for because the broken way looks like it should work.
+
+A second piece falls out of doing it this way. Because every PR ends up targeting `$BASE` directly, every PR can merge with the same command:
+
+```bash
+gh pr merge <N> --squash --delete-branch
+```
+
+No per-role strategy matrix. No intermediate-branch sweep. `--delete-branch` handles cleanup inline. Each PR's body still closes its own `Closes #N` references natively as it merges, because the squash commit lands on the default branch and GitHub parses the keywords from the squash message.
+
+There is one gotcha that retargeting doesn't fix: between merges in a chain, every still-open downstream PR has its predecessor's commits in its history under the *old* (pre-squash) SHAs. `$BASE` now carries the same content under a *new* squash SHA. GitHub flags that as `DIRTY` even though the content overlap is benign. `gh pr update-branch` cannot fix it. The merge-stack flow handles it explicitly:
+
+```bash
+git fetch origin <head-branch> $BASE
+git checkout <head-branch>
+git rebase origin/$BASE
+git push --force-with-lease origin <head-branch>
+```
+
+`git rebase` uses patch-id matching to drop the already-applied commits — you'll see `warning: skipped previously applied commit <sha>` for each one, which is the happy path, not an error. Without this rebase, the next PR flips to `CONFLICTING` the moment its predecessor merges.
+
+**Takeaway:** Stacked PRs are not a stylistic choice. They're the only safe shape for parallel agents on a shared base, and the merge step has to retarget *and* rebase to keep the platform calm.
+
+## Loop mode, file overlap, and concurrency without coordination
+
+`/swarm` has two shapes. With explicit issue numbers it runs one-shot — fan out, open PRs, exit. With no arguments (or just a label filter) it runs in loop mode and clears the board until empty. Loop mode is where the concurrency primitives matter most, because there's no human in the loop to spot a foot-gun before it fires.
+
+The primitive is straightforward. From the swarm SKILL:
+
+- No two issues touch the same files.
+- No unresolved dependencies within the batch.
+
+Both checks happen before agents spawn. The dependency graph is built from GitHub's native `blockedBy` connection (the field `/spec` wires up) with a fallback to parsing `Depends on #N` / `Blocked by #N` from the body. The file-overlap check is a pre-flight read of the issue bodies and any code paths each one announces it'll touch. Anything that overlaps with another issue in the same batch is deferred to a future cycle.
+
+**Takeaway:** Concurrency safety in swarm-loop is enforced by *not letting two agents share a file in the same cycle*, not by hoping rebase semantics work.
+
+When something does fail mid-cycle, the failure handling is also explicit. Quoting the swarm flow:
+
+```text
+── Cycle N complete ──────────────────────────
+✓ PRs opened: #25 (→ #12), #26 (→ #15)
+✗ Failed: #14 (agent crash, no PR produced)
+⊘ Blocked: #20 (depends on #14)
+⧖ Remaining open issues: 5
+──────────────────────────────────────────────
+```
+
+If issue `#14` failed, every remaining issue in the current cycle and every future cycle gets checked for file overlap with `#14` or explicit references to it. Anything that overlaps is marked blocked and skipped, with the block reported at each checkpoint. Everything else proceeds.
+
+A small set of failures are unrecoverable and halt the loop immediately:
+
+- An agent crashed without producing a PR (nothing to review, so nothing to proceed from).
+- The base branch was deleted or corrupted externally (the premise of the loop is gone).
+
+Everything else is recoverable. There are no retries — re-running an agent that just failed gives you the same failure with a slightly different stack trace. The loop's job is to surface the failure cleanly and keep moving.
+
+One detail worth knowing: loop mode sets `claude.flowkit.prBase` as a local git config at the start, and unsets it in the teardown step. While it's set, every PR created in the repo targets that base — which is what keeps independent PRs from accidentally leaking onto whatever the previous session's pin was. The teardown unset is critical; leaving the config set would silently re-route subsequent unrelated `/open-pr` runs.
+
+**Takeaway:** The swarm loop is allowed to fail, but never silently. Every failure either becomes a checkpoint line, a blocked-issue annotation, or the unrecoverable-halt reason. There is no third option.
+
+## Designing /swarm-plus: the vendored reviewer and the single-pass rule
+
+`/swarm` opens PRs and stops. The review and any follow-up commits are manual. `/swarm-plus` layers an automatic review/fix pass on top of the same swarm machinery — same arg grammar, same isolation, same final state of open PRs awaiting human merge. The only addition: each PR gets one reviewer, and if the reviewer surfaces blockers or concerns, the original builder is re-engaged via `SendMessage` to push follow-up commits to the same branch.
+
+Three design decisions inside that small wrapper carry most of the weight.
+
+### 1. The reviewer is vendored.
+
+The `swarm-reviewer` agent lives at `plugins/swarmkit/agents/swarm-reviewer.md`, inside swarmkit itself, rather than imported from another plugin. This isn't a code-locality choice — it's a dependency choice. `/swarm-plus` carries no cross-marketplace dependency, which means it works against any repo that has swarmkit installed without surprise prompts to install something else. The reviewer is also purpose-built — not a general-purpose code-review agent, but specifically a reviewer that compares a swarm-produced PR against its originating issue's acceptance criteria. The narrower the role, the easier the contract.
+
+### 2. The output structure is fixed at five sections.
+
+The reviewer is required to return its findings inline (never via `gh pr comment`) in a fixed shape:
+
+```text
+Verdict: Approve / Request changes / Comment
+Blockers: <must fix>
+Concerns: <worth raising, not blocking>
+Nits: <style, optional>
+Coverage gaps: <each tagged [recommended] or [optional]>
+```
+
+That fixed shape is what makes the next decision possible — the orchestrator can parse the reviewer output deterministically and decide what (if anything) to send back to the builder.
+
+**Takeaway:** Free-form review prose is fine for humans. For an orchestrator that has to route findings back to a standby builder, the shape has to be pinned at design time.
+
+### 3. Single fix-pass discipline.
+
+Here is the rule, copied verbatim from the swarm-plus SKILL:
+
+> Single pass — no reviewer-after-fix re-review. The user can manually trigger another review with `/review <pr>` if desired.
+
+There is no second reviewer pass after the builder applies its fixes. Why not? Because the reviewer-after-fix loop has no natural stopping condition — every reviewer pass is allowed to find something to nit, and a builder that runs in response to nits will produce a new diff that the next reviewer can find something to nit on. The swarm-plus orchestrator deliberately refuses to dispatch a second pass. If you want one, you ask for it explicitly with `/review <pr>`.
+
+The same discipline shows up in the routing table. From the SKILL:
+
+| Reviewer output | Builder message |
+|-----------------|-----------------|
+| `Approve` AND no blockers AND no concerns AND no `[recommended]` coverage gaps | `"Approved. Terminate."` |
+| Any blockers | findings + scope |
+| Any concerns | findings + scope |
+| `[recommended]` coverage gaps | findings + scope |
+| `--review-only` flag set | `"Review-only run. Terminate."` |
+
+Nits and `[optional]` coverage gaps never trigger a worker. The bar to dispatch is meaningful enough to materially change the PR.
+
+The keep-alive architecture is the other interesting bit. Builders don't terminate after reporting their PR URL — they enter standby awaiting an orchestrator message. Why? Because the builder already has every relevant file loaded, the design rationale in working memory, and the issue acceptance criteria internalized. Re-engaging it via `SendMessage` saves an entire spawn-and-orient cycle per PR with non-clean review. The cost: peak agent concurrency roughly doubles during the review window — on a 5-PR run, up to 10 alive concurrently (5 builders in standby + 5 reviewers) instead of 5 sequential builders followed by 5 sequential reviewers. Acceptable for the latency win.
+
+There's a fallback path too. If the original builder is no longer alive (crashed at PR creation, or `verify_agent.sh` recovered the PR after the builder failed to push), the orchestrator falls back to the legacy spawn-fresh-worker path. `--worker-model` continues to apply on this fallback path only.
+
+**Takeaway:** `/swarm-plus` is `/swarm` plus exactly two ideas — one reviewer per PR, one fix-pass per non-clean verdict, and both ideas are bounded explicitly so the wrapper can't grow into a quality-engineering loop that runs forever.
+
+## Putting it together
+
+The shape of a swarmkit run, end to end:
+
+```bash
+/next-issue           # see what is ready to work on
+/swarm 12 15 18       # spawn parallel agents for specific issues
+                      # or `/swarm` with no args for loop mode
+/merge-stack          # retarget non-root PRs, merge bottom-up
+/clean-worktrees      # remove worktree directories and orphaned branches
+```
+
+Or, if you want every PR to land with at least one independent pass against its acceptance criteria:
+
+```bash
+/swarm-plus 12 15 18
+```
+
+Three things are doing the load-bearing work:
+
+- **Up-front retargeting** prevents GitHub's auto-close cascade. Bottom-up merging without it is a foot-gun; bottom-up merging *with* it is the same direction Graphite and Sapling use.
+- **File-overlap detection** is the concurrency primitive in loop mode. Two agents never share a file in the same cycle, and failures cascade explicitly into blocked-issue reports rather than silent retries.
+- **`/swarm-plus`'s single-pass discipline** keeps the review/fix layer bounded. One reviewer, one fix round if needed, no escalation.
+
+What `/swarm` is *not*: a code review. The per-agent `simplify-loop` runs internally before the PR opens, but it sees only the agent's own branch — never the union of all four PRs in a stack. That's polishkit's job, downstream.
+
+**Takeaway:** swarmkit's parallelism is enabled by three counterintuitive choices — stacked PRs (not topic branches), up-front retargeting (not last-minute), and a vendored reviewer with a hard single-pass rule (not a "do another pass" loop). The methodology document at `plugins/swarmkit/METHODOLOGY.md` walks through each in depth.
+
+After the stack is reviewed and you're ready, `/merge-stack` walks the chain root-to-leaf, squash-merging each PR and deleting the remote branch as it goes. If one PR fails review or merge mid-stack, the chain stops cleanly so you can fix and resume — and because retargeting happened up front, every still-open downstream PR already targets `develop`, so resuming is just a matter of fixing the conflict and re-running.
+
+For the shipping half — turning that merged develop into a tagged release — see the [flowkit deep-dive](/blog/flowkit-deep-dive). For the quality gate that sits between merge and ship, see the [polishkit deep-dive](/blog/polishkit-deep-dive).


### PR DESCRIPTION
## Summary
- Adds three kit deep-dive posts (swarmkit, polishkit, flowkit) authored together for tonal consistency.
- swarmkit: up-front retargeting, loop-mode file-overlap detection, /swarm-plus design.
- polishkit: appraise-weight rationale, two-phase /sweep, /polish soft-cap.
- flowkit: runtime staging detection, /preview-epic Model A vs B, CalVer + .N hotfix.
- Each post 1500–2500 words; tonal match to the pillar.

## Test plan
- [ ] `npm --prefix site run build` succeeds (frontmatter validates).
- [ ] Visual review at `/blog/swarmkit-deep-dive`, `/blog/polishkit-deep-dive`, `/blog/flowkit-deep-dive` in dev.
- [ ] Every command, weight, and behavior cited resolves to real code under `plugins/{swarmkit,polishkit,flowkit}/`.

Closes #770