### PR TITLE
release: 2026-05-03

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 .sessionkit/
+.squadkit/
 .claude/settings.local.json
 .ideas.md

--- a/site/src/content/posts/flowkit-deep-dive.mdx
+++ b/site/src/content/posts/flowkit-deep-dive.mdx
@@ -1,0 +1,278 @@
+---
+title: "flowkit: runtime staging detection, two preview-epic models, and CalVer with a .N hotfix suffix"
+subtitle: "Three small opinions doing most of the load-bearing work in the kit that ships your code."
+kit: flowkit
+date: 2026-05-03
+author: "smallorbit"
+readTime: 13
+tags: ["deep-dive", "release"]
+---
+
+flowkit ships your code. That sounds like the boring half of a development loop until you've spent a Friday afternoon trying to back out a release because your config file said "staging" and your branches said otherwise, or trying to reason about which `v1.4.7` is the one in production after three back-to-back hotfixes.
+
+This deep-dive walks the three opinions that do most of the load-bearing work inside flowkit: the kit detects staging by probing branches at runtime instead of reading config; `/preview-epic` ships two distinct verify models because there are two distinct ways to assemble an epic; and the version scheme is CalVer with a `.N` hotfix suffix, deliberately, for a plugin marketplace where SemVer's promises don't apply.
+
+## Runtime staging detection: branch presence is the only signal
+
+The skill that exposes this most cleanly is `/cut`. From the SKILL:
+
+```bash
+git ls-remote --exit-code origin staging &>/dev/null && STAGING_EXISTS=true || STAGING_EXISTS=false
+```
+
+That single probe is the entire staging-detection mechanism. No config file. No environment variable. No setup wizard. The branch's presence on `origin` is the sole signal.
+
+The same probe runs in five different skills — `/cut`, `/stage`, `/release`, `/pipeline-status`, and `/hotfix` — and each one branches on the result the same way:
+
+- **Staging exists** → `/cut` pushes the RC to `staging` (via `/stage`); `/release` merges `staging` → `main`.
+- **Staging absent** → the RC merges directly to `main`. The intermediate hop simply doesn't happen.
+
+To add a staging environment to a project, you create the branch:
+
+```bash
+git checkout -b staging main && git push -u origin staging
+```
+
+From that moment on, every flowkit release skill picks it up automatically. To remove staging, delete the branch. There is no other knob. The `/stage` skill is explicit about handling the absent case as a non-error:
+
+```bash
+git ls-remote --exit-code origin staging &>/dev/null || {
+  echo "No staging branch on origin — skipping."
+  exit 0
+}
+```
+
+It's a graceful no-op, not an error. Repos without a staging branch use `rc → main` directly.
+
+**Takeaway:** Configuration that lives in the repo's actual state — does this branch exist? — is harder to forget, easier to migrate, and impossible to have in two minds about.
+
+The alternative would be a config file (`.flowkit/staging.json` or similar) saying `"useStaging": true`. That alternative has three failure modes that probing branches doesn't:
+
+- The config can drift from reality (file says yes, branch doesn't exist; file says no, branch exists and people are deploying to it).
+- The config has to be set up in every new repo before flowkit works.
+- The config has to be migrated when the convention changes — and "the convention changes" is the thing that happens, every time.
+
+Probing avoids all three. The only way the probe can be wrong is if `origin/staging` is in a state nobody intends, and that's a problem you want to surface immediately, not paper over.
+
+There's a small follow-on: because the probe is the contract, *any* tool downstream of flowkit can apply the same rule and stay consistent. CI, deploy scripts, dashboards. The shared signal is `origin/staging exists?` — not `which version of which config file does each surface have access to?`.
+
+**Takeaway:** Five skills, one probe, one branch. If you want staging, you create the branch. If you don't, you don't. Everything else follows from that.
+
+## /preview-epic: Model A vs Model B
+
+`/preview-epic` is the lifeline for multi-PR features. Each child PR's CI is green against its own base, but the union may not compile or pass tests. `/preview-epic` answers "does the integrated state actually work?" before you find out the hard way at merge time.
+
+The interesting design choice is that the kit ships *two* preview models, and the dispatcher picks between them based on what it sees on the remote. Both models share an entry point (`/preview-epic`); both produce the same shape of output (typecheck / test / lint outcomes plus a stack composition). They differ in how the integrated state is assembled.
+
+### Model A — stacked PRs (octopus merge into a throwaway preview)
+
+Model A is for epics where every contribution is still an *open* PR, with each PR's `baseRefName` pointing at the previous PR's `headRefName`, ultimately rooting at the base branch. This is the swarmkit shape — `/swarm` produces a stack of open PRs that haven't merged yet.
+
+The integrated state has to be synthesized locally. From `flowkit:preview-epic-stacked`:
+
+```bash
+git fetch origin
+git checkout -b "$PREVIEW_BRANCH" "origin/$BASE_BRANCH"
+
+# Try octopus first — combines every head in one commit
+HEADS=$(printf 'origin/%s ' "${STACK_HEADS[@]}")
+if git merge --no-ff -m "preview: epic ${PREVIEW_BRANCH}" $HEADS; then
+  STRATEGY="octopus"
+else
+  git merge --abort
+  STRATEGY="sequential"
+fi
+```
+
+Octopus merge succeeds only if every branch merges cleanly together. When it fails, the sub-skill falls back to a sequential merge — one head at a time in stack order, root to leaf, halting on the first conflict and reporting which PR introduced it.
+
+The preview branch is local-only. Nothing is pushed. The branch name (`preview/<root-num>-<root-slug>`) is collision-checked against any existing local branch and disambiguated with `-2`, `-3`, etc. After the merge succeeds, the verify commands resolved from `.squadkit/config.json` (or, for any missing command, asked of the user via `AskUserQuestion`) run against the synthesized tree:
+
+```bash
+[[ -n "$INSTALL"   ]] && eval "$INSTALL"
+[[ -n "$TYPECHECK" ]] && eval "$TYPECHECK"
+[[ -n "$TEST"      ]] && eval "$TEST"
+[[ -n "$LINT"      ]] && eval "$LINT"
+```
+
+When all green, the suggested next step is `swarmkit:merge-stack`. When the merge or verify fails, the report names the offending PR and stops.
+
+**Takeaway:** Model A synthesizes. The integrated state doesn't exist anywhere on the remote — you build it locally to ask the question.
+
+### Model B — direct-merge-to-epic (verify on the epic HEAD)
+
+Model B is for epics where a long-lived `feature/<slug>-<issue>` branch exists, and child PRs squash-merge *into the epic branch* and close. The epic HEAD already *is* the integrated state. Nothing to synthesize. Just fetch and verify:
+
+```bash
+git fetch origin "$EPIC_BRANCH":"refs/remotes/origin/$EPIC_BRANCH"
+
+if git show-ref --verify --quiet "refs/heads/$EPIC_BRANCH"; then
+  git checkout "$EPIC_BRANCH"
+  git pull --ff-only origin "$EPIC_BRANCH"
+else
+  git checkout -b "$EPIC_BRANCH" "origin/$EPIC_BRANCH"
+fi
+```
+
+Then run the same verify commands. When all green, the suggested next step is `gh pr create --base "$BASE_BRANCH" --head "$EPIC_BRANCH"` — the final epic-to-base PR.
+
+**Takeaway:** Model B doesn't synthesize. The integrated state already exists on the long-lived feature branch — you just fetch it and run verify against the HEAD.
+
+### How the dispatcher picks
+
+`/preview-epic` itself is a dispatcher. From `flowkit:preview-epic`:
+
+```bash
+OPEN_AGAINST_EPIC=$(gh pr list --state open --base "$EPIC_BRANCH" --limit 200 --json number --jq 'length')
+
+if [[ "$OPEN_AGAINST_EPIC" -gt 0 ]]; then
+  MODEL="A"
+elif git ls-remote --exit-code origin "$EPIC_BRANCH" >/dev/null 2>&1; then
+  MODEL="B"
+else
+  MODEL="none"
+fi
+```
+
+The decision is purely structural. If there are open PRs targeting the epic branch, Model A applies — there's a stack to synthesize. If there are zero open PRs but the epic branch exists on `origin` (typically with squash-merged contributions accumulated), Model B applies. If neither, there's nothing to preview and the dispatcher stops.
+
+The dispatcher then invokes the matching sub-skill via the `Skill` tool, passing structured arguments:
+
+```text
+Skill("flowkit:preview-epic-stacked", "--base develop --epic feature/payments-42 123")
+Skill("flowkit:preview-epic-direct",  "--base develop --epic feature/payments-42")
+```
+
+**Takeaway:** Two models, one dispatcher, structural detection. You never have to remember which model your epic uses — the kit looks at the remote and picks.
+
+A small but important detail: the dispatcher never edits PR metadata. It inspects, classifies, dispatches. PR retargeting is `swarmkit:merge-stack`'s job, and there's no overlap. From the SKILL: "No PR retargeting. This skill inspects PR metadata but never edits it. Use `swarmkit:merge-stack` for retargeting."
+
+## CalVer plus the `.N` hotfix suffix
+
+flowkit uses CalVer — releases tag as `vYYYY.M.D`. From the README:
+
+> Production releases are tagged with a calendar-versioned tag (e.g., `v2026.4.16`). Multiple releases on the same day append a counter (e.g., `v2026.4.16-2`).
+
+The hotfix story extends the same shape:
+
+> First hotfix on 2026-04-16: tag `v2026.4.16` + companion `hotfix/v2026.4.16`. A second hotfix the same day: `v2026.4.16.1` + companion `hotfix/v2026.4.16.1`.
+
+Two design decisions are stacked here. Each one is small. Together they avoid the common SemVer-on-a-marketplace failure modes.
+
+### Why CalVer instead of SemVer
+
+CalVer reads as time. `v2026.4.16` says "this is what shipped on April 16th, 2026." That's what the version is *for* on a plugin marketplace.
+
+SemVer reads as a contract. `v1.4.7` says "1.4.x is API-compatible with 1.4.6 and 1.5.0 may break things." That contract is load-bearing when downstream consumers rely on the API surface and need to know whether a bump is safe to apply automatically. It is *not* load-bearing for a marketplace where:
+
+- Each kit is independent — bumping `swarmkit` doesn't compose with bumping `flowkit`.
+- Users update them on their own cadence — there's no `npm install --save-exact` story to protect.
+- There's no semantic-break promise to keep — the kit's interface to its user is slash commands, and slash commands evolve in ways that don't fit "MAJOR / MINOR / PATCH."
+
+CalVer encodes the only information the marketplace consumer actually needs from the version string: when did this ship, and is it newer than the version I have. SemVer would encode information that doesn't apply — and worse, would imply a contract the marketplace cannot enforce.
+
+**Takeaway:** Use SemVer when you have a contract. Use CalVer when you have a release calendar.
+
+### Why the `.N` hotfix suffix
+
+A naive hotfix scheme would either reuse the day's tag (which loses history) or jump to the next day (which lies about when the fix shipped). The `.N` suffix avoids both:
+
+```text
+v2026.4.16        # planned release on April 16
+v2026.4.16-2      # second planned release the same day
+v2026.4.16.1      # first hotfix on top of v2026.4.16
+v2026.4.16.2      # second hotfix
+```
+
+The `.N` suffix sorts naturally alongside scheduled releases in the tag history. `git tag --list 'v2026.4.16*'` returns every tag from that day in lexical order, hotfixes interleaved with planned releases. That's the order they shipped in, and the order you want to see them in when you're tracing what was deployed when.
+
+The companion `hotfix/` tag does a different job. From `/hotfix`:
+
+```bash
+COMPANION="hotfix/$TAG"
+git tag "$COMPANION" "$TAG"
+git push origin "$COMPANION"
+```
+
+The companion tag points to the same commit as the canonical version tag, but lives in a different namespace. `git tag --list 'hotfix/*'` returns every hotfix in the repo's history without you having to remember which date carried one. The version namespace stays clean (no naming pollution from emergency releases); the hotfix namespace stays discoverable.
+
+The `/hotfix` skill itself encodes the rest of the emergency-release flow. From the SKILL:
+
+```bash
+# 1. Sync main
+# 2. Create the hotfix branch from origin/main
+git checkout -b "hotfix/$(date +%Y-%m-%d)-<slug>" origin/main
+
+# 3. Wait for the user to apply the fix
+# 4. Commit
+# 5. Detect staging (so the back-merge knows what to do)
+# 6. Scope the PR base to main (claude.flowkit.prBase = main)
+# 7. Open the PR targeting main
+# 8. Merge the PR into main
+# 9. Unset the PR base scope
+# 10. Tag — increment-on-collision, plus companion hotfix/ tag
+# 11. Close referenced issues explicitly (idempotent)
+# 12. Back-merge main into develop (preserves the merge commit's history)
+# 13. Sync develop
+```
+
+Two steps deserve a closer look. Step 10 picks the next available `.N` automatically:
+
+```bash
+BASE_TAG="v$(date +%Y.%-m.%-d)"
+N=1
+TAG="$BASE_TAG"
+while git ls-remote --exit-code origin "refs/tags/$TAG" &>/dev/null; do
+  TAG="$BASE_TAG.$N"
+  N=$((N + 1))
+done
+```
+
+You don't think about the version string. You ship the fix; the version string takes care of itself. The first hotfix on April 16 is `v2026.4.16.1` if `v2026.4.16` already exists, or `v2026.4.16` if it doesn't (in which case the planned release of the day takes the next slot when it cuts).
+
+Step 12 uses `git merge --no-ff` — a real merge commit, not a fast-forward — so the release merge history stays visible in `develop` after the back-merge:
+
+```bash
+git merge --no-ff -m "chore(develop): back-merge hotfix from main" origin/main
+```
+
+A fast-forward back-merge would produce a clean linear history, but at the cost of erasing the fact that *this commit was a hotfix*. The `--no-ff` is deliberate — the history is the audit trail.
+
+**Takeaway:** The `.N` suffix lets hotfixes coexist with planned releases in the same namespace, in the right order. The companion `hotfix/` tag keeps the fixes discoverable without polluting the version namespace. Neither piece is automatic in plain `git`; both are baked into the kit so you don't have to remember.
+
+## Putting it together
+
+The shape of a flowkit release, end to end:
+
+```bash
+# After a swarm:
+/ship                            # merge-stack → cut → release, in one command
+
+# Standard release without a swarm:
+/cut                             # rc/YYYY-MM-DD.N from develop;
+                                 # auto-stages if origin/staging exists
+/release                         # detect staging at runtime,
+                                 # merge to main, tag vYYYY.M.D,
+                                 # close issues, clean up RC branches
+
+# Emergency:
+/hotfix "fix login crash"        # off main, fix, PR, tag (.N if needed),
+                                 # back-merge into develop
+
+# Multi-PR feature in flight:
+/cut-epic <issue>                # long-lived feature/<slug>-<issue> branch
+/preview-epic                    # auto-detect Model A or Model B,
+                                 # run verify against the integrated state
+```
+
+Three opinions are doing the load-bearing work:
+
+- **Runtime staging detection.** A single `git ls-remote` probe replaces a config file, an env var, and a setup wizard. Branch presence is the only signal.
+- **Two preview-epic models, one dispatcher.** Stacked PRs synthesize an integrated state via octopus merge; long-lived epic branches verify directly on HEAD. Structural detection picks between them.
+- **CalVer with a `.N` hotfix suffix.** Time, not contract. Hotfixes interleave with planned releases in the same namespace, with a companion `hotfix/` tag in a separate namespace for discoverability.
+
+What flowkit is *not*: a thin wrapper over `git`. There are 22 skills in the kit and most of them are sub-skills the user-facing ones compose on. The opinions are the surface; the wiring is the depth.
+
+**Takeaway:** flowkit is opinionated about staging, preview, and version strings, and the opinions are load-bearing. They look small individually. They add up to a release flow you can actually trust on a Friday.
+
+For the swarm that produces the work flowkit ships, see the [swarmkit deep-dive](/blog/swarmkit-deep-dive). For the quality gate that sits between merge and ship, see the [polishkit deep-dive](/blog/polishkit-deep-dive).

--- a/site/src/content/posts/from-idea-to-release-with-smallorbit-plugins.mdx
+++ b/site/src/content/posts/from-idea-to-release-with-smallorbit-plugins.mdx
@@ -1,0 +1,434 @@
+---
+title: "From Idea to Release with smallorbit-plugins"
+subtitle: "A tour of the kits and how they compose"
+date: 2026-05-03
+author: "smallorbit"
+readTime: 19
+tags: ["deep-dive", "workflow", "tutorial"]
+---
+
+Most "AI agent" workflows hand you everything in one prompt: planning, coding, reviewing, shipping — all collapsed into a single call where you press enter and pray. The output is sometimes magical, often sloppy, and almost always opaque about which decisions were made on your behalf.
+
+smallorbit-plugins splits the work across seven small kits instead. Each kit owns one beat of the development lifecycle — the interview, the swarm, the polish, the ship — and hands off cleanly to the next. You stay in the loop at the moments that matter (approving the plan, reviewing the PRs, choosing the version bump) and out of the loop at the moments that don't (rebasing, retargeting, tagging, branch cleanup).
+
+This is what that looks like end-to-end. One chapter per kit, in lifecycle order. Real slash commands, real handoffs, no hand-waving. By the end you should have a working mental map of which kit owns which phase and what the seam between any two kits looks like.
+
+## Why a kit per beat?
+
+The monolithic-agent default optimises for one thing: minimum prompts. That's a real win the first time you watch a single command turn a vague brief into a merged PR. The cost shows up later — when the agent picks the wrong file, invents a function that already exists three modules away, or quietly skips the test you cared about. By the time you notice, the work is done and undoing it is more expensive than redoing it from scratch.
+
+Splitting the lifecycle changes the contract. Each kit is small enough to reason about, owns one verb, and emits an artefact (an issue, a PR, a tag) that the next kit reads as input. The "team" of kits doesn't need a shared memory blob; the artefacts *are* the memory. That's why a `/spec` interview can hand off to a `/swarm` two days later in a fresh session — the epic label on the GitHub issues is the entire handshake.
+
+**Takeaway:** You don't lose composability by splitting the work. You gain it. Each handoff is an artefact you can inspect, edit, or rerun independently.
+
+The seven kits, in lifecycle order:
+
+- **speckit** — interview the idea into a labelled epic.
+- **swarmkit** — resolve the epic in parallel with stacked PRs.
+- **polishkit** — gate quality between merge and ship.
+- **flowkit** — cut a release candidate, ship to `main`, tag it.
+- **sessionkit** — handoff, pickup, retro, route what you learned.
+- **squadkit** — when one problem needs multiple roles in one room.
+- **vaultkit** — capture decisions and archives in Obsidian, alongside the code.
+
+The first four form the spine. The last three run alongside.
+
+## Plan it: speckit
+
+`speckit` turns a fuzzy human request into a labelled epic and a set of child issues that downstream kits can read as a contract.
+
+The four user-facing skills:
+
+- `/interview` — runs a structured interview to clarify requirements and produce a speckit-format plan (Goal, Background, Requirements, Out of Scope, Tasks). The output is plain Markdown you can pipe into `/spec` or `/catalog` later.
+- `/spec` — the workhorse. Interviews you, builds a plan, files a GitHub epic and linked child issues with consistent labels.
+- `/catalog` — bulk-converts pre-existing findings (a code review, an audit, a polishkit appraisal) into prioritised, labelled issues. Used internally by `/spec` after plan approval.
+- `/issue` — the quick path. Drafts and files a single issue from a one-line description, with duplicate detection.
+
+The interesting design decision is `/spec`'s **two-path classifier**. Before any interview begins, `/spec` does a quick codebase scan and classifies the request as **simple** (single conceptual change, single file or tightly co-located cluster) or **full** (anything else). On the simple path it runs one lightweight interview round and files a single standalone issue with no epic wiring. On the full path it runs the multi-round interview, applies a silent consolidation pass (merging tasks that touch the same file or strictly depend on a predecessor), and files an epic plus child issues.
+
+```bash
+/spec add tags to notes
+```
+
+That single command can either file one issue (if the heuristic says simple) or kick off a five-minute interview that ends with a labelled epic like:
+
+```text
+Filed epic: #101 Epic: Add tags to notes             label: epic:tags-notes
+Filed children:
+  #102 Extend Note schema with tags field            priority:high   type:feature
+  #103 Add tag input to NoteEditor                   priority:high   type:feature
+  #104 Render tag chips on note cards                priority:medium type:feature
+  #105 Filter notes by tag from the sidebar          priority:medium type:feature
+```
+
+Every child carries the same `epic:tags-notes` label. That label is the contract. swarmkit reads it. flowkit's release notes group by it. polishkit's appraise reports filter by it. The interview is gone, but its conclusions live on as labels.
+
+**Takeaway:** speckit doesn't estimate, doesn't assign, doesn't sequence. It captures intent and emits labels. Other kits handle the rest.
+
+A second decision worth flagging: after the epic and children are filed, `/spec` runs a **team-readiness assessment** against four signals (multiple independent modules, clear interface boundaries, separable phases, non-trivial implementation surface). If at least three hold, it provisions `phase:1`, `phase:2`, `phase:3` labels, assigns each child a phase, and posts a team dispatch summary as a comment on the epic — pre-staging the work for `swarmkit` or `squadkit`. If fewer than three hold, it prints `Team decomposition skipped — <reason>` and stops. The kit knows when not to over-engineer.
+
+**Takeaway:** Use `/issue` when you already know exactly what to file. Use `/interview` to think out loud. Use `/spec` when you want the result to feed a swarm. Use `/catalog` when you have findings to bulk-load.
+
+## Resolve it: swarmkit
+
+`swarmkit` takes the issues `/spec` filed and resolves them in parallel — one isolated worktree agent per issue, opening a stack of PRs that merge bottom-up.
+
+The user-facing skills:
+
+- `/swarm` — spawns one agent per issue, each in its own `worktree-agent-<n>` branch. One-shot mode (`/swarm 102 103 104 105`) or loop mode (`/swarm` with no args clears the open board until empty).
+- `/swarm-plus` — wraps `/swarm` with a vendored `swarm-reviewer` agent per PR. If the reviewer flags blockers, a worker is dispatched to push follow-up commits onto the same PR. Single pass, no infinite loops.
+- `/next-issue` — fetches open issues, ranks them by priority, specificity, and architectural impact, and recommends what to swarm next.
+- `/merge-stack` — merges all open swarm PRs bottom-up after retargeting non-root PRs to `develop` (or whatever base branch is configured).
+- `/clean-worktrees` — removes local agent worktrees and orphaned `worktree-agent-*` branches.
+- `/clean-remote-worktrees` — sweeps remote `worktree-agent-*` branches whose PRs already merged.
+
+The canonical use:
+
+```bash
+/swarm 102 103 104 105
+```
+
+Behind the scenes, swarmkit fans out one agent per issue. Each agent works in an isolated git worktree, makes its commits with conventional-commit messages, opens a PR, and stops. You get something like:
+
+```text
+Swarm complete — 4 PRs opened:
+
+  #210 feat(notes): extend Note schema with tags field        → develop
+  #211 feat(notes): add tag input to NoteEditor               → worktree-agent-102
+  #212 feat(notes): render tag chips on note cards            → worktree-agent-103
+  #213 feat(notes): filter notes by tag from the sidebar      → worktree-agent-104
+
+Stack root: #210. Run /merge-stack to merge bottom-up.
+```
+
+That stacked-PR shape is doing real work. The naive approach — every agent branches off `develop`, every PR targets `develop` — runs into a known GitHub trap: when one PR merges into a non-default base, downstream PRs whose head branches existed before the merge get auto-closed in a cascade. swarmkit prevents that by **retargeting non-root PRs to `develop` up front, before the swarm runs**, never after. The retargeting is idempotent and survives across runs.
+
+**Takeaway:** Stacked PRs with up-front retargeting are not a stylistic choice. They're the only safe shape for parallel agents that share a base branch.
+
+A few flags worth knowing:
+
+- `/swarm --base main` — for trunk-based projects without a `develop` branch.
+- `/swarm --model opus` — override the per-agent model (default is sonnet).
+- `/swarm bug` — loop mode filtered to `bug`-labelled issues.
+- `/swarm-plus --review-only` — dispatch reviewers but never spawn workers (triage mode).
+
+The `simplify-loop` deserves a callout. After each agent finishes its implementation, swarmkit runs an internal `/simplify` loop on the agent's branch — iterative passes that tighten the code (collapse duplication, drop unused vars, prune dead branches) before the PR opens. It's a pre-PR sanity check, not a code review. The catch: it runs *per agent*, on the agent's local branch. It does not see the union of all four PRs. That's polishkit's job, downstream.
+
+**Takeaway:** swarmkit's parallelism is enabled by three counterintuitive choices — stacked PRs (not topic branches), up-front retargeting (not last-minute), and per-agent simplify-loop (not deferred). The methodology document at `plugins/swarmkit/METHODOLOGY.md` walks through each in depth.
+
+After the stack is reviewed and you're ready, `/merge-stack` walks the stack bottom-up: root first, leaves last, squash-merging each PR and deleting the remote branch as it goes. If one PR fails review or merge mid-stack, the stack stops cleanly so you can fix and resume.
+
+## Polish it: polishkit
+
+`polishkit` is the quality gate between the swarm finishing and the ship starting. Three skills, three jobs.
+
+- `/appraise` — scores code across five weighted dimensions and produces a report. Works on a single file, a directory, or the whole repo.
+- `/sweep` — runs a two-phase sweep: dead code first (unused exports, imports, vars, unreachable branches), then cruft (stale docs, build artefacts, merged branches). Confirms before any change.
+- `/polish <scope>` — applies cross-cutting fixes (reuse, quality, efficiency) across a path or themed scope, in an isolated worktree, gated on your project's verify commands, opening one PR.
+
+`/appraise` is the most opinionated of the three. The five dimensions and their weights:
+
+- **Architecture & Separation of Concerns** — 30%
+- **Naming & Readability** — 25%
+- **Algorithmic Elegance** — 20%
+- **Testability & Test Design** — 15%
+- **Idiomatic Consistency** — 10%
+
+The weights are doing more than weighting a number — they're a worldview. polishkit thinks architecture beats naming, naming beats algorithm, algorithm beats testability. If you appraise a codebase and it scores high on naming but low on architecture, the report tells you: this code reads well one file at a time but the seams between files are wrong. That's a different problem than "the variables are unclear", and polishkit refuses to flatten them into one number.
+
+```bash
+/appraise src/services
+```
+
+Outputs a scored report leading with beauty highlights (what works), followed by a per-dimension breakdown, followed by flagged violations (god classes, magic numbers, functions over 30 lines).
+
+**Takeaway:** "This code is good" means nothing. polishkit splits the question into five and tells you the weights so you can argue with them.
+
+`/sweep` is the surgical pass. Phase 1 detects the project's language and available static analysis tools (`tsc --noEmit`, `pyflakes`, `vulture`, `staticcheck`, etc.) and finds genuine dead code. Phase 2 walks for cruft — stale docs, leftover build artefacts, duplicate content, merged branches still hanging around. Both phases produce a single Remove / Update / Keep summary, and nothing is written without your approval.
+
+```bash
+/sweep              # full sweep, dead code + cruft
+/sweep src/hooks/   # scoped sweep
+```
+
+`/polish` is the cross-cutting cleanup pass. You give it a scope — a path, a glob, or a themed concern with a scope hint — and it dispatches one subagent in an isolated worktree. The agent applies semantic fixes across reuse (extract duplication, use existing helpers), quality (naming, error handling, type hygiene), and efficiency (avoidable recomputation, quadratic loops). It must keep public surfaces compatible, gate on every verify command, and open one PR.
+
+```bash
+/polish src/hooks/
+/polish error handling in src/providers/
+```
+
+**Takeaway:** Place `/sweep` after `/merge-stack` (cleanest moment to see the union dead code), `/appraise` before `/cut` (so the score reflects what's about to ship), and `/polish` between them as a targeted cleanup of any specific dimension that scored low.
+
+## Ship it: flowkit
+
+`flowkit` owns the git lifecycle from "I have something to commit" all the way to "the release is tagged and the issues are closed". Twenty-two skills total — most are sub-skills the user-facing ones compose on. The ones you'll actually invoke:
+
+- `/commit` — stage and commit with conventional-commit format, splitting changes into logical groups.
+- `/create-branch` — branch off `develop` with an inferred name.
+- `/pr` — combined `create-branch` + `commit` + `open-pr` in one step.
+- `/open-pr` — push the current branch and open a PR. Respects `claude.flowkit.prBase` for branch targeting.
+- `/merge-pr` — squash-merge the open PR for the current branch and delete the remote branch.
+- `/sync` — checkout `develop`, pull latest, prune stale branches.
+- `/cut` — cut a `rc/YYYY-MM-DD.N` release candidate from `develop`. Auto-stages if `origin/staging` exists.
+- `/stage` — force-reset the `staging` branch to a release candidate.
+- `/release` — merge the RC (or staging) to `main`, tag it `vYYYY.M.D`, close referenced issues, clean up RC branches.
+- `/ship` — collapses `merge-stack` → `cut` → `release` into one command. The post-swarm shipping path.
+- `/hotfix` — emergency fix path: branch off `main`, apply the fix, PR to `main`, tag, back-merge into `develop`.
+- `/cut-epic` — cut a long-lived `feature/<slug>-<issue>` branch and pin `claude.flowkit.prBase` so subsequent PRs target the epic, not `develop`.
+- `/preview-epic` — verify the integrated state of an epic locally before promotion. Auto-detects whether the epic uses stacked PRs (octopus-merge into a throwaway preview branch) or direct-merge-to-epic (run verify on the epic HEAD).
+- `/pipeline-status` — show the full release pipeline at a glance.
+
+The shipping path after a swarm is three commands or one:
+
+```bash
+# Three commands, explicit
+/merge-stack     # merge all swarm PRs bottom-up into develop
+/cut             # create rc/YYYY-MM-DD.N from develop
+/release         # promote to main, tag, close issues
+
+# Or collapse all three
+/ship
+```
+
+The most interesting design choice in flowkit is **runtime staging detection**. `/cut`, `/stage`, `/release`, `/pipeline-status`, and `/hotfix` all check at runtime whether `origin/staging` exists. No config, no flag, no setup wizard. Branch presence is the sole signal:
+
+- Staging exists → `/cut` pushes the RC to `staging`; `/release` merges `staging` → `main`.
+- Staging absent → the RC merges directly to `main`.
+
+To add a staging environment to a project, you create the branch:
+
+```bash
+git checkout -b staging main && git push -u origin staging
+```
+
+From that moment on, every flowkit release skill picks it up automatically. To remove staging, delete the branch. There is no other knob.
+
+**Takeaway:** Configuration that lives in the repo's actual state (does this branch exist?) instead of a config file is harder to forget, easier to migrate, and impossible to have in two minds about.
+
+The version-string story is opinionated too. flowkit uses **CalVer** — releases tag as `vYYYY.M.D`. Multiple releases on the same day append a counter (`v2026.4.16`, `v2026.4.16-2`). The first hotfix on a given day tags as `v2026.4.16` plus a companion `hotfix/v2026.4.16` tag. A second hotfix the same day becomes `v2026.4.16.1` plus `hotfix/v2026.4.16.1`. The `.N` suffix sorts hotfixes alongside scheduled releases in the tag history; the companion `hotfix/` tag makes them discoverable via `git tag --list 'hotfix/*'`.
+
+CalVer over SemVer is the right call for a plugin marketplace specifically. There's no semantic-break promise to keep — kits are independent, users update them on their own cadence — so the version number's job is to encode "when did this ship", not "did this break the contract". CalVer reads as time. SemVer reads as ambiguity.
+
+**Takeaway:** flowkit isn't a thin wrapper over `git`. It has opinions about staging, preview, hotfix, and how versions encode time — and the opinions are load-bearing.
+
+The `/preview-epic` skill is the lifeline for multi-PR features. Each child PR's CI is green against its own base, but the union may not compile. `/preview-epic` builds a throwaway preview branch by octopus-merging every open PR in the stack (with sequential fallback on conflict), runs your project's verify commands (typecheck, test, lint) against the combined tree, and reports. Nothing is pushed; nothing is merged. It just answers "does the integrated state actually work?" before you find out the hard way at merge time.
+
+## Carry it: sessionkit
+
+`sessionkit` is the connective tissue across the lifecycle. Other kits handle "do the work"; sessionkit handles "what happens between" — context limits, planning the path forward, capturing what you learned, reducing future friction.
+
+- `/handoff` — captures session goal, progress, git state, remaining work, and active tasks into `.sessionkit/HANDOFF.md`. Run when context is running low or before switching agents.
+- `/pickup` — loads `.sessionkit/HANDOFF.md` at the start of a fresh session, orients the agent, and hydrates pending and in-progress tasks back into the task system.
+- `/roadmap` — surveys current work-in-flight, classifies the state, and produces an approved task chain that takes it all the way to "shipped".
+- `/drive` — picks up an approved task chain and executes it autonomously. Marks each task `in_progress` before starting and `completed` immediately after. Surfaces only for blockers, executive decisions, or completion.
+- `/skillit` — reflects on the current session to identify patterns worth encoding as reusable skills. Checks for existing overlap before proposing anything new.
+- `/suggest-permissions` — scans recent session history for repeatedly approved permissions and proposes additions to `.claude/settings.json` to reduce future prompts.
+- `/retro` — runs a session retrospective and presents a one-keystroke action menu that delegates to the right downstream skill.
+
+The handoff/pickup pair is the bedrock. The handoff document is a structured Markdown file with six sections (Goal, Progress, Git State, Remaining Work, Task List as a fenced JSON block, and Context). The task list snapshot is a real round-trip — `id`, `subject`, `description`, `activeForm`, `status`, and `blockedBy` all survive across the session reset. `blockedBy` edges get remapped to the new task IDs after rehydration.
+
+```bash
+/handoff
+# — start a new Claude Code session —
+/pickup
+```
+
+**Takeaway:** A markdown file beats an in-memory state blob. You can edit it, diff it, commit it, or hand it to a different agent on a different machine. The handshake between sessions is plain text on disk, not a magic state store.
+
+`/roadmap` and `/drive` are the autonomous-execution pair. `/roadmap` looks at your branch, your open PRs, your peer PRs, your in-flight worktrees, your RCs, and your latest tag, then materializes a linear task chain that takes the work to shipped. It presents the chain for approval; on approval, it can hand off to `/drive` for autonomous execution. `/drive` is also standalone-invokable — if you've populated a task list any other way, you can just run `/drive` and it picks up the chain.
+
+```bash
+/roadmap        # survey, propose, ask
+/drive          # execute the approved chain end-to-end
+```
+
+The driving contract — mark `in_progress` before, `completed` immediately after, never batch — lives entirely inside the `/drive` skill. It does not depend on any rule in your global or project `CLAUDE.md`. Installs of sessionkit get the autonomous-execution semantics out of the box.
+
+**Takeaway:** `/handoff` and `/pickup` keep one session's context alive. `/roadmap` and `/drive` collapse the gap between "I see what to do" and "it's done".
+
+`/skillit` is the slow-burn capture path. After a session that did something interesting, `/skillit` reads the conversation for repeated instructions, multi-step workflows executed in a fixed pattern, and heuristics applied consistently. It scans your existing skill library for overlap before proposing anything new, then offers to create a new skill or extend an existing one. The not-capturing-an-existing-skill check is the hard part — it's what keeps your skill library from turning into a graveyard of near-duplicates.
+
+`/retro` runs a session retrospective by scanning your conversation transcript, task list, git activity, and hook/tool-denial events. It surfaces what went well and what didn't, then presents a one-keystroke action menu that delegates to the right downstream skill — `/skillit` for capturable patterns, `/suggest-permissions` for repeated approvals, `/spec` for follow-up work, etc. The retro isn't a static report. It's a router.
+
+## Coordinate it: squadkit
+
+`squadkit` is the alternative to swarmkit when the parallelism you need is *across roles*, not *across issues*. swarmkit gives you N agents working independently on N issues. squadkit gives you one team working concurrently on one problem, with each agent in a different role.
+
+The vocabulary:
+
+- **Role** — a single agent with a focused contract (architect, builder, reviewer, tester, explorer, designer, team-lead). One role definition, one agent.
+- **Squad** — a role-cohesive group of agents collaborating on one slice of work.
+- **Crew** — a team-lead orchestrating one or more squads end-to-end. The crew is the unit you spawn and ship with.
+
+Three skills bracket a crew's life:
+
+- `/squadkit:init` — interview-driven generator that writes `.squadkit/config.json` to the repo root (typecheck, test, lint, install commands plus base branch). One-time per repo.
+- `/squadkit:spawn-team` — spawn a crew from a profile. Resolves a phonetic team name (`<repo>-alpha`, `<repo>-bravo`, …), optionally cuts an epic feature branch, provisions per-builder worktrees, registers the team via `TeamCreate`, and waits for one idle notification per spawned member before the orchestrator (which IS the lead) enters its dispatch loop.
+- `/squadkit:agent-team-retro` — runs a retrospective on the currently-spawned squad after a crew completes.
+
+Crew profiles live as YAML under `plugins/squadkit/crews/`. The starter set:
+
+```yaml
+name: all-rounder
+description: Full-spectrum crew for end-to-end feature work.
+members:
+  - role: team-lead
+  - role: architect
+  - role: builder
+    count: 2
+  - role: reviewer
+  - role: tester
+  - role: explorer
+  - role: designer
+```
+
+Two other profiles ship — `qa` (team-lead, reviewer, tester, builder×1) for hardening sweeps, and `design` (architect, designer, explorer) for discovery-stage exploration with `kind: discovery`.
+
+The `kind:` field is doing real work. **Execution crews** (the default) ship code on a `feature/<slug>-<issue>` branch — they cut the branch, provision worktrees, and produce PRs. **Discovery crews** are read-only. They don't cut a branch, don't provision worktrees, don't pin `claude.flowkit.prBase`, and don't open PRs. What they do produce is a structured blueprint comment on the originating GitHub issue — the contract that a later swarm can read and execute against.
+
+```bash
+/squadkit:spawn-team --kind execution --epic tags-notes --issues 102-105
+/squadkit:spawn-team --kind discovery --issues 821,822,823 --brief @./brief.md
+```
+
+**Takeaway:** Discovery crews don't ship code. They produce blueprints. The same vocabulary covers both shapes — only the `kind:` field changes.
+
+The orchestrator-is-lead design is the other key choice. squadkit never spawns a separate `team-lead` agent. The session that ran `/squadkit:spawn-team` *is* the lead. The role contract file is the operating manual that session loads. This collapses an entire layer of indirection: there's no mailbox between you and the lead, no dispatch hop, no leaked tokens to a process you can't see. You give instructions to the lead the way you give instructions to any Claude session — directly.
+
+The trio composes with the rest of the suite:
+
+- With **flowkit** — `--epic` triggers `flowkit:cut-epic`-equivalent inline cutting and pins `claude.flowkit.prBase` so member PRs target the epic. `flowkit:preview-epic` validates the integrated state before the final epic-to-`develop` PR.
+- With **swarmkit** — squadkit and swarmkit are siblings, not alternatives. The squad-vs-swarm choice turns on whether you need parallelism across roles or across issues. They can also nest: a squad's lead can dispatch a swarm.
+- With **sessionkit** — squadkit ships a `SessionStart` hook that re-asserts role context whenever a session starts, including sessions resumed via `/pickup`. The role contract reload is automatic.
+
+## Capture it: vaultkit
+
+`vaultkit` is the only kit that lives outside the development loop. It's an Obsidian sidekick for the things that don't belong in the codebase — decisions, retros, archived conversations, daily notes — and it runs alongside every other kit without coupling.
+
+Four user-facing skills:
+
+- `/obsidian` — the catch-all interface to your Obsidian vault: read, search, tag, edit, manage templates, vault maintenance.
+- `/jot` — quickly capture a decision, task, or note into the active project. A thin entry point over the `project` skill's update operation.
+- `/archive-export` — file the latest `/export session` output into the active project's `Conversations/` folder.
+- `/project` — manage a `Projects/` second brain: load context, initialise new projects from template, and update project files.
+
+A few internal skills the others compose on — `vaultkit:load-project`, `vaultkit:list-projects`, and `vaultkit:file-edit`. The last one carries the most weight per line of code.
+
+When Claude Code's standard `Edit` and `Write` tools modify a file, they atomic-rename under the hood — and on macOS that resets the file's birth time. Obsidian uses birth time as the source of the `created` field that drives dataview queries, sort orders, and a slew of plugin behaviors. So a routine edit through standard tooling silently corrupts your "created at" history. `vaultkit:file-edit` patches the file in place and preserves the birth-time extended attribute. Every other vaultkit skill that writes goes through it.
+
+**Takeaway:** A kit that does one tiny systems-correctness thing right — preserve a birth-time `xattr` across edits — is doing more for your second brain than a shelf of feature flags.
+
+The capture path is friction-free by design:
+
+```bash
+/jot decided to use CalVer for release tagging; rationale in plugin-release.md
+```
+
+The active project is inferred from conversation context (or you'll be prompted to pick one), and the note is appended without disturbing the file's `created` timestamp. The point is to stay out of your way so you actually use it.
+
+The archive path is the cold-storage counterpart:
+
+```bash
+/export session       # writes ./session.txt in the cwd
+/archive-export       # files it into the active project's Conversations/
+```
+
+Two artefacts land in Obsidian — a `.txt` copy for plain-text viewing and a `.md` companion with the session ID embedded so the conversation can be resumed later.
+
+**Takeaway:** Six kits ship code. vaultkit captures the things that don't fit in code. The seam between "session work" and "durable second brain" is exactly where it lives.
+
+## Putting it together
+
+The composition story is what makes the kits worth installing as a set. Each handoff is an artefact, and every kit reads from and writes to the artefact stream in a predictable place. Here's the canonical idea-to-release loop, end-to-end:
+
+```text
+                   speckit         swarmkit         polishkit          flowkit
+                   -------         --------         ---------          -------
+
+human idea  ──▶  /spec  ──▶  epic + child issues
+                                    │
+                                    ▼
+                              /swarm 102 103 104 105
+                                    │
+                                    ▼
+                              4 stacked PRs (worktree-agent-*)
+                                    │
+                                    ▼
+                              /merge-stack
+                                    │
+                                    ▼
+                              all merged into develop
+                                                            │
+                                                            ▼
+                                                      /sweep --apply
+                                                      /appraise
+                                                      /polish (optional)
+                                                                              │
+                                                                              ▼
+                                                                        /cut → rc/YYYY-MM-DD.N
+                                                                              │
+                                                                              ▼
+                                                                        /release
+                                                                              │
+                                                                              ▼
+                                                                        v2026.5.3 tagged,
+                                                                        issues closed
+```
+
+Sessionkit and vaultkit run alongside that whole pipeline. Squadkit slots in when one node — usually the swarmkit or the speckit node — needs multiple roles in one room instead of one role across many issues.
+
+A worked example tying it together. You want to add tag-filtering to a notes app:
+
+```bash
+/spec add tags to notes
+# Interview, plan, approval. Files epic + 4 child issues.
+
+/swarm 102 103 104 105
+# 4 isolated worktree agents, 4 stacked PRs, all targeting develop.
+
+/merge-stack
+# Bottom-up squash-merge into develop.
+
+/sweep
+# Two-phase: dead code, then cruft. Approve the changes.
+
+/appraise
+# Score the union before shipping. Optionally /polish a low-scoring dimension.
+
+/cut
+# rc/2026-05-03.1 from develop. Auto-staged if origin/staging exists.
+
+/release
+# Merge to main, tag v2026.5.3, close referenced issues, clean up.
+```
+
+Seven commands across four kits. Three handoffs (epic-label → swarmkit, merged-develop → polishkit/flowkit, tagged-release → done). Zero manual translation steps between them.
+
+**Takeaway:** Each handoff is "free" because the artefact carries the contract. The label `epic:tags-notes` is the same string in `/spec`'s output, swarmkit's filter, polishkit's report group, and flowkit's release-notes scope. No translation, no glue script, no shared memory blob.
+
+When the lifecycle goes off-script — context runs out mid-swarm, a hotfix needs to ship before the next scheduled release, an epic needs three roles in one room — the kits that run alongside step in:
+
+- `/handoff` mid-swarm so the next session picks up exactly where this one stopped.
+- `/hotfix "fix the regression"` when a bug needs to ship before the next `/release`.
+- `/squadkit:spawn-team --kind execution --epic <slug>` when the problem is one ambiguous bug needing architect plus builder plus tester in concurrent flight.
+- `/squadkit:spawn-team --kind discovery --issues 821-823` when the problem isn't ready to be built yet and you need a research crew to produce a blueprint comment on the issue.
+- `/jot` when you make a decision worth recalling later.
+- `/skillit` after the session if a pattern emerged worth encoding as a reusable skill.
+- `/retro` at the end of the session to route what you learned to the right downstream kit.
+
+**Takeaway:** The seven kits don't compete for the same surface. They compose. Pick the ones that match your workflow today; add the others when the friction makes itself known. Nothing breaks if you start with two and grow into seven.
+
+The kits are intentionally small. None of them is trying to be a framework. Each one owns one verb, emits one artefact, and reads someone else's artefact as input. The "team" of kits doesn't need a shared memory blob, because the artefacts *are* the memory. That's the whole design.
+
+Start with `/spec` and `/swarm` — the two essential kits — and add the rest when their friction outruns your patience. The marketplace makes that easy:
+
+```bash
+/plugin marketplace add smallorbit/smallorbit-plugins
+/plugin install speckit@smallorbit-plugins
+/plugin install swarmkit@smallorbit-plugins
+```
+
+The full catalog is in the [repo README](https://github.com/smallorbit/smallorbit-plugins/blob/main/README.md#available-plugins). The end-to-end walkthrough is in [Getting Started](https://github.com/smallorbit/smallorbit-plugins/blob/main/README.md#getting-started). The methodology behind the most opinionated kit — swarmkit's stacked-PR strategy — lives in [METHODOLOGY.md](https://github.com/smallorbit/smallorbit-plugins/blob/main/plugins/swarmkit/METHODOLOGY.md).
+
+You stay in the loop where it matters. The kits handle the rest.

--- a/site/src/content/posts/polishkit-deep-dive.mdx
+++ b/site/src/content/posts/polishkit-deep-dive.mdx
@@ -1,0 +1,198 @@
+---
+title: "polishkit: weighted taste, two-phase sweep, and a soft cap on cross-cutting cleanups"
+subtitle: "What the appraise rubric's weights actually say about taste, and why /sweep and /polish stop where they do."
+kit: polishkit
+date: 2026-05-03
+author: "smallorbit"
+readTime: 11
+tags: ["deep-dive", "tips"]
+---
+
+"This code is good" is a sentence you should distrust. It collapses five different questions into one number and then asks you to argue with the number instead of the questions. polishkit is built around the opposite move: split the question, weight the parts, and let the weights say what the kit thinks "good" actually means.
+
+This deep-dive walks the three design choices that show up most clearly when you actually use the kit. Each one is a small, deliberate constraint. Together they're the difference between a quality pass that improves a codebase and a quality pass that produces an unreviewable 800-line PR.
+
+## What the appraise weights say about taste
+
+`/appraise` scores code across five weighted dimensions and produces a report with beauty highlights, per-dimension breakdowns, and flagged violations. The weights, copied verbatim from `plugins/polishkit/skills/appraise/SKILL.md`:
+
+- **Architecture & Separation of Concerns — 30%**
+- **Naming & Readability — 25%**
+- **Algorithmic Elegance — 20%**
+- **Testability & Test Design — 15%**
+- **Idiomatic Consistency — 10%**
+
+The overall score is the weighted sum of the five dimensions, each scored 1–10, rounded to one decimal place:
+
+```text
+Overall Score = (Architecture × 0.30)
+             + (Naming × 0.25)
+             + (Algorithmic Elegance × 0.20)
+             + (Testability × 0.15)
+             + (Idiomatic Consistency × 0.10)
+```
+
+Read past the weights and they're a worldview, not arithmetic.
+
+**Takeaway:** Architecture beats naming. Naming beats algorithm. Algorithm beats testability. Testability beats idiomatic consistency. Each `>` is doing real work.
+
+### Why architecture at 30%
+
+The dimension is described as "the most important dimension. Beautiful code has a clear, intentional structure." The score anchors are unambiguous about what counts:
+
+- **9–10**: "Architectural intent is immediately legible. Boundaries are crisp. You could swap infrastructure without touching domain logic."
+- **1–2**: "No discernible architectural intent. Everything depends on everything."
+
+The weight encodes a bet: a codebase with clean architecture and average naming will be cheaper to live with over five years than a codebase with poetic naming and tangled boundaries. You can rename a function with grep. You cannot rename a tangled dependency graph with grep.
+
+### Why naming at 25% — but not 30%
+
+The second-most-weighted dimension is naming, scored against "names reveal intent — you rarely need to read the body to understand what a function does." It is huge, but it sits below architecture for a deliberate reason: a beautifully-named function inside a god class is still inside a god class. Naming makes individual files readable; architecture makes the seams between files defensible. polishkit's view is that the seams come first.
+
+### Why algorithmic elegance at 20%
+
+Algorithmic elegance is scored against the principle "solutions feel inevitable — 'of course it should be done this way.'" It earns 20% because it's where genuine over-engineering shows up — the Rube Goldberg pipeline that does in seven steps what one well-chosen data structure would do in zero. But it sits below naming because most production code is not algorithmically interesting; it's CRUD, glue, and event handlers, and the cheaper win is making those readable than making them clever.
+
+### Why testability at 15%
+
+Testability is the structural support for confidence — "tests serve as living documentation. Test structure mirrors the domain." It's not 30% because tests are downstream: a well-architected, well-named codebase is *already* easy to test. The 15% catches the cases where the code is structured to resist testing (hard-wired dependencies, mocked-too-aggressively boundaries, fragile assertions on implementation details) without giving testing more weight than the architecture that enables it.
+
+### Why idiomatic consistency at only 10%
+
+The smallest weight. The principle: "a native speaker of this language would nod in approval at every file." Idiomatic consistency is real — using LINQ in C#, comprehensions in Python, hooks-and-composition in React — but it sits at 10% because a polished idiom in a tangled architecture is still a tangled architecture. You can teach idioms; you can't teach a redesign.
+
+**Takeaway:** The weights are the kit's argument with you about what "good" means. If you appraise a codebase and it scores high on naming but low on architecture, the report tells you: this code reads well one file at a time but the seams are wrong. That's a different problem than "the variables are unclear", and `/appraise` refuses to flatten them into one number.
+
+The report shape is also pinned. From the SKILL:
+
+```text
+Executive Summary (always first)
+Beauty Highlights (lead with what works)
+Dimension Breakdown (per-dimension score, justification, best example)
+Violations (always-flag list: god classes, magic numbers, functions > 30 lines, files > 300 lines, comments that restate code)
+Closing Note (the single highest-leverage action)
+```
+
+Two details are worth flagging. First: the report leads with beauty. The persona is explicit — "appreciative first. Always lead with what is done well. Genuine beauty deserves recognition before any flaw is discussed." Reviews that open with the worst thing first train the reader to skim past everything else; reviews that open with what works train the reader to read the criticism with the same attention. Second: the report has a hard 500-line cap. "Brevity is itself a form of elegance."
+
+## /sweep as a two-phase pass
+
+`/sweep` does cleanup, but it splits cleanup into two phases that look superficially similar and are actually different jobs.
+
+### Phase 1: dead code
+
+Phase 1 is at the language level. From the SKILL:
+
+> Detects the project language and available static analysis tools (`tsc --noEmit`, `pyflakes`, `vulture`, `staticcheck`, etc.) and finds genuine dead code: unused exports, unused imports, dead variables, unreachable branches, and commented-out code blocks.
+
+Tool detection is conditional on what's in the repo:
+
+```bash
+# TypeScript / JavaScript
+ls tsconfig.json 2>/dev/null && echo "TypeScript project"
+
+# Python
+which pyflakes vulture ruff 2>/dev/null
+
+# Go
+which staticcheck 2>/dev/null
+```
+
+The skill skips findings inside `node_modules/`, `dist/`, `build/`, generated files (`*.generated.ts`, `*.d.ts`), and test files (where dead code can be intentional fixtures). Findings are grouped by category and severity:
+
+```text
+| Category              | Count | Severity |
+|-----------------------|-------|----------|
+| Unused exports        | N     | Medium   |
+| Unused imports        | N     | Low      |
+| Dead variables        | N     | Low      |
+| Unreachable branches  | N     | High     |
+| Commented-out code    | N     | Low      |
+```
+
+### Phase 2: stale artifacts
+
+Phase 2 is at the file/repo level. It runs in parallel with phase 1 and looks at things a typecheck would never catch:
+
+- **Stale documentation** — WIP/tracking files that reference completed work, PRDs and task files for features that shipped months ago, handoff or planning docs for work that's long finished.
+- **Build artifacts & dead directories** — empty directories, leftover build output not in `.gitignore`, generated files committed by accident (`.DS_Store`, logs, temp files), unused config files.
+- **Documentation gaps** — README sections that don't reflect current features, keyboard shortcuts or env vars that were added but not documented, stale screenshots.
+- **Duplicate content** — root-level files that duplicate content already in `docs/`, repeated information across `CLAUDE.md`, `AGENTS.md`, `README.md`.
+- **Git hygiene** — local branches whose upstream has been merged, stale worktrees where the branch no longer exists, orphaned remote-tracking branches.
+
+**Takeaway:** Phase 1 asks "is this code reachable?" Phase 2 asks "does this artifact still describe something true?" They share a verb but they're separate disciplines.
+
+The findings from both phases are merged into a single Remove / Update / Keep summary, and nothing is written without confirmation. From the SKILL:
+
+> Use `AskUserQuestion` to confirm each proposed action, batched in groups of at most 4 questions per call.
+
+A scoped sweep restricts both phases to the matching subtree:
+
+```bash
+/sweep                  # full sweep — dead code + cruft, repo-wide
+/sweep src/components   # scoped to one directory, both phases
+/sweep dead-code-only   # category hint — runs just phase 1
+/sweep cruft-only       # runs just phase 2
+/sweep git-only         # branch / worktree / remote pruning only
+```
+
+The two phases are independent — a category hint runs just the matching phase. After approval, the skill applies removals and edits, verifies the result still parses (`tsc --noEmit` or the language equivalent), re-runs the project's verify command if one is exposed, and commits with `chore: sweep codebase`.
+
+**Takeaway:** Phase 1 needs a static analyzer. Phase 2 needs a careful read of what the project says about itself. Bundling them into one pass is a UX win; treating them as the same kind of cleanup is a category error.
+
+## /polish and the soft cap on files
+
+`/polish` is the cross-cutting cleanup pass. You give it a scope — a path, a glob, or a themed concern with a scope hint — and it dispatches one subagent in an isolated worktree. The agent applies semantic fixes across three categories: reuse (extract duplication, use existing helpers), quality (naming, error handling, type hygiene, magic numbers), and efficiency (avoidable recomputation, quadratic loops where linear is trivially possible).
+
+The scope grammar handles three shapes:
+
+```bash
+/polish src/hooks/                          # path
+/polish "src/**/use*.ts"                    # glob
+/polish error handling in src/providers/    # cross-cutting concern + scope hint
+```
+
+For a cross-cutting theme, the description becomes the agent's *theme* and the path/glob hint becomes the *file boundary*. Both are passed to the agent verbatim so it doesn't re-discover scope.
+
+### The soft cap
+
+This is the single most polishkit-flavored design choice in the kit. From the SKILL:
+
+> **SOFT CAP** — touch at most `--max-files` files (default 15). If the scope clearly exceeds the cap, fix the highest-impact subset and list the rest under deferred findings. Lightweight passes stay lightweight.
+
+Fifteen is not arbitrary. It's the rough boundary at which a cross-cutting cleanup PR stops being reviewable in one sitting. Below 15 files, a reviewer can hold the diff in their head, judge it as a unit, and either approve or push back. Above 15 files, the reviewer either rubber-stamps it (which defeats the point) or breaks it into chunks themselves (which defeats the point in a different way).
+
+The cap is *soft* because some cleanups genuinely need to touch more — you can pass `--max-files 30` if you mean it. But the default forces a deliberate decision: if the agent finds 40 files that need the same fix, it picks the 15 highest-impact ones, applies them, and surfaces the other 25 as deferred findings in the PR body's `## Findings deferred to issues` section, with file:line refs. You then choose whether to file the rest as follow-up issues, run another `/polish` pass with a tighter scope, or accept that the deferred findings document a known shape of debt.
+
+**Takeaway:** The cap is what keeps `/polish` a *cleanup* skill instead of a *refactor* skill. Refactors get their own PRs, their own reviews, and their own scoped epics — they don't ride along inside a "lightweight" pass.
+
+### What else is bounded
+
+A few other constraints, copied straight from the SKILL, are doing similar work:
+
+- **One agent per invocation, one PR per agent.** Never fan out multiple polish agents on the same scope.
+- **Verify must be green before push.** Red builds are never acceptable, even for "lightweight" passes.
+- **Defer behavior-changing fixes.** "If a fix would change a public contract, leave it untouched and surface in the PR's `## Findings deferred to issues` section."
+- **No new dependencies.** Polish is reorganizing what's there, not adding new third-party surface.
+- **No type-error suppression** — no `as any`, no `@ts-ignore`, no `# type: ignore` without justification.
+- **No-op PR is legitimate.** "If the pass finds nothing actionable in the scope, open the PR anyway with `## Summary` stating `no actionable simplifications found`. Manufactured churn is worse than a no-op PR."
+
+That last one is the same discipline that shows up in `/swarm-plus`'s single-pass rule: don't dispatch a fix round to justify the run. If there's nothing to fix, the right output is a tiny PR (or no PR) that documents what was considered and why nothing changed.
+
+## Where polishkit fits
+
+The natural ordering in a development cycle:
+
+```bash
+/sweep              # cleanest moment is right after /merge-stack
+                    # — phase 1 sees the union of all merged branches
+/appraise           # before /cut, so the score reflects what's about to ship
+/polish <scope>     # between them, targeted at any specific dimension
+                    # that scored low in the appraise report
+```
+
+`/sweep` removes; `/appraise` measures; `/polish` improves. They share a kit because they share a discipline — "improve what you've already built" — but they don't share a workflow. Each one solves a problem the others can't.
+
+**Takeaway:** polishkit is the quality gate between the swarm finishing and the ship starting. It's not a refactoring suite. It's not a linter. It's three skills with three jobs and a hard line on what each one does *not* do.
+
+For the swarm that produces the work polishkit cleans up, see the [swarmkit deep-dive](/blog/swarmkit-deep-dive). For the shipping flow that turns the polished develop into a tagged release, see the [flowkit deep-dive](/blog/flowkit-deep-dive).

--- a/site/src/content/posts/sessionkit-deep-dive.mdx
+++ b/site/src/content/posts/sessionkit-deep-dive.mdx
@@ -1,0 +1,180 @@
+---
+title: "sessionkit: continuity that survives a context reset"
+subtitle: "How HANDOFF.md round-trips your task list, why /skillit refuses duplicates, and what /retro routes where."
+kit: sessionkit
+date: 2026-05-03
+author: "smallorbit"
+readTime: 11
+tags: ["deep-dive", "tips", "workflow"]
+---
+
+Every kit in the suite handles "do the work." sessionkit handles what happens between.
+
+A real working day rarely fits inside a single session. The context window fills up. You stop for lunch and come back five hours later. You hand the work off to a teammate, or to a fresh agent, or to your future self after a weekend. Every one of those transitions burns coordination cost — restating the goal, re-reading the diff, re-deriving the gotchas you already paid for once. sessionkit's job is to make that cost trivial.
+
+This is a tour of three sessionkit surfaces that earn their keep on a real workday. The anatomy of `HANDOFF.md` and the task round-trip that pickup performs. The overlap check inside `/sessionkit:skillit` that refuses to propose duplicate skills. And `/sessionkit:retro` as a router — not a journal — that turns each finding into a one-keystroke action.
+
+Each section walks you through the contract sessionkit ships, with citations from the kit's own `SKILL.md` files so you can verify the behaviour against source.
+
+## HANDOFF.md is a contract, not a diary
+
+The premise is simple. `/sessionkit:handoff` writes one Markdown file at `.sessionkit/HANDOFF.md`. `/sessionkit:pickup` reads that file in a new session and rehydrates the agent. The interesting part is what the file actually contains and what survives the round-trip.
+
+**Takeaway:** The handoff document is the entire memory blob between sessions. Everything else — the in-flight tools, the open editor buffers, the unsaved scratchpad — is gone. The file is structured so the next agent can reconstruct enough state to make a real decision in two minutes.
+
+The section order is fixed:
+
+- `## Goal` — one bullet, one sentence. What this session is working toward.
+- `## Progress` — bullets only. What was completed, decided, or abandoned.
+- `## Git State` — branch, staged files, unstaged files, recent commits.
+- `## Remaining Work` — bullets in priority order.
+- `## Task List` — a fenced JSON block that captures the actual task graph.
+- `## Context` — bullets only. Decisions, gotchas, dead ends, external references.
+
+That order is not a stylistic choice — it's enforced by `plugins/sessionkit/skills/handoff/SKILL.md` under "Constraints," and `/sessionkit:pickup` parses positionally. Goal first because it answers "why are we even here." Context last because by the time the next agent reads it, they already know what we were doing and just need the gotchas.
+
+The file also carries an HTML-comment header on line 1:
+
+```text
+<!-- handoff-meta gitFingerprint=<sha> taskFingerprint=<sha> -->
+```
+
+That header is what enables delta mode. On the next `/sessionkit:handoff` run, the skill compares the prior `gitFingerprint` (HEAD sha plus a hash of the staged and unstaged file lists) against the current state. If git hasn't moved, the `## Git State` and `## Progress` sections are reused verbatim. Same for `taskFingerprint` over the Task List and Remaining Work sections. When both fingerprints match, four of the six sections come straight from the prior file and the synthesis sub-agent is skipped entirely.
+
+**Takeaway:** Run `/sessionkit:handoff` after every meaningful state change — opening a PR, completing a task, locking in a decision. Delta mode keeps the cost trivial. You don't have to wait for context pressure to capture state.
+
+### What survives the task round-trip
+
+The `## Task List` section is where the real engineering happens. `/sessionkit:handoff` snapshots every non-deleted task into a JSON array inside the fenced `json` block. `/sessionkit:pickup` reads that block in the next session and recreates the tasks with `TaskCreate`, then re-wires the dependency graph with `TaskUpdate`.
+
+The fields that survive the round-trip, per the table in `plugins/sessionkit/README.md`:
+
+- `id` — preserved in the snapshot so `blockedBy` edges can be rewired; the new session assigns a fresh id.
+- `subject` — the task title.
+- `description` — the full task description.
+- `activeForm` — the active-form view state.
+- `status` — original status (`pending` or `in_progress`); all recreated tasks start as `pending`.
+- `blockedBy` — dependency edges; remapped to new ids after all tasks are created.
+- `blocks` — listed in the snapshot for reference; not re-wired on pickup (the inverse of `blockedBy` is implicit and wiring both directions would double-write the graph).
+
+What does **not** survive: `owner` and `metadata`. And only `pending` or `in_progress` tasks are restored — `completed` ones appear in the orientation summary as history but are not recreated. This is deliberate. The task list is the active work plan, not the audit log; resurrecting completed tasks would just clutter the new session's queue.
+
+**Takeaway:** The task graph is the only structural state that survives a context reset. Conversation transcripts, scratchpad notes, even the orientation prose are reconstructed every time. The graph is the spine.
+
+The pickup pass is two-pass on purpose. Pass 1 calls `TaskCreate` for each `pending` or `in_progress` task and records an `oldId → newId` map. Pass 2 walks the same set, remaps each `blockedBy` array through the map, and calls `TaskUpdate` with `addBlockedBy` for the new task id. The handoff snapshot doesn't carry the new ids — those don't exist yet — so the rewire has to wait until every task is created.
+
+There's also a graceful back-compat clause. Legacy `HANDOFF.md` files written before task-list support existed (no `## Task List` section) are valid input. `/sessionkit:pickup` emits one warning line — `No task list snapshot — skipping hydration` — and continues with the orientation summary. That tiny touch matters: handoff files in the wild outlive their schema.
+
+### One subtle invariant
+
+The `## Goal` and `## Context` sections are always refreshed on a new `/sessionkit:handoff` run, even when both fingerprints match. Goal because it incorporates `$ARGUMENTS` when present (the freeform notes you fold in to steer the next agent). Context because the gotchas drift faster than the structural state — a decision made twenty minutes ago might be the most important thing the next agent reads.
+
+Everything else can be reused verbatim. That's the asymmetry that makes delta mode safe: structural state is content-addressed, narrative state is always fresh.
+
+## /skillit refuses to propose duplicates
+
+`/sessionkit:skillit` reflects on the current session and proposes new skills worth encoding. Most "agent reflection" tools are unbounded — they will happily generate the tenth variation of a skill you wrote three weeks ago. `skillit` won't.
+
+The contract from `plugins/sessionkit/skills/skillit/SKILL.md` is four steps. The third step is the one that earns the kit:
+
+```bash
+find ~/.claude/skills -name "SKILL.md" 2>/dev/null
+find .claude/skills -name "SKILL.md" 2>/dev/null
+find ~/.claude/commands -name "*.md" 2>/dev/null
+```
+
+`/skillit` scans the user-global skill library, the project-local skill library, and the legacy commands directory. It reads the `name` and `description` frontmatter of any candidates that look relevant, and surfaces close matches to you **before** proposing anything new.
+
+**Takeaway:** Capturing a reusable skill is easy. *Not* capturing one that already exists — that's the hard part. Without the overlap check, every session ends with a fresh skill proposal that overlaps the existing library at 80% and just hasn't been noticed.
+
+The presentation step is structured to make that explicit:
+
+- **What it would do** — one sentence.
+- **Why it's worth encoding** — what friction it removes.
+- **Overlap risk** — does it duplicate or extend an existing skill?
+
+The "extend an existing skill" branch is where overlap turns into a positive. If the conversation surfaced a pattern that's 60% covered by an existing skill plus a new wrinkle, `/skillit` offers to modify the existing skill rather than ship a near-duplicate. That keeps the library coherent over months.
+
+The constraints at the bottom of the SKILL file lock the discipline in:
+
+- *Always* check for existing skills before proposing something new.
+- *Never* create a skill file without user approval.
+- *Identify at least one candidate* before concluding — never report "nothing found."
+
+The first two are obvious. The third is doing more work than it looks. Without it, `/skillit` could just shrug and exit when the session was uneventful — and you'd never get the small wins (the recurring command sequence you didn't notice was a pattern). Forcing one candidate per run keeps the library growing.
+
+**Takeaway:** Run `/skillit` at the end of any session that involved a non-trivial workflow. The overlap check is what makes it safe to run often.
+
+## /retro is a router, not a journal
+
+The temptation in any retro tooling is to write a long markdown summary you'll never re-read. `/sessionkit:retro` does the opposite. It produces a short inline summary, then asks one question with a one-keystroke answer. Each finding has a delegation target — a downstream skill that owns the action.
+
+Per `plugins/sessionkit/skills/retro/SKILL.md`, the input surfaces are four:
+
+- **Conversation transcript** — repeated corrections, friction loops, mid-flight self-corrections.
+- **Task list** — `TaskList` plus per-task `TaskGet` to find stalls, scope revisions, completed-vs-cancelled patterns.
+- **Git activity within the session window** — `git log --since="8 hours ago"`, current branch, stashes, recent PRs.
+- **Hook and tool-denial events** — scanned from the most recent `~/.claude/projects/<encoded-cwd>/*.jsonl` files for `permission denied`, `tool denied`, or `hook blocked` patterns.
+
+That fourth surface is the one most retro tools miss. A `permission denied` you approved twice this session is a strong signal — the next session will burn the same approval friction unless you ship a permission tweak now.
+
+**Takeaway:** Retro isn't lessons-learned theatre. Every signal has a downstream action; the retro's job is to route, not narrate.
+
+The synthesis step organizes findings into three buckets — **What went well**, **What didn't go well**, **Recommended actions** — and the third bucket is where the routing happens. The mapping table in the SKILL file is exact:
+
+| Pattern | Delegation target |
+|---------|------------------|
+| Repeated command sequence worth automating | `sessionkit:skillit` |
+| Repeated permission approvals | `sessionkit:suggest-permissions` |
+| Context running low or session should be captured | `sessionkit:handoff` |
+| Recurring hook-blocked behavior worth enforcing | `hookify:hookify` |
+| A problem worth filing as a tracked issue | `speckit:issue` |
+| A behavioral config worth persisting | `update-config` |
+| No matching skill | Surface as plain-text guidance only |
+
+The actions are capped at four to fit the harness's `AskUserQuestion` option limit. If more than four items qualify, retro keeps the highest-signal ones and reserves the fourth slot for "Other — I'll handle this manually" when there's remaining guidance with no skill match. That cap is doing real work: a menu of nine options is functionally identical to no menu at all.
+
+The action menu is mandatory. The SKILL file is unambiguous: *"Never run delegated skills without explicit user selection. The `AskUserQuestion` call in step 4 is mandatory. Skipping it and auto-running skills is a defect."* The router is opinionated about delegation but conservative about consent.
+
+**Takeaway:** Retro is a thin reflective layer. It does not absorb `skillit`'s encoding logic, it does not absorb `suggest-permissions`' tuning logic, it does not write files. When it recommends "encode X as a skill," it delegates to `/skillit` — it does not author the skill itself.
+
+That last constraint matters more than it looks. The temptation is to fold each downstream skill's logic into retro for convenience. The cost would be every retro change touching every downstream skill's behaviour. Keeping retro thin keeps the rest of the kit composable.
+
+### A worked example
+
+Imagine a session that:
+
+- Approved `Bash(npm run build)` four times.
+- Repeated the same `git status && git diff && git commit` sequence twice.
+- Hit a `tool denied` for a Write tool inside `node_modules/`.
+- Surfaced a real bug nobody's filed yet.
+
+`/sessionkit:retro` produces an inline summary citing each turn, then asks:
+
+```text
+Which of these would you like to action now?
+
+1. Permission tune for `Bash(npm run build)`     → /sessionkit:suggest-permissions
+2. Encode the status/diff/commit sequence        → /sessionkit:skillit
+3. Hookify the node_modules write block          → /hookify:hookify
+4. File the bug as a tracked issue               → /speckit:issue
+```
+
+You pick the ones you want, retro invokes each in turn, and the session ends with concrete artifacts — not a markdown post-mortem you'll never re-read.
+
+## Putting it together
+
+sessionkit's three big surfaces compose cleanly because each one has a narrow, well-defined contract:
+
+- `/sessionkit:handoff` writes the structural state — git, tasks, gotchas — into a single Markdown file with a fingerprint header that makes the next run cheap.
+- `/sessionkit:pickup` reads that file, rebuilds the task graph (preserving `blockedBy` edges across the id remap), and ends by asking what you want to tackle first.
+- `/sessionkit:skillit` reflects on the session, checks the existing skill library for overlap, and proposes one new skill or one extension — never a duplicate.
+- `/sessionkit:retro` scans four signal surfaces (conversation, tasks, git, denials), groups findings into went-well / didn't-go-well / recommended actions, and routes each action to the right downstream skill via a one-keystroke menu.
+
+The kit doesn't ship a "session manager" abstraction. It ships four small skills that each own one beat — capture, restore, encode, route — and a Markdown file that's the entire shared state.
+
+**Takeaway:** Continuity is a discipline, not a feature. sessionkit gives you the contract; the discipline is yours.
+
+If you take one thing from this post, take this: the round-trip between `/sessionkit:handoff` and `/sessionkit:pickup` is the most-overlooked compounding lever in the suite. Run `/handoff` after every PR, every decision, every scope change — delta mode keeps the cost near-zero. The next session starts with the goal restated, the task graph rebuilt, the gotchas surfaced. The first ten minutes of a fresh session stop being a tax.
+
+Forward pointer: the squadkit deep-dive picks up where this one leaves off — multi-agent coordination layered on top of the sessionkit substrate, with squadkit's `SessionStart` hook re-asserting role context whenever a session resumes via `/pickup`. Two kits, one continuity story.

--- a/site/src/content/posts/speckit-deep-dive.mdx
+++ b/site/src/content/posts/speckit-deep-dive.mdx
@@ -1,0 +1,213 @@
+---
+title: "Speckit: from one-liner to dispatchable epic"
+subtitle: "How the simple-vs-full classifier, four silent merge rules, and the epic:<slug> contract turn a vague idea into a labelled issue set the rest of the toolchain reads."
+kit: speckit
+date: 2026-05-03
+author: "smallorbit"
+readTime: 11
+tags: ["deep-dive", "workflow"]
+---
+
+Most "AI ticket writers" do one thing: take a prompt, emit one issue. That works until the prompt is `add tags to notes` — at which point a single ticket is wrong (the work spans four files), but four hand-written tickets are wronger (you'd file three docs tasks and forget the schema migration).
+
+`speckit` solves a smaller problem than "AI ticket writer". It interviews the idea, decides whether the result wants to be one issue or a labelled epic, silently merges over-decomposed fragments, and ends with a GitHub label that every other kit in the suite reads as a contract.
+
+This is what each of those decisions looks like up close.
+
+## Section 1 — The simple-vs-full classifier
+
+`speckit` ships four user-facing skills:
+
+- `/speckit:interview` — runs the structured interview standalone and emits a plan in plain Markdown.
+- `/speckit:spec` — the workhorse. Interviews you, builds a plan, files a GitHub epic plus child issues with consistent labels.
+- `/speckit:catalog` — bulk-converts pre-existing findings (a code review, a polishkit appraisal, a file of notes) into prioritised, labelled issues.
+- `/speckit:issue` — the quick path. Drafts and files a single issue from a one-line description, with duplicate detection.
+
+The interesting choice lives inside `/speckit:spec`. Before any interview begins, `/spec` does a quick codebase scan and classifies the request as **simple** or **full**. The simple-path heuristic is two AND-gated tests, taken straight from `plugins/speckit/skills/spec/SKILL.md`:
+
+- **Single conceptual change** — one cohesive behaviour, fix, or tweak. Not a bundle of independent changes hiding behind a shared theme.
+- **Single file, or tightly co-located files in one skill/module directory** — the work touches one file, or a small number of files inside one skill/module directory (e.g. `plugins/foo/skills/bar/*`).
+
+If both pass, you get the simple path: one lightweight interview round (1–3 questions), a single-task plan, and one standalone issue with no epic wiring at all. If either fails, you get the full path: the multi-round `speckit:interview` sub-skill, the silent consolidation pass (Section 2), and an epic plus child issues.
+
+**Takeaway:** The classifier is an opinion about cost. A trivial change inflated into a multi-task epic is overhead masquerading as planning. Skipping the inflation is the entire point of the simple path.
+
+The classifier narrates inline when it's confident. You'll see something like:
+
+```text
+This looks like a single-file, single-concept change — running simple path
+```
+
+It only fires an `AskUserQuestion` routing prompt when the heuristic is genuinely ambiguous — typically a single file containing multiple plausibly-independent concepts, or an input that under-specifies scope so file count is borderline.
+
+The plan-approval gate at the end of every run is also the escape hatch. A simple-path plan offers `Run full interview instead`. A full-path plan offers `Condense to single issue`. The classifier is doing first-cut routing, not committing you for the run.
+
+Here's a real simple-path invocation against a single skill file:
+
+```bash
+/speckit:spec drop the docs row from the tasks table when the plan is a pure refactor
+```
+
+The classifier sees one cohesive behaviour change and one file (`plugins/speckit/skills/interview/SKILL.md`). Both heuristic tests pass. It narrates the routing, runs one short `AskUserQuestion` round to tighten scope, and presents a one-task plan with the simple-path approval options:
+
+```text
+Approve this plan and file the issue?
+  [ Approve and file ] [ Run full interview instead ] [ Adjust ] [ Cancel ]
+```
+
+On approval, `/spec` hands the single task to `/speckit:catalog` with **no `--epic` flag**. One standalone issue is filed — no epic tracking issue, no sub-issue wiring, no auto-appended documentation task (docs fold into the single issue's acceptance criteria). The team-readiness assessment is skipped — single-issue plans are never team-suitable.
+
+A request like `add tags to notes`, by contrast, fails the simple-path test on both axes (multiple conceptual changes; multiple files). It falls through to the full path:
+
+```bash
+/speckit:spec add tags to notes
+```
+
+Five minutes of interview later, the result is an epic plus four children:
+
+```text
+Filed epic: #101 Epic: Add tags to notes             label: epic:tags-notes
+Filed children:
+  #102 Extend Note schema with tags field            priority:high   type:feature
+  #103 Add tag input to NoteEditor                   priority:high   type:feature
+  #104 Render tag chips on note cards                priority:medium type:feature
+  #105 Filter notes by tag from the sidebar          priority:medium type:feature
+```
+
+**Takeaway:** Use `/speckit:issue` when you already know exactly what to file. Use `/speckit:interview` to think out loud (no GitHub side-effects). Use `/speckit:spec` when you want the result to feed a swarm. Use `/speckit:catalog` when you have findings to bulk-load.
+
+## Section 2 — Consolidation signals
+
+The full-path interview ends with a candidate task table. Before the plan is presented for approval, `speckit:interview` runs a **silent consolidation pass** that merges over-decomposed tasks. The user sees only the consolidated result.
+
+The four merge signals, taken verbatim from `plugins/speckit/skills/interview/SKILL.md`:
+
+1. **Same file + same logical change** — both tasks touch only the same single file and address related changes to the same function, section, or config block.
+2. **Strict ordering, no standalone value** — one task cannot ship without the other and provides no independent acceptance criteria (e.g. "wire up the X added in task A").
+3. **Soft cap on epic size** — after applying signals 1 and 2, if the consolidated task count is still greater than 4, run a second merge pass under looser interpretations of signals 1 and 2. The cap is a prompt to re-examine, not a hard limit.
+4. **Docs-only tail merge** — if the auto-appended "Update documentation" task is the only remaining non-implementation task and the impl task(s) cover the same surface that docs would cover, fold docs into impl.
+
+Each signal is doing different work. Signal 1 catches duplication that snuck in because the interview asked separate questions about the same file. Signal 2 catches the "Add config option" / "Wire config option into handler" split that LLMs love to produce — the second task has no acceptance criteria the first doesn't already imply. Signal 3 is the over-decomposition safety valve. Signal 4 prevents the auto-appended docs row from looking like work when it's really just a checkbox on the impl row.
+
+**Takeaway:** Consolidation is silent because the user shouldn't have to understand the merge rules to get a clean plan. The rules exist so the approval surface stays small.
+
+When two tasks merge, the merge rules apply deterministically (also from the SKILL.md):
+
+- **Priority** — take the higher value (`high > medium > low`).
+- **Category** — take the higher-impact value (`bug > refactor > enhancement > test > docs`).
+- **Description** — preserve both originals as sub-bullets so no work item is lost.
+- **Dependencies** — remap: if task C depended on B, and A+B merged into A', then C now depends on A'.
+
+That dependency remap matters more than it sounds. It's why consolidation can be silent: downstream tasks don't develop dangling references when their predecessor disappears into a merge.
+
+A worked before/after, lifted from the canonical example in `plugins/speckit/skills/interview/SKILL.md`:
+
+```text
+BEFORE — three candidate tasks, signal 2 is about to fire on tasks 1 & 2
+
+| # | Title                                  | Depends On |
+|---|----------------------------------------|------------|
+| 1 | Add `autoRetry` config option          | —          |
+| 2 | Wire `autoRetry` into request handler  | 1          |
+| 3 | Add retry integration tests            | 2          |
+
+AFTER — tasks 1+2 merge; task 3 remaps to depend on the merged result
+
+| # | Title                                  | Depends On |
+|---|----------------------------------------|------------|
+| 1 | Add and wire `autoRetry` config option | —          |
+| 2 | Add retry integration tests            | 1          |
+```
+
+Task 2's "wire it up" framing was the giveaway: it has no standalone acceptance criteria and cannot ship without task 1. After the merge, the description preserves both originals as sub-bullets — nothing was thrown away — but the approval surface is one task shorter. Task 3's `Depends On` is automatically rewritten to point at the merged task.
+
+**Takeaway:** Tasks that legitimately stand alone — different files, different surfaces, independent acceptance criteria — are never forced together. Consolidation eliminates redundancy, not distinction.
+
+## Section 3 — Epic labels as a contract
+
+When the full-path plan ships, every issue carries the same `epic:<slug>` label. That label is the contract.
+
+The slug is derived from the working epic title using the rules in `plugins/speckit/README.md`:
+
+- Lowercase, kebab-case (words separated by single hyphens).
+- Strip filler words: `the`, `a`, `an`, `enhance`, `add`, `update`, `to`, `for`, `of`, `in`.
+- Cap the slug at 30 characters after the `epic:` prefix (the prefix doesn't count).
+
+So `Add dark mode support` becomes `epic:dark-mode-support`. `Update the CSV export pipeline` becomes `epic:csv-export-pipeline`. Filler is gone, length is bounded, and the original title is recoverable from the label's description (every `epic:<slug>` label is created with the description `Belongs to epic: <epic title>` and the shared color `#5319e7`).
+
+The slug is a proposal. Before any issues are filed, `/spec` shows the full plan with an editable line:
+
+```text
+Epic label: epic:dark-mode-support
+```
+
+You can rename it before approval. After approval, the slug is the **single source of truth** — it flows verbatim into both the catalog handoff (applied to every child issue) and the epic tracking issue (applied as a label on the parent).
+
+If the label already exists in the repo, `/spec` doesn't silently reuse it. It surfaces a warning and asks via `AskUserQuestion`:
+
+```text
+Label epic:dark-mode-support already exists in this repo.
+  [ Reuse existing label ] [ Pick a different slug ] [ Cancel ]
+```
+
+That gate is deliberate. The whole reason the label exists is so other kits can re-find the epic by name. Two epics sharing a slug would collapse them into a single filterable bucket — a silent failure that nothing downstream could detect.
+
+**Takeaway:** The slug is a public name in the repo's namespace. `speckit` treats it like one.
+
+Once filed, the label powers three workflows that nothing else has to coordinate.
+
+**Filter.** Every child of the epic is a single `gh` query away:
+
+```bash
+gh issue list -l epic:dark-mode-support --state open
+```
+
+That's the entire scope of the epic at a glance. It's also the query a code reviewer runs before opening a PR for any single child — you check what else is in flight under the same label, not what else is open in the repo.
+
+**Dispatch.** The same label is the swarmkit handshake. When you fan out the epic, you don't pass swarmkit a mental model of the work — you pass it the label:
+
+```bash
+/swarmkit:swarm 102 103 104 105
+```
+
+`/swarmkit:swarm` reads each issue, sees the shared `epic:dark-mode-support` label, and treats them as a coordinated stack rather than four unrelated jobs. The retargeting logic, the merge ordering, and the worktree provisioning all key off that shared label. Two days later, in a fresh session with no memory of the original interview, the swarm can still pick up the work — because the label survived the session boundary and the interview did not.
+
+**Release closing.** When `/flowkit:release` promotes the RC to `main`, it closes referenced issues by walking the merged commits and matching `Closes #N` footers. The epic tracking issue itself is filed with a child checklist (`#102`, `#103`, `#104`, `#105`); GitHub auto-closes the parent when every child closes. The `epic:<slug>` label becomes the post-release filter (`gh issue list -l epic:dark-mode-support --state closed`) that confirms the epic shipped clean. Nothing in the release flow needed to know what `dark-mode-support` meant — it just needed the label to be consistent.
+
+**Takeaway:** The contract is the label, not the interview. The interview's conclusions are gone the moment `/spec` returns; the labels carry forward.
+
+A worked end-to-end example, with all three workflows in play:
+
+```bash
+# Day 1 — plan and file
+/speckit:spec add dark mode support
+# (interview, four-task plan, approve, four children + epic filed under epic:dark-mode-support)
+
+# Day 2 — fresh session, swarm the children
+gh issue list -l epic:dark-mode-support --state open
+/swarmkit:swarm 102 103 104 105
+# (four agents, four stacked PRs, all retargeted to develop)
+
+# Day 3 — ship
+/flowkit:ship
+# (merge-stack → cut → release. Children close on merge; epic auto-closes when all children close.)
+
+# Confirm
+gh issue list -l epic:dark-mode-support --state closed
+```
+
+The label is the only thing each step had to agree on. There's no shared state file, no configuration, no in-memory plan being passed around. The interview happened on day 1; days 2 and 3 read the same label and acted on it independently.
+
+**Takeaway:** Designing the handshake as a GitHub label (instead of a project file or a database row) is what makes the kits compose. Every tool that speaks GitHub already speaks the contract.
+
+## Closing
+
+`speckit` isn't "Claude writes you tickets". It's a small set of decisions about when not to over-decompose (the simple-path classifier), when to merge fragments that look like separate tasks (the four consolidation signals), and how to preserve the result so the rest of the toolchain can act on it (the `epic:<slug>` contract). Each of those decisions exists because the alternative — over-fragmented backlogs, redundant tasks, ad-hoc planning state that dies with the session — is the failure mode that the kit is built to avoid.
+
+**Takeaway recap.**
+
+- The simple-vs-full classifier is an opinion about cost. Trivial work doesn't deserve an epic.
+- The four merge signals run silently because the user shouldn't have to learn them to get a clean plan.
+- The `epic:<slug>` label is the contract every other kit reads. The interview is gone; the label remains.
+
+If you've read the [pillar post](/blog/from-idea-to-release-with-smallorbit-plugins/), you've already seen the next move: the swarm. The same label `speckit` filed becomes the input that `swarmkit` fans out into stacked PRs. That's the next deep-dive — how `/swarmkit:swarm` turns one label into N agents and one merge-safe stack of PRs.

--- a/site/src/content/posts/squadkit-deep-dive.mdx
+++ b/site/src/content/posts/squadkit-deep-dive.mdx
@@ -1,0 +1,167 @@
+---
+title: "squadkit: roles, squads, and crews — multi-agent without the chaos"
+subtitle: "The vocabulary that makes teams legible, the orchestrator-is-lead pattern that avoids a redundant agent, and the detached-HEAD trick that keeps builders from stepping on each other."
+kit: squadkit
+date: 2026-05-03
+author: "smallorbit"
+readTime: 12
+tags: ["deep-dive", "workflow", "tips"]
+---
+
+"Multi-agent" usually means an undefined pile of agents. squadkit names the pile.
+
+The premise: when a single problem needs more than one role in the room — an architect to draft, a builder (or three) to implement, a reviewer to gate, a tester to back the verify — you don't want to re-decide who-does-what every time. You want a vocabulary, a roster shape, and a coordination protocol that's been thought through once and reused. squadkit is that.
+
+This post walks the three design choices that make squadkit work in practice: the **roles → squads → crews** vocabulary that keeps the model legible, the **orchestrator-is-lead** pattern that dodges a class of phantom-agent bugs (and ships with a cooperative-shutdown handshake), and the **per-builder detached-HEAD worktrees** that prevent the branch-ref contention you hit the moment two builders try to share a feature branch.
+
+Every claim below is cited from `plugins/squadkit/README.md`, `plugins/squadkit/skills/spawn-team/SKILL.md`, or `plugins/squadkit/agents/team-lead.md`. No invented behaviour.
+
+## The vocabulary, in one paragraph
+
+The coordination model is intentionally small. Three terms, exact definitions from the README:
+
+- **Role** — a single agent with a focused contract. One role definition, one agent. The shipped role library has seven contracts under `plugins/squadkit/agents/`: `team-lead`, `architect`, `builder`, `reviewer`, `tester`, `explorer`, `designer`. Each carries a fixed model assignment that matches its cognitive load — orchestration and review run on opus, implementation and craft run on sonnet.
+- **Squad** — a role-cohesive group of agents collaborating on one slice of work. Three implementers fanning out across files in the same feature, for example.
+- **Crew** — a team-lead orchestrating one or more squads end-to-end. The crew is the unit you spawn with `/squadkit:spawn-team` and ship with.
+
+**Takeaway:** Roles are reusable. Squads compose. Crews run. The vocabulary maps cleanly to how a real team is built — you don't reach for a "role" when you mean "team," and you don't reach for "team" when you mean "agent."
+
+The shipped crew profiles live in `plugins/squadkit/crews/` as YAML. Three starters:
+
+```yaml
+name: all-rounder
+description: Full-spectrum crew for end-to-end feature work.
+members:
+  - role: team-lead
+  - role: architect
+  - role: builder
+    count: 2
+  - role: reviewer
+  - role: tester
+  - role: explorer
+  - role: designer
+```
+
+Plus `design` (a `kind: discovery` crew of architect + designer + explorer for read-only research) and `qa` (team-lead, reviewer, tester, builder×1 for hardening sweeps). At spawn time you can override the roster with `--with <role>`, `--without <role>`, or `--builders <N>` (capped at 5).
+
+The two crew kinds split the world cleanly:
+
+- **`kind: execution`** (the default) — produces code. Provisions per-builder worktrees, supports `--epic` and `claude.flowkit.prBase` pinning, ships PRs.
+- **`kind: discovery`** — read-only investigative crew. Produces blueprints and GitHub issue comments, not code. Skips worktree provisioning, rejects `--epic`, skips `claude.flowkit.prBase` pinning. Requires `--brief`.
+
+That `kind:` field is doing more than a label's worth of work. The whole worktree-provisioning, epic-cutting, PR-pinning machinery is gated on it. A discovery crew goes through a strictly different pre-flight than an execution crew. The README puts it plainly: *"Discovery crews skip worktree provisioning, epic-branch cutting, and `claude.flowkit.prBase` pinning."*
+
+**Takeaway:** When you spawn a crew, its `kind:` is the most consequential decision in the YAML. Execution crews ship code on a `feature/<slug>-<issue>` branch cut from `develop`. Discovery crews stay on `develop` and produce comments. Two different machines, same vocabulary.
+
+## The orchestrator IS the team-lead
+
+This is the choice that earns squadkit's reliability. There are seven role contracts shipped — but `/squadkit:spawn-team` only spawns six of them. The team-lead is never spawned as a separate agent. The session that ran `/squadkit:spawn-team` IS the lead.
+
+The README states it directly:
+
+> The orchestrator (the session that ran `/squadkit:spawn-team`) IS the lead — squadkit never spawns a separate `team-lead` agent. The contract file is the operating manual that session loads.
+
+The `spawn-team` SKILL file expands on the rationale:
+
+> The skill never spawns a separate `squadkit:team-lead` agent and never reserves a `team-lead` slot via `TeamCreate({agent_type: ...})` — both produce phantom roster entries that break sender attribution and routing.
+
+**Takeaway:** Spawning a redundant team-lead agent is the obvious thing to do — and it's the bug. The roster ends up with a phantom slot, peer addressing breaks, and you spend a session debugging why messages aren't landing. Putting the lead inside the orchestrator removes the slot.
+
+Three concrete consequences flow from this choice:
+
+- **No `agent_type` on `TeamCreate`.** The skill calls `TeamCreate({team_name, description})` and stops. Passing `agent_type: "team-lead"` reserves a placeholder slot under that name with no live process behind it. When the actual member spawns later, the harness renames it to `<role>-2` because the slot is taken. The roster ends up with a ghost.
+- **Idle-notification-as-ack instead of ping/ack.** The orchestrator has no addressable name in the team's `members[]`, so members can't `SendMessage` it by name. Each spawned `Agent` emits an idle notification when its first turn ends; the orchestrator (always present) reads N idle notifications as proof the N members are alive. No explicit handshake required.
+- **Phantom-slot sanity check at spawn.** Right after `TeamCreate`, the skill scans for `members[]` entries with empty `tmuxPaneId`. If any are found, the skill halts and surfaces the phantom — never proceeds with a polluted roster.
+
+The `spawn-team` SKILL puts a probe step at 8.5 — after spawning members, before waiting on idle notifications, the orchestrator sends itself a sentinel `SendMessage` to a known-addressable target and asserts the harness's delivered digest matches what was sent. This catches the silent failure mode where the orchestrator spawned missing one of the coordination tools its role contract requires (`SendMessage`, `TaskCreate`, `TaskList`, `TaskGet`, `Agent`). That turns a multi-turn diagnostic loop into a single clear failure at spawn time.
+
+### Cooperative shutdown is part of the contract
+
+Tearing a team down is a two-step handshake, not a unilateral kill. From `plugins/squadkit/agents/team-lead.md`:
+
+> Teardown is a two-step handshake, not a unilateral kill. Before invoking `TeamDelete`, send a structured `shutdown_request` to every active member and wait for each to reply with `shutdown_response approve:true`. Only then call `TeamDelete`.
+
+The role contracts for architect, builder, designer, explorer, reviewer, and tester all instruct each member to reply with a structured `shutdown_response approve:true` before going idle. Without that approval, the harness leaves the iterm2 or tmux pane stranded — context and quota burn until the user manually closes the pane. A `TeamDelete` without prior approvals cleans the registry but does not terminate the underlying sessions.
+
+**Takeaway:** Cooperative shutdown turns "tear down the team" from a registry-only operation into a real lifecycle event. The handshake is what keeps stranded panes off your machine after a long session.
+
+The README adds an override caveat worth flagging: if you author a project-local overlay at `.claude/agents/<role>.md`, preserve the cooperative-shutdown section verbatim. Stripping it leaves the lead unable to tear the team down cleanly — the registry says "team gone" but the panes are still alive.
+
+## Per-builder detached-HEAD worktrees
+
+The third design choice is the one that hits you the moment a crew has more than one builder. Multi-builder configs (>1 builder) provision per-member worktrees under `.claude/worktrees/<member>/`. Each is created with `git worktree add --detach`. The `--detach` flag is non-negotiable.
+
+The reason is in `plugins/squadkit/skills/spawn-team/SKILL.md` step 7:
+
+> Step 6 already checks the main worktree out onto `${WORK_BRANCH}`. A bare `git worktree add <path> <work_branch>` would refuse with `'feature/<slug>-<N>' is already used by worktree at '<main>'` because git holds branch refs to a single worktree at a time. Detached HEAD lets each builder start at the epic HEAD without contention; builders create per-issue branches (e.g. `worktree-agent-<issue>`) off the detached commit when they pick up a task.
+
+That's the mechanism. The implication:
+
+**Takeaway:** Branch refs are exclusive in git. Two worktrees can't both be checked out on the same branch. Detached HEAD sidesteps the rule entirely — every builder starts at the same commit but holds no branch reference, so they can each create their own per-issue branch off that commit when they pick up a task.
+
+The flow is:
+
+```bash
+mkdir -p .claude/worktrees
+git worktree add --detach ".claude/worktrees/builder-1" "${WORK_BRANCH}"
+git worktree add --detach ".claude/worktrees/builder-2" "${WORK_BRANCH}"
+```
+
+Builders then create per-issue branches off the detached commit when they're dispatched a task — typically named `worktree-agent-<issue>` so they sort cleanly alongside swarmkit's branches.
+
+The kit also handles the messy real-world cases:
+
+- **Stale-worktree detection.** If `.claude/worktrees/builder-1` already exists on a non-matching branch from a prior session, `spawn-team` prompts (sweep / reuse / abort) before reusing. It refuses to silently inherit a half-merged feature branch from a previous team.
+- **Pre-flight sweep.** Before provisioning, the skill scans `.claude/worktrees/` for paths that don't match the resolved roster (e.g. `tester` survives but is no longer in scope) and invokes `swarmkit:clean-worktrees` to clear them.
+- **Env-file seeding.** After each per-builder worktree is created, the skill auto-detects the repo's gitignored env files (`.env.local`, `.env.test.local`, etc.) and copies them into the worktree. Builders can run the verify suite without manual setup. Override the auto-detection with `worktreeSeed` in `.squadkit/config.json` for projects that need non-env files copied too (certificates, config snippets).
+- **Singleton-builder profiles share the workspace.** When the resolved roster has exactly one builder, no worktree is created — the builder works in the main workspace. Saves a worktree when there's no concurrency to manage.
+
+**Takeaway:** The per-builder worktree model isn't about isolation for its own sake. It's about dodging a specific git failure mode (branch-ref contention) cleanly. The detached HEAD is the trick; everything else (seeding, sweep, stale detection) is the housekeeping that makes the trick safe across real working sessions.
+
+### Why the auto-isolation isn't enough
+
+The skill notes a harness constraint that explains the manual provisioning:
+
+> `Agent({isolation: "worktree"})` is unreliable when combined with `team_name`. The auto-isolation does not fire reliably for team-scoped spawns, so the skill always provisions worktrees manually via `git worktree add --detach` (see step 7) and passes the resolved absolute path into each spawned agent.
+
+The "do it yourself" path is more code but it's reliable. squadkit will switch to the harness primitive when it stabilises — but until then, the manual `git worktree add --detach` path is the one that ships.
+
+## How the three choices compose
+
+Run `/squadkit:spawn-team --profile all-rounder --epic notes-tags --issues 102-105` and the three design decisions stack visibly:
+
+```text
+Resolving team name → smallorbit-plugins-bravo
+Cutting feature/notes-tags-101 from origin/develop
+Pinning claude.flowkit.prBase = feature/notes-tags-101
+Provisioning .claude/worktrees/builder-1 (detached at feature/notes-tags-101)
+Provisioning .claude/worktrees/builder-2 (detached at feature/notes-tags-101)
+Seeded .env.local into both worktrees
+TeamCreate(team_name=smallorbit-plugins-bravo)        ← no agent_type
+Spawning architect, builder-1, builder-2, reviewer, tester, explorer, designer
+Probe → SendMessage to builder-1 [success, digests match]
+Waiting on 7 idle notifications…
+All members idle. Lead (this session) entering dispatch loop.
+```
+
+What you see:
+
+- **Vocabulary at work.** The crew profile is `all-rounder`. The roster is the resolved squad. The team name is `smallorbit-plugins-bravo` — the next available NATO phonetic letter under `~/.claude/teams/smallorbit-plugins-*`.
+- **Orchestrator-is-lead at work.** `TeamCreate` carries no `agent_type`. No team-lead spawn line. The probe at step 8.5 confirms the orchestrator's coordination tools work end-to-end before idle-notification readiness.
+- **Detached-HEAD worktrees at work.** Both builders are detached at the epic HEAD. Neither holds a branch reference. They're free to cut `worktree-agent-102` and `worktree-agent-103` off that commit when the lead dispatches them.
+
+The `SessionStart` hook (`plugins/squadkit/hooks/pickup-team-context.sh`) is the last piece. It fires on every Claude Code `SessionStart` event, scans `~/.claude/teams/*/config.json`, matches the current session by either the squadkit sibling file's `repo_root` (the orchestrator-is-lead path) or by member `cwd`, and emits a single `systemMessage` reminder telling the matched session to load its role contract from disk. Both fresh `spawn-team` leads and `sessionkit:pickup`-resumed leads hit the same hook — so resuming a team after a context reset re-asserts the role context automatically.
+
+## The narrow surface that earns the kit
+
+Squadkit ships three skills today: `init`, `spawn-team`, and `agent-team-retro`. That's it. No "team manager" UI, no orchestration framework, no DSL. The three design choices above carry the weight:
+
+- The vocabulary makes the kit legible — you can read a crew profile and predict what'll happen.
+- Orchestrator-is-lead removes a phantom-agent class of bug and the cooperative-shutdown handshake keeps panes from stranding.
+- Per-builder detached-HEAD worktrees dodge git's branch-ref exclusivity cleanly, with the housekeeping (seeding, sweep, stale detection) to make the dodge safe in practice.
+
+**Takeaway:** Multi-agent coordination doesn't have to be a framework. squadkit is three good decisions, three skills, seven role contracts, and a hook. The discipline lives in the contracts; the skills enforce them at spawn time.
+
+If you've felt the friction of running multiple agents in parallel — branch contention, stranded panes, lost messages — the squadkit pattern is worth a closer look. Read the role contracts under `plugins/squadkit/agents/`, run `/squadkit:init` to bootstrap your repo's verify and base-branch commands, and spawn an `all-rounder` against a real epic. The worst outcome is you learn what coordination overhead actually costs in your codebase.
+
+Forward pointer: the vaultkit deep-dive completes the trio. Where sessionkit handles continuity in the codebase and squadkit handles coordination across agents, vaultkit handles the layer above the code — durable capture into Obsidian, with birth-time preservation for the metadata Obsidian actually uses, and a thin `/jot` surface that makes capturing decisions friction-free.

--- a/site/src/content/posts/swarmkit-deep-dive.mdx
+++ b/site/src/content/posts/swarmkit-deep-dive.mdx
@@ -1,0 +1,173 @@
+---
+title: "swarmkit: stacked PRs, up-front retargeting, and a reviewer that knows when to stop"
+subtitle: "What it actually takes to run parallel agents on one repo without the merge step turning into a second job."
+kit: swarmkit
+date: 2026-05-03
+author: "smallorbit"
+readTime: 12
+tags: ["deep-dive", "workflow"]
+---
+
+"Spawn parallel agents" is the easy part. The hard part is the merge. swarmkit's design is mostly a list of unflattering things you discover the second you try to merge a stack the obvious way: GitHub auto-closes downstream PRs the moment a non-default base disappears, two agents touching the same file produce a `CONFLICTING` graph that nobody wants to debug at 6pm, and a generic "do another pass" reviewer agent will happily review the same PR forever if you let it.
+
+This post walks the three design decisions that came out of working those problems back. Each one is small. Together they're the difference between a swarm that ships and a swarm that you stop trusting after the second time it eats a Friday.
+
+## Up-front retargeting and the auto-close cascade
+
+If you've never hit it, the cascade looks like a platform bug. You have a clean three-PR stack. Root targets `develop`. The middle PR's base is the root's head branch. The leaf's base is the middle PR's head branch. You merge the root. GitHub deletes the root's branch. The middle PR's base branch no longer exists, GitHub interprets that as abandonment, and auto-closes it. The leaf, in turn, depended on the middle PR's branch — so it auto-closes too. You now have two closed PRs that were perfectly healthy thirty seconds ago, and the only way to recover is to re-open them, re-target, and re-push.
+
+**Takeaway:** Bottom-up merging is not the bug. The bug is doing it without telling GitHub first.
+
+`/swarmkit:merge-stack` does the obvious fix in a non-obvious place. *Before* the first merge runs, every non-root PR in a multi-PR chain is retargeted to the base branch:
+
+```bash
+gh pr edit <N> --base $BASE
+```
+
+Once a child's base is `develop` (or whatever `$BASE` is), deleting its predecessor's branch on merge no longer looks like abandonment. The auto-close cascade simply does not fire. From the merge-stack source:
+
+> Before any merge runs, every non-root PR in a multi-PR chain is retargeted to `$BASE`. This neutralizes GitHub's auto-close cascade: once a child's base is `$BASE`, deleting a predecessor's branch on merge no longer looks like abandonment.
+
+The same direction is used by Graphite, git-spice, Sapling, and Phabricator. It's the boring right answer that nobody reaches for because the broken way looks like it should work.
+
+A second piece falls out of doing it this way. Because every PR ends up targeting `$BASE` directly, every PR can merge with the same command:
+
+```bash
+gh pr merge <N> --squash --delete-branch
+```
+
+No per-role strategy matrix. No intermediate-branch sweep. `--delete-branch` handles cleanup inline. Each PR's body still closes its own `Closes #N` references natively as it merges, because the squash commit lands on the default branch and GitHub parses the keywords from the squash message.
+
+There is one gotcha that retargeting doesn't fix: between merges in a chain, every still-open downstream PR has its predecessor's commits in its history under the *old* (pre-squash) SHAs. `$BASE` now carries the same content under a *new* squash SHA. GitHub flags that as `DIRTY` even though the content overlap is benign. `gh pr update-branch` cannot fix it. The merge-stack flow handles it explicitly:
+
+```bash
+git fetch origin <head-branch> $BASE
+git checkout <head-branch>
+git rebase origin/$BASE
+git push --force-with-lease origin <head-branch>
+```
+
+`git rebase` uses patch-id matching to drop the already-applied commits — you'll see `warning: skipped previously applied commit <sha>` for each one, which is the happy path, not an error. Without this rebase, the next PR flips to `CONFLICTING` the moment its predecessor merges.
+
+**Takeaway:** Stacked PRs are not a stylistic choice. They're the only safe shape for parallel agents on a shared base, and the merge step has to retarget *and* rebase to keep the platform calm.
+
+## Loop mode, file overlap, and concurrency without coordination
+
+`/swarm` has two shapes. With explicit issue numbers it runs one-shot — fan out, open PRs, exit. With no arguments (or just a label filter) it runs in loop mode and clears the board until empty. Loop mode is where the concurrency primitives matter most, because there's no human in the loop to spot a foot-gun before it fires.
+
+The primitive is straightforward. From the swarm SKILL:
+
+- No two issues touch the same files.
+- No unresolved dependencies within the batch.
+
+Both checks happen before agents spawn. The dependency graph is built from GitHub's native `blockedBy` connection (the field `/spec` wires up) with a fallback to parsing `Depends on #N` / `Blocked by #N` from the body. The file-overlap check is a pre-flight read of the issue bodies and any code paths each one announces it'll touch. Anything that overlaps with another issue in the same batch is deferred to a future cycle.
+
+**Takeaway:** Concurrency safety in swarm-loop is enforced by *not letting two agents share a file in the same cycle*, not by hoping rebase semantics work.
+
+When something does fail mid-cycle, the failure handling is also explicit. Quoting the swarm flow:
+
+```text
+── Cycle N complete ──────────────────────────
+✓ PRs opened: #25 (→ #12), #26 (→ #15)
+✗ Failed: #14 (agent crash, no PR produced)
+⊘ Blocked: #20 (depends on #14)
+⧖ Remaining open issues: 5
+──────────────────────────────────────────────
+```
+
+If issue `#14` failed, every remaining issue in the current cycle and every future cycle gets checked for file overlap with `#14` or explicit references to it. Anything that overlaps is marked blocked and skipped, with the block reported at each checkpoint. Everything else proceeds.
+
+A small set of failures are unrecoverable and halt the loop immediately:
+
+- An agent crashed without producing a PR (nothing to review, so nothing to proceed from).
+- The base branch was deleted or corrupted externally (the premise of the loop is gone).
+
+Everything else is recoverable. There are no retries — re-running an agent that just failed gives you the same failure with a slightly different stack trace. The loop's job is to surface the failure cleanly and keep moving.
+
+One detail worth knowing: loop mode sets `claude.flowkit.prBase` as a local git config at the start, and unsets it in the teardown step. While it's set, every PR created in the repo targets that base — which is what keeps independent PRs from accidentally leaking onto whatever the previous session's pin was. The teardown unset is critical; leaving the config set would silently re-route subsequent unrelated `/open-pr` runs.
+
+**Takeaway:** The swarm loop is allowed to fail, but never silently. Every failure either becomes a checkpoint line, a blocked-issue annotation, or the unrecoverable-halt reason. There is no third option.
+
+## Designing /swarm-plus: the vendored reviewer and the single-pass rule
+
+`/swarm` opens PRs and stops. The review and any follow-up commits are manual. `/swarm-plus` layers an automatic review/fix pass on top of the same swarm machinery — same arg grammar, same isolation, same final state of open PRs awaiting human merge. The only addition: each PR gets one reviewer, and if the reviewer surfaces blockers or concerns, the original builder is re-engaged via `SendMessage` to push follow-up commits to the same branch.
+
+Three design decisions inside that small wrapper carry most of the weight.
+
+### 1. The reviewer is vendored.
+
+The `swarm-reviewer` agent lives at `plugins/swarmkit/agents/swarm-reviewer.md`, inside swarmkit itself, rather than imported from another plugin. This isn't a code-locality choice — it's a dependency choice. `/swarm-plus` carries no cross-marketplace dependency, which means it works against any repo that has swarmkit installed without surprise prompts to install something else. The reviewer is also purpose-built — not a general-purpose code-review agent, but specifically a reviewer that compares a swarm-produced PR against its originating issue's acceptance criteria. The narrower the role, the easier the contract.
+
+### 2. The output structure is fixed at five sections.
+
+The reviewer is required to return its findings inline (never via `gh pr comment`) in a fixed shape:
+
+```text
+Verdict: Approve / Request changes / Comment
+Blockers: <must fix>
+Concerns: <worth raising, not blocking>
+Nits: <style, optional>
+Coverage gaps: <each tagged [recommended] or [optional]>
+```
+
+That fixed shape is what makes the next decision possible — the orchestrator can parse the reviewer output deterministically and decide what (if anything) to send back to the builder.
+
+**Takeaway:** Free-form review prose is fine for humans. For an orchestrator that has to route findings back to a standby builder, the shape has to be pinned at design time.
+
+### 3. Single fix-pass discipline.
+
+Here is the rule, copied verbatim from the swarm-plus SKILL:
+
+> Single pass — no reviewer-after-fix re-review. The user can manually trigger another review with `/review <pr>` if desired.
+
+There is no second reviewer pass after the builder applies its fixes. Why not? Because the reviewer-after-fix loop has no natural stopping condition — every reviewer pass is allowed to find something to nit, and a builder that runs in response to nits will produce a new diff that the next reviewer can find something to nit on. The swarm-plus orchestrator deliberately refuses to dispatch a second pass. If you want one, you ask for it explicitly with `/review <pr>`.
+
+The same discipline shows up in the routing table. From the SKILL:
+
+| Reviewer output | Builder message |
+|-----------------|-----------------|
+| `Approve` AND no blockers AND no concerns AND no `[recommended]` coverage gaps | `"Approved. Terminate."` |
+| Any blockers | findings + scope |
+| Any concerns | findings + scope |
+| `[recommended]` coverage gaps | findings + scope |
+| `--review-only` flag set | `"Review-only run. Terminate."` |
+
+Nits and `[optional]` coverage gaps never trigger a worker. The bar to dispatch is meaningful enough to materially change the PR.
+
+The keep-alive architecture is the other interesting bit. Builders don't terminate after reporting their PR URL — they enter standby awaiting an orchestrator message. Why? Because the builder already has every relevant file loaded, the design rationale in working memory, and the issue acceptance criteria internalized. Re-engaging it via `SendMessage` saves an entire spawn-and-orient cycle per PR with non-clean review. The cost: peak agent concurrency roughly doubles during the review window — on a 5-PR run, up to 10 alive concurrently (5 builders in standby + 5 reviewers) instead of 5 sequential builders followed by 5 sequential reviewers. Acceptable for the latency win.
+
+There's a fallback path too. If the original builder is no longer alive (crashed at PR creation, or `verify_agent.sh` recovered the PR after the builder failed to push), the orchestrator falls back to the legacy spawn-fresh-worker path. `--worker-model` continues to apply on this fallback path only.
+
+**Takeaway:** `/swarm-plus` is `/swarm` plus exactly two ideas — one reviewer per PR, one fix-pass per non-clean verdict, and both ideas are bounded explicitly so the wrapper can't grow into a quality-engineering loop that runs forever.
+
+## Putting it together
+
+The shape of a swarmkit run, end to end:
+
+```bash
+/next-issue           # see what is ready to work on
+/swarm 12 15 18       # spawn parallel agents for specific issues
+                      # or `/swarm` with no args for loop mode
+/merge-stack          # retarget non-root PRs, merge bottom-up
+/clean-worktrees      # remove worktree directories and orphaned branches
+```
+
+Or, if you want every PR to land with at least one independent pass against its acceptance criteria:
+
+```bash
+/swarm-plus 12 15 18
+```
+
+Three things are doing the load-bearing work:
+
+- **Up-front retargeting** prevents GitHub's auto-close cascade. Bottom-up merging without it is a foot-gun; bottom-up merging *with* it is the same direction Graphite and Sapling use.
+- **File-overlap detection** is the concurrency primitive in loop mode. Two agents never share a file in the same cycle, and failures cascade explicitly into blocked-issue reports rather than silent retries.
+- **`/swarm-plus`'s single-pass discipline** keeps the review/fix layer bounded. One reviewer, one fix round if needed, no escalation.
+
+What `/swarm` is *not*: a code review. The per-agent `simplify-loop` runs internally before the PR opens, but it sees only the agent's own branch — never the union of all four PRs in a stack. That's polishkit's job, downstream.
+
+**Takeaway:** swarmkit's parallelism is enabled by three counterintuitive choices — stacked PRs (not topic branches), up-front retargeting (not last-minute), and a vendored reviewer with a hard single-pass rule (not a "do another pass" loop). The methodology document at `plugins/swarmkit/METHODOLOGY.md` walks through each in depth.
+
+After the stack is reviewed and you're ready, `/merge-stack` walks the chain root-to-leaf, squash-merging each PR and deleting the remote branch as it goes. If one PR fails review or merge mid-stack, the chain stops cleanly so you can fix and resume — and because retargeting happened up front, every still-open downstream PR already targets `develop`, so resuming is just a matter of fixing the conflict and re-running.
+
+For the shipping half — turning that merged develop into a tagged release — see the [flowkit deep-dive](/blog/flowkit-deep-dive). For the quality gate that sits between merge and ship, see the [polishkit deep-dive](/blog/polishkit-deep-dive).

--- a/site/src/content/posts/vaultkit-deep-dive.mdx
+++ b/site/src/content/posts/vaultkit-deep-dive.mdx
@@ -1,0 +1,191 @@
+---
+title: "vaultkit: an Obsidian sidekick that respects your timeline"
+subtitle: "Why birth-time preservation matters, when /handoff and /archive-export trade off, and what makes /jot the lowest-friction capture path."
+kit: vaultkit
+date: 2026-05-03
+author: "smallorbit"
+readTime: 10
+tags: ["deep-dive", "tips"]
+---
+
+Six kits in the suite ship code. vaultkit captures the things that don't fit in code.
+
+The premise is small and useful: an Obsidian vault is the right home for decisions, retros, archived conversations, project notes, and the long tail of context that doesn't belong in your repo. Your code's git history records *what* changed and *when*. Your vault records *why* you decided that, what alternatives you rejected, and what the room felt like when the decision was made. Different stores, different shapes, both worth preserving.
+
+vaultkit is the bridge. It runs alongside every other kit without coupling to any of them. This post walks the three vaultkit surfaces that earn their keep over a real working week: **birth-time preservation** (which sounds esoteric until the first time you watch Obsidian's `created` sort scramble itself), the trade-off between **`/handoff` and `/archive-export`** (structured state for the next agent vs browsable history for future-you), and **`/jot`** as the lowest-friction capture path.
+
+Every behaviour cited below resolves to real source under `plugins/vaultkit/`. No invented commands.
+
+## Birth-time preservation, and why it matters
+
+Obsidian's `created` field — the one dataview queries sort by, the one templates inject, the one plugins use to compute "last 7 days" — comes from the filesystem's birth time, not from the file's modification time. On macOS that's a real attribute (`stat -f %SB`), distinct from `mtime`, that gets set when the file's inode is born and is supposed to stay there forever.
+
+Claude's standard `Edit` and `Write` tools don't preserve it. They use a temp-file-rename strategy: write the new content to a temp file, rename it over the target. The rename gives you a fresh inode with a fresh birth time. The file looks the same to a human; to Obsidian's `created` field, it just got reborn this morning.
+
+`plugins/vaultkit/skills/file-edit/SKILL.md` is unambiguous about it:
+
+> Claude's `Edit` and `Write` tools use a temp-file-rename strategy on macOS that resets birth time — this sub-skill writes through a process that modifies the existing inode instead.
+>
+> Obsidian uses filesystem birth time for the `created` field in dataview queries, sort orders, and plugin behaviors. Every rename-based write corrupts that timeline.
+
+**Takeaway:** "Atomic rename" is great for crash safety. It's catastrophic for any program that reads filesystem birth time as a semantic field. Obsidian is one of them.
+
+The fix `vaultkit:file-edit` ships is straightforward — write through a process that modifies the existing inode rather than creating a new one. The happy path is three steps, and the third step is the entire trick:
+
+```bash
+cat > "$VAULT_PATH/path/to/file.md" <<'VAULTKIT_EOF'
+<full new file content here>
+VAULTKIT_EOF
+```
+
+Shell `>` redirect, `cat > file <<EOF`, `python3 open(p, "w")`, and `node fs.writeFileSync` all write in place on macOS. They modify the existing inode. Birth time is preserved. The verification one-liner from the SKILL file is worth memorising:
+
+```bash
+stat -f "Birth: %SB | %N" "$VAULT_PATH/path/to/file.md"
+```
+
+If the birth time matches what it was before the edit, you didn't reset it. If it changed, you used the wrong tool.
+
+There's a fallback for very large files where rewriting the whole thing is genuinely wasteful — capture the birth time first, do a targeted Edit, then `SetFile -d "$BIRTH"` to restore it:
+
+```bash
+BIRTH=$(stat -f "%SB" -t "%m/%d/%Y %H:%M:%S" "$VAULT_PATH/path/to/file.md")
+# ...use the Edit tool to apply the targeted change...
+SetFile -d "$BIRTH" "$VAULT_PATH/path/to/file.md"
+```
+
+But the SKILL file is explicit that this is the fallback, not the happy path: *"Prefer the in-place write above for anything typical. Reach for this fallback only when the file is large enough that reading and re-writing the whole thing is measurably expensive."*
+
+For new files, there's no prior birth time to preserve. The SKILL guidance is to use `Write` then immediately stamp the birth time:
+
+```bash
+SetFile -d "$(date '+%m/%d/%Y %H:%M:%S')" "$PATH"
+```
+
+That stamp is what makes `/archive-export`'s two-file output (`.txt` + `.md` companion) sort correctly in Obsidian's date-based views from the moment it lands.
+
+**Takeaway:** Every other vaultkit skill that touches a vault file routes through `vaultkit:file-edit`. That's the discipline that keeps your vault's timeline intact across thousands of agent-driven edits.
+
+A useful exception: `obsidian append` and `obsidian prepend` from the Obsidian CLI preserve metadata natively. The SKILL file calls this out — *"This does not apply to `obsidian append`/`obsidian prepend` CLI commands — those preserve metadata natively."* — so when you can append rather than rewrite, append.
+
+## /handoff vs /archive-export — different shapes, different homes
+
+Both move conversation context out of the live session into a durable store. They are not interchangeable. They produce different shapes for different consumers.
+
+`/sessionkit:handoff` writes structured state to `.sessionkit/HANDOFF.md` in your repo. Goal, progress, git state, remaining work, a JSON snapshot of the task graph, and the gotchas — formatted so the *next agent* can rehydrate the work. Read by `/sessionkit:pickup`. Lives next to the code, not in your vault.
+
+`/vaultkit:archive-export` is different. It picks up the full `/export session` output (the entire conversation transcript) and files it into the active Obsidian project's `Conversations/` folder. Read by *future-you* with Obsidian search — when you're trying to remember the context around a decision you made three weeks ago and the handoff is long gone.
+
+**Takeaway:** Handoff is for live work — alive context the next agent needs to act. Archive-export is for cold storage — finished sessions you might want to grep months later. Different shapes, different homes, both useful.
+
+The archive-export contract is strict in a useful way. From `plugins/vaultkit/skills/archive-export/SKILL.md`:
+
+> The user always runs `/export session` from the current working directory. This produces a consistent file:
+>
+> ```
+> ./session.txt
+> ```
+>
+> This skill creates two copies in the project's `Conversations/` folder: a `.txt` file (plain text, well-formatted when viewed natively) and a `.md` file (Obsidian-renderable, searchable) that embeds the `.txt` as an attachment and includes the session ID for resuming the conversation.
+
+Two copies, on purpose:
+
+- The **`.txt`** is the source of truth for content. Plain text, no markdown rendering noise, readable in any tool.
+- The **`.md`** is the Obsidian-native version. Embeds the `.txt` as an attachment via `![[basename.txt]]`, inlines the full transcript inside a `plaintext` fenced code block (so Obsidian's search index covers it), and carries a session ID line for resuming the conversation.
+
+The session ID line is the second-most-useful detail in the file. Claude Code stores per-session `.jsonl` files under `~/.claude/projects/<encoded-cwd>/` where `<encoded-cwd>` is `$PWD` with every `/` replaced by `-`. The most recent file's basename (minus `.jsonl`) is the active session UUID. Archive-export resolves it like this:
+
+```bash
+PROJECT_PATH=$(echo "$PWD" | sed 's|/|-|g')
+SESSION_ID=$(ls -t ~/.claude/projects/${PROJECT_PATH}/*.jsonl 2>/dev/null | head -1 | xargs basename -s .jsonl)
+```
+
+That UUID lands at the top of the `.md` companion as:
+
+```text
+session-id: <uuid>
+resume: claude --resume <uuid>
+```
+
+So six months later, when you're searching your vault for the conversation where you settled on CalVer for plugin versioning, you can copy-paste one line into a terminal and resume the exact session. The conversation isn't a dead artifact — it's a resumable thread.
+
+The filename convention is also strict: `YYYY-MM-DD-HHMM-<slug>` (no extension yet). Today's date, current hours and minutes, a 2–4-word slug derived from the session topic. Both `.txt` and `.md` share the base name and differ only in extension. The slug is what makes Obsidian's file-explorer view scannable — `2026-04-03-2314-backtest-snapshot-playbook-fix` tells you what the conversation was about at a glance.
+
+**Takeaway:** When the session is alive and the next agent needs to act, run `/sessionkit:handoff`. When the session is finishing and you want the conversation in a place you can search and resume from, run `/export session` then `/vaultkit:archive-export`. Most days, you'll do both.
+
+The README says it cleanly under "Pairing with Other Plugins":
+
+> Run `/handoff` to capture a session's state to `.sessionkit/HANDOFF.md`, then `/archive-export` to file the conversation export into the active project — the handoff lives on disk next to the code, the archive lives in Obsidian for long-term recall.
+
+Each kit owns one shape. Don't conflate them.
+
+## /jot — the lowest-friction capture path
+
+The temptation in any "capture decision" tooling is to ship a structured form: select the project, pick a category, fill in the rationale, choose alternatives considered. By the time the form loads you've forgotten what you were going to write.
+
+`/jot` is the opposite. From `plugins/vaultkit/skills/jot/SKILL.md`:
+
+```bash
+/jot decided to use CalVer for release tagging; rationale in plugin-release.md
+```
+
+That's the entire interface. One line, no flags, no form. The skill is described in its own SKILL file as *"Quick capture for the active Obsidian project. Delegates to the `vaultkit:project` skill — Operation 3 (Update Project Files)."* It's a thin entry point. The whole point is that there's nothing to think about before you write.
+
+The work `/jot` actually does, in order:
+
+1. Identify the active project from conversation context, or prompt if it's unclear.
+2. Read the relevant file before editing (so the next step doesn't blow away anything that's already there).
+3. Determine what changed — decisions, tasks, status, blockers — and pick the right section to append to.
+4. Write the edit in place via `vaultkit:file-edit` so Obsidian's `created` metadata is preserved.
+5. Keep the entry concise. Recall notes, not documentation.
+
+**Takeaway:** Friction is the enemy of capture. `/jot` removes every choice you don't strictly need — it infers the project, picks the section, writes in place, preserves metadata — so the only thing left for you to do is type the line.
+
+That fifth point is doing more than it looks. The README puts it bluntly:
+
+> Keeps entries concise — recall notes, not documentation.
+
+There's a real failure mode in note-taking tools where the system rewards long entries (more characters = more visible activity = more "thinking captured"). `/jot` rewards short, scannable entries. The notes are designed to be re-read in a hurry — six months from now, while you're trying to remember a decision — not as a permanent record.
+
+The composition with `vaultkit:file-edit` is what makes `/jot` safe to run constantly. Every jot is an in-place edit through the inode-preserving path. Birth time stays intact. Obsidian's `created` sort stays correct. Dataview queries that say "decisions captured this week" return the right files. You can run `/jot` thirty times in a session and the vault timeline stays clean.
+
+The composition with `/project` is what makes `/jot` smart about destination. The active project is inferred from conversation context — usually the one you've been working on for the past ten turns — or you're prompted to pick one. You don't have to remember the project's path or filename. You just type the note.
+
+A typical workday rhythm:
+
+```text
+/jot decided architect-led discovery for the 771 epic, rationale below
+/jot blocker — sessionkit-deep-dive can't cite SessionStart hook source until …
+/jot done — three deep-dive posts shipped, PR #842
+```
+
+Three jots, one minute total, three durable entries in the project file. Compare to "open Obsidian, find the project, pick the section, type the note, save, switch back" and the difference per capture is the difference between capturing and not.
+
+**Takeaway:** Capture isn't about the rich form. It's about the latency between deciding to write something and the cursor being in the right place. `/jot` collapses that latency to zero.
+
+## How the three surfaces fit together
+
+vaultkit's design is intentionally narrow. Four user-facing skills (`obsidian`, `jot`, `archive-export`, `project`) and three sub-skills (`load-project`, `list-projects`, `file-edit`). Everything composes on `vaultkit:file-edit` so the birth-time discipline holds without having to think about it at the call site.
+
+A real session ties all three surfaces together:
+
+- You start with `/load-project smallorbit-plugins` to pull the project notes into context. (Sub-skill `vaultkit:list-projects` runs first if you didn't pass a name, and recommends one based on the conversation.)
+- Mid-session, decisions land via `/jot` — concise lines into the project file, written in place via `vaultkit:file-edit` so the timeline stays clean.
+- At end-of-session, `/export session` writes `./session.txt` in the cwd, and `/vaultkit:archive-export` files both `.txt` and `.md` copies into the project's `Conversations/` folder, with the session ID embedded so the conversation is resumable later.
+- In parallel, `/sessionkit:handoff` writes the structured state into `.sessionkit/HANDOFF.md` next to the code so the next agent can pick up the work.
+
+Two stores, two shapes, no overlap. The vault holds long-term recall. The repo holds short-term continuity. Each one is the right tool for its window.
+
+**Takeaway:** vaultkit's narrow surface is the feature. It is the only kit in the suite that lives outside the development loop — it doesn't ship code, doesn't gate quality, doesn't open PRs. It captures and archives. The narrow scope is what lets it run alongside every other kit without coupling.
+
+## Putting it together
+
+The vaultkit story in three lines:
+
+- **Birth-time preservation** is the foundation. Obsidian's `created` field comes from filesystem birth time; standard atomic-rename writes corrupt it; `vaultkit:file-edit` writes through paths that modify the existing inode (`cat > file <<EOF`, `python3 open(p, "w")`, `obsidian append`/`prepend`) so birth time stays intact across thousands of agent edits.
+- **`/handoff` vs `/archive-export`** is a deliberate split. Handoff writes structured state for the next agent to act on, lives next to the code, is read by `/sessionkit:pickup`. Archive-export writes a conversation transcript (with session ID embedded for resumption) into the vault's `Conversations/` folder for future-you to grep. Different consumers, different homes.
+- **`/jot` is the friction-free capture path.** One line, no form, infers the project from conversation context, writes in place via `vaultkit:file-edit`, keeps entries concise. The latency between "I want to capture this" and "it's captured" is zero, which is the only latency that matters for capture tooling.
+
+If you take one thing from this post: birth-time preservation is the kind of detail you don't notice until something breaks, and then you notice it constantly. Once you've watched Obsidian's `created` sort scramble itself after a hundred Claude-driven edits, the entire premise of `vaultkit:file-edit` becomes obvious. Use it for every vault edit. Let the rest of the kit compose on top.
+
+Forward pointer: this post closes the continuity-kits trio. The sessionkit deep-dive covers the round-trip between handoff and pickup that keeps work alive across context resets. The squadkit deep-dive covers the multi-agent coordination layer with its orchestrator-is-lead pattern and per-builder detached-HEAD worktrees. vaultkit covers the durable-capture layer above all of it. Three kits, one continuity story, no overlap in scope — which is exactly the design discipline the suite is built around.


### PR DESCRIPTION
## Summary

Ships the inaugural blog content wave under `site/src/content/posts/`: a long-form pillar post tracing the idea→release loop and seven kit deep-dives (speckit, swarmkit, polishkit, flowkit, sessionkit, squadkit, vaultkit). Also tidies the workspace by gitignoring `.squadkit/` runtime artifacts to match the existing `.sessionkit/` pattern.

## Release summary

**Built from**: `rc/2026-05-03.5`

### Release notes

**site / blog content**
- docs(blog): add pillar post — from idea to release (~3,900 words; introduces the seven-kit ecosystem)
- docs(blog): add speckit deep-dive (simple-vs-full classifier, four consolidation signals, epic-label contract)
- docs(blog): add execution kits deep-dives — swarmkit, polishkit, flowkit (up-front retargeting, appraise weights, runtime staging detection)
- docs(blog): add continuity kits deep-dives — sessionkit, squadkit, vaultkit (HANDOFF.md anatomy, orchestrator-is-lead, birth-time preservation)

**chore**
- chore: ignore `.squadkit/` runtime artifacts

Closes #766
Closes #767
Closes #770
Closes #771