### PR TITLE
feat(site:rss): serve full HTML content

### DIFF
--- a/site/src/pages/rss.xml.ts
+++ b/site/src/pages/rss.xml.ts
@@ -1,9 +1,43 @@
 import rss from '@astrojs/rss';
-import { getCollection } from 'astro:content';
+import mdxRenderer from '@astrojs/mdx/server.js';
 import type { APIContext } from 'astro';
+import { experimental_AstroContainer } from 'astro/container';
+import { getCollection, type CollectionEntry } from 'astro:content';
+
 import { stripExt } from '../lib/slug';
 
-export async function GET(context: APIContext) {
+const URL_ATTR_PATTERN =
+  /(<(?:a|img|source|video|audio)\b[^>]*?\s(?:href|src))=("|')([^"']+)\2/gi;
+const ABSOLUTE_URL_PATTERN = /^(?:[a-z]+:|\/\/|#|mailto:|tel:|data:)/i;
+
+function absolutizeUrls(html: string, siteOrigin: string, base: string): string {
+  const prefix = base.endsWith('/') ? base : `${base}/`;
+  const baseNoTrail = prefix.slice(0, -1);
+  const origin = siteOrigin.endsWith('/') ? siteOrigin.slice(0, -1) : siteOrigin;
+
+  return html.replace(URL_ATTR_PATTERN, (match, attr: string, quote: string, url: string) => {
+    if (ABSOLUTE_URL_PATTERN.test(url)) return match;
+    let path: string;
+    if (url.startsWith('/')) {
+      path = url === baseNoTrail || url.startsWith(`${baseNoTrail}/`) ? url : `${baseNoTrail}${url}`;
+    } else {
+      path = `${prefix}${url}`;
+    }
+    return `${attr}=${quote}${origin}${path}${quote}`;
+  });
+}
+
+type AstroContainer = Awaited<ReturnType<typeof experimental_AstroContainer.create>>;
+
+async function renderPostHtml(
+  entry: CollectionEntry<'posts'>,
+  container: AstroContainer,
+): Promise<string> {
+  const { Content } = await entry.render();
+  return container.renderToString(Content);
+}
+
+export async function GET(context: APIContext): Promise<Response> {
   const allPosts = await getCollection('posts');
   const posts = allPosts
     .filter((entry) => !entry.data.draft)
@@ -14,17 +48,29 @@ export async function GET(context: APIContext) {
     ? import.meta.env.BASE_URL
     : `${import.meta.env.BASE_URL}/`;
 
+  const container = await experimental_AstroContainer.create();
+  container.addServerRenderer({ renderer: mdxRenderer });
+
+  const items = await Promise.all(
+    posts.map(async (entry) => {
+      const rawHtml = await renderPostHtml(entry, container);
+      const content = absolutizeUrls(rawHtml, site.origin, base);
+      return {
+        title: entry.data.title,
+        link: `${base}blog/${stripExt(entry.id)}/`,
+        pubDate: entry.data.date,
+        description: entry.data.subtitle ?? entry.data.title,
+        content,
+      };
+    }),
+  );
+
   return rss({
     title: 'smallorbit blog',
     description:
       'Plan, execute, and ship — Claude Code plugin essays and kit deep-dives from smallorbit.',
     site,
-    items: posts.map((entry) => ({
-      title: entry.data.title,
-      link: `${base}blog/${stripExt(entry.id)}/`,
-      pubDate: entry.data.date,
-      description: entry.data.subtitle ?? entry.data.title,
-    })),
+    items,
     customData: '<language>en-us</language>',
   });
 }


### PR DESCRIPTION
## Summary
- /rss.xml now ships the full post body in `<content:encoded>`, so full-content RSS readers (NetNewsWire, Feedly, etc.) render the post as published instead of a headline + subtitle stub.
- Renders each post's `Content` at build time via Astro 5's container API + `@astrojs/mdx/server.js`, preserving Shiki syntax highlighting and the post components used in MDX (`Callout`, `CodeBlock`, etc.).
- Rewrites site-relative `<a>` / `<img>` / `<source>` / `<video>` / `<audio>` URLs to absolute URLs, prepending the configured `BASE_URL` when missing so feed readers resolve assets correctly.

## Changes
- `site/src/pages/rss.xml.ts` — instantiate `experimental_AstroContainer`, register the MDX server renderer, render each non-draft post's `Content`, absolutize URLs, and pass the rendered HTML as the rss item's `content` field. Continues to use `stripExt` from `site/src/lib/slug.ts` for permalinks.

## Test plan
- `cd site && npx astro check` — 0 errors / 0 warnings.
- `cd site && npm run build` — succeeds; 21 pages built.
- `grep -c "<content:encoded>" site/dist/rss.xml` returns 10 (matches the 10 published posts).
- Spot-checked rewritten URLs: `/blog/swarmkit-deep-dive` → `https://smallorbit.github.io/smallorbit-plugins/blog/swarmkit-deep-dive`; absolute and external URLs (e.g. `github.com`, `placehold.co`) untouched.

Closes #811

Stacked on #851 (worktree-agent-812). GitHub will auto-retarget this PR to develop when #851 merges.