### PR TITLE
chore(plugins): bump flowkit@3.13.0, sessionkit@1.9.1, squadkit@0.10.2, swarmkit@5.6.1

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship.",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sessionkit",
   "description": "Session continuity, planning, and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, map work-in-flight into an approved task chain and drive it to completion, discover reusable skills, and reduce permission noise.",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/squadkit/.claude-plugin/plugin.json
+++ b/plugins/squadkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "squadkit",
   "description": "Multi-agent team coordination for Claude Code. Roles, squads, and crews \u2014 interview-driven setup, no per-stack presets, reusable across any repo.",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "5.6.0",
+  "version": "5.6.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Bump plugin.json versions for plugins changed since their last per-plugin tag, in preparation for the next release.

## Changes

- flowkit 3.12.0 → 3.13.0 (minor) — [#916](https://github.com/smallorbit/smallorbit-plugins/pull/916) closes-token aggregator fix + [#917](https://github.com/smallorbit/smallorbit-plugins/pull/917) retire preview-epic + [#918](https://github.com/smallorbit/smallorbit-plugins/pull/918) rescope /flowkit:ship to cut → release with open-swarm-PR preflight
- sessionkit 1.9.0 → 1.9.1 (patch) — `plugins/sessionkit/skills/roadmap/SKILL.md` updated with ship-epic / ship rows and canonical-sequence callout
- squadkit 0.10.1 → 0.10.2 (patch) — `plugins/squadkit/README.md` + `plugins/squadkit/skills/spawn-team/SKILL.md` Composition table swept of preview-epic refs
- swarmkit 5.6.0 → 5.6.1 (patch) — `plugins/swarmkit/METHODOLOGY.md` updated with the four-step closer sequence

## Test plan

- [ ] Confirm each plugin.json version matches the per-plugin tag that will be created post-merge.
- [ ] After release, verify clients pick up the new versions via `/plugin update`.