### PR TITLE
fix(flowkit): harden merge-pr worktree pre-clean and warning UX

### DIFF
--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -49,6 +49,7 @@ HEAD_BRANCH=$(gh pr view "$PR_NUM" --json headRefName --jq '.headRefName')
 
 ```bash
 # Returns the worktree path currently checked out on the given branch, or empty.
+# Literal-string `==` compare; safely handles slashed refs (e.g. refs/heads/feat/foo-123).
 _find_worktree_for_branch() {
   git worktree list --porcelain \
     | awk -v target="refs/heads/$1" '
@@ -60,6 +61,8 @@ _find_worktree_for_branch() {
 BLOCKING_WORKTREE=$(_find_worktree_for_branch "$HEAD_BRANCH")
 
 if [ -n "$BLOCKING_WORKTREE" ]; then
+  printf 'Note: branch %s is held by worktree %s.\n' "$HEAD_BRANCH" "$BLOCKING_WORKTREE" >&2
+  printf '  Auto-removing the worktree before merge so the local branch can be deleted cleanly.\n' >&2
   git worktree remove --force "$BLOCKING_WORKTREE"
 fi
 ```
@@ -131,9 +134,13 @@ elif [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "false" ]; then
 fi
 
 if [ "$LOCAL_DELETE_FAILED" = "true" ]; then
-  echo "WARNING: PR #$PR_NUM merged remotely but the local branch \`$HEAD_BRANCH\` could not be deleted." >&2
-  echo "To clean up manually:" >&2
   LEFTOVER=$(_find_worktree_for_branch "$HEAD_BRANCH")
+  if [ -n "$LEFTOVER" ]; then
+    echo "WARNING: Local branch \`$HEAD_BRANCH\` still held by worktree at \`$LEFTOVER\`." >&2
+  else
+    echo "WARNING: PR #$PR_NUM merged remotely but the local branch \`$HEAD_BRANCH\` could not be deleted." >&2
+  fi
+  echo "To clean up manually:" >&2
   [ -n "$LEFTOVER" ] && echo "  git worktree remove --force $LEFTOVER" >&2
   echo "  git branch -D $HEAD_BRANCH" >&2
 fi


### PR DESCRIPTION
## Summary

Reduce noise from `/flowkit:merge-pr` when a non-swarmkit worktree (typically a squadkit `.claude/worktrees/builder-N`) still holds the merging PR's head branch — pre-flight users with a Note before the auto-remove fires, and re-word the post-merge warning so the worktree is named as the cause when it is.

## Changes

- `plugins/flowkit/skills/merge-pr/SKILL.md`
  - **Step 4 plan-preview**: when `_find_worktree_for_branch` returns a path, print a two-line `Note: ...` / `Auto-removing the worktree...` preview to stderr before `git worktree remove --force` runs.
  - **Step 4 awk audit**: one-line comment above the helper recording that literal-string `==` compare safely handles slashed refs (e.g. `refs/heads/feat/foo-123`).
  - **Step 6 sweep-hint re-word**: when local-delete fails and a worktree still holds the branch, lead the warning with the worktree as the cause (`Local branch \`X\` still held by worktree at \`Y\`.`); otherwise fall back to the original message. Manual-cleanup hint moved after both branches.

Out of scope: Steps 1, 2, 3, 5, 7; merge mechanic; sibling skill `merge-stack` (#867 is on it).

## Test plan

- [x] `git diff` — three hunks confined to `plugins/flowkit/skills/merge-pr/SKILL.md`.
- [x] `bash -n` on lifted Step 4 and Step 6 blocks — both parse clean.
- [x] Awk slashed-ref repro:
  ```bash
  git worktree list --porcelain \
    | awk -v target=\"refs/heads/feature/retro-and-merge-ux-866\" '
        /^worktree / { wt = \$2 }
        \$0 == \"branch \" target { print wt }
      '
  ```
  Returned the main worktree path; literal `==` compare confirmed working for slashed refs.
- [ ] User-level smoke (deferred to release run): `/flowkit:merge-pr` against a PR whose head branch is held by a `.claude/worktrees/builder-N` worktree — confirm Step 4 Note prints before auto-remove, and Step 6 warning leads with the worktree path when local-delete fails.

Closes #870