### PR TITLE
chore(plugins): bump vaultkit@1.1.6

### DIFF
--- a/plugins/vaultkit/.claude-plugin/plugin.json
+++ b/plugins/vaultkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vaultkit",
   "description": "Obsidian vault skills for Claude Code. Read, search, edit notes, manage projects, capture decisions, and archive conversations — all via the Obsidian CLI.",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Bump vaultkit plugin.json to satisfy the bump-or-tag invariant enforced by `.claude/hooks/check-plugin-bumps.sh`.

## Changes

- vaultkit@1.1.6

## Test plan

- [x] Tag `vaultkit--v1.1.6` will be created post-merge.