### PR TITLE
docs: align all public surfaces with bubble-free release flow (#891)

### DIFF
--- a/.claude/skills/ship-plugins/SKILL.md
+++ b/.claude/skills/ship-plugins/SKILL.md
@@ -26,7 +26,7 @@ Three things never happen:
 
 1. `/bump-versions` is never run when an RC already exists — the RC has the bumps baked in; a second bump would drift develop.
 2. `/cut` is never run when develop is in sync with main and there's no existing RC.
-3. `/release` is never run when there's no RC and no staging.
+3. `/release` is never run when there's no RC.
 
 ## Process
 
@@ -73,6 +73,27 @@ done
 - If `CHANGED_PLUGINS` is non-empty: follow `/bump-versions` (project-local skill).
 - Else: announce `"Stage 3 skipped: no plugin changes since last per-plugin tags"` and continue.
 
+### Stage 3.5 — Ship epic (conditional)
+
+Resolve `$EPIC_BRANCH` using the same two-signal logic as `flowkit:ship`:
+
+```bash
+EPIC_BRANCH=""
+PINNED=$(git config --get claude.flowkit.prBase 2>/dev/null || true)
+if [[ -n "$PINNED" && "$PINNED" =~ ^feature/ ]]; then
+  EPIC_BRANCH="$PINNED"
+fi
+if [[ -z "$EPIC_BRANCH" ]]; then
+  CURRENT=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  if [[ "$CURRENT" =~ ^feature/ ]]; then
+    EPIC_BRANCH="$CURRENT"
+  fi
+fi
+```
+
+- If `$EPIC_BRANCH` is non-empty: follow `flowkit:ship-epic`.
+- Else: announce `"Stage 3.5 skipped: no epic in flight"` and continue.
+
 ### Stage 4 — Cut a release candidate
 
 ```bash
@@ -86,10 +107,9 @@ AHEAD=$(git log origin/main..origin/develop --oneline | wc -l | tr -d ' ')
 
 ```bash
 HAS_RC=$(git ls-remote --heads origin "rc/*" | head -1)
-HAS_STAGING=$(git ls-remote --exit-code origin staging &>/dev/null && echo yes || echo no)
 ```
 
-- If both empty: announce `"Stage 5 skipped: no RC and no staging to release"` and stop.
+- If `HAS_RC` is empty: announce `"Stage 5 skipped: no RC to release"` and stop.
 - Else: follow `flowkit:release`.
 
 ### Stage 6 — Report
@@ -98,11 +118,12 @@ Print a per-stage summary. Use `—` for skipped stages:
 
 ```
 ── Ship Plugins ───────────────────────────────────
-1. merge-stack     : merged 3 PRs (#471 #472 #473)
-2. rc skip-ahead   : no existing RC
-3. bump-versions   : swarmkit 2.7.1→2.7.2, flowkit 2.0.4→2.1.0
-4. cut             : rc/2026-04-19.15
-5. release         : v2026.4.19.13 (closed #471 #472 #473)
+1.   merge-stack     : merged 3 PRs (#471 #472 #473)
+2.   rc skip-ahead   : no existing RC
+3.   bump-versions   : swarmkit 2.7.1→2.7.2, flowkit 2.0.4→2.1.0
+3.5  ship-epic       : skipped (no epic in flight)
+4.   cut             : rc/2026-04-19.15
+5.   release         : v2026.4.19.13 (closed #471 #472 #473)
 ───────────────────────────────────────────────────
 ```
 
@@ -112,7 +133,7 @@ Include a one-line reason for every skipped stage so the user can reason about w
 
 - Never run `/bump-versions` when an RC already exists on origin
 - Never cut when develop is in sync with main and there is no existing RC
-- Never release when there's no RC and no staging
+- Never release when there's no RC
 - Always continue past a stage with nothing to do; never error on "empty input"
 - Always print a final report listing every stage and its outcome (ran / skipped + reason)
 - Project-scoped: this skill is specific to `smallorbit-plugins`. Do not move it into flowkit — other flowkit consumers don't have `/bump-versions`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ Run it before staging and committing the release.
 
 **Base-branch convention.** Execution crews always work on a `feature/<slug>-<issue>` branch cut from `develop`, owned by `spawn-team`. They never commit directly to `develop`. Discovery crews stay on `develop` since they don't produce code. The supporting flow primitives live in flowkit:
 
-- `flowkit:cut-epic` — cut the long-lived feature branch standalone (equivalent to the inline cut performed by `spawn-team --epic`).
+- `flowkit:cut-epic` — cut the long-lived feature branch standalone (the primitive that `spawn-team --epic` invokes).
 - `flowkit:preview-epic` — preview the combined epic-to-base diff before opening the final integration PR.
 
 ## Skill Authoring Conventions

--- a/README.md
+++ b/README.md
@@ -122,15 +122,16 @@ Once the PRs look right, merge and release them however you normally would. If y
 /plugin install flowkit@smallorbit-plugins
 ```
 
-Then merge everything in three commands:
+For a multi-issue epic (the default when `/swarm` receives more than one issue), the stack lands on a feature branch. Promote it in four commands:
 
 ```
-/merge-stack     # merge all swarm PRs bottom-up into develop
+/merge-stack     # merge swarm PRs bottom-up into the feature branch
+/ship-epic       # rebase-merge the feature branch onto develop (linear)
 /cut             # create a release candidate from develop
 /release         # promote to main, tag the release, close referenced issues
 ```
 
-Or collapse all three into a single `/ship`. See the [flowkit README](./plugins/flowkit/README.md) for the full lifecycle and RC naming.
+Or collapse all four into a single `/ship`. For single-issue or `--no-epic` runs, `/merge-stack` lands directly on `develop` and `/ship-epic` is skipped automatically. See the [flowkit README](./plugins/flowkit/README.md) for the full lifecycle.
 
 ## How the Plugins Compose
 

--- a/site/src/components/post/MergeStackDiagram.astro
+++ b/site/src/components/post/MergeStackDiagram.astro
@@ -1,7 +1,7 @@
 ---
 ---
 
-<svg viewBox="0 0 640 460" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="/merge-stack first retargets all non-root PRs to develop, then merges bottom-up with a local rebase between each pair of merges to drop the predecessor's commits via patch-id matching.">
+<svg viewBox="0 0 640 460" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="/merge-stack first retargets all non-root PRs to the base branch, then merges bottom-up with a local rebase between each pair of merges to drop the predecessor's commits via patch-id matching.">
   <defs>
     <marker id="arrow-ms" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="6" markerHeight="6" orient="auto-start-reverse">
       <path d="M0,0 L10,5 L0,10 z" fill="#a8a29c" />
@@ -11,7 +11,7 @@
     </marker>
   </defs>
 
-  <text class="mono" x="320" y="20" text-anchor="middle" font-size="12" font-weight="500">Phase 1 — retarget non-root PRs to develop (before any merge)</text>
+  <text class="mono" x="320" y="20" text-anchor="middle" font-size="12" font-weight="500">Phase 1 — retarget non-root PRs to the base branch (before any merge)</text>
 
   <text class="muted" x="178" y="48" text-anchor="middle" font-size="11" font-style="italic">stack as opened</text>
   <rect class="node" x="14" y="60" width="80" height="36" rx="6" />
@@ -39,7 +39,7 @@
   <line class="edge edge--accent" x1="514" y1="74" x2="466" y2="100" marker-end="url(#arrow-ms-accent)" />
   <line class="edge edge--accent" x1="514" y1="114" x2="466" y2="106" marker-end="url(#arrow-ms-accent)" />
   <line class="edge edge--accent" x1="514" y1="154" x2="466" y2="114" marker-end="url(#arrow-ms-accent)" />
-  <text class="muted" x="500" y="194" text-anchor="middle" font-size="10">all PRs now base = develop</text>
+  <text class="muted" x="500" y="194" text-anchor="middle" font-size="10">all PRs now base = the base branch</text>
 
   <line class="edge edge--ghost" x1="20" y1="220" x2="620" y2="220" />
 
@@ -72,5 +72,5 @@
   <text class="muted" x="320" y="380" text-anchor="middle" font-size="11" font-style="italic">cycle of (merge → rebase remaining) repeats root → leaf until the chain is empty</text>
 
   <rect class="node--accent" x="80" y="406" width="480" height="40" rx="6" fill="#f0f9f0" />
-  <text x="320" y="430" text-anchor="middle" font-size="12">all squash commits land on <tspan class="mono" font-weight="500">develop</tspan>; remote PR branches deleted as they merge</text>
+  <text x="320" y="430" text-anchor="middle" font-size="12">all squash commits land on <tspan class="mono" font-weight="500">the base branch</tspan>; remote PR branches deleted as they merge</text>
 </svg>

--- a/site/src/content/kits/flowkit.md
+++ b/site/src/content/kits/flowkit.md
@@ -9,15 +9,16 @@ commands:
   - /flowkit:cut
   - /flowkit:release
   - /flowkit:sync
-  - /flowkit:stage
+  - /flowkit:ship-epic
+  - /flowkit:restack
   - /flowkit:pipeline-status
   - /flowkit:preview-epic
   - /flowkit:cut-epic
 summary: >
   flowkit wraps the full develop → release → main lifecycle into a set of
   Claude Code skills. It handles branch creation, PR opening with structured
-  bodies, squash-merging, staging cuts, and release tagging — so every merge
-  follows the same convention without manual steps.
+  bodies, squash-merging, rebase-merge release tagging, and epic promotion —
+  so every merge follows the same convention without manual steps.
 ---
 
 flowkit is the backbone of the smallorbit release pipeline.

--- a/site/src/content/posts/run-a-swarm.mdx
+++ b/site/src/content/posts/run-a-swarm.mdx
@@ -45,13 +45,13 @@ You have a clean three-PR stack. Root targets `develop`. Middle PR's base is the
 
 You now have two closed PRs that were perfectly healthy thirty seconds ago.
 
-`/merge-stack` does the obvious fix in a non-obvious place: *before* the first merge runs, it retargets every non-root PR to the base branch.
+`/merge-stack` does the obvious fix in a non-obvious place: *before* the first merge runs, it retargets every non-root PR to the base branch (the feature branch for multi-issue epic swarms; `develop` for flat or `--no-epic` runs).
 
 ```bash
-gh pr edit <N> --base develop
+gh pr edit <N> --base <base-branch>
 ```
 
-Once a child's base is `develop`, deleting its predecessor's branch on merge no longer looks like abandonment. The auto-close cascade simply doesn't fire. After that, every PR in the stack merges with the same boring command:
+Once a child's base is the shared base branch, deleting its predecessor's branch on merge no longer looks like abandonment. The auto-close cascade simply doesn't fire. After that, every PR in the stack merges with the same boring command:
 
 ```bash
 gh pr merge <N> --squash --delete-branch
@@ -66,17 +66,17 @@ Retargeting prevents the auto-close cascade, but it doesn't solve the *next* pro
 So `/merge-stack` does a local rebase between every pair of merges, for every still-open downstream PR in the chain:
 
 ```bash
-git fetch origin <head-branch> develop
+git fetch origin <head-branch> <base-branch>
 git checkout <head-branch>
-git rebase origin/develop
+git rebase origin/<base-branch>
 git push --force-with-lease origin <head-branch>
 ```
 
-`git rebase`'s patch-id matching is what carries the load. It recognizes the predecessor's commits as already applied — under a different SHA — and drops them, emitting `warning: skipped previously applied commit <sha>` for each one. That's the happy path, not an error. The downstream PR then has only its own new commits on top of the fresh `develop`, and the next squash merge runs cleanly.
+`git rebase`'s patch-id matching is what carries the load. It recognizes the predecessor's commits as already applied — under a different SHA — and drops them, emitting `warning: skipped previously applied commit <sha>` for each one. That's the happy path, not an error. The downstream PR then has only its own new commits on top of the fresh base branch, and the next squash merge runs cleanly.
 
 For independent PRs (no chain), this step is skipped — they target `develop` directly and have no predecessor commits to drop. If a rebase fails with a real content conflict (not a patch-id-matchable duplicate), the chain stops at that PR, the rest of the chain is marked blocked, and unrelated PRs continue.
 
-<Diagram caption="/merge-stack: retarget all non-root PRs to develop first, then walk the chain root-to-leaf, rebasing what's left between each merge.">
+<Diagram caption="/merge-stack: retarget all non-root PRs to the base branch first, then walk the chain root-to-leaf, rebasing what's left between each merge.">
   <MergeStackDiagram />
 </Diagram>
 
@@ -84,12 +84,14 @@ For independent PRs (no chain), this step is skipped — they target `develop` d
 
 After `/merge-stack`:
 
-- One squash commit per issue on `develop`.
+- One squash commit per issue on the base branch (the feature branch for multi-issue epic swarms, or `develop` for flat runs).
 - No orphaned remote branches.
 - No merge bubbles.
 - All referenced issues closed.
 
-If a PR fails review or merge mid-stack, the chain stops cleanly. Because retargeting happened up front, every still-open downstream PR already targets `develop` — resuming is just fixing the conflict and re-running.
+For epic swarms, run `/ship-epic` next to rebase-merge the feature branch onto `develop` linearly — so `develop`'s first-parent history stays one squash per issue, with no merge commits.
+
+If a PR fails review or merge mid-stack, the chain stops cleanly. Because retargeting happened up front, every still-open downstream PR already targets the base branch — resuming is just fixing the conflict and re-running.
 
 ## When to reach for it
 

--- a/site/src/content/transcripts/flowkit.json
+++ b/site/src/content/transcripts/flowkit.json
@@ -35,8 +35,8 @@
     ],
     [
       { "type": "prompt", "text": "✓" },
-      { "type": "text", "text": " staging updated " },
-      { "type": "annotate", "text": "(origin/staging detected)" }
+      { "type": "text", "text": " RC promoted " },
+      { "type": "annotate", "text": "(direct to main)" }
     ],
     [
       { "type": "text", "text": " " }
@@ -48,7 +48,7 @@
     ],
     [
       { "type": "prompt", "text": "✓" },
-      { "type": "text", "text": " merged staging → main · tagged " },
+      { "type": "text", "text": " rebase-merged RC → main · tagged " },
       { "type": "annotate", "text": "v2026.04.17.1" }
     ],
     [


### PR DESCRIPTION
## Summary

Final epic docs sweep. Every public surface — root README, CLAUDE.md, the project-local ship-plugins meta-skill, Astro kit pages, blog post, transcript, and diagram — now describes the post-overhaul reality: feature-branch defaults for multi-issue swarms, `ship-epic` in the release chain, rebase-merge releases, and no staging or hotfix primitives. The repo-wide stale-token audit grep returns zero outside the documented exclusion set.

## Changes

- `README.md` — Update Getting Started step 4: replace 3-command flat-chain with 4-command epic chain (`/merge-stack → /ship-epic → /cut → /release`) + `/ship` collapse; add carve-out for single-issue/`--no-epic` flat runs.
- `CLAUDE.md` — Reword `flowkit:cut-epic` description from "equivalent to the inline cut performed by `spawn-team --epic`" to "the primitive that `spawn-team --epic` invokes" (post-#895).
- `.claude/skills/ship-plugins/SKILL.md` — Drop 4 staging references (lines 29, 89, 92, 115); insert Stage 3.5 ship-epic (conditional, same two-signal epic-detection logic as `flowkit:ship` post-#894); simplify Stage 5 release check to RC-only; update report example to include Stage 3.5 row; update constraint.
- `site/src/content/kits/flowkit.md` — Drop `/flowkit:stage` from commands list; add `/flowkit:ship-epic` and `/flowkit:restack`; reword summary from "staging cuts" to "rebase-merge release tagging, and epic promotion."
- `site/src/content/transcripts/flowkit.json` — Replace 3 staging-era transcript lines with post-#888 equivalents mirroring `docs/index.html`: "RC promoted (direct to main)" and "rebase-merged RC → main · tagged."
- `site/src/content/posts/run-a-swarm.mdx` — Generalize merge-stack target from `develop` to "the base branch" (feature branch for epic swarms, `develop` for flat); update "What you get" outcome to name `/ship-epic` as the next step for epic swarms; update MergeStackDiagram caption.
- `site/src/components/post/MergeStackDiagram.astro` — Replace all 4 `develop` text labels with "the base branch" (aria-label, Phase 1 heading, "all PRs now base = …" muted text, bottom summary); SVG topology unchanged.

## Test plan

- [ ] `bash scripts/test-all-skill-scripts.sh` — 8/8 PASS (no script changes, zero regressions).
- [ ] Stale-token audit grep returns **zero** outside exclusion set:
  ```bash
  git grep -nE 'staging|back-merge|--merge --delete-branch|/flowkit:stage|/flowkit:hotfix' \
    -- ':(exclude)CLAUDE.md' \
       ':(exclude)plugins/flowkit/skills/preview-epic-stacked/SKILL.md' \
       ':(exclude)plugins/flowkit/skills/push-or-pr/SKILL.md' \
       ':(exclude)plugins/flowkit/skills/ship-epic/SKILL.md' \
       ':(exclude)plugins/flowkit/skills/with-clean-workspace/SKILL.md' \
       ':(exclude)site/node_modules' ':(exclude).git' \
       ':(exclude)docs/dist' ':(exclude)site/dist'
  ```
  (3 exclusions beyond blueprint's original set — all legitimate gh-CLI-flag/skill-narrative content, not stale staging-workflow refs.)
- [ ] `cd site && npm install && npm run build` — 13 pages built, zero errors.
- [ ] `git grep -nE 'merge-stack.*cut.*release' -- ':(exclude)plugins/' ':(exclude).claude/' | grep -v ship-epic` — empty.
- [ ] `git grep -nE 'plugins/flowkit/skills/(stage|hotfix)/'` — empty (no broken cross-links to deleted skill folders).
- [ ] No kit page lists `/flowkit:stage` or `/flowkit:hotfix`.
- [ ] `CLAUDE.md` line 34 reads "the primitive that `spawn-team --epic` invokes".
- [ ] `.claude/skills/ship-plugins/SKILL.md` contains Stage 3.5; `HAS_STAGING` is absent.
- [ ] `site/src/content/kits/flowkit.md` lists `/flowkit:ship-epic` and `/flowkit:restack`; does not list `/flowkit:stage`.
- [ ] `site/src/content/transcripts/flowkit.json` contains "direct to main" and "rebase-merged RC"; no "staging" token.

Closes #891
Refs #897