### PR TITLE
docs(squadkit): batch dispatch + review-only audit + late-ack handling

### DIFF
--- a/plugins/squadkit/agents/builder.md
+++ b/plugins/squadkit/agents/builder.md
@@ -53,6 +53,11 @@ If the lead's `accepted` arrives after you've already opened the PR (because the
 
 If you have been waiting more than ~60 seconds for an `accepted` on surfaced interface contracts and the lead is visibly dispatching elsewhere, you may proceed assuming implicit acceptance — but note the timeout in your completion-ack so the lead can spot a missed ack on their side.
 
+If the lead's ack arrives after you've started bodies but before you've pushed:
+
+- **Non-blocking suggestion** (typing refinement, scope tightening, naming): apply if cheap (≤5 LOC additional change); otherwise note it in the completion-ack and defer to a follow-up. Do NOT block the push.
+- **Blocking adjustment** (interface change, scope expansion, contract revision): halt, push a WIP commit if any work is committable, and `SendMessage` the lead with current state and the question "block-and-revise vs ship-and-iterate?".
+
 ## Task list discipline
 
 The team task list is a progress board, not your dispatch primitive. Honour these rules:

--- a/plugins/squadkit/agents/reviewer.md
+++ b/plugins/squadkit/agents/reviewer.md
@@ -47,6 +47,12 @@ Every dispatched audit has two SendMessage acks from you, in order:
 1. **Receipt-ack** — on dispatch, send a one-sentence `Starting <task #>` (or `Starting audit of PR #<N>`) reply via SendMessage immediately. Do NOT block on the lead acknowledging the receipt-ack — the lead may dispatch follow-on work between your receipt-ack and your completion-ack.
 2. **Completion-ack** — when the audit is done, send the verdict (`accepted` / `revise: ...` / `escalate: ...`) via SendMessage.
 
+### Batch dispatch handling
+
+When a single kickoff message dispatches N audits at once (rather than serial ack-then-next), treat the kickoff as the consolidated dispatch envelope. Process audits in ID order. Send a completion-ack per audit as you finish it; do NOT wait for per-audit receipt-acks between them. The lead's per-audit ack messages are advisory at that point — they confirm the lead saw the verdict but do not gate the next audit.
+
+Tasks created by the lead during a batch dispatch should already carry `owner` at `TaskCreate` time. Do not claim unassigned tasks created in a batch — wait for explicit ownership or a `SendMessage` routing the audit.
+
 ## Task list discipline
 
 The team task list is a progress board, not your dispatch primitive. Honour these rules:

--- a/plugins/squadkit/agents/team-lead.md
+++ b/plugins/squadkit/agents/team-lead.md
@@ -100,6 +100,15 @@ The default assumption is that a sent message reached `M` and `M` acted on it. R
 
 A one-line reminder to anchor the rule: `task #N status == completed? skip dispatch.` The cost of one missed re-dispatch (you'll hear about it) is far smaller than the cost of three duplicate dispatches in a wave (member confusion, ambiguous replies, wasted turns).
 
+### Batch dispatch handling
+
+Dispatch comes in two shapes; the role contracts disambiguate them so members do not stall on receipt-ack ping-pong:
+
+- **Serial dispatch.** One task at a time. The lead waits for the member's completion-ack before dispatching the next task. Existing dual-ack discipline applies unchanged.
+- **Batch dispatch.** A single kickoff message dispatches N tasks at once. The member processes in ID order with per-deliverable completion-acks but does NOT wait for per-deliverable receipt-acks between them. The lead's per-task ack messages are advisory at that point — they confirm the lead saw the deliverable but do not gate the next task.
+
+When creating tasks during a batch dispatch, set `owner` on each task at `TaskCreate` time (or immediately via `TaskUpdate`). Members MUST NOT claim unassigned tasks created by the lead during a batch — wait for explicit ownership or a `SendMessage` routing the task.
+
 ## Orchestrator playbook
 
 When the orchestrator (the session running this contract) hits a coordination edge case, branch into one of the named playbook entries below. Each branch names the trigger, the diagnosis, and the prescribed action — do not improvise around them.

--- a/plugins/squadkit/agents/tester.md
+++ b/plugins/squadkit/agents/tester.md
@@ -29,6 +29,12 @@ You produce one of two artifacts per task, depending on the lead's brief:
    - Pass/fail counts before and after.
    - Coverage delta if the project tracks it.
    - Verdict: `accepted` (gate is honest and green) or `revise: <gaps>`.
+3. **Review-only batch audit** — for coverage-audit briefs that span multiple PRs without authoring tests. Produce:
+   - Per-PR sections, each with: diff scope summary, coverage gaps (concrete: cite test files that should exist, name missing assertions, point at file:line of the change), and a per-PR verdict (`accepted` or `revise: <one-line reason>`).
+   - A final summary table mapping PR → verdict → action.
+   - Highest-leverage backfill targets called out separately (which PRs would most benefit from new tests if a builder is dispatched).
+
+   Stream per-PR findings if the audit is large; deliver as one consolidated `SendMessage` if the lead has not signaled urgency.
 
 ## Authoring rules
 
@@ -70,6 +76,12 @@ Every dispatched task has two SendMessage acks from you, in order:
 
 1. **Receipt-ack** — on dispatch, send a one-sentence `Starting <task #>` reply via SendMessage immediately. Do NOT block on the lead acknowledging the receipt-ack — the lead may dispatch follow-on work between your receipt-ack and your completion-ack.
 2. **Completion-ack** — when the deliverable is ready, send the test plan or test report via SendMessage.
+
+### Batch dispatch handling
+
+When a single kickoff message dispatches N test or audit tasks at once (rather than serial ack-then-next), treat the kickoff as the consolidated dispatch envelope. Process tasks in ID order. Send a completion-ack per task as you finish it; do NOT wait for per-task receipt-acks between them. The lead's per-task ack messages are advisory at that point — they confirm the lead saw the deliverable but do not gate the next task.
+
+Tasks created by the lead during a batch dispatch should already carry `owner` at `TaskCreate` time. Do not claim unassigned tasks created in a batch — wait for explicit ownership or a `SendMessage` routing the task.
 
 ## Task list discipline
 


### PR DESCRIPTION
## Summary

Land three findings from the `vorbis-player-alpha` retro as text-only edits to four squadkit role contracts, so future squads inherit the lessons by default. No code, script, or schema changes.

## Changes

- **H1 — batch dispatch semantics.**
  - `plugins/squadkit/agents/team-lead.md` — new `### Batch dispatch handling` subsection at the end of `## Dispatch discipline`. Disambiguates serial vs. batch dispatch and codifies the rule that members do NOT wait for per-deliverable receipt-acks during a batch; lead's per-task acks are advisory at that point. Owners must be set at `TaskCreate` time when batching.
  - `plugins/squadkit/agents/reviewer.md` — new `### Batch dispatch handling` subsection after `## Dual-ack protocol`, mirroring the lead-side rule on the receiving side for audit batches.
  - `plugins/squadkit/agents/tester.md` — same receiving-side mirror for test/audit task batches.
- **M1 — review-only batch audit deliverable.** `plugins/squadkit/agents/tester.md` `## Deliverables` list gains item `3. Review-only batch audit` for coverage-audit briefs spanning multiple PRs without authoring tests. Specifies per-PR sections (diff scope, concrete coverage gaps, per-PR verdict), a summary table, and a separate backfill-target callout.
- **M2 — late-ack handling.** `plugins/squadkit/agents/builder.md` `### Post-facto accepted handling` subsection extended with non-blocking-vs-blocking guidance for late acks (cheap suggestions apply ≤5 LOC, otherwise defer; interface/scope changes halt + WIP commit + ask).

Diffstat: 4 files, +32 / -0.

## Test plan

- [x] `git status --porcelain plugins/squadkit/agents/` — only the four target files modified.
- [x] `grep -n '### Batch dispatch handling'` returns exactly one new occurrence per role file (team-lead.md, reviewer.md, tester.md).
- [x] `grep -nE '^[0-9]+\.' plugins/squadkit/agents/tester.md | head -5` confirms `## Deliverables` now has items 1, 2, 3.
- [x] `git diff --stat` — zero deletions, no whitespace churn outside new blocks.
- [x] No frontmatter changes; no edits to `### Worked examples` in `team-lead.md`; no neighbouring-section rewrites.

Closes #866