### PR TITLE
fix(flowkit:open-pr): preflight error when base equals HEAD

### DIFF
--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -71,6 +71,17 @@ if [ -z "$BASE" ]; then
   echo "warning: no base branch configured and 'develop' not found on remote; falling back to repo default ($REPO_DEFAULT)" >&2
   BASE="$REPO_DEFAULT"
 fi
+
+# 5. Guard — resolved base must not equal current HEAD
+HEAD_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BASE" = "$HEAD_BRANCH" ]; then
+  echo "ERROR: resolved base ($BASE) is the same as the current branch ($HEAD_BRANCH)." >&2
+  echo "This usually means you're on an epic branch with claude.flowkit.prBase pinned" >&2
+  echo "to itself. To open the epic's own integration PR, do one of:" >&2
+  echo "  - rerun with an explicit override: /flowkit:pr --base develop" >&2
+  echo "  - unset the pin first: git config --unset claude.flowkit.prBase" >&2
+  exit 1
+fi
 ```
 
 ### 3. Push branch to origin


### PR DESCRIPTION
## Summary

- Adds a HEAD-vs-BASE guard in `flowkit:open-pr` step 2 (after BASE resolution, before push) that fails fast with a clear remediation message when the resolved base equals the current branch.
- Prevents the opaque `gh pr create --base X --head X` rejection that occurs when `claude.flowkit.prBase` is pinned to an epic the user is sitting on.

## Test plan

- Manually walk the resolution chain in the edited SKILL.md to confirm the guard sits after BASE resolution and before the push step.
- Trace: user on `feature/onboarding-v2-1264` with `claude.flowkit.prBase=feature/onboarding-v2-1264`, runs `/flowkit:open-pr` — guard fires, prints remediation, exit 1.
- Trace: user on a sub-feature with the same pin — guard does not fire, normal flow.

Closes #872