### PR TITLE
chore(plugins): bump flowkit@3.12.0, polishkit@3.0.2, squadkit@0.10.1, swarmkit@5.6.0

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship.",
-  "version": "3.11.0",
+  "version": "3.12.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/polishkit/.claude-plugin/plugin.json
+++ b/plugins/polishkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polishkit",
   "description": "Codebase quality toolkit. Appraise code craft with a connoisseur's eye, sweep dead code and cruft in one pass, and polish cross-cutting code-quality issues — three focused skills for improving what you've already built.",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/squadkit/.claude-plugin/plugin.json
+++ b/plugins/squadkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "squadkit",
   "description": "Multi-agent team coordination for Claude Code. Roles, squads, and crews \u2014 interview-driven setup, no per-stack presets, reusable across any repo.",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "5.5.0",
+  "version": "5.6.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Bump plugin.json versions for plugins changed since their last release. Lands the bubble-free overhaul epic (#897) and prerequisite refactors.

## Changes

- flowkit@3.11.0 → 3.12.0 (minor) — adds ship-epic + restack skills, rebase-merge release strategy, drops staging+hotfix
- polishkit@3.0.1 → 3.0.2 (patch) — bubble-free docs sweep
- squadkit@0.10.0 → 0.10.1 (patch) — spawn-team delegates epic-cut to flowkit:cut-epic
- swarmkit@5.5.0 → 5.6.0 (minor) — multi-issue swarm defaults to feature-branch flow

## Test plan

- [ ] Confirm each `plugin.json` version bump matches the per-plugin tag that will be created after merge.