### PR TITLE
docs(blog): add continuity kits deep-dives

### DIFF
--- a/site/src/content/posts/sessionkit-deep-dive.mdx
+++ b/site/src/content/posts/sessionkit-deep-dive.mdx
@@ -1,0 +1,180 @@
+---
+title: "sessionkit: continuity that survives a context reset"
+subtitle: "How HANDOFF.md round-trips your task list, why /skillit refuses duplicates, and what /retro routes where."
+kit: sessionkit
+date: 2026-05-03
+author: "smallorbit"
+readTime: 11
+tags: ["deep-dive", "tips", "workflow"]
+---
+
+Every kit in the suite handles "do the work." sessionkit handles what happens between.
+
+A real working day rarely fits inside a single session. The context window fills up. You stop for lunch and come back five hours later. You hand the work off to a teammate, or to a fresh agent, or to your future self after a weekend. Every one of those transitions burns coordination cost — restating the goal, re-reading the diff, re-deriving the gotchas you already paid for once. sessionkit's job is to make that cost trivial.
+
+This is a tour of three sessionkit surfaces that earn their keep on a real workday. The anatomy of `HANDOFF.md` and the task round-trip that pickup performs. The overlap check inside `/sessionkit:skillit` that refuses to propose duplicate skills. And `/sessionkit:retro` as a router — not a journal — that turns each finding into a one-keystroke action.
+
+Each section walks you through the contract sessionkit ships, with citations from the kit's own `SKILL.md` files so you can verify the behaviour against source.
+
+## HANDOFF.md is a contract, not a diary
+
+The premise is simple. `/sessionkit:handoff` writes one Markdown file at `.sessionkit/HANDOFF.md`. `/sessionkit:pickup` reads that file in a new session and rehydrates the agent. The interesting part is what the file actually contains and what survives the round-trip.
+
+**Takeaway:** The handoff document is the entire memory blob between sessions. Everything else — the in-flight tools, the open editor buffers, the unsaved scratchpad — is gone. The file is structured so the next agent can reconstruct enough state to make a real decision in two minutes.
+
+The section order is fixed:
+
+- `## Goal` — one bullet, one sentence. What this session is working toward.
+- `## Progress` — bullets only. What was completed, decided, or abandoned.
+- `## Git State` — branch, staged files, unstaged files, recent commits.
+- `## Remaining Work` — bullets in priority order.
+- `## Task List` — a fenced JSON block that captures the actual task graph.
+- `## Context` — bullets only. Decisions, gotchas, dead ends, external references.
+
+That order is not a stylistic choice — it's enforced by `plugins/sessionkit/skills/handoff/SKILL.md` under "Constraints," and `/sessionkit:pickup` parses positionally. Goal first because it answers "why are we even here." Context last because by the time the next agent reads it, they already know what we were doing and just need the gotchas.
+
+The file also carries an HTML-comment header on line 1:
+
+```text
+<!-- handoff-meta gitFingerprint=<sha> taskFingerprint=<sha> -->
+```
+
+That header is what enables delta mode. On the next `/sessionkit:handoff` run, the skill compares the prior `gitFingerprint` (HEAD sha plus a hash of the staged and unstaged file lists) against the current state. If git hasn't moved, the `## Git State` and `## Progress` sections are reused verbatim. Same for `taskFingerprint` over the Task List and Remaining Work sections. When both fingerprints match, four of the six sections come straight from the prior file and the synthesis sub-agent is skipped entirely.
+
+**Takeaway:** Run `/sessionkit:handoff` after every meaningful state change — opening a PR, completing a task, locking in a decision. Delta mode keeps the cost trivial. You don't have to wait for context pressure to capture state.
+
+### What survives the task round-trip
+
+The `## Task List` section is where the real engineering happens. `/sessionkit:handoff` snapshots every non-deleted task into a JSON array inside the fenced `json` block. `/sessionkit:pickup` reads that block in the next session and recreates the tasks with `TaskCreate`, then re-wires the dependency graph with `TaskUpdate`.
+
+The fields that survive the round-trip, per the table in `plugins/sessionkit/README.md`:
+
+- `id` — preserved in the snapshot so `blockedBy` edges can be rewired; the new session assigns a fresh id.
+- `subject` — the task title.
+- `description` — the full task description.
+- `activeForm` — the active-form view state.
+- `status` — original status (`pending` or `in_progress`); all recreated tasks start as `pending`.
+- `blockedBy` — dependency edges; remapped to new ids after all tasks are created.
+- `blocks` — listed in the snapshot for reference; not re-wired on pickup (the inverse of `blockedBy` is implicit and wiring both directions would double-write the graph).
+
+What does **not** survive: `owner` and `metadata`. And only `pending` or `in_progress` tasks are restored — `completed` ones appear in the orientation summary as history but are not recreated. This is deliberate. The task list is the active work plan, not the audit log; resurrecting completed tasks would just clutter the new session's queue.
+
+**Takeaway:** The task graph is the only structural state that survives a context reset. Conversation transcripts, scratchpad notes, even the orientation prose are reconstructed every time. The graph is the spine.
+
+The pickup pass is two-pass on purpose. Pass 1 calls `TaskCreate` for each `pending` or `in_progress` task and records an `oldId → newId` map. Pass 2 walks the same set, remaps each `blockedBy` array through the map, and calls `TaskUpdate` with `addBlockedBy` for the new task id. The handoff snapshot doesn't carry the new ids — those don't exist yet — so the rewire has to wait until every task is created.
+
+There's also a graceful back-compat clause. Legacy `HANDOFF.md` files written before task-list support existed (no `## Task List` section) are valid input. `/sessionkit:pickup` emits one warning line — `No task list snapshot — skipping hydration` — and continues with the orientation summary. That tiny touch matters: handoff files in the wild outlive their schema.
+
+### One subtle invariant
+
+The `## Goal` and `## Context` sections are always refreshed on a new `/sessionkit:handoff` run, even when both fingerprints match. Goal because it incorporates `$ARGUMENTS` when present (the freeform notes you fold in to steer the next agent). Context because the gotchas drift faster than the structural state — a decision made twenty minutes ago might be the most important thing the next agent reads.
+
+Everything else can be reused verbatim. That's the asymmetry that makes delta mode safe: structural state is content-addressed, narrative state is always fresh.
+
+## /skillit refuses to propose duplicates
+
+`/sessionkit:skillit` reflects on the current session and proposes new skills worth encoding. Most "agent reflection" tools are unbounded — they will happily generate the tenth variation of a skill you wrote three weeks ago. `skillit` won't.
+
+The contract from `plugins/sessionkit/skills/skillit/SKILL.md` is four steps. The third step is the one that earns the kit:
+
+```bash
+find ~/.claude/skills -name "SKILL.md" 2>/dev/null
+find .claude/skills -name "SKILL.md" 2>/dev/null
+find ~/.claude/commands -name "*.md" 2>/dev/null
+```
+
+`/skillit` scans the user-global skill library, the project-local skill library, and the legacy commands directory. It reads the `name` and `description` frontmatter of any candidates that look relevant, and surfaces close matches to you **before** proposing anything new.
+
+**Takeaway:** Capturing a reusable skill is easy. *Not* capturing one that already exists — that's the hard part. Without the overlap check, every session ends with a fresh skill proposal that overlaps the existing library at 80% and just hasn't been noticed.
+
+The presentation step is structured to make that explicit:
+
+- **What it would do** — one sentence.
+- **Why it's worth encoding** — what friction it removes.
+- **Overlap risk** — does it duplicate or extend an existing skill?
+
+The "extend an existing skill" branch is where overlap turns into a positive. If the conversation surfaced a pattern that's 60% covered by an existing skill plus a new wrinkle, `/skillit` offers to modify the existing skill rather than ship a near-duplicate. That keeps the library coherent over months.
+
+The constraints at the bottom of the SKILL file lock the discipline in:
+
+- *Always* check for existing skills before proposing something new.
+- *Never* create a skill file without user approval.
+- *Identify at least one candidate* before concluding — never report "nothing found."
+
+The first two are obvious. The third is doing more work than it looks. Without it, `/skillit` could just shrug and exit when the session was uneventful — and you'd never get the small wins (the recurring command sequence you didn't notice was a pattern). Forcing one candidate per run keeps the library growing.
+
+**Takeaway:** Run `/skillit` at the end of any session that involved a non-trivial workflow. The overlap check is what makes it safe to run often.
+
+## /retro is a router, not a journal
+
+The temptation in any retro tooling is to write a long markdown summary you'll never re-read. `/sessionkit:retro` does the opposite. It produces a short inline summary, then asks one question with a one-keystroke answer. Each finding has a delegation target — a downstream skill that owns the action.
+
+Per `plugins/sessionkit/skills/retro/SKILL.md`, the input surfaces are four:
+
+- **Conversation transcript** — repeated corrections, friction loops, mid-flight self-corrections.
+- **Task list** — `TaskList` plus per-task `TaskGet` to find stalls, scope revisions, completed-vs-cancelled patterns.
+- **Git activity within the session window** — `git log --since="8 hours ago"`, current branch, stashes, recent PRs.
+- **Hook and tool-denial events** — scanned from the most recent `~/.claude/projects/<encoded-cwd>/*.jsonl` files for `permission denied`, `tool denied`, or `hook blocked` patterns.
+
+That fourth surface is the one most retro tools miss. A `permission denied` you approved twice this session is a strong signal — the next session will burn the same approval friction unless you ship a permission tweak now.
+
+**Takeaway:** Retro isn't lessons-learned theatre. Every signal has a downstream action; the retro's job is to route, not narrate.
+
+The synthesis step organizes findings into three buckets — **What went well**, **What didn't go well**, **Recommended actions** — and the third bucket is where the routing happens. The mapping table in the SKILL file is exact:
+
+| Pattern | Delegation target |
+|---------|------------------|
+| Repeated command sequence worth automating | `sessionkit:skillit` |
+| Repeated permission approvals | `sessionkit:suggest-permissions` |
+| Context running low or session should be captured | `sessionkit:handoff` |
+| Recurring hook-blocked behavior worth enforcing | `hookify:hookify` |
+| A problem worth filing as a tracked issue | `speckit:issue` |
+| A behavioral config worth persisting | `update-config` |
+| No matching skill | Surface as plain-text guidance only |
+
+The actions are capped at four to fit the harness's `AskUserQuestion` option limit. If more than four items qualify, retro keeps the highest-signal ones and reserves the fourth slot for "Other — I'll handle this manually" when there's remaining guidance with no skill match. That cap is doing real work: a menu of nine options is functionally identical to no menu at all.
+
+The action menu is mandatory. The SKILL file is unambiguous: *"Never run delegated skills without explicit user selection. The `AskUserQuestion` call in step 4 is mandatory. Skipping it and auto-running skills is a defect."* The router is opinionated about delegation but conservative about consent.
+
+**Takeaway:** Retro is a thin reflective layer. It does not absorb `skillit`'s encoding logic, it does not absorb `suggest-permissions`' tuning logic, it does not write files. When it recommends "encode X as a skill," it delegates to `/skillit` — it does not author the skill itself.
+
+That last constraint matters more than it looks. The temptation is to fold each downstream skill's logic into retro for convenience. The cost would be every retro change touching every downstream skill's behaviour. Keeping retro thin keeps the rest of the kit composable.
+
+### A worked example
+
+Imagine a session that:
+
+- Approved `Bash(npm run build)` four times.
+- Repeated the same `git status && git diff && git commit` sequence twice.
+- Hit a `tool denied` for a Write tool inside `node_modules/`.
+- Surfaced a real bug nobody's filed yet.
+
+`/sessionkit:retro` produces an inline summary citing each turn, then asks:
+
+```text
+Which of these would you like to action now?
+
+1. Permission tune for `Bash(npm run build)`     → /sessionkit:suggest-permissions
+2. Encode the status/diff/commit sequence        → /sessionkit:skillit
+3. Hookify the node_modules write block          → /hookify:hookify
+4. File the bug as a tracked issue               → /speckit:issue
+```
+
+You pick the ones you want, retro invokes each in turn, and the session ends with concrete artifacts — not a markdown post-mortem you'll never re-read.
+
+## Putting it together
+
+sessionkit's three big surfaces compose cleanly because each one has a narrow, well-defined contract:
+
+- `/sessionkit:handoff` writes the structural state — git, tasks, gotchas — into a single Markdown file with a fingerprint header that makes the next run cheap.
+- `/sessionkit:pickup` reads that file, rebuilds the task graph (preserving `blockedBy` edges across the id remap), and ends by asking what you want to tackle first.
+- `/sessionkit:skillit` reflects on the session, checks the existing skill library for overlap, and proposes one new skill or one extension — never a duplicate.
+- `/sessionkit:retro` scans four signal surfaces (conversation, tasks, git, denials), groups findings into went-well / didn't-go-well / recommended actions, and routes each action to the right downstream skill via a one-keystroke menu.
+
+The kit doesn't ship a "session manager" abstraction. It ships four small skills that each own one beat — capture, restore, encode, route — and a Markdown file that's the entire shared state.
+
+**Takeaway:** Continuity is a discipline, not a feature. sessionkit gives you the contract; the discipline is yours.
+
+If you take one thing from this post, take this: the round-trip between `/sessionkit:handoff` and `/sessionkit:pickup` is the most-overlooked compounding lever in the suite. Run `/handoff` after every PR, every decision, every scope change — delta mode keeps the cost near-zero. The next session starts with the goal restated, the task graph rebuilt, the gotchas surfaced. The first ten minutes of a fresh session stop being a tax.
+
+Forward pointer: the squadkit deep-dive picks up where this one leaves off — multi-agent coordination layered on top of the sessionkit substrate, with squadkit's `SessionStart` hook re-asserting role context whenever a session resumes via `/pickup`. Two kits, one continuity story.

--- a/site/src/content/posts/squadkit-deep-dive.mdx
+++ b/site/src/content/posts/squadkit-deep-dive.mdx
@@ -1,0 +1,167 @@
+---
+title: "squadkit: roles, squads, and crews — multi-agent without the chaos"
+subtitle: "The vocabulary that makes teams legible, the orchestrator-is-lead pattern that avoids a redundant agent, and the detached-HEAD trick that keeps builders from stepping on each other."
+kit: squadkit
+date: 2026-05-03
+author: "smallorbit"
+readTime: 12
+tags: ["deep-dive", "workflow", "tips"]
+---
+
+"Multi-agent" usually means an undefined pile of agents. squadkit names the pile.
+
+The premise: when a single problem needs more than one role in the room — an architect to draft, a builder (or three) to implement, a reviewer to gate, a tester to back the verify — you don't want to re-decide who-does-what every time. You want a vocabulary, a roster shape, and a coordination protocol that's been thought through once and reused. squadkit is that.
+
+This post walks the three design choices that make squadkit work in practice: the **roles → squads → crews** vocabulary that keeps the model legible, the **orchestrator-is-lead** pattern that dodges a class of phantom-agent bugs (and ships with a cooperative-shutdown handshake), and the **per-builder detached-HEAD worktrees** that prevent the branch-ref contention you hit the moment two builders try to share a feature branch.
+
+Every claim below is cited from `plugins/squadkit/README.md`, `plugins/squadkit/skills/spawn-team/SKILL.md`, or `plugins/squadkit/agents/team-lead.md`. No invented behaviour.
+
+## The vocabulary, in one paragraph
+
+The coordination model is intentionally small. Three terms, exact definitions from the README:
+
+- **Role** — a single agent with a focused contract. One role definition, one agent. The shipped role library has seven contracts under `plugins/squadkit/agents/`: `team-lead`, `architect`, `builder`, `reviewer`, `tester`, `explorer`, `designer`. Each carries a fixed model assignment that matches its cognitive load — orchestration and review run on opus, implementation and craft run on sonnet.
+- **Squad** — a role-cohesive group of agents collaborating on one slice of work. Three implementers fanning out across files in the same feature, for example.
+- **Crew** — a team-lead orchestrating one or more squads end-to-end. The crew is the unit you spawn with `/squadkit:spawn-team` and ship with.
+
+**Takeaway:** Roles are reusable. Squads compose. Crews run. The vocabulary maps cleanly to how a real team is built — you don't reach for a "role" when you mean "team," and you don't reach for "team" when you mean "agent."
+
+The shipped crew profiles live in `plugins/squadkit/crews/` as YAML. Three starters:
+
+```yaml
+name: all-rounder
+description: Full-spectrum crew for end-to-end feature work.
+members:
+  - role: team-lead
+  - role: architect
+  - role: builder
+    count: 2
+  - role: reviewer
+  - role: tester
+  - role: explorer
+  - role: designer
+```
+
+Plus `design` (a `kind: discovery` crew of architect + designer + explorer for read-only research) and `qa` (team-lead, reviewer, tester, builder×1 for hardening sweeps). At spawn time you can override the roster with `--with <role>`, `--without <role>`, or `--builders <N>` (capped at 5).
+
+The two crew kinds split the world cleanly:
+
+- **`kind: execution`** (the default) — produces code. Provisions per-builder worktrees, supports `--epic` and `claude.flowkit.prBase` pinning, ships PRs.
+- **`kind: discovery`** — read-only investigative crew. Produces blueprints and GitHub issue comments, not code. Skips worktree provisioning, rejects `--epic`, skips `claude.flowkit.prBase` pinning. Requires `--brief`.
+
+That `kind:` field is doing more than a label's worth of work. The whole worktree-provisioning, epic-cutting, PR-pinning machinery is gated on it. A discovery crew goes through a strictly different pre-flight than an execution crew. The README puts it plainly: *"Discovery crews skip worktree provisioning, epic-branch cutting, and `claude.flowkit.prBase` pinning."*
+
+**Takeaway:** When you spawn a crew, its `kind:` is the most consequential decision in the YAML. Execution crews ship code on a `feature/<slug>-<issue>` branch cut from `develop`. Discovery crews stay on `develop` and produce comments. Two different machines, same vocabulary.
+
+## The orchestrator IS the team-lead
+
+This is the choice that earns squadkit's reliability. There are seven role contracts shipped — but `/squadkit:spawn-team` only spawns six of them. The team-lead is never spawned as a separate agent. The session that ran `/squadkit:spawn-team` IS the lead.
+
+The README states it directly:
+
+> The orchestrator (the session that ran `/squadkit:spawn-team`) IS the lead — squadkit never spawns a separate `team-lead` agent. The contract file is the operating manual that session loads.
+
+The `spawn-team` SKILL file expands on the rationale:
+
+> The skill never spawns a separate `squadkit:team-lead` agent and never reserves a `team-lead` slot via `TeamCreate({agent_type: ...})` — both produce phantom roster entries that break sender attribution and routing.
+
+**Takeaway:** Spawning a redundant team-lead agent is the obvious thing to do — and it's the bug. The roster ends up with a phantom slot, peer addressing breaks, and you spend a session debugging why messages aren't landing. Putting the lead inside the orchestrator removes the slot.
+
+Three concrete consequences flow from this choice:
+
+- **No `agent_type` on `TeamCreate`.** The skill calls `TeamCreate({team_name, description})` and stops. Passing `agent_type: "team-lead"` reserves a placeholder slot under that name with no live process behind it. When the actual member spawns later, the harness renames it to `<role>-2` because the slot is taken. The roster ends up with a ghost.
+- **Idle-notification-as-ack instead of ping/ack.** The orchestrator has no addressable name in the team's `members[]`, so members can't `SendMessage` it by name. Each spawned `Agent` emits an idle notification when its first turn ends; the orchestrator (always present) reads N idle notifications as proof the N members are alive. No explicit handshake required.
+- **Phantom-slot sanity check at spawn.** Right after `TeamCreate`, the skill scans for `members[]` entries with empty `tmuxPaneId`. If any are found, the skill halts and surfaces the phantom — never proceeds with a polluted roster.
+
+The `spawn-team` SKILL puts a probe step at 8.5 — after spawning members, before waiting on idle notifications, the orchestrator sends itself a sentinel `SendMessage` to a known-addressable target and asserts the harness's delivered digest matches what was sent. This catches the silent failure mode where the orchestrator spawned missing one of the coordination tools its role contract requires (`SendMessage`, `TaskCreate`, `TaskList`, `TaskGet`, `Agent`). That turns a multi-turn diagnostic loop into a single clear failure at spawn time.
+
+### Cooperative shutdown is part of the contract
+
+Tearing a team down is a two-step handshake, not a unilateral kill. From `plugins/squadkit/agents/team-lead.md`:
+
+> Teardown is a two-step handshake, not a unilateral kill. Before invoking `TeamDelete`, send a structured `shutdown_request` to every active member and wait for each to reply with `shutdown_response approve:true`. Only then call `TeamDelete`.
+
+The role contracts for architect, builder, designer, explorer, reviewer, and tester all instruct each member to reply with a structured `shutdown_response approve:true` before going idle. Without that approval, the harness leaves the iterm2 or tmux pane stranded — context and quota burn until the user manually closes the pane. A `TeamDelete` without prior approvals cleans the registry but does not terminate the underlying sessions.
+
+**Takeaway:** Cooperative shutdown turns "tear down the team" from a registry-only operation into a real lifecycle event. The handshake is what keeps stranded panes off your machine after a long session.
+
+The README adds an override caveat worth flagging: if you author a project-local overlay at `.claude/agents/<role>.md`, preserve the cooperative-shutdown section verbatim. Stripping it leaves the lead unable to tear the team down cleanly — the registry says "team gone" but the panes are still alive.
+
+## Per-builder detached-HEAD worktrees
+
+The third design choice is the one that hits you the moment a crew has more than one builder. Multi-builder configs (>1 builder) provision per-member worktrees under `.claude/worktrees/<member>/`. Each is created with `git worktree add --detach`. The `--detach` flag is non-negotiable.
+
+The reason is in `plugins/squadkit/skills/spawn-team/SKILL.md` step 7:
+
+> Step 6 already checks the main worktree out onto `${WORK_BRANCH}`. A bare `git worktree add <path> <work_branch>` would refuse with `'feature/<slug>-<N>' is already used by worktree at '<main>'` because git holds branch refs to a single worktree at a time. Detached HEAD lets each builder start at the epic HEAD without contention; builders create per-issue branches (e.g. `worktree-agent-<issue>`) off the detached commit when they pick up a task.
+
+That's the mechanism. The implication:
+
+**Takeaway:** Branch refs are exclusive in git. Two worktrees can't both be checked out on the same branch. Detached HEAD sidesteps the rule entirely — every builder starts at the same commit but holds no branch reference, so they can each create their own per-issue branch off that commit when they pick up a task.
+
+The flow is:
+
+```bash
+mkdir -p .claude/worktrees
+git worktree add --detach ".claude/worktrees/builder-1" "${WORK_BRANCH}"
+git worktree add --detach ".claude/worktrees/builder-2" "${WORK_BRANCH}"
+```
+
+Builders then create per-issue branches off the detached commit when they're dispatched a task — typically named `worktree-agent-<issue>` so they sort cleanly alongside swarmkit's branches.
+
+The kit also handles the messy real-world cases:
+
+- **Stale-worktree detection.** If `.claude/worktrees/builder-1` already exists on a non-matching branch from a prior session, `spawn-team` prompts (sweep / reuse / abort) before reusing. It refuses to silently inherit a half-merged feature branch from a previous team.
+- **Pre-flight sweep.** Before provisioning, the skill scans `.claude/worktrees/` for paths that don't match the resolved roster (e.g. `tester` survives but is no longer in scope) and invokes `swarmkit:clean-worktrees` to clear them.
+- **Env-file seeding.** After each per-builder worktree is created, the skill auto-detects the repo's gitignored env files (`.env.local`, `.env.test.local`, etc.) and copies them into the worktree. Builders can run the verify suite without manual setup. Override the auto-detection with `worktreeSeed` in `.squadkit/config.json` for projects that need non-env files copied too (certificates, config snippets).
+- **Singleton-builder profiles share the workspace.** When the resolved roster has exactly one builder, no worktree is created — the builder works in the main workspace. Saves a worktree when there's no concurrency to manage.
+
+**Takeaway:** The per-builder worktree model isn't about isolation for its own sake. It's about dodging a specific git failure mode (branch-ref contention) cleanly. The detached HEAD is the trick; everything else (seeding, sweep, stale detection) is the housekeeping that makes the trick safe across real working sessions.
+
+### Why the auto-isolation isn't enough
+
+The skill notes a harness constraint that explains the manual provisioning:
+
+> `Agent({isolation: "worktree"})` is unreliable when combined with `team_name`. The auto-isolation does not fire reliably for team-scoped spawns, so the skill always provisions worktrees manually via `git worktree add --detach` (see step 7) and passes the resolved absolute path into each spawned agent.
+
+The "do it yourself" path is more code but it's reliable. squadkit will switch to the harness primitive when it stabilises — but until then, the manual `git worktree add --detach` path is the one that ships.
+
+## How the three choices compose
+
+Run `/squadkit:spawn-team --profile all-rounder --epic notes-tags --issues 102-105` and the three design decisions stack visibly:
+
+```text
+Resolving team name → smallorbit-plugins-bravo
+Cutting feature/notes-tags-101 from origin/develop
+Pinning claude.flowkit.prBase = feature/notes-tags-101
+Provisioning .claude/worktrees/builder-1 (detached at feature/notes-tags-101)
+Provisioning .claude/worktrees/builder-2 (detached at feature/notes-tags-101)
+Seeded .env.local into both worktrees
+TeamCreate(team_name=smallorbit-plugins-bravo)        ← no agent_type
+Spawning architect, builder-1, builder-2, reviewer, tester, explorer, designer
+Probe → SendMessage to builder-1 [success, digests match]
+Waiting on 7 idle notifications…
+All members idle. Lead (this session) entering dispatch loop.
+```
+
+What you see:
+
+- **Vocabulary at work.** The crew profile is `all-rounder`. The roster is the resolved squad. The team name is `smallorbit-plugins-bravo` — the next available NATO phonetic letter under `~/.claude/teams/smallorbit-plugins-*`.
+- **Orchestrator-is-lead at work.** `TeamCreate` carries no `agent_type`. No team-lead spawn line. The probe at step 8.5 confirms the orchestrator's coordination tools work end-to-end before idle-notification readiness.
+- **Detached-HEAD worktrees at work.** Both builders are detached at the epic HEAD. Neither holds a branch reference. They're free to cut `worktree-agent-102` and `worktree-agent-103` off that commit when the lead dispatches them.
+
+The `SessionStart` hook (`plugins/squadkit/hooks/pickup-team-context.sh`) is the last piece. It fires on every Claude Code `SessionStart` event, scans `~/.claude/teams/*/config.json`, matches the current session by either the squadkit sibling file's `repo_root` (the orchestrator-is-lead path) or by member `cwd`, and emits a single `systemMessage` reminder telling the matched session to load its role contract from disk. Both fresh `spawn-team` leads and `sessionkit:pickup`-resumed leads hit the same hook — so resuming a team after a context reset re-asserts the role context automatically.
+
+## The narrow surface that earns the kit
+
+Squadkit ships three skills today: `init`, `spawn-team`, and `agent-team-retro`. That's it. No "team manager" UI, no orchestration framework, no DSL. The three design choices above carry the weight:
+
+- The vocabulary makes the kit legible — you can read a crew profile and predict what'll happen.
+- Orchestrator-is-lead removes a phantom-agent class of bug and the cooperative-shutdown handshake keeps panes from stranding.
+- Per-builder detached-HEAD worktrees dodge git's branch-ref exclusivity cleanly, with the housekeeping (seeding, sweep, stale detection) to make the dodge safe in practice.
+
+**Takeaway:** Multi-agent coordination doesn't have to be a framework. squadkit is three good decisions, three skills, seven role contracts, and a hook. The discipline lives in the contracts; the skills enforce them at spawn time.
+
+If you've felt the friction of running multiple agents in parallel — branch contention, stranded panes, lost messages — the squadkit pattern is worth a closer look. Read the role contracts under `plugins/squadkit/agents/`, run `/squadkit:init` to bootstrap your repo's verify and base-branch commands, and spawn an `all-rounder` against a real epic. The worst outcome is you learn what coordination overhead actually costs in your codebase.
+
+Forward pointer: the vaultkit deep-dive completes the trio. Where sessionkit handles continuity in the codebase and squadkit handles coordination across agents, vaultkit handles the layer above the code — durable capture into Obsidian, with birth-time preservation for the metadata Obsidian actually uses, and a thin `/jot` surface that makes capturing decisions friction-free.

--- a/site/src/content/posts/vaultkit-deep-dive.mdx
+++ b/site/src/content/posts/vaultkit-deep-dive.mdx
@@ -1,0 +1,191 @@
+---
+title: "vaultkit: an Obsidian sidekick that respects your timeline"
+subtitle: "Why birth-time preservation matters, when /handoff and /archive-export trade off, and what makes /jot the lowest-friction capture path."
+kit: vaultkit
+date: 2026-05-03
+author: "smallorbit"
+readTime: 10
+tags: ["deep-dive", "tips"]
+---
+
+Six kits in the suite ship code. vaultkit captures the things that don't fit in code.
+
+The premise is small and useful: an Obsidian vault is the right home for decisions, retros, archived conversations, project notes, and the long tail of context that doesn't belong in your repo. Your code's git history records *what* changed and *when*. Your vault records *why* you decided that, what alternatives you rejected, and what the room felt like when the decision was made. Different stores, different shapes, both worth preserving.
+
+vaultkit is the bridge. It runs alongside every other kit without coupling to any of them. This post walks the three vaultkit surfaces that earn their keep over a real working week: **birth-time preservation** (which sounds esoteric until the first time you watch Obsidian's `created` sort scramble itself), the trade-off between **`/handoff` and `/archive-export`** (structured state for the next agent vs browsable history for future-you), and **`/jot`** as the lowest-friction capture path.
+
+Every behaviour cited below resolves to real source under `plugins/vaultkit/`. No invented commands.
+
+## Birth-time preservation, and why it matters
+
+Obsidian's `created` field — the one dataview queries sort by, the one templates inject, the one plugins use to compute "last 7 days" — comes from the filesystem's birth time, not from the file's modification time. On macOS that's a real attribute (`stat -f %SB`), distinct from `mtime`, that gets set when the file's inode is born and is supposed to stay there forever.
+
+Claude's standard `Edit` and `Write` tools don't preserve it. They use a temp-file-rename strategy: write the new content to a temp file, rename it over the target. The rename gives you a fresh inode with a fresh birth time. The file looks the same to a human; to Obsidian's `created` field, it just got reborn this morning.
+
+`plugins/vaultkit/skills/file-edit/SKILL.md` is unambiguous about it:
+
+> Claude's `Edit` and `Write` tools use a temp-file-rename strategy on macOS that resets birth time — this sub-skill writes through a process that modifies the existing inode instead.
+>
+> Obsidian uses filesystem birth time for the `created` field in dataview queries, sort orders, and plugin behaviors. Every rename-based write corrupts that timeline.
+
+**Takeaway:** "Atomic rename" is great for crash safety. It's catastrophic for any program that reads filesystem birth time as a semantic field. Obsidian is one of them.
+
+The fix `vaultkit:file-edit` ships is straightforward — write through a process that modifies the existing inode rather than creating a new one. The happy path is three steps, and the third step is the entire trick:
+
+```bash
+cat > "$VAULT_PATH/path/to/file.md" <<'VAULTKIT_EOF'
+<full new file content here>
+VAULTKIT_EOF
+```
+
+Shell `>` redirect, `cat > file <<EOF`, `python3 open(p, "w")`, and `node fs.writeFileSync` all write in place on macOS. They modify the existing inode. Birth time is preserved. The verification one-liner from the SKILL file is worth memorising:
+
+```bash
+stat -f "Birth: %SB | %N" "$VAULT_PATH/path/to/file.md"
+```
+
+If the birth time matches what it was before the edit, you didn't reset it. If it changed, you used the wrong tool.
+
+There's a fallback for very large files where rewriting the whole thing is genuinely wasteful — capture the birth time first, do a targeted Edit, then `SetFile -d "$BIRTH"` to restore it:
+
+```bash
+BIRTH=$(stat -f "%SB" -t "%m/%d/%Y %H:%M:%S" "$VAULT_PATH/path/to/file.md")
+# ...use the Edit tool to apply the targeted change...
+SetFile -d "$BIRTH" "$VAULT_PATH/path/to/file.md"
+```
+
+But the SKILL file is explicit that this is the fallback, not the happy path: *"Prefer the in-place write above for anything typical. Reach for this fallback only when the file is large enough that reading and re-writing the whole thing is measurably expensive."*
+
+For new files, there's no prior birth time to preserve. The SKILL guidance is to use `Write` then immediately stamp the birth time:
+
+```bash
+SetFile -d "$(date '+%m/%d/%Y %H:%M:%S')" "$PATH"
+```
+
+That stamp is what makes `/archive-export`'s two-file output (`.txt` + `.md` companion) sort correctly in Obsidian's date-based views from the moment it lands.
+
+**Takeaway:** Every other vaultkit skill that touches a vault file routes through `vaultkit:file-edit`. That's the discipline that keeps your vault's timeline intact across thousands of agent-driven edits.
+
+A useful exception: `obsidian append` and `obsidian prepend` from the Obsidian CLI preserve metadata natively. The SKILL file calls this out — *"This does not apply to `obsidian append`/`obsidian prepend` CLI commands — those preserve metadata natively."* — so when you can append rather than rewrite, append.
+
+## /handoff vs /archive-export — different shapes, different homes
+
+Both move conversation context out of the live session into a durable store. They are not interchangeable. They produce different shapes for different consumers.
+
+`/sessionkit:handoff` writes structured state to `.sessionkit/HANDOFF.md` in your repo. Goal, progress, git state, remaining work, a JSON snapshot of the task graph, and the gotchas — formatted so the *next agent* can rehydrate the work. Read by `/sessionkit:pickup`. Lives next to the code, not in your vault.
+
+`/vaultkit:archive-export` is different. It picks up the full `/export session` output (the entire conversation transcript) and files it into the active Obsidian project's `Conversations/` folder. Read by *future-you* with Obsidian search — when you're trying to remember the context around a decision you made three weeks ago and the handoff is long gone.
+
+**Takeaway:** Handoff is for live work — alive context the next agent needs to act. Archive-export is for cold storage — finished sessions you might want to grep months later. Different shapes, different homes, both useful.
+
+The archive-export contract is strict in a useful way. From `plugins/vaultkit/skills/archive-export/SKILL.md`:
+
+> The user always runs `/export session` from the current working directory. This produces a consistent file:
+>
+> ```
+> ./session.txt
+> ```
+>
+> This skill creates two copies in the project's `Conversations/` folder: a `.txt` file (plain text, well-formatted when viewed natively) and a `.md` file (Obsidian-renderable, searchable) that embeds the `.txt` as an attachment and includes the session ID for resuming the conversation.
+
+Two copies, on purpose:
+
+- The **`.txt`** is the source of truth for content. Plain text, no markdown rendering noise, readable in any tool.
+- The **`.md`** is the Obsidian-native version. Embeds the `.txt` as an attachment via `![[basename.txt]]`, inlines the full transcript inside a `plaintext` fenced code block (so Obsidian's search index covers it), and carries a session ID line for resuming the conversation.
+
+The session ID line is the second-most-useful detail in the file. Claude Code stores per-session `.jsonl` files under `~/.claude/projects/<encoded-cwd>/` where `<encoded-cwd>` is `$PWD` with every `/` replaced by `-`. The most recent file's basename (minus `.jsonl`) is the active session UUID. Archive-export resolves it like this:
+
+```bash
+PROJECT_PATH=$(echo "$PWD" | sed 's|/|-|g')
+SESSION_ID=$(ls -t ~/.claude/projects/${PROJECT_PATH}/*.jsonl 2>/dev/null | head -1 | xargs basename -s .jsonl)
+```
+
+That UUID lands at the top of the `.md` companion as:
+
+```text
+session-id: <uuid>
+resume: claude --resume <uuid>
+```
+
+So six months later, when you're searching your vault for the conversation where you settled on CalVer for plugin versioning, you can copy-paste one line into a terminal and resume the exact session. The conversation isn't a dead artifact — it's a resumable thread.
+
+The filename convention is also strict: `YYYY-MM-DD-HHMM-<slug>` (no extension yet). Today's date, current hours and minutes, a 2–4-word slug derived from the session topic. Both `.txt` and `.md` share the base name and differ only in extension. The slug is what makes Obsidian's file-explorer view scannable — `2026-04-03-2314-backtest-snapshot-playbook-fix` tells you what the conversation was about at a glance.
+
+**Takeaway:** When the session is alive and the next agent needs to act, run `/sessionkit:handoff`. When the session is finishing and you want the conversation in a place you can search and resume from, run `/export session` then `/vaultkit:archive-export`. Most days, you'll do both.
+
+The README says it cleanly under "Pairing with Other Plugins":
+
+> Run `/handoff` to capture a session's state to `.sessionkit/HANDOFF.md`, then `/archive-export` to file the conversation export into the active project — the handoff lives on disk next to the code, the archive lives in Obsidian for long-term recall.
+
+Each kit owns one shape. Don't conflate them.
+
+## /jot — the lowest-friction capture path
+
+The temptation in any "capture decision" tooling is to ship a structured form: select the project, pick a category, fill in the rationale, choose alternatives considered. By the time the form loads you've forgotten what you were going to write.
+
+`/jot` is the opposite. From `plugins/vaultkit/skills/jot/SKILL.md`:
+
+```bash
+/jot decided to use CalVer for release tagging; rationale in plugin-release.md
+```
+
+That's the entire interface. One line, no flags, no form. The skill is described in its own SKILL file as *"Quick capture for the active Obsidian project. Delegates to the `vaultkit:project` skill — Operation 3 (Update Project Files)."* It's a thin entry point. The whole point is that there's nothing to think about before you write.
+
+The work `/jot` actually does, in order:
+
+1. Identify the active project from conversation context, or prompt if it's unclear.
+2. Read the relevant file before editing (so the next step doesn't blow away anything that's already there).
+3. Determine what changed — decisions, tasks, status, blockers — and pick the right section to append to.
+4. Write the edit in place via `vaultkit:file-edit` so Obsidian's `created` metadata is preserved.
+5. Keep the entry concise. Recall notes, not documentation.
+
+**Takeaway:** Friction is the enemy of capture. `/jot` removes every choice you don't strictly need — it infers the project, picks the section, writes in place, preserves metadata — so the only thing left for you to do is type the line.
+
+That fifth point is doing more than it looks. The README puts it bluntly:
+
+> Keeps entries concise — recall notes, not documentation.
+
+There's a real failure mode in note-taking tools where the system rewards long entries (more characters = more visible activity = more "thinking captured"). `/jot` rewards short, scannable entries. The notes are designed to be re-read in a hurry — six months from now, while you're trying to remember a decision — not as a permanent record.
+
+The composition with `vaultkit:file-edit` is what makes `/jot` safe to run constantly. Every jot is an in-place edit through the inode-preserving path. Birth time stays intact. Obsidian's `created` sort stays correct. Dataview queries that say "decisions captured this week" return the right files. You can run `/jot` thirty times in a session and the vault timeline stays clean.
+
+The composition with `/project` is what makes `/jot` smart about destination. The active project is inferred from conversation context — usually the one you've been working on for the past ten turns — or you're prompted to pick one. You don't have to remember the project's path or filename. You just type the note.
+
+A typical workday rhythm:
+
+```text
+/jot decided architect-led discovery for the 771 epic, rationale below
+/jot blocker — sessionkit-deep-dive can't cite SessionStart hook source until …
+/jot done — three deep-dive posts shipped, PR #842
+```
+
+Three jots, one minute total, three durable entries in the project file. Compare to "open Obsidian, find the project, pick the section, type the note, save, switch back" and the difference per capture is the difference between capturing and not.
+
+**Takeaway:** Capture isn't about the rich form. It's about the latency between deciding to write something and the cursor being in the right place. `/jot` collapses that latency to zero.
+
+## How the three surfaces fit together
+
+vaultkit's design is intentionally narrow. Four user-facing skills (`obsidian`, `jot`, `archive-export`, `project`) and three sub-skills (`load-project`, `list-projects`, `file-edit`). Everything composes on `vaultkit:file-edit` so the birth-time discipline holds without having to think about it at the call site.
+
+A real session ties all three surfaces together:
+
+- You start with `/load-project smallorbit-plugins` to pull the project notes into context. (Sub-skill `vaultkit:list-projects` runs first if you didn't pass a name, and recommends one based on the conversation.)
+- Mid-session, decisions land via `/jot` — concise lines into the project file, written in place via `vaultkit:file-edit` so the timeline stays clean.
+- At end-of-session, `/export session` writes `./session.txt` in the cwd, and `/vaultkit:archive-export` files both `.txt` and `.md` copies into the project's `Conversations/` folder, with the session ID embedded so the conversation is resumable later.
+- In parallel, `/sessionkit:handoff` writes the structured state into `.sessionkit/HANDOFF.md` next to the code so the next agent can pick up the work.
+
+Two stores, two shapes, no overlap. The vault holds long-term recall. The repo holds short-term continuity. Each one is the right tool for its window.
+
+**Takeaway:** vaultkit's narrow surface is the feature. It is the only kit in the suite that lives outside the development loop — it doesn't ship code, doesn't gate quality, doesn't open PRs. It captures and archives. The narrow scope is what lets it run alongside every other kit without coupling.
+
+## Putting it together
+
+The vaultkit story in three lines:
+
+- **Birth-time preservation** is the foundation. Obsidian's `created` field comes from filesystem birth time; standard atomic-rename writes corrupt it; `vaultkit:file-edit` writes through paths that modify the existing inode (`cat > file <<EOF`, `python3 open(p, "w")`, `obsidian append`/`prepend`) so birth time stays intact across thousands of agent edits.
+- **`/handoff` vs `/archive-export`** is a deliberate split. Handoff writes structured state for the next agent to act on, lives next to the code, is read by `/sessionkit:pickup`. Archive-export writes a conversation transcript (with session ID embedded for resumption) into the vault's `Conversations/` folder for future-you to grep. Different consumers, different homes.
+- **`/jot` is the friction-free capture path.** One line, no form, infers the project from conversation context, writes in place via `vaultkit:file-edit`, keeps entries concise. The latency between "I want to capture this" and "it's captured" is zero, which is the only latency that matters for capture tooling.
+
+If you take one thing from this post: birth-time preservation is the kind of detail you don't notice until something breaks, and then you notice it constantly. Once you've watched Obsidian's `created` sort scramble itself after a hundred Claude-driven edits, the entire premise of `vaultkit:file-edit` becomes obvious. Use it for every vault edit. Let the rest of the kit compose on top.
+
+Forward pointer: this post closes the continuity-kits trio. The sessionkit deep-dive covers the round-trip between handoff and pickup that keeps work alive across context resets. The squadkit deep-dive covers the multi-agent coordination layer with its orchestrator-is-lead pattern and per-builder detached-HEAD worktrees. vaultkit covers the durable-capture layer above all of it. Three kits, one continuity story, no overlap in scope — which is exactly the design discipline the suite is built around.


### PR DESCRIPTION
## Summary
- Adds three kit deep-dive posts (sessionkit, squadkit, vaultkit) authored together for tonal consistency.
- sessionkit: HANDOFF.md anatomy, /skillit overlap check, /retro as a router.
- squadkit: roles/squads/crews vocab, orchestrator-IS-team-lead, detached-HEAD worktrees.
- vaultkit: birth-time preservation, /handoff vs /archive-export, /jot capture path.
- Each post 1500–2500 words; tonal match to the pillar.

## Test plan
- [ ] `npm --prefix site run build` succeeds (frontmatter validates).
- [ ] Visual review at `/blog/sessionkit-deep-dive`, `/blog/squadkit-deep-dive`, `/blog/vaultkit-deep-dive` in dev.
- [ ] Every command, hook, and behavior cited resolves to real code under `plugins/{sessionkit,squadkit,vaultkit}/`.

Closes #771