### PR TITLE
fix(flowkit:merge-pr): handle spaces in worktree paths in _find_worktree_for_branch

### DIFF
--- a/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh
+++ b/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh
@@ -24,7 +24,7 @@ usage() {
 _find_worktree_for_branch() {
   git worktree list --porcelain \
     | awk -v target="refs/heads/$1" '
-        /^worktree / { wt = $2 }
+        /^worktree / { wt = $0; sub(/^worktree /, "", wt) }
         $0 == "branch " target { print wt }
       '
 }


### PR DESCRIPTION
## Summary

- Fixes the awk truncation bug in `_find_worktree_for_branch` (line ~26 of `plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh`) so worktree paths containing spaces are returned in full.
- Mirrors the fix landed in PR #934 at line ~95, applying the same `sub(/^worktree /, "", ...)` pattern to the multi-line awk used by the helper.

## Changes

- `plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh`: in the `/^worktree /` action, capture the full line via `wt = $0; sub(/^worktree /, "", wt)` instead of `wt = $2`, which previously truncated at the first whitespace.

## Test plan

- `bash plugins/flowkit/skills/merge-pr/scripts/test.sh` passes locally (3/3).
- Manual trace: feeding `worktree /Users/name/my project/repo\n...\nbranch refs/heads/foo` through the helper now prints the full path `/Users/name/my project/repo` instead of `/Users/name/my`.

Closes #935