### PR TITLE
release: 2026-05-12

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,50 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # This is an optional setting that allows Claude to read CI results on PRs
+          additional_permissions: |
+            actions: read
+
+          # Optional: Give a custom prompt to Claude. If this is not specified, Claude will perform the instructions specified in the comment that tagged it.
+          # prompt: 'Update the pull request description to include a summary of changes.'
+
+          # Optional: Add claude_args to customize behavior and configuration
+          # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
+          # or https://code.claude.com/docs/en/cli-reference for available options
+          # claude_args: '--allowed-tools Bash(gh pr *)'
+

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -39,25 +39,27 @@ if [ -z "$SOURCE" ]; then
 fi
 ```
 
-### 3. Rebase-merge preflight
+### 3. Rebase RC onto `origin/main`
 
-`gh pr merge --rebase` requires the RC to include every commit on `main`. In the bubble-free flow this is automatic — `main` only changes via release, and the RC is cut from `develop` which is always a superset of `main`. The preflight is a one-line guard against the rare case of a direct hotfix on `main`:
+`gh pr merge --rebase` requires the RC to include every commit on `main` by SHA ancestry, not just by content. After each rebase-merge release, `main`'s tip and `develop`'s tip contain content-equivalent commits with **structurally different SHAs**: `flowkit:merge-pr` squash-merges into `develop`, while `gh pr merge --rebase` rewrites committer dates on every commit it lands on `main` — even when the RC is already a linear descendant. New committer date → new commit SHA → `main`'s rebased SHAs are not in `develop`'s ancestry. The next RC, cut from `develop`, therefore fails an `is-ancestor` check against `origin/main` on every release after the first, with no hotfixes needed to trigger it.
+
+The fix is to rebase the RC onto `origin/main` unconditionally before opening the release PR. In the trivial case (no hotfixes, standard flow) the rebase is a no-op and the force-push is a fast-forward. The force-push target is the short-lived RC branch (deleted minutes later by `gh pr merge --delete-branch` in step 6), never `main`; `--force-with-lease` blocks the concurrent-writer race. A qualified refspec is required because `cut` creates both a branch and a same-named tag (e.g. `rc/2026-05-09.1`), making the unqualified form ambiguous:
+
+```bash
+git checkout "$SOURCE"
+git rebase origin/main
+git push --force-with-lease origin "refs/heads/$SOURCE:refs/heads/$SOURCE"
+```
+
+After the rebase, assert that the invariant now holds. This is a paranoid post-rebase sanity check — if it fires, something unexpected happened during the rebase (e.g. an interactive conflict left a detached HEAD) and it is safer to abort than to open a PR that will fail at merge time:
 
 ```bash
 if ! git merge-base --is-ancestor origin/main "origin/$SOURCE"; then
-  echo "release: $SOURCE does not include all of origin/main; rebase-merge will fail." >&2
-  echo "Recover with:" >&2
-  echo "  git fetch origin" >&2
-  echo "  git checkout $SOURCE" >&2
-  echo "  git rebase origin/main" >&2
-  echo "  git push --force-with-lease origin \"refs/heads/\$SOURCE:refs/heads/\$SOURCE\"" >&2
-  echo "  # Qualified refspec required: 'cut' creates both a branch and a same-named tag (e.g. rc/2026-05-09.1), so the unqualified form is ambiguous." >&2
-  echo "Then re-run /release." >&2
+  echo "release: $SOURCE does not include all of origin/main even after rebase — aborting." >&2
+  echo "Inspect the rebase output above for conflicts or unexpected state, then re-run /release." >&2
   exit 1
 fi
 ```
-
-The check is cheap (no network beyond the prior `git fetch origin` in step 1) and turns the most common rebase-merge failure mode into a recoverable, well-described abort.
 
 ### 4. Aggregate issue references from merged PRs
 


### PR DESCRIPTION
## Summary

Ship a flowkit:release happy-path fix that rebases the RC onto main unconditionally so the rebase-merge preflight no longer trips on routine SHA divergence between develop and main. Adds the Claude PR Assistant GitHub workflow alongside.

## Release summary

**Built from**: `rc/2026-05-12.1`

### Release notes

**flowkit**
- fix(flowkit:release): rebase RC onto main in happy path — flowkit:release's rebase-merge preflight failed on every release after the first because GitHub's rebase-merge rewrites committer dates.

**ci**
- "Claude PR Assistant workflow"

Closes #941