### PR TITLE
refactor(site): extract shared stripExt helper

### DIFF
--- a/site/src/components/landing/KitGrid.astro
+++ b/site/src/components/landing/KitGrid.astro
@@ -1,5 +1,6 @@
 ---
 import { getCollection, type CollectionEntry } from 'astro:content';
+import { stripExt } from '../../lib/slug';
 
 type KitEntry = CollectionEntry<'kits'>;
 
@@ -16,8 +17,6 @@ const KIT_ORDER = [
   'squadkit',
   'vaultkit',
 ];
-
-const stripExt = (id: string): string => id.replace(/\.(md|mdx)$/, '');
 
 const orderIndex = (id: string): number => {
   const idx = KIT_ORDER.indexOf(stripExt(id));

--- a/site/src/layouts/PostLayout.astro
+++ b/site/src/layouts/PostLayout.astro
@@ -5,6 +5,7 @@ import Byline from '../components/post/Byline.astro';
 import AudioPlayer from '../components/post/AudioPlayer.astro';
 import InlineSubscribe from '../components/post/InlineSubscribe.astro';
 import TocTicks from '../components/post/TocTicks.astro';
+import { stripExt } from '../lib/slug';
 import '../styles/article.css';
 
 interface Props {
@@ -21,7 +22,7 @@ const siteOrigin = Astro.site?.toString().replace(/\/$/, '') ?? 'https://smallor
 const baseHref = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
   : `${import.meta.env.BASE_URL}/`;
-const postSlug = entry.id.replace(/\.(md|mdx)$/, '');
+const postSlug = stripExt(entry.id);
 const generatedOgImage = `${siteOrigin}${baseHref}og/${postSlug}.png`;
 const resolvedOgImage = ogImage ?? generatedOgImage;
 ---

--- a/site/src/lib/slug.ts
+++ b/site/src/lib/slug.ts
@@ -1,0 +1,9 @@
+/**
+ * Astro 5's legacy `type: 'content'` collections preserve the file extension
+ * on `entry.id` (e.g. `flowkit.md`, not `flowkit`). Routes and links derived
+ * from `entry.id` must strip it. The new content layer behaves differently;
+ * if this project migrates, this helper becomes a no-op or is removed.
+ */
+export function stripExt(id: string): string {
+  return id.replace(/\.(md|mdx)$/, '');
+}

--- a/site/src/pages/blog/[...slug].astro
+++ b/site/src/pages/blog/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, type CollectionEntry } from 'astro:content';
 import PostLayout from '../../layouts/PostLayout.astro';
+import { stripExt } from '../../lib/slug';
 
 export async function getStaticPaths() {
   const entries = await getCollection('posts', ({ data }: CollectionEntry<'posts'>) => {
@@ -8,7 +9,7 @@ export async function getStaticPaths() {
   });
 
   return entries.map((entry: CollectionEntry<'posts'>) => ({
-    params: { slug: entry.id.replace(/\.(md|mdx)$/, '') },
+    params: { slug: stripExt(entry.id) },
     props: { entry },
   }));
 }

--- a/site/src/pages/blog/index.astro
+++ b/site/src/pages/blog/index.astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, type CollectionEntry } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import { stripExt } from '../../lib/slug';
 
 type PostEntry = CollectionEntry<'posts'>;
 
@@ -21,8 +22,6 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   month: 'short',
   day: 'numeric',
 });
-
-const slugFor = (id: string): string => id.replace(/\.(md|mdx)$/, '');
 
 const accentFor = (kit: string | undefined): string =>
   kit ? `var(--${kit}, var(--color-accent))` : 'var(--color-accent)';
@@ -52,7 +51,7 @@ const accentFor = (kit: string | undefined): string =>
               class="post-card"
               style={`--post-accent: ${accentFor(post.data.kit)};`}
             >
-              <a class="post-card__link" href={`${baseHref}blog/${slugFor(post.id)}/`}>
+              <a class="post-card__link" href={`${baseHref}blog/${stripExt(post.id)}/`}>
                 <div class="post-card__meta">
                   <time datetime={post.data.date.toISOString()}>
                     {dateFormatter.format(post.data.date)}

--- a/site/src/pages/kits/[...slug].astro
+++ b/site/src/pages/kits/[...slug].astro
@@ -1,6 +1,7 @@
 ---
 import { getCollection, type CollectionEntry } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
+import { stripExt } from '../../lib/slug';
 
 type KitEntry = CollectionEntry<'kits'>;
 type PostEntry = CollectionEntry<'posts'>;
@@ -14,8 +15,6 @@ export async function getStaticPaths() {
   const allPosts = await getCollection('posts', ({ data }: PostEntry) => {
     return !data.draft || import.meta.env.DEV;
   });
-
-  const stripExt = (id: string): string => id.replace(/\.(md|mdx)$/, '');
 
   return kits.map((kit: KitEntry) => {
     const kitSlug = stripExt(kit.id);
@@ -38,7 +37,7 @@ interface Props {
 }
 
 const { kit, posts } = Astro.props;
-const kitSlug = kit.id.replace(/\.(md|mdx)$/, '');
+const kitSlug = stripExt(kit.id);
 
 const dateFormatter = new Intl.DateTimeFormat('en-US', {
   year: 'numeric',
@@ -46,7 +45,6 @@ const dateFormatter = new Intl.DateTimeFormat('en-US', {
   day: 'numeric',
 });
 
-const slugFor = (id: string): string => id.replace(/\.(md|mdx)$/, '');
 ---
 
 <BaseLayout
@@ -105,7 +103,7 @@ const slugFor = (id: string): string => id.replace(/\.(md|mdx)$/, '');
           <ul class="kit-page__post-list">
             {posts.map((post) => (
               <li class="kit-post">
-                <a class="kit-post__link" href={`${baseHref}blog/${slugFor(post.id)}/`}>
+                <a class="kit-post__link" href={`${baseHref}blog/${stripExt(post.id)}/`}>
                   <span class="kit-post__date">
                     {dateFormatter.format(post.data.date)}
                   </span>

--- a/site/src/pages/og/[...slug].png.ts
+++ b/site/src/pages/og/[...slug].png.ts
@@ -1,5 +1,6 @@
 import { getCollection } from 'astro:content';
 import { renderOgPng } from '../../lib/og';
+import { stripExt } from '../../lib/slug';
 import type { APIContext } from 'astro';
 
 export async function getStaticPaths() {
@@ -7,7 +8,7 @@ export async function getStaticPaths() {
   const posts = allPosts.filter((entry) => !entry.data.draft);
 
   return posts.map((entry) => ({
-    params: { slug: entry.id.replace(/\.(md|mdx)$/, '') },
+    params: { slug: stripExt(entry.id) },
     props: {
       title: entry.data.title,
       subtitle: entry.data.subtitle,

--- a/site/src/pages/rss.xml.ts
+++ b/site/src/pages/rss.xml.ts
@@ -1,6 +1,7 @@
 import rss from '@astrojs/rss';
 import { getCollection } from 'astro:content';
 import type { APIContext } from 'astro';
+import { stripExt } from '../lib/slug';
 
 export async function GET(context: APIContext) {
   const allPosts = await getCollection('posts');
@@ -20,7 +21,7 @@ export async function GET(context: APIContext) {
     site,
     items: posts.map((entry) => ({
       title: entry.data.title,
-      link: `${base}blog/${entry.id.replace(/\.(md|mdx)$/, '')}/`,
+      link: `${base}blog/${stripExt(entry.id)}/`,
       pubDate: entry.data.date,
       description: entry.data.subtitle ?? entry.data.title,
     })),


### PR DESCRIPTION
## Summary

The pattern `entry.id.replace(/\.(md|mdx)$/, '')` was duplicated across seven files in `site/`, with three of them defining their own local `stripExt` / `slugFor` helpers. This change consolidates the regex behind a single named helper, `stripExt`, exported from `site/src/lib/slug.ts`, and rewrites every call site to import it.

The helper carries a docstring explaining *why* the strip is needed (Astro 5's legacy `type: 'content'` collections preserve the file extension on `entry.id`) so future maintainers know the helper becomes a no-op or can be removed if the project migrates to the new content layer.

## Changes

- Add `site/src/lib/slug.ts` exporting `stripExt(id: string): string` with the explanatory docstring from the issue (verbatim).
- Replace `entry.id.replace(/\.(md|mdx)$/, '')` with `stripExt(entry.id)` in:
  - `site/src/pages/blog/[...slug].astro`
  - `site/src/pages/kits/[...slug].astro`
  - `site/src/components/landing/KitGrid.astro`
  - `site/src/pages/blog/index.astro`
  - `site/src/layouts/PostLayout.astro`
  - `site/src/pages/og/[...slug].png.ts`
  - `site/src/pages/rss.xml.ts`
- Remove the now-redundant local `stripExt` / `slugFor` arrow definitions in `KitGrid.astro`, `kits/[...slug].astro`, and `blog/index.astro`.

## Test plan

- [x] `npx astro check` — 0 errors, 0 warnings, 0 hints.
- [x] `npm run build` — 21 pages built, including `/blog/welcome/`, `/kits/flowkit/`, all `/og/*.png`, `/rss.xml`.
- [x] `grep -rn '\.replace(/\\.(md|mdx)' site/src/` returns only the helper itself.
- [x] All seven files now `import { stripExt } from '...lib/slug'`.

Closes #812