### PR TITLE
fix(flowkit:release): drop already-closed issue refs from release PR body

### DIFF
--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -80,6 +80,23 @@ if [ -n "$LAST_TAG" ]; then
 fi
 ```
 
+Drop refs whose target issue is already CLOSED. Without this filter, refs collected from PRs merged in this cycle can still point at issues that were closed in a prior release (e.g. when a PR landed after the prior release tag but the referenced issue was already closed by an earlier cycle). Re-listing them in this release's PR body would falsely claim to close them again, and would also re-trigger epic auto-close paths downstream. The filter sits before the epic-detection block so already-closed children don't poison that logic:
+
+```bash
+FILTERED_REFS_FILE=$(mktemp)
+printf '%s\n' "$ISSUE_REFS" | while read REF; do
+  N=$(echo "$REF" | grep -oE '[0-9]+')
+  [ -z "$N" ] && continue
+  STATE=$(gh issue view "$N" --json state --jq '.state' 2>/dev/null)
+  if [ "$STATE" = "OPEN" ]; then
+    echo "$REF" >> "$FILTERED_REFS_FILE"
+  else
+    echo "Skipped already-closed issue $N from release PR body" >&2
+  fi
+done
+ISSUE_REFS=$(cat "$FILTERED_REFS_FILE"); rm -f "$FILTERED_REFS_FILE"
+```
+
 Then find open epics whose children are all now closed and append their `Closes #N` refs. Epics may be wired to children via two mechanisms:
 
 - **Legacy checklist** — epic body contains `- [ ] #N` / `- [x] #N` lines


### PR DESCRIPTION
## Summary

- After `ISSUE_REFS` is aggregated in `flowkit:release` step 4, filter out refs whose target issue is already CLOSED via `gh issue view --json state`.
- Skipped refs are logged to stderr (`Skipped already-closed issue N from release PR body`) so the operator sees the drops.
- Filter sits before the epic-detection block so already-closed children don't trigger epic auto-close paths.

## Test plan

- Trace through edited `release/SKILL.md` step 4: confirm filter placement, stderr logging, and that `ISSUE_REFS` is rebound to the filtered list.
- Reproduction case (vorbis-player v2026.5.9): issues 1483 and 1497 closed by the prior release would now be dropped from the new release PR body instead of being re-listed.
- Epic auto-close: trace that epics whose children all closed in a prior release are not re-closed by the new cycle.

Closes #940