### PR TITLE
fix(flowkit:release): qualify recovery refspec; publish per-plugin tags

### DIFF
--- a/.claude/skills/bump-versions/SKILL.md
+++ b/.claude/skills/bump-versions/SKILL.md
@@ -177,8 +177,7 @@ Bumped:
   swarmkit  1.0.0 → 2.0.0  (tag: swarmkit--v2.0.0)
   flowkit   1.0.0 → 1.1.0  (tag: flowkit--v1.1.0)
 
-Tags created locally. Push with:
-  git push origin --tags
+Tags created locally. Release publishes them via step 8 — no manual push needed.
 ```
 
 If Step 6 detected new plugin entries, append a reminder block:

--- a/.claude/skills/bump-versions/SKILL.md
+++ b/.claude/skills/bump-versions/SKILL.md
@@ -145,7 +145,7 @@ After the bump commit is on origin's protected branch (via merged PR), create a 
 git tag {plugin-name}--v{new-version}
 ```
 
-Do NOT push tags — leave that to the release flow.
+Do NOT push tags — release publishes them as part of its tag-push step (step 8), so bump-versions intentionally creates the tags locally only.
 
 ### Step 6 — Detect new marketplace entries
 

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -337,15 +337,13 @@ git push origin "$TAG"
 # aren't already on origin. bump-versions creates these locally; release publishes them.
 LOCAL_PLUGIN_TAGS=$(git tag --list '*--v*')
 PUSHED_PLUGIN_TAG_COUNT=0
-if [ -n "$LOCAL_PLUGIN_TAGS" ]; then
-  printf '%s\n' "$LOCAL_PLUGIN_TAGS" | while read PT; do
-    [ -z "$PT" ] && continue
-    if ! git ls-remote --exit-code origin "refs/tags/$PT" &>/dev/null; then
-      git push origin "refs/tags/$PT"
-      PUSHED_PLUGIN_TAG_COUNT=$((PUSHED_PLUGIN_TAG_COUNT + 1))
-    fi
-  done
-fi
+while read PT; do
+  [ -z "$PT" ] && continue
+  if ! git ls-remote --exit-code origin "refs/tags/$PT" &>/dev/null; then
+    git push origin "refs/tags/$PT"
+    PUSHED_PLUGIN_TAG_COUNT=$((PUSHED_PLUGIN_TAG_COUNT + 1))
+  fi
+done < <(printf '%s\n' "$LOCAL_PLUGIN_TAGS")
 if [ "$PUSHED_PLUGIN_TAG_COUNT" -eq 0 ]; then
   echo "No per-plugin tags to push (none local or all already on origin)"
 fi

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -328,6 +328,31 @@ git tag "$TAG"
 git push origin "$TAG"
 ```
 
+#### Push per-plugin tags
+
+`/bump-versions` creates per-plugin tags (`{plugin-name}--v{version}`) locally after merging the bump PR, but intentionally does not push them — release is the publication moment. Push any local per-plugin tags that aren't already on origin now, alongside the calver tag. This ensures consumers and future bump-versions runs always see fresh per-plugin tags without a separate manual push.
+
+```bash
+# Push any per-plugin tags (`{plugin}--v{version}`) created during this cycle that
+# aren't already on origin. bump-versions creates these locally; release publishes them.
+LOCAL_PLUGIN_TAGS=$(git tag --list '*--v*')
+PUSHED_PLUGIN_TAG_COUNT=0
+if [ -n "$LOCAL_PLUGIN_TAGS" ]; then
+  printf '%s\n' "$LOCAL_PLUGIN_TAGS" | while read PT; do
+    [ -z "$PT" ] && continue
+    if ! git ls-remote --exit-code origin "refs/tags/$PT" &>/dev/null; then
+      git push origin "refs/tags/$PT"
+      PUSHED_PLUGIN_TAG_COUNT=$((PUSHED_PLUGIN_TAG_COUNT + 1))
+    fi
+  done
+fi
+if [ "$PUSHED_PLUGIN_TAG_COUNT" -eq 0 ]; then
+  echo "No per-plugin tags to push (none local or all already on origin)"
+fi
+```
+
+This block is idempotent — re-running on a clean cycle pushes nothing and does not error.
+
 ### 9. Close referenced issues explicitly
 
 When `main` is the GitHub default branch, the merged release PR's `Closes #N` footer auto-closed every aggregated issue. When the repo's default is `develop` (or any other non-`main` branch), the auto-close path silently no-ops and aggregated issues stay open. Run an explicit `gh issue close` loop over the same `$ISSUE_REFS` collected in step 4 so the lifecycle works on either default-branch configuration. The loop is idempotent — already-closed issues are skipped — so it's safe even when auto-close already fired.

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -50,7 +50,8 @@ if ! git merge-base --is-ancestor origin/main "origin/$SOURCE"; then
   echo "  git fetch origin" >&2
   echo "  git checkout $SOURCE" >&2
   echo "  git rebase origin/main" >&2
-  echo "  git push --force-with-lease origin $SOURCE" >&2
+  echo "  git push --force-with-lease origin \"refs/heads/\$SOURCE:refs/heads/\$SOURCE\"" >&2
+  echo "  # Qualified refspec required: 'cut' creates both a branch and a same-named tag (e.g. rc/2026-05-09.1), so the unqualified form is ambiguous." >&2
   echo "Then re-run /release." >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- Release preflight's recovery hint now uses a fully-qualified refspec (`refs/heads/$SOURCE:refs/heads/$SOURCE`), so operators following the post-rebase-merge recovery path don't hit `src refspec matches more than one` from the cut-leaves-both-branch-and-tag collision.
- Release step 8 now publishes any local per-plugin tags (`*--v*`) that aren't already on origin, alongside the calver tag. Closes the bump-versions → release tag-publication gap so consumers and future bump-versions runs always see fresh per-plugin tags.

## Changes

- `plugins/flowkit/skills/release/SKILL.md` — step 3 preflight failure message: refspec qualified with one-line rationale; step 8: new sub-section pushing per-plugin tags idempotently.
- `.claude/skills/bump-versions/SKILL.md` — step 5 caveat updated to reference release step 8 explicitly so the contract is visible from both ends.

## Test plan

- [ ] Run `/flowkit:release` on a release that needs the post-rebase-merge recovery path; the qualified refspec push succeeds without manual intervention.
- [ ] Run `/ship-plugins` on a release that includes per-plugin bumps; verify per-plugin tags are on origin after the release flow completes (no manual `git push origin --tags` needed).
- [ ] Re-run `/flowkit:release` on a no-op cycle (no new local per-plugin tags); the new push block emits a brief no-op note and does not error.

Closes #930
Closes #931