### PR TITLE
fix(flowkit:ship-epic): aggregate closes tokens from child PR bodies

### DIFF
--- a/plugins/flowkit/skills/ship-epic/SKILL.md
+++ b/plugins/flowkit/skills/ship-epic/SKILL.md
@@ -61,7 +61,7 @@ If the script exits non-zero (empty stdout), surface stderr and stop. Do not ret
 | `epic_branch` | string | The promoted branch, e.g. `feature/onboarding-v2-1264`. |
 | `pr_number` | number | Epic-to-develop PR number. |
 | `pr_url` | string | Full PR URL. |
-| `closes_tokens` | array of strings | Closing-keyword lines aggregated from child squash commits and the epic issue ref. |
+| `closes_tokens` | array of strings | Closing-keyword lines aggregated from child squash commits, merged child PR bodies (in case `gh pr merge --squash` dropped the token from the commit message), and the epic issue ref. De-duped case-insensitively. |
 | `pr_base_unset` | boolean | `true` if `claude.flowkit.prBase` was set and cleared; `false` if it was already unset. |
 | `develop_advanced` | boolean | `true` if local develop fast-forwarded; `false` if the operator is on a different worktree (local develop ref was not touched). Operators on a non-develop worktree should run `/sync` to pull the updated develop. |
 

--- a/plugins/flowkit/skills/ship-epic/scripts/ship_epic.sh
+++ b/plugins/flowkit/skills/ship-epic/scripts/ship_epic.sh
@@ -107,11 +107,29 @@ if [[ -n "$RAW_MERGE" ]]; then
 fi
 
 # --- Aggregate closes tokens -------------------------------------------------
+#
+# Tokens are sourced from two places and de-duped:
+#   1. Commit messages on the epic branch (origin/develop..origin/$EPIC).
+#   2. Bodies of child PRs that targeted $EPIC as their base and are merged.
+#
+# The PR-body pass exists because `gh pr merge --squash` does not always carry
+# the PR body's `Closes #N` token into the squash commit message — survival is
+# operator-config dependent. Without the second pass, ship-epic silently misses
+# tokens that lived only in PR bodies, and the parent issues stay open. See
+# https://github.com/smallorbit/smallorbit-plugins/issues/909.
 
 CLOSES_TOKENS=$(
-  git log "origin/develop..origin/$EPIC" --pretty=format:'%B' \
-    | (grep -oiE '(closes|fixes|resolves) #[0-9]+' || true) \
-    | awk '!seen[tolower($0)]++'
+  {
+    git log "origin/develop..origin/$EPIC" --pretty=format:'%B' \
+      | (grep -oiE '(closes|fixes|resolves) #[0-9]+' || true)
+
+    gh pr list --base "$EPIC" --state merged --limit 1000 --json number --jq '.[].number' \
+      | while read -r child_pr; do
+          [[ -n "$child_pr" ]] || continue
+          gh pr view "$child_pr" --json body --jq '.body' \
+            | (grep -oiE '(closes|fixes|resolves) #[0-9]+' || true)
+        done
+  } | awk '!seen[tolower($0)]++'
 )
 
 FOOTER_LINES=()


### PR DESCRIPTION
## Summary

Extend `flowkit:ship-epic`'s closes-token aggregator to scan merged child PR bodies in addition to commit messages. `gh pr merge --squash` does not always carry a child PR body's `Closes #N` token into the squash commit — survival is operator-config dependent — so the aggregator was silently dropping those tokens, leaving parent issues open after the epic shipped (hit twice in the v2026.5.8 release: #889 and #894).

## Changes

- `plugins/flowkit/skills/ship-epic/scripts/ship_epic.sh` — add a second pass that lists merged PRs whose base equals the epic branch (`gh pr list --base "$EPIC" --state merged --limit 1000`) and greps each body for closing keywords. Pipe both passes into the existing `awk '!seen[tolower($0)]++'` to de-dup. Add a comment block explaining the failure mode and pointing to #909.
- `plugins/flowkit/skills/ship-epic/SKILL.md` — update the `closes_tokens` row in the Output table to reflect the broadened source (squash commits + merged child PR bodies + epic ref), with a note about case-insensitive de-dup.

## Test plan

- [ ] `bash plugins/flowkit/skills/ship-epic/scripts/test.sh` — argument-validation smoke tests still pass.
- [ ] Empirically verify the second pass: `gh pr view 907 --json body --jq '.body' | grep -oiE '(closes|fixes|resolves) #[0-9]+'` returns `Closes #894` (the token the prior session's aggregator missed because PR #907's squash commit body had no closes keyword).
- [ ] Next time an epic ships, confirm aggregated `closes_tokens` includes every issue referenced by a merged child PR body, even when the squash commit body dropped the token.
- [ ] Confirm idempotency: when a token appears in both the commit message and the PR body, only one entry survives the de-dup pass.

Closes #909