### PR TITLE
fix(swarmkit:swarm): assert origin/<base> ancestry to catch post-rebase-merge worktree drift

### DIFF
--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -252,19 +252,10 @@ Each agent prompt MUST include these **workflow steps** (in order):
    # SHA chain even though the checkout targeted develop, producing a 50+-file diff
    # for an 11-file change. Fail fast here instead.
    #
-   # Use the variant that matches the checkout above — one or the other, not both:
-   #
-   # For independent issues (base = origin/develop):
-   if ! git merge-base --is-ancestor origin/develop HEAD; then
-     echo "ERROR: HEAD is not a descendant of origin/develop. Worktree may be rooted on a stale base." >&2
-     echo "       Run: git fetch origin develop && git reset --hard origin/develop" >&2
-     exit 1
-   fi
-
-   # For dependent issues (base = origin/worktree-agent-<dependency-issue>):
-   if ! git merge-base --is-ancestor origin/worktree-agent-<dependency-issue> HEAD; then
-     echo "ERROR: HEAD is not a descendant of origin/worktree-agent-<dependency-issue>. Worktree may be rooted on a stale base." >&2
-     echo "       Run: git fetch origin worktree-agent-<dependency-issue> && git reset --hard origin/worktree-agent-<dependency-issue>" >&2
+   # Use the same <base> as the checkout above — one variant, not both:
+   if ! git merge-base --is-ancestor origin/<base> HEAD; then
+     echo "ERROR: HEAD is not a descendant of origin/<base>. Worktree may be rooted on a stale base." >&2
+     echo "       Run: git fetch origin <base> && git reset --hard origin/<base>" >&2
      exit 1
    fi
 

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -245,6 +245,29 @@ Each agent prompt MUST include these **workflow steps** (in order):
    # Safety check — abort if not in an isolated worktree
    [[ "$PWD" != *"worktrees"* ]] && echo "ERROR: Not running in an isolated worktree. Aborting to prevent branch collision." && exit 1
 
+   # Ancestry sanity — abort if HEAD doesn't descend from the requested base.
+   # Defends against the post-rebase-merge worktree-base drift bug (#923): after a
+   # rebase-merge release, origin/main and origin/develop share identical trees but
+   # diverge in SHA history. EnterWorktree may silently root the worktree on main's
+   # SHA chain even though the checkout targeted develop, producing a 50+-file diff
+   # for an 11-file change. Fail fast here instead.
+   #
+   # Use the variant that matches the checkout above — one or the other, not both:
+   #
+   # For independent issues (base = origin/develop):
+   if ! git merge-base --is-ancestor origin/develop HEAD; then
+     echo "ERROR: HEAD is not a descendant of origin/develop. Worktree may be rooted on a stale base." >&2
+     echo "       Run: git fetch origin develop && git reset --hard origin/develop" >&2
+     exit 1
+   fi
+
+   # For dependent issues (base = origin/worktree-agent-<dependency-issue>):
+   if ! git merge-base --is-ancestor origin/worktree-agent-<dependency-issue> HEAD; then
+     echo "ERROR: HEAD is not a descendant of origin/worktree-agent-<dependency-issue>. Worktree may be rooted on a stale base." >&2
+     echo "       Run: git fetch origin worktree-agent-<dependency-issue> && git reset --hard origin/worktree-agent-<dependency-issue>" >&2
+     exit 1
+   fi
+
 2. Make changes (the actual issue work)
 3. Stage and commit using conventional-commit-message format:
    - No Claude mentions, no co-author lines


### PR DESCRIPTION
## Summary

- Adds a `git merge-base --is-ancestor origin/<base> HEAD` assertion to the swarm agent's spawn workflow, immediately after the existing isolated-worktree check.
- Defends against the post-rebase-merge worktree-base drift symptom: `origin/main` and `origin/develop` share identical trees but diverge in SHA history, and the harness's `EnterWorktree` may silently root the worktree on main's SHA chain. The new check fails the agent fast, with a one-line remediation hint, instead of producing an inflated 50+-file PR diff for an 11-file change.
- Two variants are provided in the workflow — one for independent issues (asserting `origin/develop`) and one for dependent issues (asserting `origin/worktree-agent-<dependency-issue>`) — with a comment making clear they are mutually exclusive alternatives.

## Changes

- `plugins/swarmkit/skills/swarm/SKILL.md` — step 4 workflow block: ancestry assertion block appended to the safety-check stanza, covering both the independent-issue and dependent-issue branches.

## Test plan

- [ ] Post-rebase-merge release, spawn a swarm agent and verify the worktree's HEAD has the requested base's SHA chain (not main's).
- [ ] If the symptom recurs, the agent now exits non-zero at spawn time with the documented `git fetch + git reset --hard` remediation, instead of pushing a branch with an inflated diff.

Closes #923