### PR TITLE
chore(plugins): bump flowkit@3.13.1

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship.",
-  "version": "3.13.0",
+  "version": "3.13.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Bump plugin.json version for flowkit, changed since its last release.

## Changes

- flowkit@3.13.1 (patch — fix(flowkit:release) qualified refspec + per-plugin tag push in #933; fix(flowkit:merge-pr) main-worktree auto-checkout in #934)

## Test plan

- [ ] Confirm `plugin.json` version bump matches the per-plugin tag created after merge.