### PR TITLE
chore(plugins): bump flowkit@3.9.3, speckit@1.7.0, swarmkit@5.4.3

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship \u2014 with runtime staging detection and a one-command hotfix flow.",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/speckit/.claude-plugin/plugin.json
+++ b/plugins/speckit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "speckit",
   "description": "Define and capture work as GitHub issues. Interview a feature into existence with /spec, bulk-convert findings with /catalog, or quickly file a single issue with /issue.",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "5.4.2",
+  "version": "5.4.3",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Bump plugin.json versions for plugins changed since their last release.

## Changes

- flowkit@3.9.3
- speckit@1.7.0
- swarmkit@5.4.3

## Test plan

- [ ] Confirm each `plugin.json` version bump matches the per-plugin tag that will be created after merge.