### PR TITLE
fix(flowkit:merge-pr): auto-checkout base when main worktree holds head

### DIFF
--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: merge-pr
-description: Squash-merge the open PR for the current branch and delete the remote branch (retargets stacked children; clears blocking swarm worktrees).
+description: Squash-merge the open PR for the current branch and delete the remote branch (retargets stacked children; clears blocking worktrees — auto-checks out base branch when the main worktree holds the head).
 triggers:
   - "/merge-pr"
   - "merge this PR"
@@ -45,7 +45,7 @@ Squash-merge the open PR for the current branch and delete the remote branch. Op
 
 ## Script contract
 
-`scripts/merge_pr.sh` implements worktree cleanup, stacked-PR retargeting, and a `with-clean-workspace`–wrapped `gh pr merge --squash --delete-branch`. On success it prints **bare JSON** on stdout:
+`scripts/merge_pr.sh` implements worktree cleanup, stacked-PR retargeting, and a `with-clean-workspace`–wrapped `gh pr merge --squash --delete-branch`. When the PR's head branch is held by a linked worktree the script removes it via `git worktree remove --force`; when it is held by the main worktree (the canonical state after `push-or-pr`) the script instead runs `git checkout <base>` in the main worktree so the branch can be released without the operator needing to do it manually. On success it prints **bare JSON** on stdout:
 
 | Field | Type | Meaning |
 | --- | --- | --- |

--- a/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh
+++ b/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh
@@ -92,13 +92,22 @@ fi
 
 BLOCKING_WORKTREE=$(_find_worktree_for_branch "$HEAD_BRANCH")
 if [[ -n "$BLOCKING_WORKTREE" ]]; then
-  printf 'Note: branch %s is held by worktree %s.\n' "$HEAD_BRANCH" "$BLOCKING_WORKTREE" >&2
-  printf '  Auto-removing the worktree before merge so the local branch can be deleted cleanly.\n' >&2
-  if ! git worktree remove --force "$BLOCKING_WORKTREE"; then
-    echo "merge_pr: Cannot remove worktree at '${BLOCKING_WORKTREE}' that holds '${HEAD_BRANCH}'." >&2
-    printf '  git worktree remove --force %q\n' "$BLOCKING_WORKTREE" >&2
-    echo "Then re-run merge_pr." >&2
-    exit 1
+  MAIN_WORKTREE=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
+  if [[ "$BLOCKING_WORKTREE" == "$MAIN_WORKTREE" ]]; then
+    echo "merge_pr: switching main worktree to ${BASE_BRANCH} so head branch can be deleted cleanly." >&2
+    if ! git -C "$MAIN_WORKTREE" checkout -q "$BASE_BRANCH"; then
+      echo "merge_pr: cannot auto-checkout ${BASE_BRANCH} in main worktree (commit/stash uncommitted changes first), then re-run." >&2
+      exit 1
+    fi
+  else
+    printf 'Note: branch %s is held by worktree %s.\n' "$HEAD_BRANCH" "$BLOCKING_WORKTREE" >&2
+    printf '  Auto-removing the worktree before merge so the local branch can be deleted cleanly.\n' >&2
+    if ! git worktree remove --force "$BLOCKING_WORKTREE"; then
+      echo "merge_pr: Cannot remove worktree at '${BLOCKING_WORKTREE}' that holds '${HEAD_BRANCH}'." >&2
+      printf '  git worktree remove --force %q\n' "$BLOCKING_WORKTREE" >&2
+      echo "Then re-run merge_pr." >&2
+      exit 1
+    fi
   fi
 fi
 

--- a/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh
+++ b/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh
@@ -92,7 +92,8 @@ fi
 
 BLOCKING_WORKTREE=$(_find_worktree_for_branch "$HEAD_BRANCH")
 if [[ -n "$BLOCKING_WORKTREE" ]]; then
-  MAIN_WORKTREE=$(git worktree list --porcelain | awk '/^worktree / {print $2; exit}')
+  MAIN_WORKTREE=$(git worktree list --porcelain | awk '/^worktree / { sub(/^worktree /, ""); print; exit }')
+  [[ -z "$MAIN_WORKTREE" ]] && { echo "merge_pr: could not determine main worktree path" >&2; exit 1; }
   if [[ "$BLOCKING_WORKTREE" == "$MAIN_WORKTREE" ]]; then
     echo "merge_pr: switching main worktree to ${BASE_BRANCH} so head branch can be deleted cleanly." >&2
     if ! git -C "$MAIN_WORKTREE" checkout -q "$BASE_BRANCH"; then


### PR DESCRIPTION
## Summary

- merge-pr's auto-cleanup now detects when the worktree holding the PR's head branch is the main worktree, and resolves it by checking out the resolved base branch (from the PR metadata) instead of aborting with the impossible `git worktree remove --force` hint.
- The push-or-pr → merge-pr chain (the canonical sequence after `/bump-versions` and most other auto-PR flows) now succeeds without manual `git checkout <base>` intervention.

## Changes

- `plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh` — worktree-detection block: when the holding worktree is the main one, run `git -C <main-path> checkout -q <base>` (using the PR's resolved base from existing `gh pr view` metadata), then proceed with `gh pr merge --delete-branch`. Linked-worktree path unchanged.
- `plugins/flowkit/skills/merge-pr/SKILL.md` — updated description frontmatter and script-contract prose to reflect the new auto-checkout behavior for the main-worktree case.

## Test plan

- [ ] After `/flowkit:push-or-pr` (operator left on the chore branch in the main worktree), invoking `/flowkit:merge-pr <pr>` completes the merge cleanly without manual checkout.
- [ ] Linked-worktree case (head branch held by a `.claude/worktrees/agent-*` worktree, not the main one) still uses `git worktree remove` as before.
- [ ] If the main worktree has uncommitted changes that would block the auto-checkout, the script emits a clear "commit/stash first" error rather than the impossible `--force` hint.

Closes #932