### PR TITLE
refactor(flowkit): drop legacy claude.prBase fallback (#896)

### DIFF
--- a/plugins/_shared/base-resolution.md
+++ b/plugins/_shared/base-resolution.md
@@ -25,12 +25,12 @@ A consuming plugin MAY check a sibling plugin's scoped key as a courtesy slot �
 
 ## Reference implementations
 
-- [`plugins/flowkit/skills/open-pr/SKILL.md`](../flowkit/skills/open-pr/SKILL.md) — flowkit implementation (includes legacy `claude.prBase` deviation until [#896](https://github.com/smallorbit/smallorbit-plugins/issues/896) lands).
+- [`plugins/flowkit/skills/open-pr/SKILL.md`](../flowkit/skills/open-pr/SKILL.md) — flowkit implementation.
 - [`plugins/polishkit/skills/polish/SKILL.md`](../polishkit/skills/polish/SKILL.md) — polishkit implementation (includes optional flowkit courtesy interop slot).
 
 ## Anti-patterns
 
 - **Do not hardcode `develop`** — always use the resolution algorithm so repos without a `develop` branch fall through gracefully.
 - **Do not skip the `$BASE` non-empty check** — an empty `$BASE` silently targets the GitHub default, which is almost always wrong in a feature-branch workflow.
-- **Do not write to `claude.prBase`** — the legacy unscoped key is read-only for backward compatibility. All new writes go to `claude.<plugin>.prBase`.
+- **Do not write to or rely on `claude.prBase`** — the unscoped legacy key is no longer read by any plugin. All writes go to `claude.<plugin>.prBase`.
 - **Do not add new fallback layers without updating this doc first** — the algorithm is the contract; undocumented layers create invisible precedence conflicts across plugins.

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -169,20 +169,16 @@ queue
 
 When the file is present, `/release` uses it verbatim and skips auto-detection. Use the same token you put in commit messages and PR titles.
 
-### Migrating from `claude.prBase`
+### Removed: `claude.prBase` (legacy)
 
-The legacy key `claude.prBase` is still read as a fallback so existing setups don't break. When flowkit falls back to the legacy key, it emits a one-line deprecation notice with the exact commands below. Migrate at your convenience:
+The unscoped legacy key `claude.prBase` is no longer read by any flowkit skill (removed in [#896](https://github.com/smallorbit/smallorbit-plugins/issues/896)). If you have it set in a repo, clear it once and adopt the scoped key instead:
 
 ```bash
-# Read whatever was set on the legacy key
-LEGACY=$(git config claude.prBase)
-
-# Remove the legacy key and write the new one
 git config --unset claude.prBase
-git config claude.flowkit.prBase "$LEGACY"
+git config claude.flowkit.prBase develop   # or whatever value you had
 ```
 
-The legacy fallback is a soft deprecation and will be kept indefinitely — no hard break is planned. The new key aligns with the `claude.<plugin>.<key>` convention used across smallorbit plugins.
+Use the same `claude.<plugin>.prBase` convention for any other plugin that needs a session-pinned base.
 
 ## Assumptions & Conventions
 

--- a/plugins/flowkit/skills/cut-epic/SKILL.md
+++ b/plugins/flowkit/skills/cut-epic/SKILL.md
@@ -140,6 +140,6 @@ To close out by hand (manual fallback):
 
 - Always branch from `origin/develop`, never from a local `develop` (which may be behind).
 - Never write a non-`feature/` prefix — this skill is purposely narrow.
-- Never modify `claude.prBase` (the legacy key) — only `claude.flowkit.prBase`. See `pr-base-scope` for the rationale.
+- Never modify `claude.prBase` (the legacy unscoped key, no longer read by any plugin) — only `claude.flowkit.prBase`. See `pr-base-scope` for the rationale.
 - Idempotent: re-running with the same arguments must not error if the branch already exists.
 - This skill does not open a PR. It only sets up the branch and scope. Use `flowkit:pr` / `flowkit:open-pr` for sub-work.

--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -46,8 +46,6 @@ Resolve `$BASE` per the canonical chain at [`plugins/_shared/base-resolution.md`
 
 <!-- include: plugins/_shared/base-resolution.md -->
 
-**Deviation: legacy `claude.prBase` fallback.** This skill additionally reads the unscoped `claude.prBase` key between the scoped key (`claude.flowkit.prBase`) and the `develop` fallback, emitting a deprecation notice when found. This extra step is a backward-compatibility deviation not present in the canonical algorithm. It is removed by [#896](https://github.com/smallorbit/smallorbit-plugins/issues/896).
-
 ```bash
 # 1. Explicit caller arg
 BASE=""
@@ -60,25 +58,14 @@ if [ -z "$BASE" ]; then
   BASE=$(git config claude.flowkit.prBase 2>/dev/null)
 fi
 
-# 3. Legacy claude.prBase (deprecated)
-if [ -z "$BASE" ]; then
-  LEGACY=$(git config claude.prBase 2>/dev/null)
-  if [ -n "$LEGACY" ]; then
-    BASE="$LEGACY"
-    echo "note: claude.prBase is deprecated. Migrate with:" >&2
-    echo "  git config --unset claude.prBase" >&2
-    echo "  git config claude.flowkit.prBase $LEGACY" >&2
-  fi
-fi
-
-# 4. develop if it exists on the remote
+# 3. develop if it exists on the remote
 if [ -z "$BASE" ]; then
   if git ls-remote --heads origin develop | grep -q 'refs/heads/develop'; then
     BASE="develop"
   fi
 fi
 
-# 5. Fallback — use the repo default and warn
+# 4. Fallback — use the repo default and warn
 if [ -z "$BASE" ]; then
   REPO_DEFAULT=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
   echo "warning: no base branch configured and 'develop' not found on remote; falling back to repo default ($REPO_DEFAULT)" >&2
@@ -179,8 +166,8 @@ Output the PR URL returned by `gh pr create`.
 
 ## Constraints
 
-- Always resolve `--base` before calling `gh pr create` per [`plugins/_shared/base-resolution.md`](../../../_shared/base-resolution.md) (plus the legacy `claude.prBase` deviation documented in step 2). `$BASE` is always non-empty; `--base "$BASE"` is always passed.
-- Never target `main` directly unless `claude.flowkit.prBase` (or legacy `claude.prBase`) is explicitly set to `main`
+- Always resolve `--base` before calling `gh pr create` per [`plugins/_shared/base-resolution.md`](../../../_shared/base-resolution.md). `$BASE` is always non-empty; `--base "$BASE"` is always passed.
+- Never target `main` directly unless `claude.flowkit.prBase` is explicitly set to `main`
 - Never open a PR from a protected branch (`develop`, `main`, `master`)
 - If `gh` is not installed or not authenticated, report the error and stop — do not attempt workarounds
 - Do not force-push; use a plain `git push -u origin HEAD`

--- a/plugins/flowkit/skills/pr-base-scope/SKILL.md
+++ b/plugins/flowkit/skills/pr-base-scope/SKILL.md
@@ -7,8 +7,6 @@ description: Set or unset the claude.flowkit.prBase git config key to scope the 
 
 Set or unset `claude.flowkit.prBase` — a local git config key that tells `/open-pr` which branch to target when creating a pull request. Used by `/ship` to pin PRs to `develop` during the ship flow, and by swarm loop mode to scope multi-PR sessions.
 
-The legacy key `claude.prBase` is still read as a fallback for backward compatibility, but is never written. When read, it emits a one-line deprecation notice pointing at the migration commands.
-
 ## Operations
 
 ### Set
@@ -35,11 +33,10 @@ git config --unset claude.flowkit.prBase
 
 ### Read
 
-Resolution order is the canonical chain at [`plugins/_shared/base-resolution.md`](../../../_shared/base-resolution.md). This skill writes only to `claude.flowkit.prBase`; the legacy `claude.prBase` key is read as a deprecation fallback by `open-pr` (removed by [#896](https://github.com/smallorbit/smallorbit-plugins/issues/896)).
+Resolution order is the canonical chain at [`plugins/_shared/base-resolution.md`](../../../_shared/base-resolution.md). This skill writes only to `claude.flowkit.prBase`.
 
 ## Constraints
 
 - This key is local to the repo — it is never committed or pushed
 - Always unset after a scoped flow completes to avoid stale targeting in future sessions
 - Never write to the legacy `claude.prBase` key. All set/unset operations target `claude.flowkit.prBase` only
-- The legacy fallback is a soft deprecation — keep it indefinitely

--- a/plugins/swarmkit/METHODOLOGY.md
+++ b/plugins/swarmkit/METHODOLOGY.md
@@ -85,7 +85,7 @@ Failure is handled explicitly rather than by retrying. If an issue fails during 
 
 A small set of failures are treated as unrecoverable and halt the loop immediately: an agent that crashed without producing a PR (there is nothing to review, so there is nothing to proceed from) and the base branch being deleted or corrupted externally (the premise of the loop is gone). Everything else is recoverable and surfaces in the checkpoint report.
 
-Loop mode sets `claude.prBase` as a local git config at the start and unsets it in teardown. While it is set, every pull request created in the repository targets that base, which is what keeps independent PRs merging into the intended base branch even when the command line that created them did not specify `--base`. The teardown unset is critical — leaving the config set leaks the scoped base into unrelated PR-creation commands in the same repository.
+Loop mode sets `claude.flowkit.prBase` as a local git config at the start and unsets it in teardown. While it is set, every pull request created in the repository targets that base, which is what keeps independent PRs merging into the intended base branch even when the command line that created them did not specify `--base`. The teardown unset is critical — leaving the config set leaks the scoped base into unrelated PR-creation commands in the same repository.
 
 ## End-to-End Walkthrough
 


### PR DESCRIPTION
## Summary

Removes the legacy `claude.prBase` read-fallback from `flowkit:open-pr`'s base-resolution chain and purges all doc surfaces that referenced it as active. After this PR, the canonical 4-step algorithm in `plugins/_shared/base-resolution.md` is the sole authority across every plugin — no skill reads the unscoped legacy key. Rolls in a 1-word stale-doc fix in `swarmkit/METHODOLOGY.md` (L88: `claude.prBase` → `claude.flowkit.prBase`).

## Changes

- **`plugins/flowkit/skills/open-pr/SKILL.md`** — delete Deviation paragraph and legacy bash block (step 3 `claude.prBase`); renumber chain comments to 4 steps; remove two parenthetical legacy references from Constraints.
- **`plugins/flowkit/skills/pr-base-scope/SKILL.md`** — delete top-level legacy-fallback paragraph; rewrite Read subsection to drop `#896` callout; delete "soft deprecation — keep it indefinitely" constraint bullet. Anti-foot-gun "Never write to the legacy key" constraint preserved.
- **`plugins/_shared/base-resolution.md`** — drop `(includes legacy claude.prBase deviation until #896 lands)` parenthetical from reference-implementations bullet; reword anti-pattern bullet to "no longer read by any plugin".
- **`plugins/flowkit/skills/cut-epic/SKILL.md`** — reword L143 constraint from "(the legacy key)" to "(the legacy unscoped key, no longer read by any plugin)".
- **`plugins/flowkit/README.md`** — replace "Migrating from `claude.prBase`" open-ended deprecation section with a 4-line terminal-state "Removed" callout naming the cleanup command.
- **`plugins/swarmkit/METHODOLOGY.md`** — fix L88 stale prose: `claude.prBase` → `claude.flowkit.prBase`.

## Test plan

- [x] `bash scripts/test-all-skill-scripts.sh` — 8/8 passed (no regressions; docs-only change)
- [x] Code-surface audit (`*.sh`, `*.json`): zero matches for `claude\.prBase`
- [x] SKILL.md bash-block audit (`git config.*claude\.prBase`): two expected matches only — README cleanup command + `default-branch-prompt` anti-foot-gun line (both allowed)
- [x] Full repo-wide grep: surviving matches exactly in the 5 allowed anti-foot-gun / terminal-state locations; zero matches in `open-pr/SKILL.md`, `METHODOLOGY.md`, `pr-base-scope` top paragraph
- [x] Cross-reference integrity: no `removed by #896`, `until #896`, or `Deviation:` strings in post-#896 files
- [x] Migration callout: cleanup command (`git config --unset claude.prBase`) appears in `flowkit/README.md`

## Migration

If you have `claude.prBase` set in any repo, run once to clean up:

```bash
git config --unset claude.prBase
git config claude.flowkit.prBase develop   # or whatever value you had
```

Closes #896
Refs #897