### PR TITLE
chore(flowkit): drop --no-ff from release/hotfix back-merge

### DIFF
--- a/plugins/flowkit/skills/hotfix/SKILL.md
+++ b/plugins/flowkit/skills/hotfix/SKILL.md
@@ -125,13 +125,13 @@ If a hotfix is targeting a repo where `main` is the GitHub default, the auto-clo
 
 ### 12. Back-merge main into develop
 
-Keep `develop` in sync with the hotfix. Merge locally first:
+Keep `develop` in sync with the hotfix. Allow git to fast-forward when develop hasn't moved since the hotfix landed. When develop has drifted, git falls back to a real merge commit automatically.
 
 ```bash
 git fetch origin
 git checkout develop
 git pull --ff-only origin develop
-git merge --no-ff origin/main -m "chore(develop): back-merge hotfix from main"
+git merge origin/main -m "chore(develop): back-merge hotfix from main"
 ```
 
 Then publish via the [`flowkit:push-or-pr`](../push-or-pr/SKILL.md) sub-skill so the back-merge lands on develop whether or not develop is push-protected:

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -387,14 +387,16 @@ fi
 
 ### 11. Back-merge main into develop
 
-Bring develop's tip up to main so the next release cycle starts from parity. Use a real merge commit (not a fast-forward / squash) so the release merge from step 6 stays visible in develop's history.
+Bring develop's tip up to main so the next release cycle starts from parity. Allow git to fast-forward when develop hasn't moved since the RC was cut — the typical case. The release tag on main is the canonical "shipped" marker; duplicating that boundary on develop with a forced merge bubble adds noise without information.
 
 ```bash
 git fetch origin
 git checkout develop
 git pull --ff-only origin develop
-git merge --no-ff -m "chore(develop): back-merge release $TAG from main" origin/main
+git merge -m "chore(develop): back-merge release $TAG from main" origin/main
 ```
+
+When develop has actually drifted since the RC was cut, git falls back to a real merge commit automatically — the `-m` message is then used. When develop hasn't drifted, the merge fast-forwards and no commit is created.
 
 Publish the back-merge via the [`flowkit:push-or-pr`](../../push-or-pr/SKILL.md) sub-skill — direct pushes succeed when develop is unprotected and fall through to a merge-strategy back-merge PR when it isn't:
 


### PR DESCRIPTION
## Summary

Drop `--no-ff` from the back-merge step in both `flowkit:release` and `flowkit:hotfix`. Lets develop fast-forward when it hasn't drifted since the RC was cut (or hotfix landed) — the typical case — so each release no longer adds a useless merge bubble to develop's history.

Closes #868.

## Why

The back-merge currently forces a merge commit even when develop is unchanged since the RC was cut. Combined with push-or-pr's PR fallback (when develop is branch-protected), every release adds 1–2 merge commits to develop that don't represent any new code:

```
*   Merge pull request #N from chore/sync-develop-...     ← back-merge PR's merge commit
|\
| * chore(develop): back-merge release vX.Y.Z from main   ← --no-ff merge commit
|/|
| * Merge pull request #M from rc/...                     ← release PR's merge commit
```

The release tag on main is already the canonical "shipped" marker. Duplicating that boundary on develop with a forced bubble was ceremony, not information.

## Changes

**`plugins/flowkit/skills/release/SKILL.md`** (line 396):
```diff
-git merge --no-ff -m "chore(develop): back-merge release $TAG from main" origin/main
+git merge -m "chore(develop): back-merge release $TAG from main" origin/main
```
Plus comment update around line 390 explaining the new fast-forward-when-possible behavior.

**`plugins/flowkit/skills/hotfix/SKILL.md`** (line 134):
```diff
-git merge --no-ff origin/main -m "chore(develop): back-merge hotfix from main"
+git merge origin/main -m "chore(develop): back-merge hotfix from main"
```
Plus the same comment-style update.

## Behavior

- **No drift since RC was cut** (typical): `git merge` fast-forwards develop to main. Zero new commits on develop. Linear history.
- **Drift case**: `git merge` falls back to a real merge commit (the `-m` message is then used). Same outcome as before, minus the explicit `--no-ff` enforcement layer. push-or-pr's PR fallback path is unchanged.

## Test plan

- [x] `git diff` confirms only the two intended SKILL.md changes are staged (no other files).
- [ ] Manual repro on a test repo: cut a release, run `/flowkit:release`, observe develop tree:
  - With no drift: develop ends at main's tip with no new commits.
  - With drift: develop has exactly one new merge commit.
- [ ] Same for `/flowkit:hotfix`.

## Out of scope, mentioned for follow-up

A more aggressive cleanup for the drift case would switch the back-merge **PR's** merge strategy from `--merge` to `--squash` (`release/SKILL.md:425`, `hotfix/SKILL.md:163`). That collapses the drift-case two-bubble pattern into a single squash commit on develop. Different semantic trade-off (loses the merge's two-parent link), so splittable as a separate proposal.