### PR TITLE
refactor(_shared): extract canonical base-resolution spec

### DIFF
--- a/plugins/_shared/base-resolution.md
+++ b/plugins/_shared/base-resolution.md
@@ -1,0 +1,36 @@
+# Base Branch Resolution
+
+Canonical specification for PR base-branch resolution. Every plugin that calls `gh pr create` MUST resolve `$BASE` via this algorithm so the resolution order is consistent across the monorepo.
+
+## Algorithm
+
+Resolve `$BASE` in this order, stopping at the first non-empty result:
+
+1. **Explicit caller arg** — if `$ARGUMENTS` contains a `--base <branch>` flag, extract and use it.
+2. **Plugin-scoped config key** — read `git config claude.<plugin>.prBase`. Each plugin substitutes its own name (e.g. `claude.flowkit.prBase`, `claude.polishkit.prBase`).
+3. **`develop` if it exists on the remote** — check with `git ls-remote --heads origin develop | grep -q 'refs/heads/develop'`.
+4. **Repo default** — `gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'`. Emit a one-line stderr warning before using this fallback.
+
+## Post-condition
+
+`$BASE` is always non-empty after step 4; consumers MUST pass `--base "$BASE"` to `gh pr create`. Never call `gh pr create` without an explicit `--base` — without it, gh falls through to the GitHub default branch (often `main`), which silently produces wrong-base PRs against repos that develop on a non-default branch.
+
+## Plugin-scoped key naming rule
+
+Each plugin owns exactly one key under its own namespace: `claude.<plugin>.prBase`. A plugin MUST NOT write to another plugin's scoped key. The separation ensures that a polishkit session pin cannot accidentally redirect flowkit PRs and vice versa.
+
+## Cross-plugin courtesy interop (optional)
+
+A consuming plugin MAY check a sibling plugin's scoped key as a courtesy slot — **after** its own scoped key (step 2) and **before** the `develop` fallback (step 3). This is an opt-in deviation; document it explicitly in the consuming skill. Example: polishkit checks `claude.flowkit.prBase` if its own `claude.polishkit.prBase` is unset, so a flowkit session pin propagates automatically when both plugins are installed together. The courtesy read is best-effort only — the consuming plugin works correctly without the sibling key present.
+
+## Reference implementations
+
+- [`plugins/flowkit/skills/open-pr/SKILL.md`](../flowkit/skills/open-pr/SKILL.md) — flowkit implementation (includes legacy `claude.prBase` deviation until [#896](https://github.com/smallorbit/smallorbit-plugins/issues/896) lands).
+- [`plugins/polishkit/skills/polish/SKILL.md`](../polishkit/skills/polish/SKILL.md) — polishkit implementation (includes optional flowkit courtesy interop slot).
+
+## Anti-patterns
+
+- **Do not hardcode `develop`** — always use the resolution algorithm so repos without a `develop` branch fall through gracefully.
+- **Do not skip the `$BASE` non-empty check** — an empty `$BASE` silently targets the GitHub default, which is almost always wrong in a feature-branch workflow.
+- **Do not write to `claude.prBase`** — the legacy unscoped key is read-only for backward compatibility. All new writes go to `claude.<plugin>.prBase`.
+- **Do not add new fallback layers without updating this doc first** — the algorithm is the contract; undocumented layers create invisible precedence conflicts across plugins.

--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -42,13 +42,11 @@ If the current branch is `develop`, `main`, `master`, or `staging`, stop immedia
 
 ### 2. Determine base branch
 
-Resolve the base branch using the following precedence order:
+Resolve `$BASE` per the canonical chain at [`plugins/_shared/base-resolution.md`](../../../_shared/base-resolution.md).
 
-1. **Explicit caller arg** — if `$ARGUMENTS` contains a `--base <branch>` flag, extract and use it.
-2. **`claude.flowkit.prBase`** — per-session config key (set by swarm loop / cut-epic).
-3. **Legacy `claude.prBase`** — deprecated key (with migration notice).
-4. **`develop` if it exists on the remote** — check with `git ls-remote`.
-5. **GitHub default** — fall through to gh CLI default, but emit a one-line warning.
+<!-- include: plugins/_shared/base-resolution.md -->
+
+**Deviation: legacy `claude.prBase` fallback.** This skill additionally reads the unscoped `claude.prBase` key between the scoped key (`claude.flowkit.prBase`) and the `develop` fallback, emitting a deprecation notice when found. This extra step is a backward-compatibility deviation not present in the canonical algorithm. It is removed by [#896](https://github.com/smallorbit/smallorbit-plugins/issues/896).
 
 ```bash
 # 1. Explicit caller arg
@@ -87,8 +85,6 @@ if [ -z "$BASE" ]; then
   BASE="$REPO_DEFAULT"
 fi
 ```
-
-`$BASE` is always non-empty after step 2 — pass it explicitly as `--base "$BASE"` to `gh pr create`. This respects any scoped override set by the `pr-base-scope` sub-skill.
 
 ### 3. Push branch to origin
 
@@ -183,7 +179,7 @@ Output the PR URL returned by `gh pr create`.
 
 ## Constraints
 
-- Always resolve `--base` before calling `gh pr create` using the precedence: explicit caller arg → `claude.flowkit.prBase` → legacy `claude.prBase` → `develop` (if remote exists) → repo default (with warning). `$BASE` is always non-empty; `--base "$BASE"` is always passed.
+- Always resolve `--base` before calling `gh pr create` per [`plugins/_shared/base-resolution.md`](../../../_shared/base-resolution.md) (plus the legacy `claude.prBase` deviation documented in step 2). `$BASE` is always non-empty; `--base "$BASE"` is always passed.
 - Never target `main` directly unless `claude.flowkit.prBase` (or legacy `claude.prBase`) is explicitly set to `main`
 - Never open a PR from a protected branch (`develop`, `main`, `master`, `staging`)
 - If `gh` is not installed or not authenticated, report the error and stop — do not attempt workarounds

--- a/plugins/flowkit/skills/pr-base-scope/SKILL.md
+++ b/plugins/flowkit/skills/pr-base-scope/SKILL.md
@@ -35,15 +35,7 @@ git config --unset claude.flowkit.prBase
 
 ### Read
 
-Resolution order (authoritative spec in [`open-pr/SKILL.md`](../open-pr/SKILL.md) step 2):
-
-1. `--base <branch>` in `$ARGUMENTS`
-2. `claude.flowkit.prBase`
-3. `claude.prBase` — legacy fallback (emits deprecation notice)
-4. `develop` if it exists on the remote
-5. Repo default branch via `gh repo view` (with warning)
-
-`$BASE` is always non-empty after resolution.
+Resolution order is the canonical chain at [`plugins/_shared/base-resolution.md`](../../../_shared/base-resolution.md). This skill writes only to `claude.flowkit.prBase`; the legacy `claude.prBase` key is read as a deprecation fallback by `open-pr` (removed by [#896](https://github.com/smallorbit/smallorbit-plugins/issues/896)).
 
 ## Constraints
 

--- a/plugins/polishkit/skills/polish/SKILL.md
+++ b/plugins/polishkit/skills/polish/SKILL.md
@@ -77,7 +77,7 @@ Pass the resolved verify commands to the agent prompt as `VERIFY_COMMANDS`.
 
 The agent's branch must be cut from the project's PR base, and `gh pr create` must explicitly target the same branch (otherwise it falls through to the GitHub default — usually `main` — which silently produces wrong-base PRs against repos that develop on a non-default branch).
 
-Polishkit resolves the base standalone — no other plugin is required. If flowkit is also installed and has set its own per-session base, polishkit silently honors it as a courtesy, but never depends on it.
+Implements the canonical chain at [`plugins/_shared/base-resolution.md`](../../../_shared/base-resolution.md), with one polishkit-specific variation: a polishkit-scoped key (`claude.polishkit.prBase`) is checked at step 2 before the optional flowkit-interop slot. The flowkit courtesy read (`claude.flowkit.prBase`) is placed after polishkit's own key and before the `develop` fallback, as documented in the canonical spec's cross-plugin courtesy interop section. Polishkit works correctly without flowkit installed.
 
 Resolve `BASE` in this order:
 


### PR DESCRIPTION
## Summary

Promotes PR base-branch resolution from duplicated inline prose in `flowkit:open-pr` and `polishkit:polish` to a single canonical spec at `plugins/_shared/base-resolution.md`. Every PR-creating skill now resolves its base via the same documented precedence, making future drift impossible by construction. Bash implementation blocks in all three consumers are preserved verbatim — only the prose explanation is replaced with a link, mirroring the established `_shared/pr-body.md` pattern.

## Changes

- **Create** `plugins/_shared/base-resolution.md` — canonical 4-level algorithm (explicit arg → plugin-scoped key → `develop` → repo default), post-condition, plugin-scoped key naming rule, cross-plugin courtesy interop slot, reference implementations, anti-patterns.
- **Update** `plugins/flowkit/skills/open-pr/SKILL.md` — step 2 prose list replaced with canonical link + "Deviation: legacy `claude.prBase`…removed by #896" paragraph; constraint bullet updated to reference canonical spec.
- **Update** `plugins/flowkit/skills/pr-base-scope/SKILL.md` — Read subsection prose replaced with single sentence + canonical link + legacy-fallback note.
- **Update** `plugins/polishkit/skills/polish/SKILL.md` — step 3 preamble drops "bypasses flowkit primitives" justification; replaced with canonical-reference paragraph documenting polishkit-scoped key and courtesy interop slot against the spec.

## Test plan

- [ ] `bash scripts/test-all-skill-scripts.sh` — 6/6 smoke tests pass (docs-only change, zero script regressions).
- [ ] Link audit: `grep -RIn '_shared/base-resolution.md' plugins/` — every `../../../_shared/base-resolution.md` link resolves to the created file.
- [ ] Drift audit: all three consumer SKILLs contain a `plugins/_shared/base-resolution.md` reference.
- [ ] `plugins/_shared/base-resolution.md` has all six required sections: Algorithm, Post-condition, Plugin-scoped key naming rule, Cross-plugin courtesy interop, Reference implementations, Anti-patterns.
- [ ] `flowkit/skills/open-pr/SKILL.md` retains bash block verbatim and carries "Deviation: legacy `claude.prBase`…removed by #896".
- [ ] `polishkit/skills/polish/SKILL.md` no longer carries the "deliberately bypasses flowkit primitives" justification.

Closes #892
Refs #897