### PR TITLE
refactor(squadkit): delegate epic-cut from spawn-team to flowkit:cut-epic primitive (#895)

### DIFF
--- a/plugins/squadkit/README.md
+++ b/plugins/squadkit/README.md
@@ -142,16 +142,14 @@ It scans `~/.claude/teams/<repo>-*` and picks the first letter without a `config
 
 `spawn-team` integrates with the flowkit epic flow. When you pass `--epic <slug>`, the skill:
 
-1. Reads `baseBranch` from `.squadkit/config.json` (defaults to `develop` if missing).
-2. Cuts `feature/<slug>-<issue>` from `origin/<baseBranch>` (idempotent against existing branches).
-3. Pushes the branch to origin.
-4. Pins `claude.flowkit.prBase` so every member PR opened during the session targets the epic branch.
+1. Resolves `<issue>` from the `--epic` argument shape (or prompts when omitted).
+2. Invokes `flowkit:cut-epic` (idempotent against existing branches; pins `claude.flowkit.prBase`; pushes to origin).
 
 If `--epic` is not provided, the skill prompts whether to cut one or run on the base branch directly.
 
 See the related flowkit skills:
 
-- [`flowkit:cut-epic`](../flowkit/skills/cut-epic/SKILL.md) — standalone epic cut, equivalent to the inline cut performed by `spawn-team --epic`.
+- [`flowkit:cut-epic`](../flowkit/skills/cut-epic/SKILL.md) — the primitive that `spawn-team --epic` invokes.
 - [`flowkit:preview-epic`](../flowkit/skills/preview-epic/SKILL.md) — preview the epic-to-base diff before opening the final integration PR.
 
 ### Idempotency and per-builder worktrees

--- a/plugins/squadkit/skills/spawn-team/SKILL.md
+++ b/plugins/squadkit/skills/spawn-team/SKILL.md
@@ -263,28 +263,31 @@ If `--epic <slug>` was provided, the skill cuts the epic branch. Otherwise promp
 When cutting an epic:
 
 1. Resolve `<issue>` from `--epic` arguments or prompt for it. The expected slug is kebab-case (`[a-z0-9-]+`).
-2. Compose `FEATURE_BRANCH="feature/<slug>-<issue>"`.
-3. Cut it from the configured base branch — idempotent against existing branches:
+2. **Cross-pin guard.** Before invoking cut-epic, read the existing pin:
 
-```bash
-git fetch origin "${BASE_BRANCH}"
-if git show-ref --verify --quiet "refs/heads/${FEATURE_BRANCH}"; then
-  git checkout "${FEATURE_BRANCH}"
-elif git show-ref --verify --quiet "refs/remotes/origin/${FEATURE_BRANCH}"; then
-  git checkout -b "${FEATURE_BRANCH}" "origin/${FEATURE_BRANCH}"
-else
-  git checkout -b "${FEATURE_BRANCH}" "origin/${BASE_BRANCH}"
-fi
-git push -u origin "${FEATURE_BRANCH}"
-```
+   ```bash
+   EXISTING_PIN=$(git config --local --get claude.flowkit.prBase 2>/dev/null || true)
+   if [[ -n "$EXISTING_PIN" && "$EXISTING_PIN" =~ ^feature/ && "$EXISTING_PIN" != "feature/${slug}-${issue}" ]]; then
+     echo "spawn-team: an epic is already pinned (\`$EXISTING_PIN\`)." >&2
+     echo "  Re-run without --epic and answer \`Use \${BASE_BRANCH}\` to spawn against the base branch instead," >&2
+     echo "  or re-run with --epic matching the pinned slug to reuse it." >&2
+     exit 1
+   fi
+   ```
 
-4. Pin the PR base for the session:
+   When the existing pin matches the resolved feature branch, proceed silently — cut-epic is idempotent and will reuse the branch.
 
-```bash
-git config --local claude.flowkit.prBase "${FEATURE_BRANCH}"
-```
+3. Invoke `flowkit:cut-epic` via the Skill tool, forwarding the resolved slug and issue number verbatim (cut-epic input shape 2 — issue + slug pair):
 
-The pin is local to the repo (not the worktree) so every member inherits it. `WORK_BRANCH=${FEATURE_BRANCH}` from here on; if no epic was cut, `WORK_BRANCH=${BASE_BRANCH}`.
+   ```
+   Skill({skill: "flowkit:cut-epic", arguments: "<slug> <issue>"})
+   ```
+
+   cut-epic owns the rest: idempotent branch create-or-reuse from `origin/${BASE_BRANCH}`, push to origin, and pin `claude.flowkit.prBase` to `feature/<slug>-<issue>`. Surface cut-epic's report in spawn-team's final summary.
+
+4. Set `WORK_BRANCH=feature/<slug>-<issue>`. The pin is now live; every member's `flowkit:open-pr` invocation in this session targets the epic branch automatically.
+
+`WORK_BRANCH=${FEATURE_BRANCH}` from here on; if no epic was cut, `WORK_BRANCH=${BASE_BRANCH}`.
 
 ### 6.5 Stale-worktree pre-flight
 
@@ -616,7 +619,7 @@ These are observed limitations of the `Agent` and `TeamCreate` primitives at the
 
 | Caller | Behavior |
 |--------|----------|
-| `flowkit:cut-epic` | Equivalent epic-cutting flow when run standalone. `spawn-team --epic` performs the same operation inline so the team is born on the epic branch. |
+| `flowkit:cut-epic` | The canonical epic-cutting primitive. `spawn-team --epic` invokes this skill via the Skill tool so both entry points share one implementation. |
 | `flowkit:preview-epic` | Run after the team has merged sub-PRs to preview the epic-to-`${BASE_BRANCH}` diff. |
 | `flowkit:open-pr` / `flowkit:pr` | Member PRs target `claude.flowkit.prBase` automatically once the spawn pins it. |
 | `swarmkit:gh-fetch-issues` | Resolves `--issues <range>` into a filtered (open + non-on-hold) list for the lead's first dispatch prompt. |


### PR DESCRIPTION
## Summary

Replaces `spawn-team`'s inline epic-cut block (git fetch / checkout / push / pin) with a single `Skill("flowkit:cut-epic", "<slug> <issue>")` invocation. After this PR, `flowkit:cut-epic` is the sole implementation of the epic-cut primitive — both `/cut-epic` standalone and `spawn-team --epic` share it. Adds a cross-pin guard (mirroring swarmkit:swarm post-#890) that aborts with recovery instructions when a different feature branch is already pinned.

## Changes

- `plugins/squadkit/skills/spawn-team/SKILL.md` — Replace Step 6 inline sub-steps (resolve branch name, git checkout-or-create, push, pin) with: cross-pin guard + `Skill({skill: "flowkit:cut-epic", arguments: "<slug> <issue>"})` invocation. Surrounding prose (discovery-skip guard, ≥3-PR pre-flight rule, AskUserQuestion prompt, WORK_BRANCH assignment) preserved verbatim.
- `plugins/squadkit/skills/spawn-team/SKILL.md` — Reword Composition table entry for `flowkit:cut-epic` from "equivalent inline cut" to "canonical primitive that spawn-team invokes."
- `plugins/squadkit/README.md` — Reword "Epic feature-branch convention" bullet list from 4-step inline description to 2-step resolve+invoke shape. Update cut-epic link wording from "equivalent to the inline cut" to "the primitive that spawn-team --epic invokes."

## Test plan

- [ ] `bash scripts/test-all-skill-scripts.sh` returns 8/8 (no script changes, zero regressions).
- [ ] `git grep -nE 'git config --local claude\.flowkit\.prBase' plugins/squadkit/` returns empty — inline pin-write is gone.
- [ ] `grep -q 'flowkit:cut-epic' plugins/squadkit/skills/spawn-team/SKILL.md` succeeds.
- [ ] `grep -q 'Skill.*cut-epic' plugins/squadkit/skills/spawn-team/SKILL.md` succeeds.
- [ ] `grep -q 'an epic is already pinned' plugins/squadkit/skills/spawn-team/SKILL.md` succeeds — cross-pin guard prose is present.
- [ ] `grep -q 'EXISTING_PIN' plugins/squadkit/skills/spawn-team/SKILL.md` succeeds.
- [ ] `grep -q 'Skip entirely when \`kind: discovery\`' plugins/squadkit/skills/spawn-team/SKILL.md` succeeds — discovery-skip guard survives.
- [ ] `grep -q 'Pre-flight rule (execution only)' plugins/squadkit/skills/spawn-team/SKILL.md` succeeds — ≥3-PR pre-flight survives.
- [ ] `grep -q 'No --epic given. Cut a feature branch' plugins/squadkit/skills/spawn-team/SKILL.md` succeeds — AskUserQuestion prompt survives.
- [ ] `! grep -q 'Equivalent epic-cutting flow when run standalone' plugins/squadkit/skills/spawn-team/SKILL.md` succeeds — old composition wording is gone.
- [ ] `grep -q 'canonical epic-cutting primitive' plugins/squadkit/skills/spawn-team/SKILL.md` succeeds — new wording present.
- [ ] `! grep -q 'equivalent to the inline cut' plugins/squadkit/README.md` succeeds.
- [ ] `grep -nE 'feature/<slug>|FEATURE_BRANCH|git checkout -b.*feature' plugins/squadkit/docs/patterns/discovery-coordination.md` returns empty — no epic-cut narrative in discovery doc.

Closes #895
Refs #897