### PR TITLE
refactor(flowkit:ship): rescope to develop→main with open-swarm-PR preflight

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,21 @@ The bump-versions skill handles:
 
 Run it before staging and committing the release.
 
+### Canonical bubble-free release sequence
+
+The full operator-controlled release flow is four explicit steps, with a verify gate sitting between integration and promotion:
+
+```
+/swarmkit:merge-stack            # land all open worktree-agent-* PRs into the epic (or develop)
+# verify on the integrated branch — run typecheck/test/lint
+/flowkit:ship-epic               # rebase-merge the epic to develop, unset prBase, delete epic branch
+/flowkit:ship                    # cut → release: develop → main
+```
+
+`/flowkit:ship` is the release closer only — it chains `cut → release`. It refuses to run while open `worktree-agent-*` PRs target the resolved base, which is what makes the verify step between `merge-stack` and `ship-epic` mandatory in practice. Operators who skip the verify step and try to ship anyway will be turned around by ship's preflight.
+
+For a release with no swarm in flight (no epic, no open `worktree-agent-*` PRs), `/flowkit:ship` runs unconditionally — it is just `cut → release`.
+
 ## Plugins
 
 `squadkit` is the interactive multi-role collaboration plugin (sibling to swarmkit's parallel-issue resolution). It introduces the `roles → squads → crews` vocabulary and ships `spawn-team`, `init`, and a `SessionStart` hook that re-asserts role context on resume.

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -42,7 +42,7 @@ claude --plugin-dir /path/to/flowkit
 | **sync** | `/sync` | Checkout `develop`, pull latest, prune stale branches. |
 | **cut** | `/cut` | Create a `rc/YYYY-MM-DD.N` release candidate from `develop`. |
 | **release** | `/release` | Merge the newest RC to `main`, tag, close issues, clean up RC branches. |
-| **ship** | `/ship` | Repo-level orchestrator. Chains `merge-stack → ship-epic (when epic in flight) → cut → release`. End-state: linear `develop`, linear `main`, prBase unset. |
+| **ship** | `/ship` | Release closer. Chains `cut → release` to promote `develop` to `main`. Aborts if open `worktree-agent-*` PRs target the resolved base — run `/swarmkit:merge-stack` (and `/ship-epic` when an epic is in flight) first. |
 | **pipeline-status** | `/pipeline-status` | Show the full release pipeline: open PRs in flight, `develop` awaiting a cut, RCs awaiting release, and the most recent tag. |
 
 ### Sub-Skills (internal)
@@ -57,13 +57,24 @@ These are called by the skills above — you don't invoke them directly.
 
 ## Typical Workflows
 
-### After a swarm run
+### After a swarm run (canonical bubble-free release)
 
 ```
-/ship                            # merge-stack → ship-epic → cut → release (auto-detects feature branch)
+/swarmkit:merge-stack            # land all open worktree-agent-* PRs into the epic (or develop)
+# verify on the integrated branch — run your project's typecheck/test/lint
+/ship-epic                       # rebase-merge the epic to develop, unset prBase, delete epic branch
+/ship                            # cut → release: develop → main
 ```
+
+The operator-controlled stop between `merge-stack` and `ship-epic` is where the verify gate runs against the cumulative integrated state. `/ship` itself is the release closer only — it refuses to run while open `worktree-agent-*` PRs target the resolved base, pointing the operator back at `merge-stack`.
 
 ### Standard release (no swarm)
+
+```
+/ship                            # cut → release: develop → main
+```
+
+Or run the underlying steps directly:
 
 ```
 /cut                             # cut a release candidate from develop
@@ -93,7 +104,7 @@ The epic branch composes with `swarmkit:swarm`: agents spawned while `claude.flo
 
 To verify the integrated state of an epic locally before promotion, check out the feature branch and run your project's verify commands directly — after `swarmkit:merge-stack` lands every sub-PR onto the feature branch, the branch HEAD already is the integrated state, so no synthesis step is needed.
 
-> `/ship` from an epic branch (or with `claude.flowkit.prBase` pinned to a `feature/*`) automatically inserts `ship-epic` between `merge-stack` and `cut`. The epic branch is rebase-merged to `develop`, the pin is cleared, and the chain continues with the freshly-updated `develop`. `/ship` does not auto-verify — check out the feature branch and run verify yourself first if you want to gate promotion on it.
+> `/ship` is a develop→main release closer; it does not promote epics. From an epic in flight, run `/swarmkit:merge-stack`, verify on the integrated feature branch, run `/ship-epic` to rebase-merge the epic into `develop`, then run `/ship`. `/ship` aborts if any open `worktree-agent-*` PRs still target the resolved base — that abort is what makes the verify gate between `merge-stack` and `ship-epic` mandatory in practice.
 
 ### Mid-review restack
 
@@ -121,7 +132,7 @@ The subtree is walked breadth-first: siblings continue independently if one bran
 
 ## Ship boundaries
 
-`/ship` orchestrates `merge-stack → ship-epic (conditional) → cut → release`. Branch creation, commits, and PR opening live in `/pr` and `/swarm`. If any step fails, `/ship` stops before the next step; state is left recoverable for re-run after the operator resolves the failure.
+`/ship` is the release closer: it chains `cut → release` to promote `develop` to `main`. It does not merge open swarm PRs and does not promote epics. Those steps belong to `/swarmkit:merge-stack` and `/flowkit:ship-epic`, run by the operator beforehand so a verify gate can sit between integration and release. The canonical bubble-free sequence is `/swarmkit:merge-stack → verify → /flowkit:ship-epic → /flowkit:ship`. Branch creation, commits, and PR opening live in `/pr` and `/swarm`. `/ship` aborts up front if any open `worktree-agent-*` PRs target the resolved base. If any step fails, `/ship` stops before the next step; state is left recoverable for re-run after the operator resolves the failure.
 
 ## Configuration
 
@@ -129,7 +140,7 @@ Flowkit reads one repo-local git config key:
 
 | Key | Purpose | Default |
 |-----|---------|---------|
-| `claude.flowkit.prBase` | Target base branch for `/open-pr` when no override is passed. Set automatically by `/cut-epic`, `/swarm` (loop mode), and `squadkit:spawn-team --epic`; unset by `/ship-epic` (and therefore by `/ship` when an epic is in flight). | `develop` |
+| `claude.flowkit.prBase` | Target base branch for `/open-pr` when no override is passed. Set automatically by `/cut-epic`, `/swarm` (loop mode), and `squadkit:spawn-team --epic`; unset by `/ship-epic`. | `develop` |
 
 Inspect or set manually:
 
@@ -238,7 +249,10 @@ Flowkit handles the shipping half of the development loop. Use it with speckit a
 ```
 /spec add CSV export              # Plan the feature, file issues  (speckit)
 /swarm                            # Resolve issues with parallel agents  (swarmkit)
-/ship                             # merge-stack → ship-epic → cut → release  (flowkit)
+/swarmkit:merge-stack             # Land the swarm PRs into the epic branch
+# verify on the epic branch
+/ship-epic                        # Promote epic → develop  (flowkit)
+/ship                             # cut → release: develop → main  (flowkit)
 ```
 
-The natural sequence is **speckit → swarmkit → flowkit**: speckit defines the work, swarmkit executes it, flowkit ships it. Use [sessionkit](../sessionkit)'s `/handoff` if a release session runs long, and `/skillit` afterwards to capture any new conventions or one-off scripts worth keeping.
+The natural sequence is **speckit → swarmkit → flowkit**: speckit defines the work, swarmkit executes it, flowkit ships it. The operator-controlled stop between `merge-stack` and `ship-epic` is the verify gate against the cumulative integrated state — `/ship` itself refuses to run while swarm PRs are still open against the resolved base. Use [sessionkit](../sessionkit)'s `/handoff` if a release session runs long, and `/skillit` afterwards to capture any new conventions or one-off scripts worth keeping.

--- a/plugins/flowkit/skills/ship/SKILL.md
+++ b/plugins/flowkit/skills/ship/SKILL.md
@@ -28,9 +28,9 @@ BASE=$(git config --get claude.flowkit.prBase 2>/dev/null || echo "develop")
 
 OPEN=$(gh pr list \
   --base "$BASE" \
-  --head 'worktree-agent-*' \
   --state open \
-  --json number,title,headRefName 2>/dev/null)
+  --json number,title,headRefName 2>/dev/null \
+  | jq '[.[] | select(.headRefName | startswith("worktree-agent-"))]')
 
 if [[ -n "$OPEN" && "$OPEN" != "[]" ]]; then
   echo "$OPEN" | jq -r '.[] | "  #\(.number) (\(.headRefName)): \(.title)"' >&2
@@ -39,6 +39,8 @@ if [[ -n "$OPEN" && "$OPEN" != "[]" ]]; then
   exit 1
 fi
 ```
+
+`gh pr list --head` is exact-match only — it does not support glob patterns, so the previous `--head 'worktree-agent-*'` filter silently returned an empty list and the abort guard never fired. Filtering the full open-PR set through `jq`'s `startswith` matches the intended prefix semantics.
 
 The preflight is a hard gate. Open swarm PRs against the resolved base mean the integrated `develop` (or epic) state ship would package up does not yet include their work — releasing now would silently strand them. The operator clears this by running `/swarmkit:merge-stack` and (when an epic is in flight) `/flowkit:ship-epic` first, with a verify pass against the integrated state in between.
 

--- a/plugins/flowkit/skills/ship/SKILL.md
+++ b/plugins/flowkit/skills/ship/SKILL.md
@@ -1,17 +1,17 @@
 ---
 name: ship
-description: Repo-level skill that orchestrates the full bubble-free release flow: merge-stack → ship-epic (when epic in flight) → cut → release. End-state: develop and main are linear, prBase is unset, RC branch deleted.
+description: Repo-level release closer that chains flowkit:cut → flowkit:release to promote develop to main. Aborts up front if any open worktree-agent-* PRs target the resolved base — operators land them via /swarmkit:merge-stack first so a verify gate can run against the integrated develop snapshot before ship.
 triggers:
   - "/ship"
-  - "ship everything"
-  - "merge stack and release"
-  - "ship after swarm"
+  - "ship the release"
+  - "cut and release"
+  - "promote develop to main"
 allowed-tools: Bash
 ---
 
 # Ship
 
-Orchestrate the full bubble-free release flow in one shot: detect any epic in flight, merge all open swarm PRs, promote the epic to develop (when applicable), cut a release candidate, and ship to main. End-state: `develop` and `main` are linear, `claude.flowkit.prBase` is unset, and the RC branch is deleted.
+Cut a release candidate from `develop` and ship it to `main` in one shot. Ship is the **release closer** — it does not merge open swarm PRs and does not promote epics to develop. Those steps belong to `/swarmkit:merge-stack` and `/flowkit:ship-epic` respectively, run by the operator beforehand so a verify gate can sit between integration and release.
 
 ## Input
 
@@ -19,60 +19,32 @@ Orchestrate the full bubble-free release flow in one shot: detect any epic in fl
 
 ## Process
 
-### 1. Detect epic-in-flight
+### 1. Preflight: refuse to ship while swarm PRs are open
 
-Resolve `$EPIC_BRANCH` from two signals:
+Resolve the base branch and query for open `worktree-agent-*` PRs that target it:
 
 ```bash
-EPIC_BRANCH=""
+BASE=$(git config --get claude.flowkit.prBase 2>/dev/null || echo "develop")
 
-# Signal 1: pinned config (the canonical signal — set by cut-epic, swarm, spawn-team).
-PINNED=$(git config --get claude.flowkit.prBase 2>/dev/null || true)
-if [[ -n "$PINNED" && "$PINNED" =~ ^feature/ ]]; then
-  EPIC_BRANCH="$PINNED"
-fi
+OPEN=$(gh pr list \
+  --base "$BASE" \
+  --head 'worktree-agent-*' \
+  --state open \
+  --json number,title,headRefName 2>/dev/null)
 
-# Signal 2: current HEAD is a feature/* branch (covers operators who checked out
-# an epic without setting the pin).
-if [[ -z "$EPIC_BRANCH" ]]; then
-  CURRENT=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
-  if [[ "$CURRENT" =~ ^feature/ ]]; then
-    EPIC_BRANCH="$CURRENT"
-  fi
+if [[ -n "$OPEN" && "$OPEN" != "[]" ]]; then
+  echo "$OPEN" | jq -r '.[] | "  #\(.number) (\(.headRefName)): \(.title)"' >&2
+  echo >&2
+  echo "flowkit:ship: open swarm PRs detected against $BASE. Run /swarmkit:merge-stack to land them before shipping." >&2
+  exit 1
 fi
 ```
 
-Signal 1 (pin) wins when both fire. If `$EPIC_BRANCH` is non-empty, this run promotes the epic before cutting. If empty, ship runs the develop-direct shape (merge-stack → cut → release, no ship-epic).
+The preflight is a hard gate. Open swarm PRs against the resolved base mean the integrated `develop` (or epic) state ship would package up does not yet include their work — releasing now would silently strand them. The operator clears this by running `/swarmkit:merge-stack` and (when an epic is in flight) `/flowkit:ship-epic` first, with a verify pass against the integrated state in between.
 
-### 2. Merge open swarm PRs
+If `claude.flowkit.prBase` is set to a `feature/*` branch, that branch is the resolved base — the preflight catches stack PRs targeting the epic. After the operator runs `/flowkit:ship-epic` to promote the epic, the pin is unset and `BASE` falls through to `develop` on the next ship attempt.
 
-Invoke `swarmkit:merge-stack` via the Skill tool:
-
-```
-Skill({skill: "swarmkit:merge-stack"})
-```
-
-merge-stack discovers and merges every open `worktree-agent-*` PR bottom-up. When `$EPIC_BRANCH` is set, the children target the epic branch — merge-stack handles that automatically.
-
-If merge-stack reports "no open swarm PRs found", continue to the next step. If any merge fails with a conflict, stop immediately and report which PR is blocked. Do not proceed to step 3 until conflicts are resolved.
-
-### 3. Promote the epic (conditional)
-
-When `$EPIC_BRANCH` is empty, **skip this step**. Print a one-line note:
-
-> No epic in flight — skipping ship-epic.
-
-When `$EPIC_BRANCH` is non-empty, invoke `flowkit:ship-epic` via the Skill tool:
-
-```
-Skill({skill: "flowkit:ship-epic"})
-```
-
-ship-epic resolves the epic from `claude.flowkit.prBase`, opens the feature → develop PR with aggregated `Closes #N` tokens, rebase-merges, deletes the epic branch, and unsets `claude.flowkit.prBase`. Local `develop` is fast-forwarded.
-
-If ship-epic fails (preflight failure, rebase-merge conflict, network), stop and surface its stderr. State is recoverable per ship-epic's own contract — pin and branch are intact. Do not proceed to step 4.
-
-### 4. Cut a release candidate
+### 2. Cut a release candidate
 
 Invoke `flowkit:cut` via the Skill tool:
 
@@ -84,7 +56,7 @@ cut creates `rc/<YYYY-MM-DD>.N` from `origin/develop`, pushes it, and pushes the
 
 If cut fails (e.g., empty diff against main), stop and report.
 
-### 5. Release
+### 3. Release
 
 Invoke `flowkit:release` via the Skill tool:
 
@@ -98,33 +70,18 @@ release runs the rebase-merge preflight, opens the RC → main PR, rebase-merges
 
 If release fails, stop and report.
 
-### 6. Final assertion and report
-
-After all preceding steps complete:
-
-```bash
-PIN_AFTER=$(git config --get claude.flowkit.prBase 2>/dev/null || true)
-if [[ -n "$PIN_AFTER" ]]; then
-  echo "warning: claude.flowkit.prBase is still set to '$PIN_AFTER' after ship completed." >&2
-  echo "  Expected empty when ship finishes from a clean state. Run \`git config --unset claude.flowkit.prBase\` to clear." >&2
-fi
-```
+### 4. Final report
 
 Report:
 
-- Whether ship-epic ran (and the resulting epic PR number/URL if so)
 - The RC branch created
 - The release tag created on main
 - Issues closed (aggregated from release's own report)
-- The closing pin state (empty on the happy path; warning surfaced if not)
 
 ## Constraints
 
-- If `merge-stack` encounters a conflict, stop — do not proceed with unresolved conflicts
 - Never commit directly to `develop` or `main`
-- No branch/commit/PR creation — those belong to `/pr` and `/swarm`
-- If any step fails, stop immediately and report what failed and why
-- ship-epic runs only when epic-in-flight is detected (Step 1's `$EPIC_BRANCH` non-empty). Otherwise it is silently skipped — calling ship-epic on a develop-direct run would produce a guaranteed error
-- No internal verify gate. Operators check out the feature branch and run verify themselves before invoking `/ship`. Symmetry with `ship-epic` and `cut-epic` themes
+- No branch/commit/PR creation outside what `cut` and `release` produce — those belong to `/pr` and `/swarm`
+- The preflight is non-negotiable: do not bypass or weaken it. Open swarm PRs must be merged via `/swarmkit:merge-stack` (and the epic promoted via `/flowkit:ship-epic` when applicable) before ship runs
+- No internal verify gate. Ship assumes the operator has already verified the integrated state against the project's tests between merge-stack and ship-epic (or between ship-epic and ship). Ship just packages what is already on `develop`
 - Stop on any sub-skill failure. State is recoverable across partial failures: re-running `/ship` after the operator resolves the failure picks up where the chain left off
-- No `--no-ship-epic` opt-out. Operators who need to skip ship-epic for an unusual reason invoke `/merge-stack && /cut && /release` directly

--- a/plugins/sessionkit/skills/roadmap/SKILL.md
+++ b/plugins/sessionkit/skills/roadmap/SKILL.md
@@ -89,11 +89,22 @@ Compose the entry sub-chains into a single ordered chain. Standard step library 
 | Self-review the PR diff | `/review` (or manual read-through) |
 | Merge a single PR | `/flowkit:merge-pr` |
 | Merge a stacked PR set | `/swarmkit:merge-stack` |
+| Verify the integrated state | manual: project's typecheck/test/lint on the feature branch |
+| Promote epic → develop | `/flowkit:ship-epic` |
 | Sync local develop with origin | `/flowkit:sync` |
 | Bump per-plugin versions + tags | `/bump-versions` |
 | Cut a release candidate | `/flowkit:cut` |
 | Promote RC → main, tag, close issues | `/flowkit:release` |
+| Cut + release in one shot (develop → main) | `/flowkit:ship` |
 | Verify post-release pipeline state | `/flowkit:pipeline-status` |
+
+**Canonical bubble-free release sequence.** When an epic is in flight (open `worktree-agent-*` PRs targeting a `feature/<slug>-<N>` branch), the standard chain is:
+
+```
+/swarmkit:merge-stack → verify (manual) → /flowkit:ship-epic → /flowkit:ship
+```
+
+`/flowkit:ship` aborts if open `worktree-agent-*` PRs still target the resolved base, so the verify step between `merge-stack` and `ship-epic` is a hard prerequisite — operators cannot collapse the chain into a single step. For releases with no epic in flight, `/flowkit:ship` alone (cut → release) is the entire chain.
 
 For each step in the chain, write a task with:
 

--- a/plugins/swarmkit/METHODOLOGY.md
+++ b/plugins/swarmkit/METHODOLOGY.md
@@ -128,14 +128,26 @@ In loop mode the feature branch is cut once — at the first cycle that selects 
 
 After all child PRs are merged into the feature branch via `/merge-stack`, the feature branch carries N squash commits — one per merged-from-stack PR. Swarm's responsibility ends here: PRs are open (or merged into the feature branch), and the pin is intact.
 
-The operator then runs `/ship-epic` (separately, after review) to:
+The canonical release sequence from this point is four steps, run by the operator with a verify gate between integration and promotion:
+
+```
+/swarmkit:merge-stack            # land the open worktree-agent-* PRs into the feature branch
+# verify on the feature branch — run typecheck/test/lint against the integrated state
+/flowkit:ship-epic               # rebase-merge the feature branch to develop, unset prBase, delete it
+/flowkit:ship                    # cut → release: develop → main
+```
+
+`/flowkit:ship-epic` does the develop promotion:
+
 1. Open the feature→`develop` PR with aggregated `Closes #N` from the squash commits.
 2. Rebase-merge (so the squash commits replay onto `develop` linearly, no merge bubbles).
 3. Unset `claude.flowkit.prBase`.
 4. Delete the feature branch on origin.
 5. Fast-forward local `develop`.
 
-Swarm never invokes `/ship-epic`. The operator must explicitly trigger promotion.
+`/flowkit:ship` then handles the develop→main release: cut a release candidate, merge to main, tag, close issues. It is the release closer only — it does not invoke `merge-stack` or `ship-epic`, and aborts up front if any open `worktree-agent-*` PRs still target the resolved base.
+
+Swarm never invokes `/ship-epic` or `/ship`. The operator must explicitly trigger promotion and release.
 
 ### Escape Hatches
 


### PR DESCRIPTION
## Summary

Rescope `/flowkit:ship` to the develop→main release closer (chains `flowkit:cut → flowkit:release` only) and add a preflight that aborts when open `worktree-agent-*` PRs still target the resolved base — operators land them via `/swarmkit:merge-stack` first so a verify gate can run against the cumulative integrated state. Cross-cutting docs are updated to describe the new canonical manual sequence `/swarmkit:merge-stack → verify → /flowkit:ship-epic → /flowkit:ship`.

## Changes

- `plugins/flowkit/skills/ship/SKILL.md` — frontmatter narrowed to release-cut scope; process rewritten with a `gh pr list --base "$BASE" --state open` query post-filtered through `jq '[.[] | select(.headRefName | startswith("worktree-agent-"))]'` for the preflight + abort hint, then `flowkit:cut → flowkit:release` only. EPIC_BRANCH detection, `swarmkit:merge-stack` invocation, conditional `flowkit:ship-epic` invocation, and the closing-pin assertion all removed.
- `plugins/flowkit/README.md` — skills table, "After a swarm run" workflow, ship boundaries, prBase config row, and the speckit→swarmkit→flowkit pairing rewritten for the four-step manual sequence.
- `CLAUDE.md` — new "Canonical bubble-free release sequence" subsection under Release Process.
- `plugins/swarmkit/METHODOLOGY.md` — Ship-Epic Handoff section spells out the four-step closer chain and the role split between `ship-epic` and `ship`.
- `plugins/sessionkit/skills/roadmap/SKILL.md` — standard step library gains `ship-epic`, `ship`, and verify rows; canonical-sequence call-out added beneath the table.

## Test plan

- [x] Inspect `plugins/flowkit/skills/ship/SKILL.md` — process chain mentions only `flowkit:cut` and `flowkit:release`; no `merge-stack` or `ship-epic` references.
- [x] Frontmatter `description:` and `triggers:` reflect the narrowed scope (no "ship after swarm", no "merge stack and release").
- [x] Preflight section describes a `gh pr list --base "$BASE" --state open` query post-filtered through `jq '[.[] | select(.headRefName | startswith("worktree-agent-"))]'` and the abort hint pointing at `/swarmkit:merge-stack`. (Note: `gh`'s `--head` flag is exact-match only and does not support glob patterns, so jq prefix-matching is the correct mechanism.)
- [x] The 4 cross-cutting docs describe the new manual flow `/swarmkit:merge-stack → verify → /flowkit:ship-epic → /flowkit:ship`.
- [x] `bash scripts/test-all-skill-scripts.sh` exits 0 (8 passed, 0 failed).
- [ ] Verify preflight: from a clean develop with no open swarm PRs, `/flowkit:ship` runs the chain. From a state with an open `worktree-agent-*` PR targeting the resolved base, `/flowkit:ship` aborts with the expected hint.

Closes #914
Refs #915