### PR TITLE
feat(site): add Kits link to TopNav and Kits index page

### DIFF
--- a/site/src/components/nav/TopNav.astro
+++ b/site/src/components/nav/TopNav.astro
@@ -25,6 +25,13 @@ const githubRepoUrl = 'https://github.com/smallorbit/smallorbit-plugins';
         Blog
       </a>
       <a
+        href={`${baseHref}kits/`}
+        class:list={[{ 'is-active': active === 'kits' }]}
+        aria-current={active === 'kits' ? 'page' : undefined}
+      >
+        Kits
+      </a>
+      <a
         href={`${baseHref}about/`}
         class:list={[{ 'is-active': active === 'about' }]}
         aria-current={active === 'about' ? 'page' : undefined}

--- a/site/src/pages/kits/index.astro
+++ b/site/src/pages/kits/index.astro
@@ -1,0 +1,12 @@
+---
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import KitGrid from '../../components/landing/KitGrid.astro';
+---
+
+<BaseLayout
+  title="Kits · smallorbit-plugins"
+  description="Browse the smallorbit-plugins kit catalog — one card per kit with the commands you'll reach for."
+  active="kits"
+>
+  <KitGrid />
+</BaseLayout>


### PR DESCRIPTION
## Summary

- Add a `Kits` anchor to `TopNav.astro` between Blog and About, mirroring the existing `is-active` / `aria-current="page"` wiring so the `active="kits"` prop already passed by `/kits/<slug>/` pages now produces a visible indicator.
- Add `site/src/pages/kits/index.astro` — a one-card-per-kit landing page that reuses the existing `KitGrid` component, rendered through `BaseLayout` with `active="kits"`.

## Changes

- `site/src/components/nav/TopNav.astro`: insert `<a href={`${baseHref}kits/`}>Kits</a>` between Blog and About with the same active-link wiring.
- `site/src/pages/kits/index.astro`: new page rendering `KitGrid` inside `BaseLayout` with title/description and `active="kits"`. No new component extraction — reuses `KitGrid` as-is.

## Test plan

- [x] `cd site && npx astro check` → 0 errors / 0 warnings / 0 hints.
- [x] `cd site && npm run build` → 22 pages built; `/kits/index.html` emitted.
- [x] Spot-checked generated `dist/kits/index.html`: contains `<a href="/smallorbit-plugins/kits/" class="is-active" aria-current="page">` in the nav, plus all 7 kit cards (`speckit`, `swarmkit`, `polishkit`, `flowkit`, `sessionkit`, `squadkit`, `vaultkit`) rendered with names, roles, descriptions, and command chips.
- [ ] Manual visual check after deploy: `/kits/` shows the grid with Kits indicated; clicking through to `/kits/speckit/` keeps Kits active.

Closes #827