### PR TITLE
release: 2026-05-09

### DIFF
--- a/plugins/squadkit/.claude-plugin/plugin.json
+++ b/plugins/squadkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "squadkit",
   "description": "Multi-agent team coordination for Claude Code. Roles, squads, and crews \u2014 interview-driven setup, no per-stack presets, reusable across any repo.",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/squadkit/skills/spawn-team/SKILL.md
+++ b/plugins/squadkit/skills/spawn-team/SKILL.md
@@ -631,3 +631,17 @@ Two coordination shapes are supported:
 
 - **Execution crews** (default) — architect drafts blueprints, builders implement, tester/reviewer gate. Output is merged code via PRs.
 - **Discovery crews** (`kind: discovery`) — architect IS the lead and synthesizes explorer/designer replies into long-form blueprints posted as GitHub issue comments. Builders are absent. See [`../../docs/patterns/discovery-coordination.md`](../../docs/patterns/discovery-coordination.md) for the full coordination protocol, role scopes, deliverable shape, stop condition, and a worked example.
+
+## Known issue: TeamDelete leaves zombie subprocesses
+
+`TeamDelete` returns success but does not signal or kill the long-running agent processes whose `--team-name` flag matches. This is a harness-level limitation and will be addressed upstream (see #924). Until the harness fix lands, operators should sweep lingering agent subprocesses manually after calling `TeamDelete` to tear down a team:
+
+```bash
+ps aux \
+  | grep -- "--team-name <team-name>" \
+  | grep -v grep \
+  | awk '{print $2}' \
+  | xargs -r kill
+```
+
+Replace `<team-name>` with the team name passed to `TeamDelete`. Run this sweep immediately after `TeamDelete` returns — the zombie processes consume no dispatch but do hold open file descriptors and tmux panes.

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "5.6.1",
+  "version": "5.6.2",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/swarmkit/agents/swarm-reviewer.md
+++ b/plugins/swarmkit/agents/swarm-reviewer.md
@@ -72,3 +72,15 @@ Return your findings in this exact structure. Every section must be present even
 - **Do not close the issue.** Leave issue lifecycle to the PR merge.
 - **Be specific.** Vague findings ("consider improving X") waste the worker's time. Cite file paths and line numbers where possible.
 - **Defer rather than guess.** If you are uncertain whether something is a blocker vs. a concern, classify it as a concern and say so.
+
+## Verdict delivery (REQUIRED)
+
+After producing the five-section structured review, you MUST `SendMessage` the complete structured payload to the parent agent (the orchestrator that spawned you) before terminating. The message body must contain the full structure verbatim — not a summary — so the orchestrator can parse it and apply the skip-on-clean rule.
+
+```
+SendMessage({
+  message: "<full five-section review verbatim, starting from **Verdict**: ...>"
+})
+```
+
+Do not paraphrase, trim, or reformat the payload. The orchestrator's skip-on-clean rule (step 3 of `swarmkit:swarm-plus`) keys on the exact section headers and tag strings (`Approve`, `[recommended]`, etc.). Only after `SendMessage` returns successfully should you terminate.

--- a/plugins/swarmkit/skills/swarm-plus/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-plus/SKILL.md
@@ -92,11 +92,13 @@ The reviewer prompt MUST include:
   - **Nits** (style, optional)
   - **Coverage gaps** (with `[recommended]` or `[optional]` tag per gap)
 
+**Verdict delivery contract.** Per the reviewer agent's contract (`plugins/swarmkit/agents/swarm-reviewer.md`), the reviewer `SendMessage`s its complete structured verdict to the parent (this orchestrator) before terminating. The idle notification alone does not carry the verdict text — wait for the `SendMessage` payload to parse the result and apply the skip-on-clean rule in step 3. If only an idle notification arrives with no accompanying `SendMessage` payload, treat the reviewer as having returned no output and note the missing review in the final summary.
+
 Track each reviewer's agent ID against the PR it covers.
 
 ### 3. Decide whether to spawn a fix-round worker
 
-When a reviewer's task notification arrives, parse its result and apply the **skip-on-clean** rule.
+When the reviewer's `SendMessage` payload arrives (delivered separately from the idle notification — see step 2's verdict delivery contract), parse its result and apply the **skip-on-clean** rule.
 
 | Reviewer output | Action |
 |-----------------|--------|
@@ -190,3 +192,17 @@ Suggest next step: `/merge-pr` for one PR or `/merge-stack` for two or more.
 | Reviewer crashes or returns no output | Note the missing review in the final summary; leave PR open without a fix pass |
 | Fix-round worker push rejected (branch advanced underneath) | Worker re-fetches and rebases (`git fetch origin <head>; git rebase origin/<head>`); if conflicts arise, abort and report to user |
 | Fix-round worker introduces new test failures | Worker MUST resolve before push — never push a red build |
+
+## Known issue: TeamDelete leaves zombie subprocesses
+
+`TeamDelete` returns success but does not signal or kill the long-running agent processes whose `--team-name` flag matches. This is a harness-level limitation and will be addressed upstream (see #924). Until the harness fix lands, operators should sweep lingering agent subprocesses manually after `TeamDelete`:
+
+```bash
+ps aux \
+  | grep -- "--team-name <team-name>" \
+  | grep -v grep \
+  | awk '{print $2}' \
+  | xargs -r kill
+```
+
+Replace `<team-name>` with the team name passed to `TeamDelete`. Run this sweep immediately after `TeamDelete` returns — the zombie processes consume no dispatch but do hold open file descriptors and tmux panes.

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -245,6 +245,20 @@ Each agent prompt MUST include these **workflow steps** (in order):
    # Safety check — abort if not in an isolated worktree
    [[ "$PWD" != *"worktrees"* ]] && echo "ERROR: Not running in an isolated worktree. Aborting to prevent branch collision." && exit 1
 
+   # Ancestry sanity — abort if HEAD doesn't descend from the requested base.
+   # Defends against the post-rebase-merge worktree-base drift bug (#923): after a
+   # rebase-merge release, origin/main and origin/develop share identical trees but
+   # diverge in SHA history. EnterWorktree may silently root the worktree on main's
+   # SHA chain even though the checkout targeted develop, producing a 50+-file diff
+   # for an 11-file change. Fail fast here instead.
+   #
+   # Use the same <base> as the checkout above — one variant, not both:
+   if ! git merge-base --is-ancestor origin/<base> HEAD; then
+     echo "ERROR: HEAD is not a descendant of origin/<base>. Worktree may be rooted on a stale base." >&2
+     echo "       Run: git fetch origin <base> && git reset --hard origin/<base>" >&2
+     exit 1
+   fi
+
 2. Make changes (the actual issue work)
 3. Stage and commit using conventional-commit-message format:
    - No Claude mentions, no co-author lines


### PR DESCRIPTION
## Summary

Three swarmkit reliability fixes from the 2026-05-09 swarm-plus session: the reviewer agent now SendMessages its structured verdict to the orchestrator (#922), the swarm spawn workflow asserts ancestry against the requested base to catch post-rebase-merge worktree drift (#923), and the TeamDelete subprocess-sweep workaround is now documented in both swarm-plus and squadkit:spawn-team teardown sections (#924).

## Release summary

**Built from**: `rc/2026-05-09.1`

### Version bumps
- chore(plugins): bump swarmkit@5.6.2, squadkit@0.10.3 (#928)

### Release notes

**swarmkit (5.6.1 → 5.6.2)**
- fix(swarmkit:swarm-reviewer): SendMessage verdict to orchestrator so swarm-plus skip-on-clean dispatch works (#922)
- fix(swarmkit:swarm): assert origin/<base> ancestry after worktree branch to catch post-rebase-merge drift (#923)

**squadkit (0.10.2 → 0.10.3)**
- docs(squadkit:spawn-team): document post-TeamDelete subprocess sweep workaround (#924)


Closes #922
Closes #923
Closes #924
