### PR TITLE
feat(epic): ship flowkit-release-recovery-force-push-refs-930

### DIFF
--- a/.claude/skills/bump-versions/SKILL.md
+++ b/.claude/skills/bump-versions/SKILL.md
@@ -145,7 +145,7 @@ After the bump commit is on origin's protected branch (via merged PR), create a 
 git tag {plugin-name}--v{new-version}
 ```
 
-Do NOT push tags — leave that to the release flow.
+Do NOT push tags — release publishes them as part of its tag-push step (step 8), so bump-versions intentionally creates the tags locally only.
 
 ### Step 6 — Detect new marketplace entries
 
@@ -177,8 +177,7 @@ Bumped:
   swarmkit  1.0.0 → 2.0.0  (tag: swarmkit--v2.0.0)
   flowkit   1.0.0 → 1.1.0  (tag: flowkit--v1.1.0)
 
-Tags created locally. Push with:
-  git push origin --tags
+Tags created locally. Release publishes them via step 8 — no manual push needed.
 ```
 
 If Step 6 detected new plugin entries, append a reminder block:

--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: merge-pr
-description: Squash-merge the open PR for the current branch and delete the remote branch (retargets stacked children; clears blocking swarm worktrees).
+description: Squash-merge the open PR for the current branch and delete the remote branch (retargets stacked children; clears blocking worktrees — auto-checks out base branch when the main worktree holds the head).
 triggers:
   - "/merge-pr"
   - "merge this PR"
@@ -45,7 +45,7 @@ Squash-merge the open PR for the current branch and delete the remote branch. Op
 
 ## Script contract
 
-`scripts/merge_pr.sh` implements worktree cleanup, stacked-PR retargeting, and a `with-clean-workspace`–wrapped `gh pr merge --squash --delete-branch`. On success it prints **bare JSON** on stdout:
+`scripts/merge_pr.sh` implements worktree cleanup, stacked-PR retargeting, and a `with-clean-workspace`–wrapped `gh pr merge --squash --delete-branch`. When the PR's head branch is held by a linked worktree the script removes it via `git worktree remove --force`; when it is held by the main worktree (the canonical state after `push-or-pr`) the script instead runs `git checkout <base>` in the main worktree so the branch can be released without the operator needing to do it manually. On success it prints **bare JSON** on stdout:
 
 | Field | Type | Meaning |
 | --- | --- | --- |

--- a/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh
+++ b/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh
@@ -92,13 +92,23 @@ fi
 
 BLOCKING_WORKTREE=$(_find_worktree_for_branch "$HEAD_BRANCH")
 if [[ -n "$BLOCKING_WORKTREE" ]]; then
-  printf 'Note: branch %s is held by worktree %s.\n' "$HEAD_BRANCH" "$BLOCKING_WORKTREE" >&2
-  printf '  Auto-removing the worktree before merge so the local branch can be deleted cleanly.\n' >&2
-  if ! git worktree remove --force "$BLOCKING_WORKTREE"; then
-    echo "merge_pr: Cannot remove worktree at '${BLOCKING_WORKTREE}' that holds '${HEAD_BRANCH}'." >&2
-    printf '  git worktree remove --force %q\n' "$BLOCKING_WORKTREE" >&2
-    echo "Then re-run merge_pr." >&2
-    exit 1
+  MAIN_WORKTREE=$(git worktree list --porcelain | awk '/^worktree / { sub(/^worktree /, ""); print; exit }')
+  [[ -z "$MAIN_WORKTREE" ]] && { echo "merge_pr: could not determine main worktree path" >&2; exit 1; }
+  if [[ "$BLOCKING_WORKTREE" == "$MAIN_WORKTREE" ]]; then
+    echo "merge_pr: switching main worktree to ${BASE_BRANCH} so head branch can be deleted cleanly." >&2
+    if ! git -C "$MAIN_WORKTREE" checkout -q "$BASE_BRANCH"; then
+      echo "merge_pr: cannot auto-checkout ${BASE_BRANCH} in main worktree (commit/stash uncommitted changes first), then re-run." >&2
+      exit 1
+    fi
+  else
+    printf 'Note: branch %s is held by worktree %s.\n' "$HEAD_BRANCH" "$BLOCKING_WORKTREE" >&2
+    printf '  Auto-removing the worktree before merge so the local branch can be deleted cleanly.\n' >&2
+    if ! git worktree remove --force "$BLOCKING_WORKTREE"; then
+      echo "merge_pr: Cannot remove worktree at '${BLOCKING_WORKTREE}' that holds '${HEAD_BRANCH}'." >&2
+      printf '  git worktree remove --force %q\n' "$BLOCKING_WORKTREE" >&2
+      echo "Then re-run merge_pr." >&2
+      exit 1
+    fi
   fi
 fi
 

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -50,7 +50,8 @@ if ! git merge-base --is-ancestor origin/main "origin/$SOURCE"; then
   echo "  git fetch origin" >&2
   echo "  git checkout $SOURCE" >&2
   echo "  git rebase origin/main" >&2
-  echo "  git push --force-with-lease origin $SOURCE" >&2
+  echo "  git push --force-with-lease origin \"refs/heads/\$SOURCE:refs/heads/\$SOURCE\"" >&2
+  echo "  # Qualified refspec required: 'cut' creates both a branch and a same-named tag (e.g. rc/2026-05-09.1), so the unqualified form is ambiguous." >&2
   echo "Then re-run /release." >&2
   exit 1
 fi
@@ -326,6 +327,29 @@ done
 git tag "$TAG"
 git push origin "$TAG"
 ```
+
+#### Push per-plugin tags
+
+`/bump-versions` creates per-plugin tags (`{plugin-name}--v{version}`) locally after merging the bump PR, but intentionally does not push them — release is the publication moment. Push any local per-plugin tags that aren't already on origin now, alongside the calver tag. This ensures consumers and future bump-versions runs always see fresh per-plugin tags without a separate manual push.
+
+```bash
+# Push any per-plugin tags (`{plugin}--v{version}`) created during this cycle that
+# aren't already on origin. bump-versions creates these locally; release publishes them.
+LOCAL_PLUGIN_TAGS=$(git tag --list '*--v*')
+PUSHED_PLUGIN_TAG_COUNT=0
+while read PT; do
+  [ -z "$PT" ] && continue
+  if ! git ls-remote --exit-code origin "refs/tags/$PT" &>/dev/null; then
+    git push origin "refs/tags/$PT"
+    PUSHED_PLUGIN_TAG_COUNT=$((PUSHED_PLUGIN_TAG_COUNT + 1))
+  fi
+done < <(printf '%s\n' "$LOCAL_PLUGIN_TAGS")
+if [ "$PUSHED_PLUGIN_TAG_COUNT" -eq 0 ]; then
+  echo "No per-plugin tags to push (none local or all already on origin)"
+fi
+```
+
+This block is idempotent — re-running on a clean cycle pushes nothing and does not error.
 
 ### 9. Close referenced issues explicitly
 


### PR DESCRIPTION
## Summary

Ship epic `feature/flowkit-release-recovery-force-push-refs-930` to develop via rebase-merge. This branch contains 2 squashed child commit(s) that will replay linearly onto develop's first-parent line.

## Changes

- Rebase-merge promotes 2 squashed child PR(s) onto develop linearly.
- `claude.flowkit.prBase` will be unset after merge; epic branch deleted.

## Test plan

- [ ] Verify `git log --first-parent origin/develop` shows 2 new commit(s) with no merge bubbles.
- [ ] Verify `git config --get claude.flowkit.prBase` is empty after ship.

Closes #932
Closes #930
Closes #931
Refs #930