### PR TITLE
feat: agent retro fixes + worktree UX in merge-stack/merge-pr

### DIFF
--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -49,6 +49,7 @@ HEAD_BRANCH=$(gh pr view "$PR_NUM" --json headRefName --jq '.headRefName')
 
 ```bash
 # Returns the worktree path currently checked out on the given branch, or empty.
+# Literal-string `==` compare; safely handles slashed refs (e.g. refs/heads/feat/foo-123).
 _find_worktree_for_branch() {
   git worktree list --porcelain \
     | awk -v target="refs/heads/$1" '
@@ -60,6 +61,8 @@ _find_worktree_for_branch() {
 BLOCKING_WORKTREE=$(_find_worktree_for_branch "$HEAD_BRANCH")
 
 if [ -n "$BLOCKING_WORKTREE" ]; then
+  printf 'Note: branch %s is held by worktree %s.\n' "$HEAD_BRANCH" "$BLOCKING_WORKTREE" >&2
+  printf '  Auto-removing the worktree before merge so the local branch can be deleted cleanly.\n' >&2
   git worktree remove --force "$BLOCKING_WORKTREE"
 fi
 ```
@@ -131,9 +134,13 @@ elif [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "false" ]; then
 fi
 
 if [ "$LOCAL_DELETE_FAILED" = "true" ]; then
-  echo "WARNING: PR #$PR_NUM merged remotely but the local branch \`$HEAD_BRANCH\` could not be deleted." >&2
-  echo "To clean up manually:" >&2
   LEFTOVER=$(_find_worktree_for_branch "$HEAD_BRANCH")
+  if [ -n "$LEFTOVER" ]; then
+    echo "WARNING: Local branch \`$HEAD_BRANCH\` still held by worktree at \`$LEFTOVER\`." >&2
+  else
+    echo "WARNING: PR #$PR_NUM merged remotely but the local branch \`$HEAD_BRANCH\` could not be deleted." >&2
+  fi
+  echo "To clean up manually:" >&2
   [ -n "$LEFTOVER" ] && echo "  git worktree remove --force $LEFTOVER" >&2
   echo "  git branch -D $HEAD_BRANCH" >&2
 fi

--- a/plugins/squadkit/agents/builder.md
+++ b/plugins/squadkit/agents/builder.md
@@ -53,6 +53,11 @@ If the lead's `accepted` arrives after you've already opened the PR (because the
 
 If you have been waiting more than ~60 seconds for an `accepted` on surfaced interface contracts and the lead is visibly dispatching elsewhere, you may proceed assuming implicit acceptance — but note the timeout in your completion-ack so the lead can spot a missed ack on their side.
 
+If the lead's ack arrives after you've started bodies but before you've pushed:
+
+- **Non-blocking suggestion** (typing refinement, scope tightening, naming): apply if cheap (≤5 LOC additional change); otherwise note it in the completion-ack and defer to a follow-up. Do NOT block the push.
+- **Blocking adjustment** (interface change, scope expansion, contract revision): halt, push a WIP commit if any work is committable, and `SendMessage` the lead with current state and the question "block-and-revise vs ship-and-iterate?".
+
 ## Task list discipline
 
 The team task list is a progress board, not your dispatch primitive. Honour these rules:

--- a/plugins/squadkit/agents/reviewer.md
+++ b/plugins/squadkit/agents/reviewer.md
@@ -47,6 +47,12 @@ Every dispatched audit has two SendMessage acks from you, in order:
 1. **Receipt-ack** — on dispatch, send a one-sentence `Starting <task #>` (or `Starting audit of PR #<N>`) reply via SendMessage immediately. Do NOT block on the lead acknowledging the receipt-ack — the lead may dispatch follow-on work between your receipt-ack and your completion-ack.
 2. **Completion-ack** — when the audit is done, send the verdict (`accepted` / `revise: ...` / `escalate: ...`) via SendMessage.
 
+### Batch dispatch handling
+
+When a single kickoff message dispatches N audits at once (rather than serial ack-then-next), treat the kickoff as the consolidated dispatch envelope. Process audits in ID order. Send a completion-ack per audit as you finish it; do NOT wait for per-audit receipt-acks between them. The lead's per-audit ack messages are advisory at that point — they confirm the lead saw the verdict but do not gate the next audit.
+
+Tasks created by the lead during a batch dispatch should already carry `owner` at `TaskCreate` time. Do not claim unassigned tasks created in a batch — wait for explicit ownership or a `SendMessage` routing the audit.
+
 ## Task list discipline
 
 The team task list is a progress board, not your dispatch primitive. Honour these rules:

--- a/plugins/squadkit/agents/team-lead.md
+++ b/plugins/squadkit/agents/team-lead.md
@@ -100,6 +100,15 @@ The default assumption is that a sent message reached `M` and `M` acted on it. R
 
 A one-line reminder to anchor the rule: `task #N status == completed? skip dispatch.` The cost of one missed re-dispatch (you'll hear about it) is far smaller than the cost of three duplicate dispatches in a wave (member confusion, ambiguous replies, wasted turns).
 
+### Batch dispatch handling
+
+Dispatch comes in two shapes; the role contracts disambiguate them so members do not stall on receipt-ack ping-pong:
+
+- **Serial dispatch.** One task at a time. The lead waits for the member's completion-ack before dispatching the next task. Existing dual-ack discipline applies unchanged.
+- **Batch dispatch.** A single kickoff message dispatches N tasks at once. The member processes in ID order with per-deliverable completion-acks but does NOT wait for per-deliverable receipt-acks between them. The lead's per-task ack messages are advisory at that point — they confirm the lead saw the deliverable but do not gate the next task.
+
+When creating tasks during a batch dispatch, set `owner` on each task at `TaskCreate` time (or immediately via `TaskUpdate`). Members MUST NOT claim unassigned tasks created by the lead during a batch — wait for explicit ownership or a `SendMessage` routing the task.
+
 ## Orchestrator playbook
 
 When the orchestrator (the session running this contract) hits a coordination edge case, branch into one of the named playbook entries below. Each branch names the trigger, the diagnosis, and the prescribed action — do not improvise around them.

--- a/plugins/squadkit/agents/tester.md
+++ b/plugins/squadkit/agents/tester.md
@@ -29,6 +29,12 @@ You produce one of two artifacts per task, depending on the lead's brief:
    - Pass/fail counts before and after.
    - Coverage delta if the project tracks it.
    - Verdict: `accepted` (gate is honest and green) or `revise: <gaps>`.
+3. **Review-only batch audit** — for coverage-audit briefs that span multiple PRs without authoring tests. Produce:
+   - Per-PR sections, each with: diff scope summary, coverage gaps (concrete: cite test files that should exist, name missing assertions, point at file:line of the change), and a per-PR verdict (`accepted` or `revise: <one-line reason>`).
+   - A final summary table mapping PR → verdict → action.
+   - Highest-leverage backfill targets called out separately (which PRs would most benefit from new tests if a builder is dispatched).
+
+   Stream per-PR findings if the audit is large; deliver as one consolidated `SendMessage` if the lead has not signaled urgency.
 
 ## Authoring rules
 
@@ -70,6 +76,12 @@ Every dispatched task has two SendMessage acks from you, in order:
 
 1. **Receipt-ack** — on dispatch, send a one-sentence `Starting <task #>` reply via SendMessage immediately. Do NOT block on the lead acknowledging the receipt-ack — the lead may dispatch follow-on work between your receipt-ack and your completion-ack.
 2. **Completion-ack** — when the deliverable is ready, send the test plan or test report via SendMessage.
+
+### Batch dispatch handling
+
+When a single kickoff message dispatches N test or audit tasks at once (rather than serial ack-then-next), treat the kickoff as the consolidated dispatch envelope. Process tasks in ID order. Send a completion-ack per task as you finish it; do NOT wait for per-task receipt-acks between them. The lead's per-task ack messages are advisory at that point — they confirm the lead saw the deliverable but do not gate the next task.
+
+Tasks created by the lead during a batch dispatch should already carry `owner` at `TaskCreate` time. Do not claim unassigned tasks created in a batch — wait for explicit ownership or a `SendMessage` routing the task.
 
 ## Task list discipline
 

--- a/plugins/swarmkit/skills/merge-stack/SKILL.md
+++ b/plugins/swarmkit/skills/merge-stack/SKILL.md
@@ -28,6 +28,13 @@ gh pr list --state open --json number,title,headRefName,baseRefName,body \
 
 If no open swarm PRs are found, report "No open swarm PRs found" and stop.
 
+Capture the set of head-branch names — Step 4's worktree pre-scan needs it:
+
+```bash
+MERGE_SET_BRANCHES=$(gh pr list --state open --json headRefName \
+  --jq '.[] | select(.headRefName | startswith("worktree-agent-")) | .headRefName')
+```
+
 ### 2. Build the stack graph
 
 Model the PRs as a directed graph where an edge A → B means "A's head branch is B's base branch" (A sits on top of B). Build this from the `headRefName` / `baseRefName` fields — no issue-body parsing needed for ordering.
@@ -51,7 +58,31 @@ Apply this to every PR in a multi-PR chain except the chain root. Independent PR
 
 ### 4. Present merge plan
 
-Show the plan before proceeding:
+Before showing the plan, pre-scan local worktrees for any branch in the merge set. `gh pr merge --delete-branch` prints a benign-but-confusing `failed to delete local branch ... used by worktree at ...` warning when a branch is held by an active worktree; the merge itself still succeeds and the remote branch is deleted. Forewarning the user keeps that warning from reading like a failure.
+
+The pre-scan is read-only — never remove worktrees here. Worktree reaping is `swarmkit:clean-worktrees`'s job.
+
+```bash
+HELD_BY_WORKTREE=$(git worktree list --porcelain \
+  | awk '/^branch refs\/heads\// {sub("refs/heads/", "", $2); print $2}' \
+  | grep -E '^worktree-agent-' \
+  | while read -r branch; do
+      if printf '%s\n' "$MERGE_SET_BRANCHES" | grep -Fxq -- "$branch"; then
+        printf '%s\n' "$branch"
+      fi
+    done)
+```
+
+Where `$MERGE_SET_BRANCHES` is the newline-delimited list of `headRefName`s collected in step 1. If `git worktree list` fails for any reason, treat `HELD_BY_WORKTREE` as empty and proceed without the note.
+
+Render the count + comma-joined list for the note:
+
+```bash
+HELD_COUNT=$(printf '%s' "$HELD_BY_WORKTREE" | grep -c .)
+HELD_LIST=$(printf '%s' "$HELD_BY_WORKTREE" | tr '\n' ',' | sed 's/,$//;s/,/, /g')
+```
+
+Show the plan before proceeding. When `HELD_BY_WORKTREE` is non-empty, prepend the note inside the plan block (one line for the count, one for the warning context, one for the remediation):
 
 ```
 Merge order (bottom-up per chain):
@@ -65,6 +96,10 @@ Merge order (bottom-up per chain):
   Step 4. Rebase #105 onto develop (drop #104's commits via patch-id)
   Step 5. Merge PR #105 into develop (squash, delete branch)
   Step 6. Merge PR #108 into develop (squash, delete branch)
+
+  Note: 2 branches are held by worktrees (worktree-agent-1361, worktree-agent-1393).
+  `gh pr merge --delete-branch` will warn but the merges will succeed.
+  Run `/swarmkit:clean-worktrees` after to reap them.
 ```
 
 Proceed immediately.
@@ -160,6 +195,16 @@ Where `$BASE` is the base branch of the root PRs (typically `develop`).
 
 ### 7. Report
 
+Append a follow-up suggestion that points the user at `swarmkit:clean-worktrees`. If any `worktree-agent-*` worktrees still exist, recommend running it; otherwise note that the worktrees are already gone:
+
+```bash
+if git worktree list --porcelain | awk '/^branch refs\/heads\/worktree-agent-/' | grep -q .; then
+  FOLLOWUP="Next: /swarmkit:clean-worktrees   (remove worktrees + prune orphan local branches)"
+else
+  FOLLOWUP="(no worktree-agent-* worktrees remain — skip clean-worktrees)"
+fi
+```
+
 ```
 ── merge-stack complete ──────────────────────────────
 ✓ Retargeted 2 non-root PRs to develop
@@ -167,6 +212,8 @@ Where `$BASE` is the base branch of the root PRs (typically `develop`).
 ✓ Merged (independent): PR #108 → develop
 ✗ Conflicted: PR #107 — stopped mid-chain
 ⊘ Blocked: PR #106 — depends on #107
+
+Next: /swarmkit:clean-worktrees   (remove worktrees + prune orphan local branches)
 ──────────────────────────────────────────────────────
 ```
 


### PR DESCRIPTION
## Summary

Lands three accepted PRs from squad `smallorbit-plugins-alpha` as a single integration into develop. The retro recommendations from `vorbis-player-alpha` (issue #866) are now baseline contract behavior, and the worktree-held-branch UX is fixed in both `swarmkit:merge-stack` and `flowkit:merge-pr`.

## Changes

- **squadkit agents (#866):** new `### Batch dispatch handling` subsections in `team-lead.md`, `reviewer.md`, `tester.md` (H1 — owner-at-TaskCreate rule, no per-deliverable receipt-ack waits in batch dispatch); new `3. Review-only batch audit` deliverable in `tester.md` (M1); late-ack non-blocking-vs-blocking guidance in `builder.md`'s `### Post-facto accepted handling` (M2).
- **swarmkit/merge-stack (#867):** Step 4 pre-scan of `git worktree list --porcelain` against the merge-set branches; a Note in the plan-preview when worktrees still hold branches; conditional `Next: /swarmkit:clean-worktrees` follow-up in the Step 7 report (or `(no worktree-agent-* worktrees remain — skip clean-worktrees)` when nothing to reap). Includes `HELD_COUNT` + `HELD_LIST` templating helpers so the example block is self-derivable.
- **flowkit/merge-pr (#870):** Step 4 plan-preview Note printf'd before auto-removing a blocking worktree; `_find_worktree_for_branch` audit comment documenting the literal-string `==` compare's safe handling of slashed refs (e.g. `refs/heads/feat/foo-123`); Step 6 `LOCAL_DELETE_FAILED` block re-worded so the warning headline names the worktree path when one is still held.

Doc-only changes (markdown + inline bash). 6 files / +89 / -3 LOC.

## Test plan

- [x] Each sub-PR's inline bash snippet parses with `bash -n` (verified by tester during the squad's batch audit).
- [x] Awk slashed-ref repro: `_find_worktree_for_branch "refs/heads/feature/retro-and-merge-ux-866"` returns the worktree path correctly (verified by tester with synthetic fixtures including deeply-slashed refs).
- [x] Cross-contract prose mirroring (#866): `### Batch dispatch handling` subsections in `team-lead.md`, `reviewer.md`, `tester.md` use parallel wording with appropriate role-specific specialization (`tasks` / `audits` / `tasks`); each role's existing `## Dual-ack protocol` and `## Task list discipline` sections remain unchanged.
- [x] Live dogfood: this very integration was driven by a squad operating under the new batch-dispatch contract from #866, exercised by the merge-stack into `feature/retro-and-merge-ux-866` (which fired the exact UX-warnings #867 + #870 fix).
- [ ] **Reviewer manual check**: confirm the integration commit graph is the 3 squashed commits (`51ce429`, `84d5663`, `2fddec4`) on top of `aa2ad69` (no #871 inversion).

Closes #866
Closes #867
Closes #870