### PR TITLE
fix(flowkit:release): make RC-cleanup loop diagnostic and prune-aware

### DIFF
--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -369,14 +369,20 @@ EXPLICITLY_CLOSED=$(sort -u "$CLOSED_ISSUES_FILE" 2>/dev/null); rm -f "$CLOSED_I
 
 ### 10. Clean up RC branches for today
 
+The primary RC remote-branch cleanup happens in step 6 via `gh pr merge --delete-branch`, which removes the RC branch as part of the merge. This step is a safety net for RC branches that were ever created but never PR'd, or whose PR was closed without merging — in the happy path it should find nothing to delete. The leading `git fetch --prune` keeps local remote-tracking refs in sync with what step 6 already cleaned up so `git branch -a` stops listing the merged RC.
+
 ```bash
 TODAY=$(date +%Y-%m-%d)
-git ls-remote --heads origin "rc/$TODAY*" \
-  | awk '{print $2}' \
-  | sed 's|refs/heads/||' \
-  | while read rc; do
-      git push origin --delete "$rc" 2>/dev/null || true
-    done
+git fetch --prune origin
+RC_BRANCHES=$(git ls-remote --heads origin "rc/$TODAY*" | awk '{print $2}' | sed 's|refs/heads/||')
+if [ -z "$RC_BRANCHES" ]; then
+  echo "No RC branches matching rc/$TODAY* on origin (already cleaned by --delete-branch)"
+else
+  echo "$RC_BRANCHES" | while read rc; do
+    echo "Deleting orphan RC branch: $rc"
+    git push origin --delete "$rc"
+  done
+fi
 ```
 
 ### 11. Back-merge main into develop


### PR DESCRIPTION
## Summary

Step 10 of `flowkit:release` ran a silent loop that swallowed both stderr and the empty-set case, masking whether the cleanup had nothing to do or was failing. In a real release run (vorbis-player, RC `rc/2026-05-03.1`) the loop emitted no output, and the merged RC branch remained listed under `git branch -a` until a separate `git fetch --prune`.

This change keeps step 10 as a safety net (it still catches RC branches that were ever created but never PR'd, or whose PR closed without merging), but makes its outcomes observable.

## Changes

- `plugins/flowkit/skills/release/SKILL.md` (step 10):
  - Add `git fetch --prune origin` at the top so local remote-tracking refs reflect what `gh pr merge --delete-branch` already cleaned up in step 6.
  - Branch on whether `git ls-remote` returned anything: emit `No RC branches matching rc/$TODAY* on origin (already cleaned by --delete-branch)` for the empty case, `Deleting orphan RC branch: $rc` per branch otherwise.
  - Drop `2>/dev/null || true` from `git push origin --delete` so real errors surface.
  - Add narrative noting that `gh pr merge --delete-branch` is the primary cleanup path and step 10 is the safety net.

## Test plan

- [ ] Next release run: confirm step 10 prints the "No RC branches matching ..." line in the happy path.
- [ ] After release, `git branch -a` no longer lists the merged `origin/rc/$TODAY.*` branch (prune happened in-step).
- [ ] If an orphan RC remains intentionally (e.g. abandoned RC), step 10 deletes it and prints `Deleting orphan RC branch: ...`.

Closes #802