### PR TITLE
feat(flowkit): scriptify with-clean-workspace and migrate callers

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,8 +24,11 @@
       "Bash($SKILL_DIR/scripts/classify.sh:*)",
       "Bash($SKILL_DIR/scripts/delete.sh:*)",
       "Bash($SKILL_DIR/scripts/detect_changed.sh:*)",
+      "Bash($SKILL_DIR/scripts/with_clean_workspace.sh:*)",
       "Bash(plugins/flowkit/skills/push-or-pr/scripts/push_or_pr.sh:*)",
-      "Bash(*/plugins/flowkit/skills/push-or-pr/scripts/push_or_pr.sh:*)"
+      "Bash(*/plugins/flowkit/skills/push-or-pr/scripts/push_or_pr.sh:*)",
+      "Bash(plugins/flowkit/skills/with-clean-workspace/scripts/with_clean_workspace.sh:*)",
+      "Bash(*/plugins/flowkit/skills/with-clean-workspace/scripts/with_clean_workspace.sh:*)"
     ]
   }
 }

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -55,7 +55,7 @@ These are called by the skills above — you don't invoke them directly.
 | **git-sync-main** | release, hotfix | Checkout `main` and pull latest from origin. |
 | **git-sync-develop** | sync, release, hotfix | Checkout `develop` and pull latest from origin. |
 | **pr-base-scope** | swarm | Set/unset `claude.flowkit.prBase` git config for scoped PR targeting. |
-| **with-clean-workspace** | merge-pr, release | Auto-stash dirty workspace around implicit post-merge pull. |
+| **with-clean-workspace** | merge-pr, release | Auto-stash dirty workspace around implicit post-merge pull via `scripts/with_clean_workspace.sh -- <command ...>`. |
 
 ## Typical Workflows
 

--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -71,7 +71,7 @@ If `git worktree remove` fails, abort with:
 
 > Cannot remove worktree at `$BLOCKING_WORKTREE` that holds `$HEAD_BRANCH`. Remove it manually with:
 >
-> ```
+> ```bash
 > git worktree remove --force <path>
 > ```
 >
@@ -97,41 +97,39 @@ gh pr list --base "$HEAD_BRANCH" --state open --json number --jq '.[].number' \
 
 ### 6. Squash-merge and delete the remote branch
 
-`gh pr merge --squash --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. The block below mirrors the stash-guard logic from `flowkit:with-clean-workspace` — auto-stashing dirty state before the merge and restoring it after:
+`gh pr merge --squash --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. Use the `flowkit:with-clean-workspace` script wrapper so stash behavior is consistent across callers:
 
 ```bash
-DIRTY=false
-if [ -n "$(git status --porcelain)" ]; then
-  DIRTY=true
-  git stash push -u -m "flowkit-auto-stash" >/dev/null
-fi
+WITH_CLEAN_WORKSPACE_DIR="$(dirname "$SKILL_DIR")/with-clean-workspace"
+MERGE_STATUS_FILE=$(mktemp)
 
-if gh pr merge "$PR_NUM" --squash --delete-branch; then
+if bash "$WITH_CLEAN_WORKSPACE_DIR/scripts/with_clean_workspace.sh" -- \
+  bash -lc '
+    PR_NUM="$1"
+    STATUS_FILE="$2"
+    if gh pr merge "$PR_NUM" --squash --delete-branch; then
+      printf "%s\n" "ok" > "$STATUS_FILE"
+      exit 0
+    fi
+
+    PR_STATE=$(gh pr view "$PR_NUM" --json state --jq ".state" 2>/dev/null || true)
+    if [ "$PR_STATE" = "MERGED" ]; then
+      printf "%s\n" "local-delete-failed" > "$STATUS_FILE"
+      exit 0
+    fi
+
+    printf "%s\n" "failed" > "$STATUS_FILE"
+    exit 1
+  ' _ "$PR_NUM" "$MERGE_STATUS_FILE"; then
   MERGE_OK=true
-  LOCAL_DELETE_FAILED=false
 else
-  # gh pr merge exited non-zero — re-query the PR state. If the remote merge
-  # actually succeeded, only the local branch-delete failed (e.g. another
-  # worktree still held the branch, or a race condition). Treat that as a
-  # recoverable warning, not a hard failure.
-  PR_STATE=$(gh pr view "$PR_NUM" --json state --jq '.state' 2>/dev/null)
-  if [ "$PR_STATE" = "MERGED" ]; then
-    MERGE_OK=true
-    LOCAL_DELETE_FAILED=true
-  else
-    MERGE_OK=false
-    LOCAL_DELETE_FAILED=false
-  fi
+  MERGE_OK=false
 fi
 
-if [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "true" ]; then
-  if ! git stash pop; then
-    echo "WARNING: stash pop conflicted. Your changes are preserved on the stash stack." >&2
-    echo "Run \`git stash list\` to see the saved entry (message: flowkit-auto-stash) and \`git stash pop\` after resolving." >&2
-  fi
-elif [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "false" ]; then
-  echo "WARNING: merge failed — stash preserved. Run \`git stash pop\` after resolving the merge error." >&2
-fi
+MERGE_STATUS=$(cat "$MERGE_STATUS_FILE" 2>/dev/null || true)
+rm -f "$MERGE_STATUS_FILE"
+LOCAL_DELETE_FAILED=false
+[ "$MERGE_STATUS" = "local-delete-failed" ] && LOCAL_DELETE_FAILED=true
 
 if [ "$LOCAL_DELETE_FAILED" = "true" ]; then
   LEFTOVER=$(_find_worktree_for_branch "$HEAD_BRANCH")
@@ -153,7 +151,6 @@ fi
 Print a summary:
 
 > Merged PR #N.
-
 
 ## Constraints
 

--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -101,33 +101,32 @@ gh pr list --base "$HEAD_BRANCH" --state open --json number --jq '.[].number' \
 
 ```bash
 WITH_CLEAN_WORKSPACE_DIR="$(dirname "$SKILL_DIR")/with-clean-workspace"
-MERGE_STATUS_FILE=$(mktemp)
+set +e
+MERGE_STATUS=$(
+  bash "$WITH_CLEAN_WORKSPACE_DIR/scripts/with_clean_workspace.sh" -- \
+    bash -c '
+      PR_NUM="$1"
+      if gh pr merge "$PR_NUM" --squash --delete-branch; then
+        printf "%s\n" "ok"
+        exit 0
+      fi
 
-if bash "$WITH_CLEAN_WORKSPACE_DIR/scripts/with_clean_workspace.sh" -- \
-  bash -lc '
-    PR_NUM="$1"
-    STATUS_FILE="$2"
-    if gh pr merge "$PR_NUM" --squash --delete-branch; then
-      printf "%s\n" "ok" > "$STATUS_FILE"
-      exit 0
-    fi
+      if PR_STATE=$(gh pr view "$PR_NUM" --json state --jq ".state" 2>/dev/null); then
+        if [ "$PR_STATE" = "MERGED" ]; then
+          printf "%s\n" "local-delete-failed"
+          exit 0
+        fi
+      else
+        echo "WARNING: could not query PR #$PR_NUM state after failed merge attempt." >&2
+      fi
 
-    PR_STATE=$(gh pr view "$PR_NUM" --json state --jq ".state" 2>/dev/null || true)
-    if [ "$PR_STATE" = "MERGED" ]; then
-      printf "%s\n" "local-delete-failed" > "$STATUS_FILE"
-      exit 0
-    fi
+      printf "%s\n" "failed"
+      exit 1
+    ' _ "$PR_NUM"
+)
+MERGE_EXIT=$?
+set -e
 
-    printf "%s\n" "failed" > "$STATUS_FILE"
-    exit 1
-  ' _ "$PR_NUM" "$MERGE_STATUS_FILE"; then
-  MERGE_OK=true
-else
-  MERGE_OK=false
-fi
-
-MERGE_STATUS=$(cat "$MERGE_STATUS_FILE" 2>/dev/null || true)
-rm -f "$MERGE_STATUS_FILE"
 LOCAL_DELETE_FAILED=false
 [ "$MERGE_STATUS" = "local-delete-failed" ] && LOCAL_DELETE_FAILED=true
 
@@ -143,7 +142,7 @@ if [ "$LOCAL_DELETE_FAILED" = "true" ]; then
   echo "  git branch -D $HEAD_BRANCH" >&2
 fi
 
-[ "$MERGE_OK" = "false" ] && exit 1
+[ "$MERGE_EXIT" -ne 0 ] && exit 1
 ```
 
 ### 7. Report

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -289,13 +289,8 @@ Capture the PR number from the URL output.
 
 ```bash
 WITH_CLEAN_WORKSPACE_DIR="$(dirname "$SKILL_DIR")/with-clean-workspace"
-if bash "$WITH_CLEAN_WORKSPACE_DIR/scripts/with_clean_workspace.sh" -- gh pr merge "$PR_URL" --merge --delete-branch; then
-  MERGE_OK=true
-else
-  MERGE_OK=false
-fi
-
-[ "$MERGE_OK" = "false" ] && exit 1
+bash "$WITH_CLEAN_WORKSPACE_DIR/scripts/with_clean_workspace.sh" -- \
+  gh pr merge "$PR_URL" --merge --delete-branch || exit 1
 ```
 
 Use `--merge` to preserve the full commit history from the RC branch in main.

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -285,28 +285,14 @@ Capture the PR number from the URL output.
 
 ### 6. Merge the PR
 
-`gh pr merge --merge --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. Wrap the call with the `flowkit:with-clean-workspace` sub-skill so any dirty state is auto-stashed and restored:
+`gh pr merge --merge --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. Wrap the call with the `flowkit:with-clean-workspace` script so any dirty state is auto-stashed and restored:
 
 ```bash
-DIRTY=false
-if [ -n "$(git status --porcelain)" ]; then
-  DIRTY=true
-  git stash push -u -m "flowkit-auto-stash" >/dev/null
-fi
-
-if gh pr merge "$PR_URL" --merge --delete-branch; then
+WITH_CLEAN_WORKSPACE_DIR="$(dirname "$SKILL_DIR")/with-clean-workspace"
+if bash "$WITH_CLEAN_WORKSPACE_DIR/scripts/with_clean_workspace.sh" -- gh pr merge "$PR_URL" --merge --delete-branch; then
   MERGE_OK=true
 else
   MERGE_OK=false
-fi
-
-if [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "true" ]; then
-  if ! git stash pop; then
-    echo "WARNING: stash pop conflicted. Your changes are preserved on the stash stack." >&2
-    echo "Run \`git stash list\` to see the saved entry (message: flowkit-auto-stash) and \`git stash pop\` after resolving." >&2
-  fi
-elif [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "false" ]; then
-  echo "WARNING: merge failed — stash preserved. Run \`git stash pop\` after resolving the merge error." >&2
 fi
 
 [ "$MERGE_OK" = "false" ] && exit 1
@@ -428,6 +414,7 @@ Branch on `$PUSH_RESULT`:
 ### 12. Report
 
 Output:
+
 - Tag created (e.g. `v2026.4.16`)
 - PR number and URL
 - Issues closed — list the aggregated `$ISSUE_REFS` numbers, and note which subset was closed by step 9's explicit loop (`$EXPLICITLY_CLOSED`) versus by GitHub's auto-close at merge time

--- a/plugins/flowkit/skills/with-clean-workspace/SKILL.md
+++ b/plugins/flowkit/skills/with-clean-workspace/SKILL.md
@@ -7,46 +7,27 @@ description: Auto-stash uncommitted changes around a command that triggers an im
 
 Wrap a command whose side effects include an implicit `git pull` (most notably `gh pr merge --squash --delete-branch` / `--merge --delete-branch`) so a dirty workspace cannot break the post-merge pull with `cannot pull with rebase: You have unstaged changes`.
 
-The guard auto-stashes uncommitted changes (tracked + untracked) before the wrapped command and pops the stash after. If the pop conflicts, it leaves the stash on the stack and surfaces that to the user — never auto-resolves.
+The deterministic stash-guard behavior lives in [`scripts/with_clean_workspace.sh`](./scripts/with_clean_workspace.sh). Callers should invoke that script contract directly rather than re-implementing stash logic inline.
 
-## Process
-
-### 1. Detect dirty workspace before the wrapped command
+## Invocation
 
 ```bash
-DIRTY=false
-if [ -n "$(git status --porcelain)" ]; then
-  DIRTY=true
-  git stash push -u -m "flowkit-auto-stash" >/dev/null
-fi
+bash "$SKILL_DIR/scripts/with_clean_workspace.sh" -- <command> [args...]
 ```
 
-### 2. Run the wrapped command
+`$SKILL_DIR` is the absolute runtime path to the *with-clean-workspace* skill (from the invocation header: `Base directory for this skill: ...`).
 
-Whatever the caller needs to invoke (`gh pr merge ...`, etc.). Capture whether it succeeded:
+For cross-skill callers inside flowkit (for example `merge-pr` and `release`), derive the target skill path from the caller:
 
 ```bash
-if <wrapped-command>; then
-  MERGE_OK=true
-else
-  MERGE_OK=false
-fi
+WITH_CLEAN_WORKSPACE_DIR="$(dirname "$SKILL_DIR")/with-clean-workspace"
+bash "$WITH_CLEAN_WORKSPACE_DIR/scripts/with_clean_workspace.sh" -- <command> [args...]
 ```
 
-### 3. Restore the stash only if the wrapped command succeeded
+## Contract
 
-The pop is conditional on the wrapped command exiting 0. If the command failed (e.g. merge conflict on GitHub, network error), the stash is left on the stack so the user can retry without losing their workspace state:
-
-```bash
-if [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "true" ]; then
-  if ! git stash pop; then
-    echo "WARNING: stash pop conflicted. Your changes are preserved on the stash stack." >&2
-    echo "Run \`git stash list\` to see the saved entry (message: flowkit-auto-stash) and \`git stash pop\` after resolving." >&2
-  fi
-elif [ "$DIRTY" = "true" ] && [ "$MERGE_OK" = "false" ]; then
-  echo "WARNING: merge failed — stash preserved. Run \`git stash pop\` after resolving the merge error." >&2
-fi
-
-[ "$MERGE_OK" = "false" ] && exit 1
-```
-
+- Interface: `-- <command ...>`; missing `--` or command exits `2` with stderr usage text.
+- Dirty workspace handling: stashes tracked + untracked changes (`git stash push -u -m "flowkit-auto-stash"`).
+- Success path: restores stash (`git stash pop`).
+- Pop conflict path: warns to stderr and leaves stash on stack.
+- Failure path: keeps stash, warns to stderr, exits with wrapped command's non-zero exit code.

--- a/plugins/flowkit/skills/with-clean-workspace/scripts/test.sh
+++ b/plugins/flowkit/skills/with-clean-workspace/scripts/test.sh
@@ -1,10 +1,13 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
-# test.sh — smoke tests for flowkit:with-clean-workspace scripts.
+# test.sh — deterministic behavior tests for flowkit:with-clean-workspace.
 #
-# Happy-path stash behavior depends on a mutable git workspace state; this test
-# harness focuses on deterministic argument-validation coverage.
+# These tests build throwaway git repositories to validate stash semantics for:
+# - invalid usage
+# - dirty-worktree success path (auto-stash + auto-pop)
+# - dirty-worktree failure path (stash preserved + warning)
+# - dirty-worktree pop-conflict path (warning + stash preserved)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PASS=0
@@ -12,6 +15,28 @@ FAIL=0
 
 red()   { printf '\033[31m%s\033[0m\n' "$*"; }
 green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+TMP_REPO=""
+
+create_temp_repo() {
+  TMP_REPO="$(mktemp -d)"
+  cd "$TMP_REPO" || return 1
+  git init -q
+  git config user.name "with-clean-workspace-tests"
+  git config user.email "tests@example.invalid"
+  printf 'base\n' > tracked.txt
+  git add tracked.txt
+  git commit -qm "init"
+}
+
+cleanup_temp_repo() {
+  local original_pwd="$1"
+  cd "$original_pwd" || true
+  if [[ -n "$TMP_REPO" ]]; then
+    rm -rf "$TMP_REPO"
+  fi
+  TMP_REPO=""
+}
 
 assert_invalid_args() {
   local script="$1"; shift
@@ -24,8 +49,8 @@ assert_invalid_args() {
   "$SCRIPT_DIR/$script" "$@" >"$tmp_out" 2>"$tmp_err"
   rc=$?
   set -e
-  stdout="$(cat "$tmp_out")"
-  stderr="$(cat "$tmp_err")"
+  stdout="$(<"$tmp_out")"
+  stderr="$(<"$tmp_err")"
   rm -f "$tmp_out" "$tmp_err"
 
   if [[ $rc -eq 0 ]]; then
@@ -48,12 +73,160 @@ assert_invalid_args() {
   PASS=$((PASS + 1))
 }
 
-echo "with-clean-workspace: smoke-testing argument validation contracts"
+test_dirty_success_pops_stash() {
+  local rc stash_count tracked_contents untracked_restored
+  local tmp_out tmp_err original_pwd
+  original_pwd="$(pwd)"
+  tmp_out="$(mktemp)"
+  tmp_err="$(mktemp)"
+  if ! create_temp_repo; then
+    red "  FAIL [dirty-success]: failed to create temp git repo"
+    FAIL=$((FAIL + 1))
+    rm -f "$tmp_out" "$tmp_err"
+    return
+  fi
+
+  printf 'dirty change\n' > tracked.txt
+  printf 'scratch\n' > untracked.txt
+
+  set +e
+  "$SCRIPT_DIR/with_clean_workspace.sh" -- bash -lc 'test -f tracked.txt && test ! -f untracked.txt' >"$tmp_out" 2>"$tmp_err"
+  rc=$?
+  set -e
+
+  git stash list >"$tmp_out"
+  stash_count="$(wc -l < "$tmp_out" | tr -d ' ')"
+  tracked_contents="$(<tracked.txt)"
+  if [[ -f untracked.txt ]]; then
+    untracked_restored="yes"
+  else
+    untracked_restored="no"
+  fi
+  cleanup_temp_repo "$original_pwd"
+  rm -f "$tmp_out" "$tmp_err"
+
+  if [[ $rc -ne 0 ]]; then
+    red "  FAIL [dirty-success]: expected exit 0, got $rc"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ "$stash_count" -ne 0 ]]; then
+    red "  FAIL [dirty-success]: expected empty stash after pop, found $stash_count entries"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ "$tracked_contents" != "dirty change" || "$untracked_restored" != "yes" ]]; then
+    red "  FAIL [dirty-success]: expected tracked/untracked changes restored"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  green "  PASS [dirty-success]: stash popped and local changes restored"
+  PASS=$((PASS + 1))
+}
+
+test_dirty_failure_preserves_stash() {
+  local rc stderr stash_count
+  local tmp_err tmp_out original_pwd
+  original_pwd="$(pwd)"
+  tmp_err="$(mktemp)"
+  tmp_out="$(mktemp)"
+  if ! create_temp_repo; then
+    red "  FAIL [dirty-failure]: failed to create temp git repo"
+    FAIL=$((FAIL + 1))
+    rm -f "$tmp_out" "$tmp_err"
+    return
+  fi
+
+  printf 'dirty change\n' > tracked.txt
+  printf 'scratch\n' > untracked.txt
+
+  set +e
+  "$SCRIPT_DIR/with_clean_workspace.sh" -- bash -lc 'exit 7' >"$tmp_out" 2>"$tmp_err"
+  rc=$?
+  set -e
+  stderr="$(<"$tmp_err")"
+  stash_count="$(git stash list | wc -l | tr -d ' ')"
+  cleanup_temp_repo "$original_pwd"
+  rm -f "$tmp_err" "$tmp_out"
+
+  if [[ $rc -ne 7 ]]; then
+    red "  FAIL [dirty-failure]: expected exit 7, got $rc"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ "$stash_count" -lt 1 ]]; then
+    red "  FAIL [dirty-failure]: expected preserved stash entry"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ "$stderr" != *"wrapped command failed — stash preserved"* ]]; then
+    red "  FAIL [dirty-failure]: expected preserved-stash warning on stderr"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  green "  PASS [dirty-failure]: non-zero exit preserved stash with warning"
+  PASS=$((PASS + 1))
+}
+
+test_pop_conflict_preserves_stash() {
+  local rc stderr stash_count tracked_contents
+  local tmp_err tmp_out original_pwd
+  original_pwd="$(pwd)"
+  tmp_err="$(mktemp)"
+  tmp_out="$(mktemp)"
+  if ! create_temp_repo; then
+    red "  FAIL [pop-conflict]: failed to create temp git repo"
+    FAIL=$((FAIL + 1))
+    rm -f "$tmp_out" "$tmp_err"
+    return
+  fi
+
+  printf 'dirty change\n' > tracked.txt
+
+  # Wrapped command edits the same path differently so stash pop cannot apply cleanly.
+  set +e
+  "$SCRIPT_DIR/with_clean_workspace.sh" -- bash -lc "printf 'wrapped change\n' > tracked.txt" >"$tmp_out" 2>"$tmp_err"
+  rc=$?
+  set -e
+  stderr="$(<"$tmp_err")"
+  stash_count="$(git stash list | wc -l | tr -d ' ')"
+  tracked_contents="$(<tracked.txt)"
+  cleanup_temp_repo "$original_pwd"
+  rm -f "$tmp_err" "$tmp_out"
+
+  if [[ $rc -ne 0 ]]; then
+    red "  FAIL [pop-conflict]: expected wrapped command exit 0, got $rc"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ "$stderr" != *"stash pop conflicted"* ]]; then
+    red "  FAIL [pop-conflict]: expected conflict warning on stderr"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ "$stash_count" -lt 1 ]]; then
+    red "  FAIL [pop-conflict]: expected stash entry to remain after conflict"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ "$tracked_contents" != "wrapped change" ]]; then
+    red "  FAIL [pop-conflict]: expected wrapped command edits to remain in workspace"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  green "  PASS [pop-conflict]: warned and preserved stash on conflict"
+  PASS=$((PASS + 1))
+}
+
+echo "with-clean-workspace: testing argument validation + stash behavior"
 echo
 
 assert_invalid_args with_clean_workspace.sh "missing-separator"
 assert_invalid_args with_clean_workspace.sh "separator-only" --
 assert_invalid_args with_clean_workspace.sh "unknown-flag" --help
+test_dirty_success_pops_stash
+test_dirty_failure_preserves_stash
+test_pop_conflict_preserves_stash
 
 echo
 echo "with-clean-workspace: ${PASS} passed, ${FAIL} failed"

--- a/plugins/flowkit/skills/with-clean-workspace/scripts/test.sh
+++ b/plugins/flowkit/skills/with-clean-workspace/scripts/test.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# test.sh — smoke tests for flowkit:with-clean-workspace scripts.
+#
+# Happy-path stash behavior depends on a mutable git workspace state; this test
+# harness focuses on deterministic argument-validation coverage.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PASS=0
+FAIL=0
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+assert_invalid_args() {
+  local script="$1"; shift
+  local label="$1"; shift
+  local stdout stderr rc
+  local tmp_out tmp_err
+  tmp_out="$(mktemp)"
+  tmp_err="$(mktemp)"
+  set +e
+  "$SCRIPT_DIR/$script" "$@" >"$tmp_out" 2>"$tmp_err"
+  rc=$?
+  set -e
+  stdout="$(cat "$tmp_out")"
+  stderr="$(cat "$tmp_err")"
+  rm -f "$tmp_out" "$tmp_err"
+
+  if [[ $rc -eq 0 ]]; then
+    red   "  FAIL [$script $label]: expected non-zero exit, got 0"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -n "$stdout" ]]; then
+    red   "  FAIL [$script $label]: expected empty stdout on invalid args, got:"
+    printf '%s\n' "$stdout" | sed 's/^/         /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -z "$stderr" ]]; then
+    red   "  FAIL [$script $label]: expected non-empty stderr message"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  green "  PASS [$script $label]: exit=$rc, stdout empty, stderr non-empty"
+  PASS=$((PASS + 1))
+}
+
+echo "with-clean-workspace: smoke-testing argument validation contracts"
+echo
+
+assert_invalid_args with_clean_workspace.sh "missing-separator"
+assert_invalid_args with_clean_workspace.sh "separator-only" --
+assert_invalid_args with_clean_workspace.sh "unknown-flag" --help
+
+echo
+echo "with-clean-workspace: ${PASS} passed, ${FAIL} failed"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/plugins/flowkit/skills/with-clean-workspace/scripts/with_clean_workspace.sh
+++ b/plugins/flowkit/skills/with-clean-workspace/scripts/with_clean_workspace.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# with_clean_workspace.sh — run a command behind flowkit's auto-stash guard.
+#
+# Usage:
+#   with_clean_workspace.sh -- <command> [args...]
+#
+# Behavior:
+# - If workspace is dirty, stash tracked + untracked changes.
+# - Execute wrapped command exactly as passed.
+# - On success: attempt stash pop. If pop conflicts, keep stash and warn.
+# - On failure: keep stash and warn.
+# - Exit with the wrapped command's exit code.
+
+if [[ $# -lt 2 || "$1" != "--" ]]; then
+  echo "with_clean_workspace: usage: with_clean_workspace.sh -- <command> [args...]" >&2
+  exit 2
+fi
+
+shift
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "with_clean_workspace: required dependency 'git' not found on PATH" >&2
+  exit 1
+fi
+
+DIRTY=false
+if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+  DIRTY=true
+  git stash push -u -m "flowkit-auto-stash" >/dev/null
+fi
+
+set +e
+"$@"
+COMMAND_EXIT=$?
+set -e
+
+if [[ "$DIRTY" == "true" && "$COMMAND_EXIT" -eq 0 ]]; then
+  if ! git stash pop; then
+    echo "WARNING: stash pop conflicted. Your changes are preserved on the stash stack." >&2
+    echo "Run \`git stash list\` to see the saved entry (message: flowkit-auto-stash) and \`git stash pop\` after resolving." >&2
+  fi
+elif [[ "$DIRTY" == "true" && "$COMMAND_EXIT" -ne 0 ]]; then
+  echo "WARNING: wrapped command failed — stash preserved. Run \`git stash pop\` after resolving the command error." >&2
+fi
+
+exit "$COMMAND_EXIT"


### PR DESCRIPTION
## Summary
- Move `flowkit:with-clean-workspace` from prompt-only steps to a shared executable script at `plugins/flowkit/skills/with-clean-workspace/scripts/with_clean_workspace.sh` with a `-- <command ...>` interface.
- Preserve stash semantics in script form: stash tracked+untracked when dirty, restore only on success, keep stash on failure/conflict with stderr warnings, and propagate wrapped command exit status.
- Migrate flowkit callers (`merge-pr`, `release`) and related docs/permissions to use the script contract, and add smoke tests for the new script.

## Test plan
- [x] `bash plugins/flowkit/skills/with-clean-workspace/scripts/test.sh`
- [x] `bash scripts/test-all-skill-scripts.sh`

Closes #877

Made with [Cursor](https://cursor.com)