### PR TITLE
feat(flowkit): add ship-epic skill (#887)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,7 +31,10 @@
       "Bash(*/plugins/flowkit/skills/with-clean-workspace/scripts/with_clean_workspace.sh:*)",
       "Bash($SKILL_DIR/scripts/merge_pr.sh:*)",
       "Bash(plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh:*)",
-      "Bash(*/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh:*)"
+      "Bash(*/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh:*)",
+      "Bash($SKILL_DIR/scripts/ship_epic.sh:*)",
+      "Bash(plugins/flowkit/skills/ship-epic/scripts/ship_epic.sh:*)",
+      "Bash(*/plugins/flowkit/skills/ship-epic/scripts/ship_epic.sh:*)"
     ]
   }
 }

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -34,6 +34,7 @@ claude --plugin-dir /path/to/flowkit
 | **commit** | `/commit` | Stage and commit changes with conventional commit format. Infers logical groupings and writes `type(scope): description` messages. |
 | **create-branch** | `/create-branch` | Create a new git branch off `develop` with an inferred or provided name. |
 | **cut-epic** | `/cut-epic` | Cut a long-lived `feature/<slug>-<issue>` branch from `develop`, push it, and pin `claude.flowkit.prBase` so subsequent PRs target it. |
+| **ship-epic** | `/ship-epic` | Promote a `feature/<slug>-<N>` epic to `develop` via rebase-merge, unset `claude.flowkit.prBase`, delete the epic branch. Closer for `cut-epic`. |
 | **preview-epic** | `/preview-epic` | Build a local preview branch combining every open PR in an epic stack via octopus merge (sequential fallback), then run configurable verify commands to validate the epic end-to-end. |
 | **open-pr** | `/open-pr` | Push current branch and open a GitHub PR. Respects `claude.flowkit.prBase` for branch targeting. |
 | **pr** | `/pr` | Combined: `create-branch` → `commit` → `open-pr` in one step. |
@@ -87,8 +88,7 @@ When a feature spans multiple PRs and needs to stay isolated from `develop` unti
 /pr wire exporter into UI        # next sub-PR, also targets the epic branch
 # When ready to ship:
 /preview-epic                    # verify the integrated state before promoting
-gh pr create --base develop --head feature/<slug>-1264
-git config --unset claude.flowkit.prBase
+/ship-epic                       # rebase-merge to develop, unset prBase, delete epic branch
 ```
 
 The epic branch composes with `swarmkit:swarm`: agents spawned while `claude.flowkit.prBase` is set will open PRs against the epic branch automatically. Use `swarmkit:merge-stack` to fan the child PRs into the epic, then open the final epic-to-`develop` PR for review.

--- a/plugins/flowkit/skills/cut-epic/SKILL.md
+++ b/plugins/flowkit/skills/cut-epic/SKILL.md
@@ -118,23 +118,23 @@ Print a confirmation including the branch name, the upstream, and the scoped con
 
 ## Teardown
 
-When the epic is ready to ship:
+When the epic is ready to ship, run `flowkit:ship-epic`. It opens the epic-to-`develop` PR, rebase-merges (so children's squashes replay onto develop linearly), unsets `claude.flowkit.prBase`, deletes the epic branch, and fast-forwards local develop. See [`ship-epic/SKILL.md`](../ship-epic/SKILL.md) for full details.
 
-1. Open a final PR from the epic branch into `develop`. The simplest path is to manually invoke `flowkit:open-pr` after temporarily clearing the scope, or run `gh pr create --base develop --head <epic-branch>` directly.
-2. Clear the scope so future PRs default back to `develop`:
+To close out by hand (manual fallback):
 
-```bash
-git config --unset claude.flowkit.prBase
-```
-
-This is the **Unset** operation defined by `pr-base-scope`. Once cleared, `flowkit:open-pr` falls through to its default (`develop`).
-
-3. (Optional) Delete the epic branch after the merge:
-
-```bash
-git push origin --delete feature/<slug>-<issue>
-git branch -D feature/<slug>-<issue>
-```
+1. Open a final PR from the epic branch into `develop`:
+   ```bash
+   gh pr create --base develop --head feature/<slug>-<issue>
+   ```
+2. Rebase-merge via the GitHub UI or CLI (`gh pr merge --rebase --delete-branch`).
+3. Clear the scope so future PRs default back to `develop`:
+   ```bash
+   git config --unset claude.flowkit.prBase
+   ```
+4. (Optional) Delete the local epic branch:
+   ```bash
+   git branch -D feature/<slug>-<issue>
+   ```
 
 ## Constraints
 

--- a/plugins/flowkit/skills/ship-epic/SKILL.md
+++ b/plugins/flowkit/skills/ship-epic/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: ship-epic
+description: Promote a long-lived feature/<slug>-<N> epic to develop via rebase-merge, unset claude.flowkit.prBase, delete the epic branch, and fast-forward develop. Closer for flowkit:cut-epic.
+triggers:
+  - "/ship-epic"
+  - "ship the epic"
+  - "close out epic"
+  - "promote feature branch to develop"
+allowed-tools: Bash
+---
+
+# Ship Epic
+
+Promote a long-lived `feature/<slug>-<N>` epic branch to `develop` via rebase-merge, clear the session scope, and delete the epic branch. The symmetric closer for `flowkit:cut-epic`.
+
+After this skill runs: `develop`'s first-parent line stays linear (one squashed commit per merged feature, no octopus or back-merge bubbles), `claude.flowkit.prBase` is cleared, and the local epic branch is gone.
+
+## Input
+
+`$ARGUMENTS` — optional. Either:
+
+1. `--epic <branch>` — explicit epic branch override. Must start with `feature/` and must not equal `develop`, `main`, `master`, or `staging`.
+2. Empty — resolved from `git config --get claude.flowkit.prBase`. If unset or equal to `develop`, the skill stops:
+
+> No epic in flight. `claude.flowkit.prBase` is unset (or equals `develop`) and no `--epic` flag was passed. Run `/cut-epic` first, pass `--epic <branch>`, or check out the epic branch.
+
+## Process
+
+### 1. Capture `$SKILL_DIR`
+
+```bash
+export SKILL_DIR="<absolute path from the 'Base directory for this skill:' header line>"
+```
+
+### 2. Run the script
+
+```bash
+RESULT=$(bash "$SKILL_DIR/scripts/ship_epic.sh" $ARGUMENTS)
+```
+
+The script handles: epic resolution, push, preflight guardrails, closes-token aggregation, PR creation, rebase-merge via `with-clean-workspace`, config unset, and local develop fast-forward.
+
+### 3. On success
+
+If `RESULT` is non-empty JSON, report:
+
+> Shipped epic `<epic_branch>` to develop via PR #`<pr_number>`. `claude.flowkit.prBase` cleared. Local develop fast-forwarded.
+
+Include the PR URL from `result.pr_url`. If `result.develop_advanced` is `false`, note:
+
+> Local develop was not fast-forwarded (operator is on a different worktree). Run `/sync` to pull develop.
+
+### 4. On failure
+
+If the script exits non-zero (empty stdout), surface stderr and stop. Do not retry — the error message includes a recovery hint.
+
+## Output
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `epic_branch` | string | The promoted branch, e.g. `feature/onboarding-v2-1264`. |
+| `pr_number` | number | Epic-to-develop PR number. |
+| `pr_url` | string | Full PR URL. |
+| `closes_tokens` | array of strings | Closing-keyword lines aggregated from child squash commits and the epic issue ref. |
+| `pr_base_unset` | boolean | `true` if `claude.flowkit.prBase` was set and cleared; `false` if it was already unset. |
+| `develop_advanced` | boolean | `true` if local develop fast-forwarded; `false` if the operator is on a different worktree (local develop ref was not touched). Operators on a non-develop worktree should run `/sync` to pull the updated develop. |
+
+## Constraints
+
+- Always rebase-merge to `develop`, never squash-merge, never merge-commit. This preserves per-feature first-parent linearity.
+- Always promotes to `develop` only. ship-epic is opinionated about the target branch.
+- Preflight guardrails are advisory — no `--force-promote` bypass flag. If the epic has no commits ahead of `develop`, or contains raw `worktree-agent-*` merge commits (meaning `swarmkit:merge-stack` was not run), the skill stops with a recovery hint. Use the manual fallback in `flowkit:cut-epic` Teardown for rare edge cases.
+- On rebase-merge conflict: exits 1 with a recovery hint; `claude.flowkit.prBase` and the epic branch are left intact so the operator can rebase and re-invoke.
+- Concurrent invocations (second call while first `gh pr merge --rebase` is in flight) fail at PR-create or merge; both paths exit 1 with stderr and no state corruption.
+
+## Composition
+
+| Caller | Behavior |
+|--------|----------|
+| `flowkit:cut-epic` | Creates the epic branch and pins `claude.flowkit.prBase`. ship-epic is the symmetric closer. |
+| `flowkit:preview-epic` | Recommended to run before ship-epic to validate the integrated epic state. ship-epic does not call preview-epic internally. |
+| `swarmkit:merge-stack` | Must run before ship-epic when the epic uses the stacked-PR model, to squash `worktree-agent-*` merge commits into linear history. |
+| `flowkit:ship` (#894) | Will orchestrate `merge-stack → ship-epic → cut → release` when it ships. |

--- a/plugins/flowkit/skills/ship-epic/scripts/ship_epic.sh
+++ b/plugins/flowkit/skills/ship-epic/scripts/ship_epic.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ship_epic.sh — promote a long-lived feature/<slug>-<N> epic to develop via
+# rebase-merge, unset claude.flowkit.prBase, and fast-forward local develop.
+#
+# Usage:
+#   ship_epic.sh [--epic <branch>]
+#   ship_epic.sh --help
+#
+# Success: exit 0, one bare JSON object on stdout.
+# Failure: non-zero exit, human-readable message on stderr, empty stdout.
+# Invalid args: exit 2.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SHIP_EPIC_DIR="$(dirname "$SCRIPT_DIR")"
+SKILLS_DIR="$(dirname "$SHIP_EPIC_DIR")"
+WITH_CLEAN_SH="$SKILLS_DIR/with-clean-workspace/scripts/with_clean_workspace.sh"
+
+usage() {
+  echo "ship_epic: usage: ship_epic.sh [--epic <branch>]"
+}
+
+# --- Argument parsing --------------------------------------------------------
+
+EPIC_ARG=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    --epic=*)
+      EPIC_ARG="${1#--epic=}"
+      shift
+      ;;
+    --epic)
+      if [[ $# -lt 2 ]]; then
+        echo "ship_epic: --epic requires a branch name" >&2
+        exit 2
+      fi
+      EPIC_ARG="$2"
+      shift 2
+      ;;
+    -*)
+      echo "ship_epic: unknown flag: $1" >&2
+      exit 2
+      ;;
+    *)
+      echo "ship_epic: unexpected positional argument: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+# --- Resolve epic branch -----------------------------------------------------
+
+EPIC=""
+if [[ -n "$EPIC_ARG" ]]; then
+  EPIC="$EPIC_ARG"
+else
+  EPIC=$(git config --get claude.flowkit.prBase 2>/dev/null || true)
+fi
+
+if [[ -z "$EPIC" || "$EPIC" == "develop" || "$EPIC" == "main" || "$EPIC" == "master" || "$EPIC" == "staging" ]]; then
+  echo "ship_epic: No epic in flight. claude.flowkit.prBase is unset (or equals develop) and no --epic flag was passed. Run /cut-epic first, pass --epic <branch>, or check out the epic branch." >&2
+  exit 1
+fi
+
+if [[ ! "$EPIC" =~ ^feature/ ]]; then
+  echo "ship_epic: epic branch must start with 'feature/', got: $EPIC" >&2
+  exit 2
+fi
+
+# --- Dependency check --------------------------------------------------------
+
+for cmd in jq git gh; do
+  if ! command -v "$cmd" >/dev/null 2>&1; then
+    echo "ship_epic: required dependency '$cmd' not found on PATH" >&2
+    exit 1
+  fi
+done
+
+if [[ ! -f "$WITH_CLEAN_SH" ]]; then
+  echo "ship_epic: expected with-clean-workspace at $WITH_CLEAN_SH (flowkit layout)" >&2
+  exit 1
+fi
+
+# --- Fetch and push ----------------------------------------------------------
+
+git fetch origin develop "$EPIC"
+git push --set-upstream origin "$EPIC"
+
+# --- Preflight ---------------------------------------------------------------
+
+COMMIT_COUNT=$(git rev-list --count "origin/develop..origin/$EPIC")
+if [[ "$COMMIT_COUNT" -eq 0 ]]; then
+  echo "ship_epic: Epic branch has no commits ahead of develop; nothing to ship." >&2
+  exit 1
+fi
+
+RAW_MERGE=$(git log "origin/develop..origin/$EPIC" --merges --grep='Merge.*worktree-agent' --oneline | head -1 || true)
+if [[ -n "$RAW_MERGE" ]]; then
+  echo "ship_epic: Epic branch contains raw worktree-agent merge commits. Run \`swarmkit:merge-stack\` first to squash them into linear history before shipping." >&2
+  exit 1
+fi
+
+# --- Aggregate closes tokens -------------------------------------------------
+
+CLOSES_TOKENS=$(
+  git log "origin/develop..origin/$EPIC" --pretty=format:'%B' \
+    | (grep -oiE '(closes|fixes|resolves) #[0-9]+' || true) \
+    | awk '!seen[tolower($0)]++'
+)
+
+FOOTER_LINES=()
+if [[ -n "$CLOSES_TOKENS" ]]; then
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && FOOTER_LINES+=("$line")
+  done <<< "$CLOSES_TOKENS"
+fi
+
+EPIC_ISSUE=""
+if [[ "$EPIC" =~ ([0-9]+)$ ]]; then
+  EPIC_ISSUE="${BASH_REMATCH[1]}"
+fi
+if [[ -n "$EPIC_ISSUE" ]]; then
+  FOOTER_LINES+=("Refs #$EPIC_ISSUE")
+fi
+
+if [[ ${#FOOTER_LINES[@]} -gt 0 ]]; then
+  for line in "${FOOTER_LINES[@]}"; do
+    if echo "$line" | grep -qiE '(Closes|Fixes|Resolves) #[0-9]+[[:space:]]+#[0-9]+'; then
+      echo "ship_epic: PR body footer contains a space-separated closing-keyword line ('$line'). GitHub only parses one keyword per line; trailing refs would silently stay open. Rewrite with one token per line." >&2
+      exit 1
+    fi
+  done
+fi
+
+# --- Build PR title and body -------------------------------------------------
+
+SLUG="${EPIC#feature/}"
+CHILD_COUNT=$(git log "origin/develop..origin/$EPIC" --oneline | wc -l | tr -d '[:space:]')
+
+PR_TITLE="feat(epic): ship $SLUG"
+
+FOOTER_TEXT=""
+if [[ ${#FOOTER_LINES[@]} -gt 0 ]]; then
+  FOOTER_TEXT=$(printf '%s\n' "${FOOTER_LINES[@]}")
+fi
+
+PR_BODY="## Summary
+
+Ship epic \`$EPIC\` to develop via rebase-merge. This branch contains $CHILD_COUNT squashed child commit(s) that will replay linearly onto develop's first-parent line.
+
+## Changes
+
+- Rebase-merge promotes $CHILD_COUNT squashed child PR(s) onto develop linearly.
+- \`claude.flowkit.prBase\` will be unset after merge; epic branch deleted.
+
+## Test plan
+
+- [ ] Verify \`git log --first-parent origin/develop\` shows $CHILD_COUNT new commit(s) with no merge bubbles.
+- [ ] Verify \`git config --get claude.flowkit.prBase\` is empty after ship."
+
+if [[ -n "$FOOTER_TEXT" ]]; then
+  PR_BODY="$PR_BODY
+
+$FOOTER_TEXT"
+fi
+
+# --- Open PR -----------------------------------------------------------------
+
+PR_URL=$(gh pr create \
+  --base develop \
+  --head "$EPIC" \
+  --title "$PR_TITLE" \
+  --body "$PR_BODY")
+
+PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+if [[ -z "$PR_NUM" ]]; then
+  echo "ship_epic: could not parse PR number from URL: $PR_URL" >&2
+  exit 1
+fi
+
+# --- Rebase-merge ------------------------------------------------------------
+
+set +e
+bash "$WITH_CLEAN_SH" -- gh pr merge "$PR_NUM" --rebase --delete-branch
+MERGE_EXIT=$?
+set -e
+
+if [[ $MERGE_EXIT -ne 0 ]]; then
+  echo "ship_epic: Rebase-merge failed (likely a conflict). Resolve with: git checkout $EPIC && git fetch origin && git rebase origin/develop, then re-run /ship-epic." >&2
+  exit 1
+fi
+
+# --- Unset claude.flowkit.prBase ---------------------------------------------
+
+PR_BASE_UNSET=false
+if git config --get claude.flowkit.prBase >/dev/null 2>&1; then
+  git config --unset claude.flowkit.prBase
+  PR_BASE_UNSET=true
+fi
+
+# --- Fast-forward local develop ----------------------------------------------
+
+git fetch origin develop
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
+if [[ "$CURRENT_BRANCH" == "HEAD" || "$CURRENT_BRANCH" == "$EPIC" ]]; then
+  git checkout develop 2>/dev/null || true
+  echo "ship_epic: checked out develop (was on now-deleted epic branch)" >&2
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
+fi
+
+DEVELOP_ADVANCED=false
+if [[ "$CURRENT_BRANCH" == "develop" ]]; then
+  git pull --ff-only origin develop
+  DEVELOP_ADVANCED=true
+fi
+
+# --- Emit JSON ---------------------------------------------------------------
+
+if [[ ${#FOOTER_LINES[@]} -gt 0 ]]; then
+  CLOSES_JSON=$(printf '%s\n' "${FOOTER_LINES[@]}" | jq -R . | jq -s .)
+else
+  CLOSES_JSON="[]"
+fi
+
+jq -n \
+  --arg epic_branch "$EPIC" \
+  --argjson pr_number "$PR_NUM" \
+  --arg pr_url "$PR_URL" \
+  --argjson closes_tokens "$CLOSES_JSON" \
+  --argjson pr_base_unset "$PR_BASE_UNSET" \
+  --argjson develop_advanced "$DEVELOP_ADVANCED" \
+  '{
+    epic_branch: $epic_branch,
+    pr_number: $pr_number,
+    pr_url: $pr_url,
+    closes_tokens: $closes_tokens,
+    pr_base_unset: $pr_base_unset,
+    develop_advanced: $develop_advanced
+  }'

--- a/plugins/flowkit/skills/ship-epic/scripts/test.sh
+++ b/plugins/flowkit/skills/ship-epic/scripts/test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# test.sh — smoke tests for flowkit:ship-epic scripts.
+#
+# Per plugins/_shared/script-authoring.md:
+# - Successful invocations exit 0 with parseable JSON on stdout.
+# - Invalid-argument invocations exit non-zero with empty stdout and
+#   non-empty stderr.
+#
+# ship_epic.sh requires git, gh, a live remote, and a configured
+# claude.flowkit.prBase or --epic flag for its happy path. This harness
+# covers argument validation only. The full happy-path flow is exercised
+# manually via /ship-epic in a repository with a real epic branch.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PASS=0
+FAIL=0
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+assert_invalid_args() {
+  local script="$1"; shift
+  local label="$1"; shift
+  local stdout stderr rc
+  local tmp_out tmp_err
+  tmp_out="$(mktemp)"
+  tmp_err="$(mktemp)"
+  set +e
+  "$SCRIPT_DIR/$script" "$@" >"$tmp_out" 2>"$tmp_err"
+  rc=$?
+  set -e
+  stdout="$(cat "$tmp_out")"
+  stderr="$(cat "$tmp_err")"
+  rm -f "$tmp_out" "$tmp_err"
+
+  if [[ $rc -eq 0 ]]; then
+    red   "  FAIL [$script $label]: expected non-zero exit, got 0"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -n "$stdout" ]]; then
+    red   "  FAIL [$script $label]: expected empty stdout on invalid args, got:"
+    printf '%s\n' "$stdout" | sed 's/^/         /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -z "$stderr" ]]; then
+    red   "  FAIL [$script $label]: expected non-empty stderr message"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  green "  PASS [$script $label]: exit=$rc, stdout empty, stderr non-empty"
+  PASS=$((PASS + 1))
+}
+
+echo "ship-epic: smoke-testing argument validation contracts"
+echo
+
+assert_invalid_args ship_epic.sh "epic-missing-value"    --epic
+assert_invalid_args ship_epic.sh "unknown-flag"          --not-a-flag
+assert_invalid_args ship_epic.sh "extra-positional"      --epic feature/x extra-arg
+
+echo
+echo "ship-epic: ${PASS} passed, ${FAIL} failed"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

Adds `flowkit:ship-epic` as the symmetric closer for `flowkit:cut-epic`. The skill rebase-merges a `feature/<slug>-<N>` epic branch to `develop` via `gh pr merge --rebase --delete-branch`, unsets `claude.flowkit.prBase`, deletes the epic branch, and fast-forwards local develop — keeping `develop`'s first-parent line linear with no merge bubbles.

## Changes

- Add `plugins/flowkit/skills/ship-epic/SKILL.md` — new user-facing skill with frontmatter, Input, Process (delegates to script), Output table, Constraints, and Composition table.
- Add `plugins/flowkit/skills/ship-epic/scripts/ship_epic.sh` — bash script implementing epic resolution, push, preflight (empty epic guard + raw worktree-agent merge guard), closes-token aggregation, PR creation, rebase-merge via `with-clean-workspace`, config unset, and develop fast-forward. Emits bare JSON on success (6 fields).
- Add `plugins/flowkit/skills/ship-epic/scripts/test.sh` — argument-validation smoke tests (3 cases; happy-path is out-of-harness per `_shared/script-authoring.md`).
- Update `.claude/settings.json` — add 3 allowlist entries for `ship_epic.sh` (per `_shared/script-authoring.md § Allowlist for cross-skill scripts`).
- Update `plugins/flowkit/skills/cut-epic/SKILL.md` Teardown section — replace manual steps with pointer to `flowkit:ship-epic`; retain manual fallback commands.
- Update `plugins/flowkit/README.md` — insert `ship-epic` row in the user-facing skill table; replace `gh pr create … && git config --unset …` in the epic-flow example with `/ship-epic`.

## Test plan

- [ ] `bash scripts/test-all-skill-scripts.sh` exits 0 — ship-epic test.sh appears in output and passes.
- [ ] `bash plugins/flowkit/skills/ship-epic/scripts/ship_epic.sh --help` exits 0 with usage on stdout.
- [ ] `bash plugins/flowkit/skills/ship-epic/scripts/ship_epic.sh` exits non-zero, empty stdout, clear stderr ("No epic in flight").
- [ ] `bash plugins/flowkit/skills/ship-epic/scripts/ship_epic.sh --epic` exits 2, empty stdout, stderr mentions `--epic requires a branch name`.
- [ ] `bash plugins/flowkit/skills/ship-epic/scripts/ship_epic.sh --unknown-flag` exits 2, empty stdout.
- [ ] `jq . .claude/settings.json` parses cleanly; `grep -c ship_epic.sh .claude/settings.json` returns `3`.
- [ ] `grep -q '/ship-epic' plugins/flowkit/README.md` succeeds.
- [ ] `grep -q 'flowkit:ship-epic' plugins/flowkit/skills/cut-epic/SKILL.md` succeeds.
- [ ] Live happy-path (by reviewer, on a scratch repo): run `/ship-epic` against a real epic branch with squashed child commits, confirm PR opens, rebase-merges, epic branch deleted on origin, `claude.flowkit.prBase` empty, `git log --first-parent origin/develop` shows child commits with no merge bubbles.

Closes #887
Refs #897