### PR TITLE
refactor(flowkit:ship): re-orchestrate as merge-stack → ship-epic → cut → release (#894)

### DIFF
--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -43,7 +43,7 @@ claude --plugin-dir /path/to/flowkit
 | **sync** | `/sync` | Checkout `develop`, pull latest, prune stale branches. |
 | **cut** | `/cut` | Create a `rc/YYYY-MM-DD.N` release candidate from `develop`. |
 | **release** | `/release` | Merge the newest RC to `main`, tag, close issues, clean up RC branches. |
-| **ship** | `/ship` | Repo-level skill: `merge-stack` → `cut` → `release`. Run after a swarm to merge everything. |
+| **ship** | `/ship` | Repo-level orchestrator. Chains `merge-stack → ship-epic (when epic in flight) → cut → release`. End-state: linear `develop`, linear `main`, prBase unset. |
 | **pipeline-status** | `/pipeline-status` | Show the full release pipeline: open PRs in flight, `develop` awaiting a cut, RCs awaiting release, and the most recent tag. |
 
 ### Sub-Skills (internal)
@@ -61,7 +61,7 @@ These are called by the skills above — you don't invoke them directly.
 ### After a swarm run
 
 ```
-/ship                            # merge-stack → cut → release
+/ship                            # merge-stack → ship-epic → cut → release (auto-detects feature branch)
 ```
 
 ### Standard release (no swarm)
@@ -100,7 +100,7 @@ The epic branch composes with `swarmkit:swarm`: agents spawned while `claude.flo
 
 Nothing is pushed and the epic branch is fetched read-only. See `/preview-epic` for the full Model A vs. Model B detection rules.
 
-> Do not run `/ship` while an epic is in flight unless you intend to ship the epic. `/ship` will rescope `claude.flowkit.prBase` to `develop` for its own flow.
+> `/ship` from an epic branch (or with `claude.flowkit.prBase` pinned to a `feature/*`) automatically inserts `ship-epic` between `merge-stack` and `cut`. The epic branch is rebase-merged to `develop`, the pin is cleared, and the chain continues with the freshly-updated `develop`. Run `/preview-epic` first to verify the integrated state — `/ship` does not auto-verify.
 
 ### Mid-review restack
 
@@ -128,7 +128,7 @@ The subtree is walked breadth-first: siblings continue independently if one bran
 
 ## Ship boundaries
 
-`/ship` only handles the merge-cut-release cascade. Branch creation, commits, and PR opening live in `/pr` and `/swarm`. If `merge-stack` hits a conflict, `/ship` stops before cutting or releasing.
+`/ship` orchestrates `merge-stack → ship-epic (conditional) → cut → release`. Branch creation, commits, and PR opening live in `/pr` and `/swarm`. If any step fails, `/ship` stops before the next step; state is left recoverable for re-run after the operator resolves the failure.
 
 ## Configuration
 
@@ -136,7 +136,7 @@ Flowkit reads one repo-local git config key:
 
 | Key | Purpose | Default |
 |-----|---------|---------|
-| `claude.flowkit.prBase` | Target base branch for `/open-pr` when no override is passed. Set automatically by `/ship`, `/swarm` loop mode, and `/cut-epic`; unset on teardown. | `develop` |
+| `claude.flowkit.prBase` | Target base branch for `/open-pr` when no override is passed. Set automatically by `/cut-epic`, `/swarm` (loop mode), and `squadkit:spawn-team --epic`; unset by `/ship-epic` (and therefore by `/ship` when an epic is in flight). | `develop` |
 
 Inspect or set manually:
 
@@ -245,7 +245,7 @@ Flowkit handles the shipping half of the development loop. Use it with speckit a
 ```
 /spec add CSV export              # Plan the feature, file issues  (speckit)
 /swarm                            # Resolve issues with parallel agents  (swarmkit)
-/ship                             # Merge stack → cut → release  (flowkit)
+/ship                             # merge-stack → ship-epic → cut → release  (flowkit)
 ```
 
 The natural sequence is **speckit → swarmkit → flowkit**: speckit defines the work, swarmkit executes it, flowkit ships it. Use [sessionkit](../sessionkit)'s `/handoff` if a release session runs long, and `/skillit` afterwards to capture any new conventions or one-off scripts worth keeping.

--- a/plugins/flowkit/skills/ship/SKILL.md
+++ b/plugins/flowkit/skills/ship/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship
-description: Repo-level skill that merges all open swarm PRs, cuts a release candidate, and promotes to main. Run this after a swarm to merge everything in one shot.
+description: Repo-level skill that orchestrates the full bubble-free release flow: merge-stack → ship-epic (when epic in flight) → cut → release. End-state: develop and main are linear, prBase is unset, RC branch deleted.
 triggers:
   - "/ship"
   - "ship everything"
@@ -11,7 +11,7 @@ allowed-tools: Bash
 
 # Ship
 
-Merge a completed swarm run in one shot: merge all open swarm PRs into develop, cut a release candidate, and promote it to main.
+Orchestrate the full bubble-free release flow in one shot: detect any epic in flight, merge all open swarm PRs, promote the epic to develop (when applicable), cut a release candidate, and ship to main. End-state: `develop` and `main` are linear, `claude.flowkit.prBase` is unset, and the RC branch is deleted.
 
 ## Input
 
@@ -19,35 +19,112 @@ Merge a completed swarm run in one shot: merge all open swarm PRs into develop, 
 
 ## Process
 
-### 1. Merge open swarm PRs
+### 1. Detect epic-in-flight
 
-Follow `swarmkit:merge-stack`.
+Resolve `$EPIC_BRANCH` from two signals:
 
-- If no `worktree-agent-*` PRs are open, `merge-stack` will report "No open swarm PRs found" and stop gracefully — continue to step 2.
-- If any merge fails with a conflict, stop immediately and report which PR is blocked. Do not proceed to cut or release until conflicts are resolved.
+```bash
+EPIC_BRANCH=""
 
-### 2. Cut a release candidate
+# Signal 1: pinned config (the canonical signal — set by cut-epic, swarm, spawn-team).
+PINNED=$(git config --get claude.flowkit.prBase 2>/dev/null || true)
+if [[ -n "$PINNED" && "$PINNED" =~ ^feature/ ]]; then
+  EPIC_BRANCH="$PINNED"
+fi
 
-Follow `flowkit:cut` to create an `rc/YYYY-MM-DD.N` branch from `origin/develop`.
+# Signal 2: current HEAD is a feature/* branch (covers operators who checked out
+# an epic without setting the pin).
+if [[ -z "$EPIC_BRANCH" ]]; then
+  CURRENT=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  if [[ "$CURRENT" =~ ^feature/ ]]; then
+    EPIC_BRANCH="$CURRENT"
+  fi
+fi
+```
 
-### 3. Release
+Signal 1 (pin) wins when both fire. If `$EPIC_BRANCH` is non-empty, this run promotes the epic before cutting. If empty, ship runs the develop-direct shape (merge-stack → cut → release, no ship-epic).
 
-Follow `flowkit:release` to merge the RC to `main`, create the version tag, close referenced issues, and clean up RC branches.
+### 2. Merge open swarm PRs
 
-Pass `$ARGUMENTS` as the argument if provided.
+Invoke `swarmkit:merge-stack` via the Skill tool:
 
-### 4. Report
+```
+Skill({skill: "swarmkit:merge-stack"})
+```
 
-Summarize what happened:
+merge-stack discovers and merges every open `worktree-agent-*` PR bottom-up. When `$EPIC_BRANCH` is set, the children target the epic branch — merge-stack handles that automatically.
 
-- How many swarm PRs were merged (or that the step was skipped)
-- Which RC was created
-- Which tag was created on main
-- Which issues were closed
+If merge-stack reports "no open swarm PRs found", continue to the next step. If any merge fails with a conflict, stop immediately and report which PR is blocked. Do not proceed to step 3 until conflicts are resolved.
+
+### 3. Promote the epic (conditional)
+
+When `$EPIC_BRANCH` is empty, **skip this step**. Print a one-line note:
+
+> No epic in flight — skipping ship-epic.
+
+When `$EPIC_BRANCH` is non-empty, invoke `flowkit:ship-epic` via the Skill tool:
+
+```
+Skill({skill: "flowkit:ship-epic"})
+```
+
+ship-epic resolves the epic from `claude.flowkit.prBase`, opens the feature → develop PR with aggregated `Closes #N` tokens, rebase-merges, deletes the epic branch, and unsets `claude.flowkit.prBase`. Local `develop` is fast-forwarded.
+
+If ship-epic fails (preflight failure, rebase-merge conflict, network), stop and surface its stderr. State is recoverable per ship-epic's own contract — pin and branch are intact. Do not proceed to step 4.
+
+### 4. Cut a release candidate
+
+Invoke `flowkit:cut` via the Skill tool:
+
+```
+Skill({skill: "flowkit:cut"})
+```
+
+cut creates `rc/<YYYY-MM-DD>.N` from `origin/develop`, pushes it, and pushes the matching tag.
+
+If cut fails (e.g., empty diff against main), stop and report.
+
+### 5. Release
+
+Invoke `flowkit:release` via the Skill tool:
+
+```
+Skill({skill: "flowkit:release", arguments: $ARGUMENTS})
+```
+
+Pass `$ARGUMENTS` (this skill's input) through to release as its release-notes hint.
+
+release runs the rebase-merge preflight, opens the RC → main PR, rebase-merges, tags, runs the explicit `gh issue close` loop, and cleans up RC branches.
+
+If release fails, stop and report.
+
+### 6. Final assertion and report
+
+After all preceding steps complete:
+
+```bash
+PIN_AFTER=$(git config --get claude.flowkit.prBase 2>/dev/null || true)
+if [[ -n "$PIN_AFTER" ]]; then
+  echo "warning: claude.flowkit.prBase is still set to '$PIN_AFTER' after ship completed." >&2
+  echo "  Expected empty when ship finishes from a clean state. Run \`git config --unset claude.flowkit.prBase\` to clear." >&2
+fi
+```
+
+Report:
+
+- Whether ship-epic ran (and the resulting epic PR number/URL if so)
+- The RC branch created
+- The release tag created on main
+- Issues closed (aggregated from release's own report)
+- The closing pin state (empty on the happy path; warning surfaced if not)
 
 ## Constraints
 
-- If `merge-stack` encounters a conflict, stop — do not cut or release with unresolved conflicts
+- If `merge-stack` encounters a conflict, stop — do not proceed with unresolved conflicts
 - Never commit directly to `develop` or `main`
 - No branch/commit/PR creation — those belong to `/pr` and `/swarm`
 - If any step fails, stop immediately and report what failed and why
+- ship-epic runs only when epic-in-flight is detected (Step 1's `$EPIC_BRANCH` non-empty). Otherwise it is silently skipped — calling ship-epic on a develop-direct run would produce a guaranteed error
+- No internal verify gate. Operators run `/preview-epic` explicitly before invoking `/ship`. Symmetry with `ship-epic` and `cut-epic` themes
+- Stop on any sub-skill failure. State is recoverable across partial failures: re-running `/ship` after the operator resolves the failure picks up where the chain left off
+- No `--no-ship-epic` opt-out. Operators who need to skip ship-epic for an unusual reason invoke `/merge-stack && /cut && /release` directly


### PR DESCRIPTION
## Summary

Re-orchestrates `flowkit:ship` to chain `merge-stack → ship-epic (conditional) → cut → release`, completing the bubble-free release path. `ship-epic` is inserted only when an epic is in flight (detected by `claude.flowkit.prBase` pinned to a `feature/*` branch, or current HEAD on a `feature/*` branch); develop-direct ships silently skip it. The README's "Do not run /ship while an epic is in flight" warning is replaced with a positive description of the integrated flow.

## Changes

- `plugins/flowkit/skills/ship/SKILL.md` — full Process rewrite: 4 steps → 6 steps (detect epic → merge-stack → conditional ship-epic → cut → release → final assertion). Description updated to reflect bubble-free orchestrator role. Constraints extended with conditional-skip rule, no-internal-verify-gate rule, stop-on-failure rule, and no-opt-out rule. `Follow <skill>` prose replaced with `Skill({skill: "..."})` invocations throughout.
- `plugins/flowkit/README.md` — 5 targeted updates: skill-table ship row, after-swarm workflow comment, polarity-flip of the "Do not run /ship while an epic" warning, Ship boundaries subsection, configuration-table prBase setter list (removes `/ship`, adds `spawn-team --epic`; attributes unset to `ship-epic`). Pairing example updated.

## Test plan

- [ ] `bash scripts/test-all-skill-scripts.sh` — 8/8 pass.
- [ ] `grep -E '^### [0-9]+\.' plugins/flowkit/skills/ship/SKILL.md` shows steps 1–6 contiguous.
- [ ] All four sub-skills (`swarmkit:merge-stack`, `flowkit:ship-epic`, `flowkit:cut`, `flowkit:release`) referenced in SKILL.md with `Skill({skill: "..."})` invocations — no `Follow \`<skill>\`` prose remaining.
- [ ] Epic detection logic present: `EPIC_BRANCH=`, `claude.flowkit.prBase`, `^feature/` all grep positive.
- [ ] `grep -nE 'merge-stack.*ship-epic.*cut.*release' plugins/flowkit/README.md` returns ≥3 matches.
- [ ] `grep -qE 'Do not run.*ship.*epic'` returns negative (old warning gone).
- [ ] `git grep -nE 'merge-stack.*cut.*release' -- plugins/flowkit/ | grep -v ship-epic` returns empty (no stale chains).
- [ ] Manual: on a scratch branch with `claude.flowkit.prBase` pinned to a `feature/*`: (a) merge-stack reports nothing or merges remaining children; (b) ship-epic rebase-merges feature → develop and unsets pin; (c) cut creates `rc/<date>.N`; (d) release rebase-merges rc → main and tags. After: `git config --get claude.flowkit.prBase` empty; `git log --first-parent --merges origin/develop` and `... origin/main` since prior tag both empty (zero merge bubbles).
- [ ] Manual (develop-direct): on a `develop`-checkout with no `feature/*` pin, Step 3 emits "No epic in flight — skipping ship-epic" and chain completes.

Closes #894
Refs #897