### PR TITLE
feat(flowkit): add restack skill and wire into swarmkit:merge-stack

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,7 +34,10 @@
       "Bash(*/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh:*)",
       "Bash($SKILL_DIR/scripts/ship_epic.sh:*)",
       "Bash(plugins/flowkit/skills/ship-epic/scripts/ship_epic.sh:*)",
-      "Bash(*/plugins/flowkit/skills/ship-epic/scripts/ship_epic.sh:*)"
+      "Bash(*/plugins/flowkit/skills/ship-epic/scripts/ship_epic.sh:*)",
+      "Bash($SKILL_DIR/scripts/restack.sh:*)",
+      "Bash(plugins/flowkit/skills/restack/scripts/restack.sh:*)",
+      "Bash(*/plugins/flowkit/skills/restack/scripts/restack.sh:*)"
     ]
   }
 }

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -39,6 +39,7 @@ claude --plugin-dir /path/to/flowkit
 | **open-pr** | `/open-pr` | Push current branch and open a GitHub PR. Respects `claude.flowkit.prBase` for branch targeting. |
 | **pr** | `/pr` | Combined: `create-branch` → `commit` → `open-pr` in one step. |
 | **merge-pr** | `/merge-pr` | Squash-merge the open PR for the current branch and delete the remote branch (retargets stacked children; clears blocking swarm worktrees). |
+| **restack** | `/restack` | Rebase open descendant PRs of a parent PR onto its updated head and force-push, recursing through the subtree. Use mid-review after revising a stacked PR. |
 | **sync** | `/sync` | Checkout `develop`, pull latest, prune stale branches. |
 | **cut** | `/cut` | Create a `rc/YYYY-MM-DD.N` release candidate from `develop`; auto-stages if a staging branch exists. |
 | **stage** | `/stage` | Force-reset the `staging` branch to a release candidate. No-op if staging doesn't exist. |
@@ -101,6 +102,17 @@ The epic branch composes with `swarmkit:swarm`: agents spawned while `claude.flo
 Nothing is pushed and the epic branch is fetched read-only. See `/preview-epic` for the full Model A vs. Model B detection rules.
 
 > Do not run `/ship` while an epic is in flight unless you intend to ship the epic. `/ship` will rescope `claude.flowkit.prBase` to `develop` for its own flow.
+
+### Mid-review restack
+
+After pushing new commits to a parent PR in a stack, bring every still-open descendant PR up to date in one command:
+
+```
+/restack --pr <N>       # rebase all open descendants of PR N and force-push
+/restack                # auto-resolve the PR for the current branch
+```
+
+The subtree is walked breadth-first: siblings continue independently if one branch hits a conflict. Conflicted branches are reported; the operator resolves by hand and re-runs `/restack`.
 
 ### Feature flow
 

--- a/plugins/flowkit/skills/restack/SKILL.md
+++ b/plugins/flowkit/skills/restack/SKILL.md
@@ -18,7 +18,7 @@ Rebase the open descendant PRs of a parent PR onto its updated head and force-pu
 `$ARGUMENTS` — required. One of:
 
 - `--pr <N>` — PR whose descendant subtree is rebased onto its head. Recursive.
-- Empty — auto-resolve the PR for the current branch (`gh pr list --head $BRANCH`); equivalent to passing the resolved PR as `--pr`.
+- Empty — auto-resolve the PR for the current branch (`gh pr list --head $BRANCH`); equivalent to passing the resolved PR as `--pr`. Empty args resolve to `--pr <N>` and execute mode 1 — they are not a third invocation mode.
 
 The `--branch <head> --upstream <ref>` form is a cross-plugin entry point used by `swarmkit:merge-stack` step 5e. Operators don't pass it directly; documented here for completeness.
 

--- a/plugins/flowkit/skills/restack/SKILL.md
+++ b/plugins/flowkit/skills/restack/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: restack
+description: Rebase the open descendant PRs of a parent PR onto its updated head and force-push, recursing through transitive descendants. Use mid-review when a parent PR receives new commits and the stack needs to stay current. Powers swarmkit:merge-stack step 5e.
+triggers:
+  - "/restack"
+  - "rebase descendants"
+  - "restack the stack"
+  - "rebase children of PR"
+allowed-tools: Bash
+---
+
+# restack
+
+Rebase the open descendant PRs of a parent PR onto its updated head and force-push, recursing through transitive descendants. Use mid-review after revising a stacked PR to keep the stack consistent for reviewers.
+
+## Input
+
+`$ARGUMENTS` — required. One of:
+
+- `--pr <N>` — PR whose descendant subtree is rebased onto its head. Recursive.
+- Empty — auto-resolve the PR for the current branch (`gh pr list --head $BRANCH`); equivalent to passing the resolved PR as `--pr`.
+
+The `--branch <head> --upstream <ref>` form is a cross-plugin entry point used by `swarmkit:merge-stack` step 5e. Operators don't pass it directly; documented here for completeness.
+
+## Process
+
+1. Capture the skill directory from the harness header line:
+
+   `Base directory for this skill: <absolute path>`
+
+   ```bash
+   export SKILL_DIR="<absolute path from the header line>"
+   ```
+
+2. Run the script:
+
+   ```bash
+   RESULT=$(bash "$SKILL_DIR/scripts/restack.sh" $ARGUMENTS)
+   ```
+
+3. On success (`RESULT` is non-empty JSON), report a summary:
+
+   > Restacked subtree of PR #N. Succeeded: K branches. Failed: M branches (subtrees skipped). See log above for details.
+
+   where `N` is `.parent.pr_number`, `K` is `(.succeeded | length)`, and `M` is `(.failed | length)` from `RESULT`.
+
+   For single-branch mode (no `.parent`), report:
+
+   > Rebased branch onto upstream. Succeeded: K. Failed: M.
+
+4. On failure (non-zero exit, empty stdout), surface stderr and stop.
+
+## Script contract
+
+`scripts/restack.sh` implements dirty-workspace stashing, BFS descendant discovery, and a `git rebase` + `git push --force-with-lease` loop. On success it prints **bare JSON** on stdout:
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `mode` | string | `"recursive"` or `"single-branch"`. |
+| `parent` | object \| null | `{pr_number, head_branch}` for recursive mode; `null` for single-branch. |
+| `succeeded` | array | `[{branch, upstream, force_pushed: true}, ...]`. |
+| `failed` | array | `[{branch, upstream, reason: "rebase-conflict" \| "force-push-rejected" \| "branch-not-found"}, ...]`. |
+| `skipped` | array | `[{branch, reason: "ancestor-failed", ancestor: "<branch>"}, ...]`. |
+| `original_head` | string | The git ref the operator was on at invocation, restored before exit. |
+
+Exit codes: `0` success (including no descendants). `1` runtime failure. `2` invalid argument.

--- a/plugins/flowkit/skills/restack/scripts/restack.sh
+++ b/plugins/flowkit/skills/restack/scripts/restack.sh
@@ -1,0 +1,298 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# restack.sh — rebase the open descendant PRs of a parent onto its updated head.
+#
+# Usage (two modes, mutually exclusive):
+#   restack.sh --pr <N>                           # recursive subtree (user-facing)
+#   restack.sh --branch <head> --upstream <ref>  # single-branch (cross-plugin)
+#   restack.sh                                    # auto-resolve PR for current branch
+#
+# Success: exit 0, bare JSON object on stdout.
+# Failure: exit 1, human-readable stderr, empty stdout.
+# Invalid args: exit 2, human-readable stderr, empty stdout.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESTACK_DIR="$(dirname "$SCRIPT_DIR")"
+SKILLS_DIR="$(dirname "$RESTACK_DIR")"
+WITH_CLEAN_SH="$SKILLS_DIR/with-clean-workspace/scripts/with_clean_workspace.sh"
+
+die()       { echo "restack: $*" >&2; exit 1; }
+die_usage() { echo "restack: $*" >&2; exit 2; }
+
+usage() {
+  cat >&2 <<'EOF'
+restack: usage:
+  restack.sh --pr <N>                           # rebase subtree of PR N (recursive)
+  restack.sh --branch <head> --upstream <ref>  # rebase single branch onto ref
+  restack.sh                                    # auto-resolve PR for current branch
+EOF
+}
+
+# ── Save original args before parsing (needed for re-invocation guard) ────────
+ORIGINAL_ARGS=("$@")
+
+# ── Arg parsing ───────────────────────────────────────────────────────────────
+PR_NUM=""
+BRANCH_ARG=""
+UPSTREAM_ARG=""
+EXTRA_POSITIONAL=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)
+      [[ $# -ge 2 ]] || die_usage "--pr requires a value"
+      PR_NUM="$2"
+      shift 2
+      ;;
+    --branch)
+      [[ $# -ge 2 ]] || die_usage "--branch requires a value"
+      BRANCH_ARG="$2"
+      shift 2
+      ;;
+    --upstream)
+      [[ $# -ge 2 ]] || die_usage "--upstream requires a value"
+      UPSTREAM_ARG="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    -*)
+      die_usage "unknown flag: $1"
+      ;;
+    *)
+      EXTRA_POSITIONAL=$((EXTRA_POSITIONAL + 1))
+      shift
+      ;;
+  esac
+done
+
+[[ $EXTRA_POSITIONAL -gt 0 ]] && die_usage "unexpected positional argument(s)"
+
+[[ -n "$PR_NUM" && -n "$BRANCH_ARG" ]] && die_usage "--pr and --branch are mutually exclusive"
+
+[[ -n "$UPSTREAM_ARG" && -z "$BRANCH_ARG" ]] && die_usage "--upstream requires --branch"
+
+[[ -n "$BRANCH_ARG" && -z "$UPSTREAM_ARG" ]] && die_usage "--branch requires --upstream"
+
+if [[ -n "$PR_NUM" && ! "$PR_NUM" =~ ^[0-9]+$ ]]; then
+  die_usage "--pr must be a numeric PR number, got: $PR_NUM"
+fi
+
+[[ -n "$BRANCH_ARG" ]] && MODE="single-branch" || MODE="recursive"
+
+# ── Dep checks ────────────────────────────────────────────────────────────────
+for cmd in jq git gh; do
+  command -v "$cmd" >/dev/null 2>&1 || die "required dependency '$cmd' not found on PATH"
+done
+
+[[ -f "$WITH_CLEAN_SH" ]] || die "expected with-clean-workspace at $WITH_CLEAN_SH (flowkit layout)"
+
+# ── Dirty-workspace guard: re-invoke via with-clean-workspace once ────────────
+if [[ "${_RESTACK_WCW:-0}" != "1" ]]; then
+  exec "$WITH_CLEAN_SH" -- env _RESTACK_WCW=1 bash "$0" "${ORIGINAL_ARGS[@]+"${ORIGINAL_ARGS[@]}"}"
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# From here the workspace is clean (stash was applied if needed).
+# ══════════════════════════════════════════════════════════════════════════════
+
+ORIGINAL_HEAD=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || git rev-parse HEAD 2>/dev/null || echo "")
+
+# Temp files for JSON accumulation (one JSON object per line)
+TMP_DIR=$(mktemp -d)
+TMP_SUCCEEDED="$TMP_DIR/succeeded"
+TMP_FAILED="$TMP_DIR/failed"
+TMP_SKIPPED="$TMP_DIR/skipped"
+touch "$TMP_SUCCEEDED" "$TMP_FAILED" "$TMP_SKIPPED"
+
+_restore_head() {
+  if [[ -n "$ORIGINAL_HEAD" ]]; then
+    git checkout "$ORIGINAL_HEAD" 2>/dev/null || {
+      echo "restack: WARNING: could not restore HEAD to '$ORIGINAL_HEAD'; falling back to develop" >&2
+      git checkout develop 2>/dev/null || true
+    }
+  fi
+}
+
+_cleanup() {
+  _restore_head
+  rm -rf "$TMP_DIR"
+}
+trap _cleanup EXIT
+
+# ── JSON helpers ──────────────────────────────────────────────────────────────
+
+_record_success() {
+  local branch="$1" upstream="$2"
+  jq -n --arg b "$branch" --arg u "$upstream" \
+    '{branch:$b,upstream:$u,force_pushed:true}' >> "$TMP_SUCCEEDED"
+}
+
+_record_failure() {
+  local branch="$1" upstream="$2" reason="$3"
+  jq -n --arg b "$branch" --arg u "$upstream" --arg r "$reason" \
+    '{branch:$b,upstream:$u,reason:$r}' >> "$TMP_FAILED"
+}
+
+_record_skipped() {
+  local branch="$1" ancestor="$2"
+  jq -n --arg b "$branch" --arg a "$ancestor" \
+    '{branch:$b,reason:"ancestor-failed",ancestor:$a}' >> "$TMP_SKIPPED"
+}
+
+_emit_result() {
+  local mode="$1" parent_json="$2"
+  local succeeded_arr failed_arr skipped_arr
+  succeeded_arr=$(jq -s '. // []' "$TMP_SUCCEEDED")
+  failed_arr=$(jq -s '. // []' "$TMP_FAILED")
+  skipped_arr=$(jq -s '. // []' "$TMP_SKIPPED")
+  jq -n \
+    --arg mode "$mode" \
+    --argjson parent "$parent_json" \
+    --argjson succeeded "$succeeded_arr" \
+    --argjson failed "$failed_arr" \
+    --argjson skipped "$skipped_arr" \
+    --arg original_head "$ORIGINAL_HEAD" \
+    '{mode:$mode,parent:$parent,succeeded:$succeeded,failed:$failed,skipped:$skipped,original_head:$original_head}'
+}
+
+_has_failures() {
+  [[ $(jq -s '. // [] | length' "$TMP_FAILED") -gt 0 ]]
+}
+
+# ── Core: rebase one branch onto an upstream ref ──────────────────────────────
+_rebase_single() {
+  local branch="$1" upstream="$2"
+  local upstream_short="${upstream#origin/}"
+
+  git fetch origin "$branch" "${upstream_short}" 2>/dev/null || true
+
+  if ! git ls-remote --heads origin "$branch" | grep -q "refs/heads/$branch"; then
+    echo "restack: branch '$branch' not found on remote origin" >&2
+    _record_failure "$branch" "$upstream" "branch-not-found"
+    return 1
+  fi
+
+  git checkout "$branch"
+
+  set +e
+  git rebase "$upstream"
+  local rebase_exit=$?
+  set -e
+
+  if [[ $rebase_exit -ne 0 ]]; then
+    git rebase --abort 2>/dev/null || true
+    echo "restack: rebase conflict on '$branch' onto '$upstream'" >&2
+    _record_failure "$branch" "$upstream" "rebase-conflict"
+    return 1
+  fi
+
+  set +e
+  git push --force-with-lease origin "$branch"
+  local push_exit=$?
+  set -e
+
+  if [[ $push_exit -ne 0 ]]; then
+    echo "restack: force-push rejected for '$branch'" >&2
+    _record_failure "$branch" "$upstream" "force-push-rejected"
+    return 1
+  fi
+
+  _record_success "$branch" "$upstream"
+  return 0
+}
+
+# ── BFS helpers ───────────────────────────────────────────────────────────────
+
+_get_open_descendants() {
+  local parent_branch="$1"
+  gh pr list --base "$parent_branch" --state open --json headRefName \
+    --jq '.[].headRefName' 2>/dev/null || true
+}
+
+_skip_subtree() {
+  local root_branch="$1" ancestor="$2"
+  local queue=("$root_branch")
+  local qi=0
+  while [[ $qi -lt ${#queue[@]} ]]; do
+    local cur="${queue[$qi]}"
+    qi=$((qi + 1))
+    while IFS= read -r child; do
+      [[ -z "$child" ]] && continue
+      _record_skipped "$child" "$ancestor"
+      queue+=("$child")
+    done < <(_get_open_descendants "$cur")
+  done
+}
+
+# ══════════════════════════════════════════════════════════════════════════════
+# SINGLE-BRANCH MODE
+# ══════════════════════════════════════════════════════════════════════════════
+
+if [[ "$MODE" == "single-branch" ]]; then
+  _rebase_single "$BRANCH_ARG" "$UPSTREAM_ARG" || true
+  _emit_result "single-branch" "null"
+  _has_failures && exit 1
+  exit 0
+fi
+
+# ══════════════════════════════════════════════════════════════════════════════
+# RECURSIVE MODE (--pr N or auto-resolve)
+# ══════════════════════════════════════════════════════════════════════════════
+
+if [[ -z "$PR_NUM" ]]; then
+  CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  if [[ -z "$CURRENT_BRANCH" || "$CURRENT_BRANCH" == "HEAD" ]]; then
+    die "not on a named branch and no --pr given; cannot auto-resolve PR"
+  fi
+  PR_NUM=$(gh pr list --head "$CURRENT_BRANCH" --json number \
+    --jq 'if length > 0 then .[0].number | tostring else empty end' 2>/dev/null || true)
+  if [[ -z "$PR_NUM" ]]; then
+    die "no open PR found for branch '$CURRENT_BRANCH'"
+  fi
+fi
+
+PR_META=$(gh pr view "$PR_NUM" --json headRefName,number)
+PARENT_HEAD=$(printf '%s' "$PR_META" | jq -r '.headRefName')
+PARENT_PR_NUM=$(printf '%s' "$PR_META" | jq -r '.number')
+
+if [[ -z "$PARENT_HEAD" || "$PARENT_HEAD" == "null" ]]; then
+  die "could not read headRefName for PR #$PR_NUM"
+fi
+
+PARENT_JSON=$(jq -n --argjson n "$PARENT_PR_NUM" --arg h "$PARENT_HEAD" \
+  '{pr_number:$n,head_branch:$h}')
+
+# BFS queue: parallel arrays of (branch, upstream_ref)
+declare -a Q_BRANCH=()
+declare -a Q_UPSTREAM=()
+
+while IFS= read -r child; do
+  [[ -z "$child" ]] && continue
+  Q_BRANCH+=("$child")
+  Q_UPSTREAM+=("origin/$PARENT_HEAD")
+done < <(_get_open_descendants "$PARENT_HEAD")
+
+QI=0
+while [[ $QI -lt ${#Q_BRANCH[@]} ]]; do
+  CB="${Q_BRANCH[$QI]}"
+  CU="${Q_UPSTREAM[$QI]}"
+  QI=$((QI + 1))
+
+  if _rebase_single "$CB" "$CU"; then
+    while IFS= read -r grandchild; do
+      [[ -z "$grandchild" ]] && continue
+      Q_BRANCH+=("$grandchild")
+      Q_UPSTREAM+=("origin/$CB")
+    done < <(_get_open_descendants "$CB")
+  else
+    _skip_subtree "$CB" "$CB"
+  fi
+done
+
+_emit_result "recursive" "$PARENT_JSON"
+_has_failures && exit 1
+exit 0

--- a/plugins/flowkit/skills/restack/scripts/test.sh
+++ b/plugins/flowkit/skills/restack/scripts/test.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# test.sh — smoke tests for flowkit:restack scripts.
+#
+# Per plugins/_shared/script-authoring.md:
+# - Successful invocations exit 0 with parseable JSON on stdout.
+# - Invalid-argument invocations exit non-zero with empty stdout.
+#
+# restack.sh requires git, gh, and live GitHub state for happy paths.
+# This harness covers argument-validation contracts only.
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PASS=0
+FAIL=0
+
+red()   { printf '\033[31m%s\033[0m\n' "$*"; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+
+assert_invalid_args() {
+  local script="$1"; shift
+  local label="$1"; shift
+  local stdout stderr rc
+  local tmp_out tmp_err
+  tmp_out="$(mktemp)"
+  tmp_err="$(mktemp)"
+  set +e
+  "$SCRIPT_DIR/$script" "$@" >"$tmp_out" 2>"$tmp_err"
+  rc=$?
+  set -e
+  stdout="$(cat "$tmp_out")"
+  stderr="$(cat "$tmp_err")"
+  rm -f "$tmp_out" "$tmp_err"
+
+  if [[ $rc -eq 0 ]]; then
+    red   "  FAIL [$script $label]: expected non-zero exit, got 0"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -n "$stdout" ]]; then
+    red   "  FAIL [$script $label]: expected empty stdout on invalid args, got:"
+    printf '%s\n' "$stdout" | sed 's/^/         /'
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  if [[ -z "$stderr" ]]; then
+    red   "  FAIL [$script $label]: expected non-empty stderr message"
+    FAIL=$((FAIL + 1))
+    return
+  fi
+  green "  PASS [$script $label]: exit=$rc, stdout empty, stderr non-empty"
+  PASS=$((PASS + 1))
+}
+
+echo "restack: smoke-testing argument validation contracts"
+echo
+
+assert_invalid_args restack.sh "non-numeric-pr"        --pr abc
+assert_invalid_args restack.sh "pr-and-branch-mutex"   --pr 1 --branch foo
+assert_invalid_args restack.sh "branch-without-upstream" --branch foo
+assert_invalid_args restack.sh "upstream-without-branch" --upstream main
+assert_invalid_args restack.sh "unknown-flag"          --unknown-flag
+assert_invalid_args restack.sh "extra-positional"      extra-arg
+
+echo
+echo "restack: ${PASS} passed, ${FAIL} failed"
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/plugins/swarmkit/skills/merge-stack/SKILL.md
+++ b/plugins/swarmkit/skills/merge-stack/SKILL.md
@@ -157,18 +157,11 @@ After merging a non-leaf PR in a chain, every still-open downstream PR in that c
 For every still-open PR in the chain, from closest-to-root to leaf:
 
 ```bash
-git fetch origin <head-branch> $BASE
-git checkout <head-branch>
-if ! git rebase origin/$BASE; then
-  git rebase --abort
-  # Real content conflict (e.g. add/add on a file two chains both created).
-  # Fall through to 5d: stop this chain, block its dependents, continue with
-  # other chains/independents. Do NOT force-push; leave the PR untouched so
-  # the user can resolve by hand.
-  continue  # or equivalent control flow in the skill's execution loop
-fi
-git push --force-with-lease origin <head-branch>
+RESTACK_SH="plugins/flowkit/skills/restack/scripts/restack.sh"
+bash "$RESTACK_SH" --branch "<head-branch>" --upstream "origin/$BASE"
 ```
+
+Implementation lives at [`flowkit:restack`](../../../flowkit/skills/restack/SKILL.md). The same script powers `/restack --pr N` for mid-review use.
 
 `git rebase` will emit `warning: skipped previously applied commit <sha>` for each predecessor commit it drops via patch-id — that's the expected happy path, not an error. A non-zero exit from `git rebase` means a real merge conflict git could not auto-resolve; handle it per 5d. Always `git rebase --abort` before falling through so the branch returns to its pre-rebase state and no partial work is pushed.
 


### PR DESCRIPTION
## Summary

Adds `flowkit:restack`, a BFS-recursive stacked-PR rebaser that promotes the `git rebase` / `git push --force-with-lease` loop currently inlined in `swarmkit:merge-stack` step 5e into a shared, testable script with two invocation modes: `--pr N` (user-facing recursive subtree) and `--branch/--upstream` (cross-plugin single-branch call from merge-stack). Every still-open descendant PR is rebased breadth-first; sibling branches continue independently when one subtree hits a conflict. The merge-stack step 5e shell block is replaced with a one-line script call; surrounding explanatory prose is preserved verbatim.

## Changes

- **Create** `plugins/flowkit/skills/restack/SKILL.md` — skill frontmatter (name, description, triggers, `allowed-tools: Bash`), Input table, Process steps mirroring `merge-pr`, and script contract table.
- **Create** `plugins/flowkit/skills/restack/scripts/restack.sh` — BFS rebase engine with dirty-workspace guard (re-invokes via `with-clean-workspace`), original-HEAD restore on EXIT trap, `--force-with-lease`-only pushes, and bare-payload JSON output (`mode`, `parent`, `succeeded`, `failed`, `skipped`, `original_head`).
- **Create** `plugins/flowkit/skills/restack/scripts/test.sh` — 6 argument-validation smoke tests (non-numeric `--pr`, `--pr`/`--branch` mutual exclusivity, `--branch` without `--upstream`, `--upstream` without `--branch`, unknown flag, extra positional).
- **Update** `.claude/settings.json` — three allowlist matchers for `restack.sh` (`$SKILL_DIR`, repo-relative, suffix-glob).
- **Update** `plugins/swarmkit/skills/merge-stack/SKILL.md` — step 5e `git fetch/checkout/rebase/push` block replaced with `bash "$RESTACK_SH" --branch <head> --upstream "origin/$BASE"` call + `flowkit:restack` cross-reference link.
- **Update** `plugins/flowkit/README.md` — `restack` row in the user-facing skill table (between `merge-pr` and `sync`) + "Mid-review restack" workflow section under Typical Workflows.

## Test plan

- [ ] `bash scripts/test-all-skill-scripts.sh` — 7 suites, 0 failures (restack suite now appears).
- [ ] `bash plugins/flowkit/skills/restack/scripts/test.sh` — 6/6 argument-validation cases pass.
- [ ] `jq . .claude/settings.json > /dev/null` — JSON parses cleanly.
- [ ] `grep -c 'restack.sh' .claude/settings.json` returns `3`.
- [ ] `grep -q 'plugins/flowkit/skills/restack/scripts/restack.sh' plugins/swarmkit/skills/merge-stack/SKILL.md` — merge-stack references the shared script.
- [ ] `grep -q 'flowkit:restack' plugins/swarmkit/skills/merge-stack/SKILL.md` — merge-stack cross-links the skill doc.
- [ ] `grep -q '/restack' plugins/flowkit/README.md` — README registers the skill.
- [ ] Confirm `restack.sh --branch` mode contains no `gh pr view` / `gh pr list` calls (merge-stack hot loop stays fast).
- [ ] Confirm merge-stack step 5e prose at original lines ~155 and ~173–177 is preserved verbatim around the new script call.
- [ ] **Live happy path (reviewer):** set up a 3-PR stack (`parent` → `child` base=parent → `grandchild` base=child), push a new commit to `parent`, run `/restack --pr <parent-PR>`, confirm both `child` and `grandchild` are rebased + force-pushed with `git log child` including the new parent commit.

Closes #893
Refs #897