### PR TITLE
chore: ignore .squadkit/ runtime artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 .sessionkit/
+.squadkit/
 .claude/settings.local.json
 .ideas.md


### PR DESCRIPTION
## Summary
- Add `.squadkit/` to `.gitignore` to match the existing `.sessionkit/` pattern — both directories hold per-session runtime artifacts (briefs, handoffs) that aren't part of the source tree.

## Test plan
- [ ] `git status` no longer flags `.squadkit/briefs/blog-phase-1-discovery.md` as untracked.
- [ ] No tracked files removed.