### PR TITLE
fix(swarmkit): anchor bookkeeping scripts to repo root

### DIFF
--- a/plugins/swarmkit/skills/clean-worktrees/scripts/gather.sh
+++ b/plugins/swarmkit/skills/clean-worktrees/scripts/gather.sh
@@ -10,6 +10,12 @@ set -euo pipefail
 #   {caller_branch, main_worktree, worktrees_to_remove: [{path}], branches_to_delete: [string], stuck: [{path, branch}]}
 # On failure: non-zero exit, empty stdout, human-readable message on stderr.
 
+# Anchor to the main repo root. The harness can drop the operator's shell into
+# an agent worktree after a swarm; without this anchor `git branch
+# --show-current` would report the agent's branch as caller_branch and the
+# downstream `git checkout <caller_branch>` would fail.
+cd "$(git rev-parse --path-format=absolute --git-common-dir | xargs dirname)" || exit 1
+
 for cmd in git jq; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "gather: required dependency '$cmd' not found on PATH" >&2

--- a/plugins/swarmkit/skills/clean-worktrees/scripts/gather.sh
+++ b/plugins/swarmkit/skills/clean-worktrees/scripts/gather.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 # an agent worktree after a swarm; without this anchor `git branch
 # --show-current` would report the agent's branch as caller_branch and the
 # downstream `git checkout <caller_branch>` would fail.
-cd "$(git rev-parse --path-format=absolute --git-common-dir | xargs dirname)" || exit 1
+cd "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")" || exit 1
 
 for cmd in git jq; do
   if ! command -v "$cmd" >/dev/null 2>&1; then

--- a/plugins/swarmkit/skills/clean-worktrees/scripts/test.sh
+++ b/plugins/swarmkit/skills/clean-worktrees/scripts/test.sh
@@ -222,6 +222,46 @@ else
   fi
 fi
 
+# gather.sh — caller_branch anchor test (regression for #844).
+# Run gather.sh with CWD inside an agent worktree on a different branch and
+# verify that caller_branch reflects the main worktree's checked-out branch,
+# not the agent worktree's. Without the repo-root anchor in gather.sh, this
+# would silently return the agent's branch.
+echo "  [gather.sh anchor-from-agent-cwd] setting up scratch repo..."
+SCRATCH3_DIR="$(mktemp -d)"
+cleanup_scratch3() { rm -rf "$SCRATCH3_DIR"; }
+trap cleanup_scratch3 EXIT
+
+MAIN3_REPO="$SCRATCH3_DIR/main"
+git init -q -b main-branch "$MAIN3_REPO"
+git -C "$MAIN3_REPO" commit -q --allow-empty -m "init"
+
+git -C "$MAIN3_REPO" branch worktree-agent-810
+AGENT3_WT="$SCRATCH3_DIR/main/.claude/worktrees/agent-d41eff07445c39395"
+mkdir -p "$(dirname "$AGENT3_WT")"
+git -C "$MAIN3_REPO" worktree add -q "$AGENT3_WT" worktree-agent-810
+
+# Run gather.sh from inside the agent worktree CWD. The anchor in gather.sh
+# should redirect git operations to the main repo before reading the branch.
+GATHER3_OUT="$(cd "$AGENT3_WT" && bash "$SCRIPT_DIR/gather.sh" 2>/tmp/gather3_stderr)"
+GATHER3_RC=$?
+
+if [[ $GATHER3_RC -ne 0 ]]; then
+  red   "  FAIL [gather.sh anchor-from-agent-cwd]: gather.sh exited $GATHER3_RC"
+  sed 's/^/         stderr: /' /tmp/gather3_stderr || true
+  FAIL=$((FAIL + 1))
+else
+  CALLER_BRANCH="$(printf '%s' "$GATHER3_OUT" | jq -r '.caller_branch')"
+  if [[ "$CALLER_BRANCH" == "main-branch" ]]; then
+    green "  PASS [gather.sh anchor-from-agent-cwd]: caller_branch=main-branch (anchor held)"
+    PASS=$((PASS + 1))
+  else
+    red   "  FAIL [gather.sh anchor-from-agent-cwd]: expected caller_branch=main-branch, got '$CALLER_BRANCH'"
+    printf '%s\n' "$GATHER3_OUT" | jq . | sed 's/^/         /'
+    FAIL=$((FAIL + 1))
+  fi
+fi
+
 echo
 echo "clean-worktrees: ${PASS} passed, ${FAIL} failed"
 [[ $FAIL -eq 0 ]] || exit 1

--- a/plugins/swarmkit/skills/swarm/scripts/preflight.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/preflight.sh
@@ -11,6 +11,11 @@ set -euo pipefail
 #   {base, base_existed, base_created, gh_authenticated, repo}
 # On failure: non-zero exit, empty stdout, human-readable message on stderr.
 
+# Anchor to the main repo root. The harness can drop the operator's shell into
+# an agent worktree between swarm runs; `git config --local` would otherwise
+# write to the wrong worktree's config.
+cd "$(git rev-parse --path-format=absolute --git-common-dir | xargs dirname)" || exit 1
+
 BASE="develop"
 SCOPE_PR_BASE=0
 

--- a/plugins/swarmkit/skills/swarm/scripts/preflight.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/preflight.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 # Anchor to the main repo root. The harness can drop the operator's shell into
 # an agent worktree between swarm runs; `git config --local` would otherwise
 # write to the wrong worktree's config.
-cd "$(git rev-parse --path-format=absolute --git-common-dir | xargs dirname)" || exit 1
+cd "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")" || exit 1
 
 BASE="develop"
 SCOPE_PR_BASE=0

--- a/plugins/swarmkit/skills/swarm/scripts/teardown.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/teardown.sh
@@ -11,6 +11,11 @@ set -euo pipefail
 #   {base, base_restored, config_unset}
 # On failure: non-zero exit, empty stdout, human-readable message on stderr.
 
+# Anchor to the main repo root. The harness can drop the operator's shell into
+# an agent worktree after a swarm; `git checkout <base>` then fails because
+# `<base>` is already checked out in the main worktree.
+cd "$(git rev-parse --path-format=absolute --git-common-dir | xargs dirname)" || exit 1
+
 BASE="develop"
 
 while [[ $# -gt 0 ]]; do

--- a/plugins/swarmkit/skills/swarm/scripts/teardown.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/teardown.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 # Anchor to the main repo root. The harness can drop the operator's shell into
 # an agent worktree after a swarm; `git checkout <base>` then fails because
 # `<base>` is already checked out in the main worktree.
-cd "$(git rev-parse --path-format=absolute --git-common-dir | xargs dirname)" || exit 1
+cd "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")" || exit 1
 
 BASE="develop"
 

--- a/plugins/swarmkit/skills/swarm/scripts/verify_agent.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/verify_agent.sh
@@ -11,6 +11,11 @@ set -euo pipefail
 #   {issue, branch, branch_pushed, pushed_now, pr_exists, pr_url, pr_base}
 # On failure: non-zero exit, empty stdout, human-readable message on stderr.
 
+# Anchor to the main repo root. The harness can drop the operator's shell into
+# an agent worktree after a swarm; bookkeeping operations must run from the
+# main worktree, not whichever worktree happens to be CWD.
+cd "$(git rev-parse --path-format=absolute --git-common-dir | xargs dirname)" || exit 1
+
 if [[ $# -ne 1 ]]; then
   echo "verify_agent: exactly one argument required: <issue-number>" >&2
   exit 2

--- a/plugins/swarmkit/skills/swarm/scripts/verify_agent.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/verify_agent.sh
@@ -14,7 +14,7 @@ set -euo pipefail
 # Anchor to the main repo root. The harness can drop the operator's shell into
 # an agent worktree after a swarm; bookkeeping operations must run from the
 # main worktree, not whichever worktree happens to be CWD.
-cd "$(git rev-parse --path-format=absolute --git-common-dir | xargs dirname)" || exit 1
+cd "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")" || exit 1
 
 if [[ $# -ne 1 ]]; then
   echo "verify_agent: exactly one argument required: <issue-number>" >&2


### PR DESCRIPTION
## Summary
- After a swarm run, the harness's task-notification handoff drops the operator's shell into the agent's worktree. Bookkeeping scripts that assume CWD == main repo then read the wrong branch (e.g. `gather.sh` reports the agent's branch as `caller_branch`) and downstream `git checkout develop` fails with "develop is already used by worktree at ...".
- Anchor every CWD-sensitive bookkeeping script to the main repo root before any git/gh work, using a single inline snippet.

## Changes
- `plugins/swarmkit/skills/clean-worktrees/scripts/gather.sh` — anchor before `git branch --show-current` so `caller_branch` is always the operator's pre-swarm branch.
- `plugins/swarmkit/skills/swarm/scripts/verify_agent.sh` — anchor before fetch/push/`gh pr list` so the verify step always operates against the main repo.
- `plugins/swarmkit/skills/swarm/scripts/preflight.sh` — anchor before `git config --local` and base-branch creation.
- `plugins/swarmkit/skills/swarm/scripts/teardown.sh` — anchor before `git checkout <base>` and `git config --local --unset`, the exact failure mode described in #844.

The snippet is inlined per `plugins/_shared/script-authoring.md`, which states "There is no `_shared/scripts/` directory. Each skill owns its scripts." Scripts that are already CWD-agnostic (`gather_issues.sh`, `clean-remote-worktrees/*`, `clean-worktrees/remove.sh` which already cd's to `\$MAIN_WORKTREE`) are left alone.

## Test plan
- `bash -n` clean on all four modified scripts.
- Ran `gather.sh` from inside an agent worktree's `scripts/` subdirectory; it correctly reported `caller_branch` as the operator's main-repo branch and `main_worktree` as the operator's repo root.
- Existing smoke tests pass: `bash plugins/swarmkit/skills/clean-worktrees/scripts/test.sh` (7/7) and `bash plugins/swarmkit/skills/swarm/scripts/test.sh` (12/12).

Closes #844