### PR TITLE
feat(swarmkit): default multi-issue swarm to feature-branch flow (#890)

### DIFF
--- a/plugins/swarmkit/METHODOLOGY.md
+++ b/plugins/swarmkit/METHODOLOGY.md
@@ -87,6 +87,74 @@ A small set of failures are treated as unrecoverable and halt the loop immediate
 
 Loop mode sets `claude.flowkit.prBase` as a local git config at the start and unsets it in teardown. While it is set, every pull request created in the repository targets that base, which is what keeps independent PRs merging into the intended base branch even when the command line that created them did not specify `--base`. The teardown unset is critical — leaving the config set leaks the scoped base into unrelated PR-creation commands in the same repository.
 
+## Feature-Branch Mode
+
+### Trigger Rule
+
+Swarm automatically cuts a feature branch whenever a run will spawn two or more agents. A run that spawns only one agent (a single-issue one-shot) stays flat — it targets `$BASE` directly, the same as before this feature landed. The trigger fires for:
+
+- **One-shot multi-issue**: `/swarm 12 15 18` — three issues → epic cut.
+- **Loop mode (all issues)**: `/swarm` — any board with ≥1 issue → epic cut at first non-empty cycle.
+- **Loop mode (label filter)**: `/swarm bug` — same trigger as loop mode.
+
+Single-issue one-shot (`/swarm 12`) always stays flat. The logic is: a standalone issue, by definition, cannot form a stack that needs isolation from `develop`.
+
+### What Happens at Epic Cut
+
+When the trigger fires, swarm invokes `flowkit:cut-epic` via the Skill tool before any agent spawns. `cut-epic` is idempotent — if the branch already exists on origin it is reused and the pin is refreshed. After `cut-epic` completes:
+
+- The feature branch `feature/<slug>-<N>` exists on origin.
+- `claude.flowkit.prBase` is pinned to that branch in the local repo config.
+- Every subsequent `/open-pr` invocation in this repo (and every spawned agent's `gh pr create`) auto-targets the feature branch.
+
+The slug is derived as follows:
+
+| Run shape | Slug argument to cut-epic |
+|---|---|
+| One-shot multi-issue | Lowest issue number (cut-epic resolves slug from the issue title) |
+| Loop mode, no label | `feature/swarm-<YYYY-MM-DD>` (full branch name; cut-epic accepts it directly) |
+| Loop mode + label | `feature/<label>-<YYYY-MM-DD>` |
+| `--epic <slug>` explicit | The given slug verbatim |
+
+### Inheritance
+
+Every spawned agent's PR targets the feature branch automatically via `claude.flowkit.prBase`. Stack-root PRs (independent issues) target the feature branch; stack-leaf PRs still target their predecessor, which ultimately roots at the feature branch. When `/merge-stack` later retargets non-root PRs, it retargets them to the feature branch (not `develop`), maintaining the same stack shape — just rooted at the epic instead of `develop`.
+
+### Loop-Mode Reuse
+
+In loop mode the feature branch is cut once — at the first cycle that selects ≥1 issue. Subsequent cycles reuse the same branch. A cycle that selects zero issues does not cut anything. If the board is clear at loop entry, the loop exits "Board is clear" before any cut happens.
+
+### Ship-Epic Handoff
+
+After all child PRs are merged into the feature branch via `/merge-stack`, the feature branch carries N squash commits — one per merged-from-stack PR. Swarm's responsibility ends here: PRs are open (or merged into the feature branch), and the pin is intact.
+
+The operator then runs `/ship-epic` (separately, after review) to:
+1. Open the feature→`develop` PR with aggregated `Closes #N` from the squash commits.
+2. Rebase-merge (so the squash commits replay onto `develop` linearly, no merge bubbles).
+3. Unset `claude.flowkit.prBase`.
+4. Delete the feature branch on origin.
+5. Fast-forward local `develop`.
+
+Swarm never invokes `/ship-epic`. The operator must explicitly trigger promotion.
+
+### Escape Hatches
+
+- **`--no-epic`** — suppress the cut for a single run; PRs target `$BASE` directly. Use when you want the old flat-to-`develop` shape for a specific multi-issue run.
+- **`--base <branch>`** — overrides targeting entirely and suppresses the cut. Use for trunk-based dev (`--base main`) or any explicit targeting assertion.
+- **`--epic <slug>`** — provide an explicit slug instead of the derived one. Useful when the lowest issue title produces an unwieldy slug, or when you want to resume an existing epic by name.
+
+### Cross-Pin Guard
+
+Before invoking `cut-epic`, swarm reads `claude.flowkit.prBase`. If it is set, starts with `feature/`, and differs from the branch about to be cut, swarm exits with:
+
+> `swarm: an epic is already pinned (\`<existing>\`); pass \`--no-epic\` to swarm against develop, or \`--epic <existing-slug>\` to reuse the pinned branch.`
+
+This prevents silently overwriting an in-flight epic from a parallel `squadkit:spawn-team --epic` run or a previous swarm session.
+
+### Symmetry with squadkit
+
+`swarmkit:swarm --epic` and `squadkit:spawn-team --epic` share the same primitive stack: `flowkit:cut-epic` cuts the branch and sets the pin; spawned PRs target the epic; `flowkit:ship-epic` is the operator-driven closer. The difference is orchestration: swarm dispatches fire-and-forget parallel agents against a list of issues; spawn-team dispatches an interactive team-lead + builder crew against a blueprint.
+
 ## End-to-End Walkthrough
 
 Consider a small epic with three issues.
@@ -95,30 +163,34 @@ Consider a small epic with three issues.
 - **#102** — adds a CSV exporter that uses `ReportSerializer`. Depends on #101.
 - **#103** — adds a CLI flag that calls the CSV exporter. Depends on #102.
 
-You invoke `/swarm 101 102 103`. Swarmkit fetches the three issue bodies, parses `Depends on` and `Blocked by` references, and produces a topological order: #101 is independent, #102 depends on #101, #103 depends on #102. The swarm plan is presented before any agent runs, showing three agents, their branches (`worktree-agent-101`, `worktree-agent-102`, `worktree-agent-103`), the files affected, and the proposed model per agent.
+You invoke `/swarm 101 102 103`. Because three issues are given, `EPIC_MODE=on`. Swarmkit derives the slug from issue #101's title — the lowest number in the batch. It invokes `flowkit:cut-epic` with `101`, which creates `feature/report-serializer-101` on origin and pins `claude.flowkit.prBase` to it. Swarmkit then fetches the three issue bodies, parses `Depends on` and `Blocked by` references, and produces a topological order: #101 is independent, #102 depends on #101, #103 depends on #102. The swarm plan is presented before any agent runs, showing three agents, their branches (`worktree-agent-101`, `worktree-agent-102`, `worktree-agent-103`), the files affected, and the proposed model per agent.
 
-Agent 101 spawns first. It branches from `origin/develop`, writes the `ReportSerializer` class, commits with `feat(reports): add ReportSerializer`, pushes `worktree-agent-101`, and opens PR #201 with base `develop` and head `worktree-agent-101`.
+Agent 101 spawns first. It branches from `origin/develop`, writes the `ReportSerializer` class, commits with `feat(reports): add ReportSerializer`, pushes `worktree-agent-101`, and opens PR #201 with base `feature/report-serializer-101` and head `worktree-agent-101`.
 
 Agent 102 waits for #201 to exist, then spawns. It does not wait for #201 to merge. It fetches `origin/worktree-agent-101` and branches from that tip, so the new `ReportSerializer` class is already in its working tree. It adds the CSV exporter on top, commits, pushes `worktree-agent-102`, and opens PR #202 with base `worktree-agent-101` and head `worktree-agent-102`.
 
 Agent 103 waits for #202 to exist, then spawns. It fetches `origin/worktree-agent-102` and branches from that tip, so both the serializer and the exporter are present. It wires up the CLI flag, commits, pushes `worktree-agent-103`, and opens PR #203 with base `worktree-agent-102` and head `worktree-agent-103`.
 
-At this point three PRs are open: #201 (→ `develop`), #202 (→ `worktree-agent-101`), #203 (→ `worktree-agent-102`). You review each one. None of them has merged yet.
+At this point three PRs are open: #201 (→ `feature/report-serializer-101`), #202 (→ `worktree-agent-101`), #203 (→ `worktree-agent-102`). You review each one. None of them has merged yet.
 
-You run `/merge-stack`. It discovers the three PRs by scanning for open PRs with `worktree-agent-` head branches, builds the stack graph from the head/base fields, retargets every non-root PR to `develop`, and prints a merge plan:
+You run `/merge-stack`. It discovers the three PRs by scanning for open PRs with `worktree-agent-` head branches, builds the stack graph from the head/base fields, retargets every non-root PR to `feature/report-serializer-101`, and prints a merge plan:
 
 ```
-Chain 1:  develop ← PR #201 ← PR #202 ← PR #203
+Chain 1:  feature/report-serializer-101 ← PR #201 ← PR #202 ← PR #203
 
-  Retargeted 2 non-root PRs to develop: #202, #203
-  Step 1. Merge PR #201 into develop (squash, delete branch)
-  Step 2. Merge PR #202 into develop (squash, delete branch)
-  Step 3. Merge PR #203 into develop (squash, delete branch)
+  Retargeted 2 non-root PRs to feature/report-serializer-101: #202, #203
+  Step 1. Merge PR #201 into feature/report-serializer-101 (squash, delete branch)
+  Step 2. Merge PR #202 into feature/report-serializer-101 (squash, delete branch)
+  Step 3. Merge PR #203 into feature/report-serializer-101 (squash, delete branch)
 ```
 
-Step 1 squash-merges #201 into `develop` and deletes `worktree-agent-101`. Because #202 was already retargeted to `develop`, GitHub does not auto-close it — #202's base is still `develop`. Step 2 squash-merges #202 into `develop` and deletes `worktree-agent-102`; step 3 does the same for #203. Each PR carries its own `Closes #10N` reference, so each issue closes natively on merge. Finally `/clean-worktrees` removes the three worktree directories and the three local `worktree-agent-*` branches.
+Step 1 squash-merges #201 into the epic branch and deletes `worktree-agent-101`. Because #202 was already retargeted, GitHub does not auto-close it. Steps 2 and 3 do the same for #202 and #203. Each PR carries its own `Closes #10N` reference, so each issue closes natively on merge. The epic branch now carries three squash commits.
 
-If anything had gone wrong on the way up — a merge conflict on #202, for example — the merge would have stopped there and reported the chain as halted at #202 with #203 as blocked upstream. The retarget happened before the first merge, so #203 still targets `develop`; the user can resolve the conflict on #202 and re-run `/merge-stack` without re-threading the stack.
+You run `/ship-epic`. It opens a PR from `feature/report-serializer-101` to `develop`, rebase-merges it (so the three squash commits replay onto `develop` linearly — no merge bubble), deletes the epic branch on origin, unsets `claude.flowkit.prBase`, and fast-forwards local `develop`. The result: `git log --first-parent origin/develop` shows three new squash commits in order, exactly one commit per issue, with no merge commits.
+
+Finally `/clean-worktrees` removes the three worktree directories and the three local `worktree-agent-*` branches.
+
+If anything had gone wrong during `/merge-stack` — a merge conflict on #202, for example — the merge would have stopped there and reported the chain as halted at #202 with #203 as blocked upstream. The retarget happened before the first merge, so #203 still targets `feature/report-serializer-101`; the user can resolve the conflict on #202 and re-run `/merge-stack` without re-threading the stack.
 
 ## Layered Review with `/swarm-plus`
 

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -50,7 +50,7 @@ Swarmkit is designed to run best when agents don't have to pause for per-command
 
 | Skill | Invoke | What it does |
 |-------|--------|--------------|
-| **swarm** | `/swarm` | Spawn parallel isolated-worktree agents to resolve GitHub issues. Supports one-shot mode (specific issues) and loop mode (clear the board). Auto-creates PRs targeting `develop`. |
+| **swarm** | `/swarm` | Spawn parallel isolated-worktree agents to resolve GitHub issues. Multi-issue/loop/label runs auto-cut a `feature/<slug>-<N>` branch and route all child PRs to it (run `/ship-epic` to close out). Single-issue one-shot runs target `develop` directly. |
 | **swarm-plus** | `/swarm-plus` | Wraps `/swarm` with an automatic review/fix pass. After each swarm PR opens, dispatches the vendored `swarm-reviewer` agent per PR; if the reviewer flags blockers or concerns, dispatches a worker to push follow-up commits. Single pass per PR. |
 | **next-issue** | `/next-issue` | Fetches open issues, ranks them by priority, specificity, and architectural impact, and recommends what to work on next. |
 | **merge-stack** | `/merge-stack` | Merges all open swarm PRs bottom-up (root PRs first, leaves last) after retargeting non-root PRs to `$BASE`. Pre-scans worktrees to flag merge-set branches still held locally and tails the report with a `/clean-worktrees` follow-up when any `worktree-agent-*` paths remain. |
@@ -79,9 +79,11 @@ Swarmkit vendors a specialized reviewer agent used by `/swarm-plus`. It is not a
 
 ```
 /next-issue                          # See what's ready to work on
-/swarm 12 15 18                      # Resolve specific issues in parallel
-/merge-pr       # If one PR — merge it directly (flowkit skill)
-/merge-stack    # If two or more PRs — retargets non-root PRs to $BASE, merges bottom-up: root first, leaves last
+/swarm 12 15 18                      # Auto-cuts feature branch, opens PRs against it
+/merge-stack                         # Fan child PRs into the epic branch bottom-up
+/ship-epic                           # Rebase-merge epic → develop, clear pin, delete epic branch
+/swarm 12                            # Single issue — flat to develop, no epic cut
+/merge-pr                            # Merge the one PR directly (flowkit skill)
 /swarm                               # Or clear the entire board in a loop
 /clean-worktrees                     # Tidy up after a swarm run
 ```
@@ -90,19 +92,23 @@ Swarmkit vendors a specialized reviewer agent used by `/swarm-plus`. It is not a
 
 1. Ensures a `develop` branch exists (creates from `main` if needed)
 2. Fetches issues, analyzes dependencies, and presents a swarm plan
-3. Spawns one agent per issue (or grouped set) in isolated git worktrees
-4. Each agent: creates branch, makes changes, commits, pushes, opens PR — then stops
-5. Use `/merge-pr` (1 PR, from [flowkit](../flowkit)) or `/merge-stack` (2+ PRs) to merge into `develop` — bottom-up: root PRs first, leaves last, after retargeting non-root PRs to `develop`
-6. Cleans up worktrees and orphaned branches
+3. If the run will spawn ≥2 agents, cuts a `feature/<slug>-<N>` branch via `flowkit:cut-epic` and pins `claude.flowkit.prBase` to it — all spawned PRs target the epic branch
+4. Spawns one agent per issue (or grouped set) in isolated git worktrees
+5. Each agent: creates branch, makes changes, commits, pushes, opens PR — then stops
+6. Use `/merge-pr` (1 PR, from [flowkit](../flowkit)) or `/merge-stack` (2+ PRs) to merge child PRs into the epic branch bottom-up; then run `/ship-epic` to rebase-merge the epic onto `develop`
+7. Cleans up worktrees and orphaned branches
 
-**One-shot mode**: `/swarm 12 15 18` — resolve those issues and stop.
-**Loop mode**: `/swarm` — fetch, swarm, open PRs, repeat until the board is clear.
+**One-shot mode**: `/swarm 12 15 18` — auto-cuts epic branch, opens PRs against it; use `/merge-stack → /ship-epic` to land.
+**Single issue (one-shot)**: `/swarm 12` — flat to `develop`, no epic cut; use `/merge-pr` to merge.
+**Loop mode**: `/swarm` — fetch, swarm, open PRs, repeat until the board is clear; epic branch is cut once and reused across cycles.
 **Label filter**: `/swarm bug` — loop mode, but only `bug`-labeled issues.
 
 ### Flags
 
 - `--model <sonnet|opus>` — override model selection for all agents
-- `--base <branch>` — override the default base branch (`develop`)
+- `--base <branch>` — override the default base branch (`develop`); also suppresses the epic cut
+- `--no-epic` — suppress feature-branch mode for this run; PRs target `$BASE` directly
+- `--epic <slug>` — explicit slug for the auto-cut epic branch
 
 ## How Swarm Plus Works
 

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -18,6 +18,44 @@ Parse `$ARGUMENTS` to determine the mode:
 - **Issue numbers** (`12 15 18`, `#12 #15 #18`, range `12-18`) → **one-shot mode**, specific issues → `develop`
 - `--model <tier>` (`sonnet`, `opus`) → model override for all agents
 - `--base <branch>` → override default base branch
+- `--no-epic` → suppress feature-branch mode for this run; PRs target `$BASE` directly
+- `--epic <slug>` → explicit slug for the auto-cut epic branch (verbatim; `flowkit:cut-epic` enforces the `feature/` prefix)
+
+**Default behavior — feature-branch mode.** When the run will spawn ≥2 agents (any of: 2+ issue numbers, label filter, or loop mode), swarm cuts a `feature/<slug>-<N>` branch via `flowkit:cut-epic`, pins `claude.flowkit.prBase` to it, and routes every spawned PR to that branch. Single-issue one-shot runs are flat-to-`$BASE` (unchanged). Pass `--no-epic` to suppress the cut for a multi-issue run, or `--base <branch>` to override targeting entirely (which also suppresses the cut).
+
+---
+
+## Epic Mode Resolution
+
+Compute `EPIC_MODE` before any setup work:
+
+```
+if --base is set:                                  EPIC_MODE=off
+elif --no-epic is set:                             EPIC_MODE=off
+elif arg-mode == one-shot AND issue_count == 1:    EPIC_MODE=off
+else:                                              EPIC_MODE=on
+```
+
+### When EPIC_MODE=on
+
+**Resolve the slug** (in order):
+
+1. `--epic <slug>` arg → pass verbatim to `flowkit:cut-epic` (`cut-epic` enforces the `feature/` prefix).
+2. One-shot multi-issue → pass the lowest issue number to `cut-epic`; it resolves the slug from the issue title via `gh issue view`.
+3. Loop mode (no issues, no label) → pass `feature/swarm-$(date +%Y-%m-%d)` as the full branch name (cut-epic accepts the `feature/…` input shape directly).
+4. Loop mode + label → pass `feature/<label>-$(date +%Y-%m-%d)` as the full branch name.
+
+**Empty-board edge case (loop mode only)**: defer the cut-epic invocation until the first cycle that selects ≥1 issue. If the board is clear at loop entry, announce "Board is clear" and exit without cutting any branch.
+
+**Cross-pin defensive guard**: before invoking `cut-epic`, read `claude.flowkit.prBase`. If it is set AND starts with `feature/` AND the value differs from the branch about to be cut, exit with:
+
+> `swarm: an epic is already pinned (\`<existing>\`); pass \`--no-epic\` to swarm against develop, or \`--epic <existing-slug>\` to reuse the pinned branch.`
+
+**Invoke `flowkit:cut-epic`** via the Skill tool: `Skill("flowkit:cut-epic", "<resolved-arg>")`. `cut-epic` is idempotent — if the branch already exists locally or on origin it is reused and the pin is refreshed. Capture `EPIC_BRANCH` from cut-epic's report output (the resolved branch name, e.g. `feature/report-serializer-101`).
+
+### When EPIC_MODE=off
+
+Skip the cut. `EPIC_BRANCH` is unset; PRs target `$BASE` directly. Behavior is identical to today's flat-to-`$BASE` flow.
 
 ---
 
@@ -34,7 +72,11 @@ Use `"$SKILL_DIR/scripts/..."` for every script invocation below. Do **not** har
 Run the preflight script once. It handles fetch, base-branch verification (creating it from `main` and pushing if missing), and `gh` auth check in a single call:
 
 ```bash
-"$SKILL_DIR/scripts/preflight.sh" --base "$BASE"
+if [ "$EPIC_MODE" = "on" ] || [ "$LOOP_MODE" = "on" ]; then
+  "$SKILL_DIR/scripts/preflight.sh" --base "${EPIC_BRANCH:-$BASE}" --scope-pr-base
+else
+  "$SKILL_DIR/scripts/preflight.sh" --base "$BASE"
+fi
 ```
 
 On success the script exits 0 and emits a single JSON object on stdout:
@@ -150,6 +192,8 @@ gh issue edit <issue> --add-label "status:in-progress"
 GitHub will automatically remove `status:in-progress` visibility when the issue closes via the `Closes #N` PR reference — no manual cleanup needed.
 
 Apply the hybrid spawn strategy based on the dependency graph from Step 2:
+
+In epic mode, agents still branch from `origin/$BASE` (e.g. `origin/develop`) for their initial worktree, but their PRs target `$EPIC_BRANCH` because `claude.flowkit.prBase` is pinned to it. Stack-root PRs target `$EPIC_BRANCH` instead of `$BASE`; stack-leaf PRs still target their predecessor (which ultimately roots at `$EPIC_BRANCH`).
 
 **Independent issues** (no dependencies within this batch):
 - Spawn all in parallel
@@ -288,7 +332,7 @@ Run `/clean-worktrees` to remove agent worktrees and orphaned branches. This fre
 | #18, #19 | #26 | chore/clean-hooks   | Open |
 ```
 
-All PRs are left open for review. If 1 PR open: use `/merge-pr` to merge it into `develop`. If 2+ PRs: use `/merge-stack` — retargets non-root PRs to `$BASE` and merges bottom-up: root PRs first, leaves last.
+All PRs are left open for review. If 1 PR open: use `/merge-pr` to merge it. If 2+ PRs: use `/merge-stack` — retargets non-root PRs to the stack root's base and merges bottom-up: root PRs first, leaves last. In epic mode, after all child PRs are merged into the epic branch via `/merge-stack`, run `/ship-epic` to rebase-merge the epic branch onto `develop`, clear the pin, and delete the epic branch.
 
 ---
 
@@ -339,7 +383,21 @@ Proceed immediately to the next cycle after printing the checkpoint summary. The
 ### Teardown
 
 1. Run the `clean-worktrees` skill
-2. Run `scripts/teardown.sh` (optionally `--base <branch>` to override the default `develop`). Parse the returned JSON and confirm `base_restored: true`. If `config_unset: false`, log that `claude.flowkit.prBase` was already clear — this is not a failure.
+2. Run `scripts/teardown.sh` with the appropriate flags:
+
+```bash
+if [ "$EPIC_MODE" = "on" ]; then
+  "$SKILL_DIR/scripts/teardown.sh" --base "$BASE" --keep-pr-base
+else
+  "$SKILL_DIR/scripts/teardown.sh" --base "$BASE"
+fi
+```
+
+Parse the returned JSON and confirm `base_restored: true`. If `config_unset: false` and `config_kept_for_epic` is absent, log that `claude.flowkit.prBase` was already clear — this is not a failure.
+
+When `config_kept_for_epic: true` appears in the JSON, announce:
+
+> Epic branch `<EPIC_BRANCH>` is left in place with `claude.flowkit.prBase` pinned. Run `/ship-epic` to promote it to `develop` and clear the pin.
 
 Optionally, run `swarmkit:clean-remote-worktrees` afterwards to sweep orphaned remote `worktree-agent-*` branches left behind by merged PRs. This is not automatic — invoke it when you want to tidy up.
 
@@ -352,7 +410,8 @@ Issues addressed: #12, #14, #15 (PRs open, awaiting review)
 Issues remaining: #25
 Open PRs: #31, #32, #33
 
-Open PRs are ready for review. If 1 PR open: use `/merge-pr` to merge it into `$BASE`. If 2+ PRs: use `/merge-stack` — retargets non-root PRs to `$BASE` and merges bottom-up: root PRs first, leaves last.
+Open PRs are ready for review. If 1 PR open: use `/merge-pr` to merge it. If 2+ PRs: use `/merge-stack` — retargets non-root PRs to the stack root's base and merges bottom-up: root PRs first, leaves last.
+In epic mode: after /merge-stack fans child PRs into the epic branch, run /ship-epic to promote the epic to develop and clear the pin.
 ─────────────────────────────────────────────
 ```
 

--- a/plugins/swarmkit/skills/swarm/scripts/teardown.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/teardown.sh
@@ -5,10 +5,11 @@ set -euo pipefail
 # claude.flowkit.prBase unset) into one call, mirroring preflight.sh.
 #
 # Usage:
-#   teardown.sh [--base <branch>]
+#   teardown.sh [--base <branch>] [--keep-pr-base]
 #
 # On success: exit 0, single JSON object on stdout with keys:
-#   {base, base_restored, config_unset}
+#   {base, base_restored, config_unset}                       (default shape)
+#   {base, base_restored, config_unset, config_kept_for_epic} (when --keep-pr-base)
 # On failure: non-zero exit, empty stdout, human-readable message on stderr.
 
 # Anchor to the main repo root. The harness can drop the operator's shell into
@@ -17,6 +18,7 @@ set -euo pipefail
 cd "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")" || exit 1
 
 BASE="develop"
+KEEP_PR_BASE=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -24,6 +26,10 @@ while [[ $# -gt 0 ]]; do
       [[ $# -ge 2 ]] || { echo "teardown: --base requires a value" >&2; exit 2; }
       BASE="$2"
       shift 2
+      ;;
+    --keep-pr-base)
+      KEEP_PR_BASE=1
+      shift
       ;;
     *)
       echo "teardown: unknown argument: $1" >&2
@@ -40,12 +46,14 @@ for cmd in git jq; do
 done
 
 config_unset=false
-if git config --local --get claude.flowkit.prBase >/dev/null 2>&1; then
-  if ! git config --local --unset claude.flowkit.prBase >/dev/null 2>&1; then
-    echo "teardown: failed to unset claude.flowkit.prBase" >&2
-    exit 1
+if [[ $KEEP_PR_BASE -eq 0 ]]; then
+  if git config --local --get claude.flowkit.prBase >/dev/null 2>&1; then
+    if ! git config --local --unset claude.flowkit.prBase >/dev/null 2>&1; then
+      echo "teardown: failed to unset claude.flowkit.prBase" >&2
+      exit 1
+    fi
+    config_unset=true
   fi
-  config_unset=true
 fi
 
 base_restored=false
@@ -59,8 +67,17 @@ if ! git pull origin "$BASE" >/dev/null 2>&1; then
 fi
 base_restored=true
 
-jq -n \
-  --arg base "$BASE" \
-  --argjson base_restored "$base_restored" \
-  --argjson config_unset "$config_unset" \
-  '{base: $base, base_restored: $base_restored, config_unset: $config_unset}'
+if [[ $KEEP_PR_BASE -eq 1 ]]; then
+  jq -n \
+    --arg base "$BASE" \
+    --argjson base_restored "$base_restored" \
+    --argjson config_unset "false" \
+    --argjson config_kept_for_epic "true" \
+    '{base: $base, base_restored: $base_restored, config_unset: $config_unset, config_kept_for_epic: $config_kept_for_epic}'
+else
+  jq -n \
+    --arg base "$BASE" \
+    --argjson base_restored "$base_restored" \
+    --argjson config_unset "$config_unset" \
+    '{base: $base, base_restored: $base_restored, config_unset: $config_unset}'
+fi

--- a/plugins/swarmkit/skills/swarm/scripts/test.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/test.sh
@@ -63,9 +63,10 @@ assert_invalid_args preflight.sh "unknown-flag"      --not-a-flag
 assert_invalid_args preflight.sh "missing-value"     --base
 assert_invalid_args preflight.sh "extra-positional"  positional-not-allowed
 
-# teardown.sh — accepts --base <value>.
-assert_invalid_args teardown.sh "unknown-flag"   --not-a-flag
-assert_invalid_args teardown.sh "missing-value"  --base
+# teardown.sh — accepts --base <value>, --keep-pr-base (no value).
+assert_invalid_args teardown.sh "unknown-flag"              --not-a-flag
+assert_invalid_args teardown.sh "missing-value"             --base
+assert_invalid_args teardown.sh "keep-pr-base-extra-positional" --keep-pr-base extra-positional
 
 # verify_agent.sh — exactly one positive integer.
 assert_invalid_args verify_agent.sh "no-args"


### PR DESCRIPTION
## Summary

Multi-issue/loop/label swarm runs now auto-cut a `feature/<slug>-<N>` branch via `flowkit:cut-epic`, pin `claude.flowkit.prBase`, and route all child PRs to the epic branch. The user-visible invariant: a multi-issue swarm produces exactly one rebase-merged PR onto `develop` (the epic PR via `/ship-epic`) instead of N independent squashes. Single-issue one-shot runs remain flat-to-`develop`, unchanged.

## Changes

- **`swarm/SKILL.md`** — new `--no-epic` and `--epic <slug>` flags in Arguments; new "Epic Mode Resolution" section documenting the 4-rule `EPIC_MODE` decision tree, slug-derivation rules, empty-board edge case, cross-pin defensive guard, and cut-epic invocation via the Skill tool; preflight conditional for `--scope-pr-base` in epic/loop mode; epic-mode note in Step 4 (spawn agents); updated one-shot report and loop-mode teardown with `--keep-pr-base` conditional.
- **`teardown.sh`** — new `--keep-pr-base` flag (takes no value) that suppresses the `claude.flowkit.prBase` unset and emits `config_kept_for_epic: true` in the JSON output. Backwards-compatible: existing callers see the legacy 3-key shape.
- **`test.sh`** — adds `teardown.sh keep-pr-base-extra-positional` invalid-arg case (confirms the flag takes no value).
- **`swarmkit/README.md`** — updated skill-table description, Typical Workflow snippet (multi-issue → `/merge-stack → /ship-epic`), How Swarm Works step 3 (feature-branch cut), flags table (two new flags), mode descriptions.
- **`swarmkit/METHODOLOGY.md`** — new "Feature-Branch Mode" section (trigger rule, what happens at epic cut, slug-derivation table, loop-mode reuse, ship-epic handoff, escape hatches, cross-pin guard, squadkit symmetry); End-to-End Walkthrough rewritten so 3-issue example uses `feature/report-serializer-101`, PRs target the epic branch, `/merge-stack → /ship-epic` produces one rebase-merged epic PR onto `develop`.

## Test plan

- [x] `bash scripts/test-all-skill-scripts.sh` — 8/8 passed (no regressions)
- [x] `bash plugins/swarmkit/skills/swarm/scripts/test.sh` — 13/13 passed (12 existing + 1 new `keep-pr-base-extra-positional`)
- [x] `bash -n teardown.sh` — syntax OK
- [x] `config_kept_for_epic` field present in `teardown.sh`
- [x] SKILL.md contract audit: `--no-epic`, `--epic <slug>`, `flowkit:cut-epic`, `EPIC_MODE`, `/ship-epic` all present
- [x] `merge-stack` directory diff vs epic head: empty (untouched)
- [x] `Feature-Branch Mode` section in METHODOLOGY.md: present
- [x] `/ship-epic` reference in README.md: present
- [ ] **Manual happy-path (reviewer)**: on a scratch repo with 2 test issues, `/swarm <#1> <#2>` confirms: (a) `feature/<slug>-<#1>` on origin; (b) `git config --get claude.flowkit.prBase` returns the feature branch; (c) both PRs target the feature branch; then `/swarm <#3>` (single-issue) flat-targets develop with no new epic cut

Closes #890
Refs #897