### PR TITLE
docs(flowkit:release): polish SKILL.md — remove redundant comment, add sub-skill link

### DIFF
--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -231,9 +231,6 @@ Example: "Ship swarmkit stacked-merge bugfix alongside flowkit hotfix workflow t
 
 # --- assemble PR body ---
 # <!-- include: plugins/_shared/pr-body.md -->
-# The body shape below follows the canonical PR body spec defined in
-# plugins/_shared/pr-body.md: Summary → Release summary → Version bumps →
-# Release notes → issue-reference footer. Keep that order.
 PR_BODY="## Summary
 
 $NARRATIVE_SUMMARY
@@ -285,7 +282,7 @@ Capture the PR number from the URL output.
 
 ### 6. Merge the PR
 
-`gh pr merge --merge --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. Wrap the call with the `flowkit:with-clean-workspace` script so any dirty state is auto-stashed and restored:
+`gh pr merge --merge --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. Wrap the call with the [`flowkit:with-clean-workspace`](../../with-clean-workspace/SKILL.md) script so any dirty state is auto-stashed and restored:
 
 ```bash
 WITH_CLEAN_WORKSPACE_DIR="$(dirname "$SKILL_DIR")/with-clean-workspace"


### PR DESCRIPTION
## Summary

Polish pass over `plugins/flowkit/skills/release/SKILL.md` — remove a 3-line comment that restated the PR body spec already documented at `plugins/_shared/pr-body.md` (comment-policy violation), and add a hyperlink to `flowkit:with-clean-workspace` in step 6 for consistency with the existing link to `flowkit:push-or-pr` in step 11.

## Changes

- `plugins/flowkit/skills/release/SKILL.md:232-236`: Remove redundant prose comment `# The body shape below follows the canonical PR body spec defined in plugins/_shared/pr-body.md: ...` — violates comment policy (restates what the canonical doc already documents). Keep the `<!-- include: plugins/_shared/pr-body.md -->` annotation.
- `plugins/flowkit/skills/release/SKILL.md:288`: Add `[flowkit:with-clean-workspace](../../with-clean-workspace/SKILL.md)` hyperlink, matching the existing hyperlink for `flowkit:push-or-pr` in step 11.

## Test plan

- [ ] Manual review: render the SKILL.md and confirm step numbering, fenced-block balance (26 delimiters = 13 pairs), and cross-references read cleanly
- [ ] Confirm no observable behavior change in the release workflow (commands invoked, ordering, tag format, merge strategy unchanged)

## Findings deferred to issues

- `SKILL.md:315` (efficiency): `[ "$(git ls-remote --exit-code origin refs/tags/$TAG &>/dev/null; echo $?)" = "0" ]` is an awkward idiom — a direct `git ls-remote --exit-code origin "refs/tags/$TAG" &>/dev/null` in an `if` conditional would be cleaner. Deferred because the change is behavior-adjacent (existing idiom is correct) and deserves its own targeted PR.
- `SKILL.md:204-221` (quality): The 17-line smoke-test comment block in step 5 is operator runbook material. Moving it to a `## Diagnostics` appendix section would reduce inline clutter. Deferred: per polish task instructions, bash blocks cannot be relocated across steps, and restructuring the surrounding prose warrants its own PR.
- `SKILL.md:62-64 + 176-183` (efficiency): Two separate `gh pr list --base develop --state merged` calls with the same date filter (steps 4 and 5) could be collapsed into one call with a broader `--json` selection. Deferred: the two calls request different field shapes (`body,mergedAt` vs `title,body,mergedAt`); merging them is a behavior-adjacent refactor that deserves its own PR.
- `SKILL.md:26 + 357 + 374` (efficiency): Three `git fetch origin` / `git fetch --prune origin` calls across steps 1, 10, and 11 cannot be safely merged — each runs after a state-changing operation (merge, RC delete, back-merge) and must remain in place.