### PR TITLE
fix(flowkit): detect RC/main patch-id divergence and document refspec collision

### DIFF
--- a/plugins/flowkit/skills/cut/SKILL.md
+++ b/plugins/flowkit/skills/cut/SKILL.md
@@ -46,12 +46,26 @@ RC_BRANCH="rc/$TODAY.$N"
 
 ```bash
 git checkout -b "$RC_BRANCH" origin/develop
-git push -u origin "$RC_BRANCH"
+git push -u origin "refs/heads/$RC_BRANCH:refs/heads/$RC_BRANCH"
 git tag "$RC_BRANCH"
 git push origin "refs/tags/$RC_BRANCH"
 ```
 
-The tag (`rc/YYYY-MM-DD.N`) shares the branch name; push it via full `refs/tags/` path to avoid the ambiguous-refspec error. The tag is pushed immediately so future cuts count it correctly even after the branch is deleted.
+The tag (`rc/YYYY-MM-DD.N`) intentionally shares the branch name. The tag is pushed immediately so future cuts count it correctly even after the branch is deleted.
+
+**Refspec collision (read before pushing an RC branch anywhere else).** Once both the RC branch and the same-named tag exist locally, every subsequent `git push origin <name>` against that name is ambiguous and fails with:
+
+```
+error: src refspec rc/YYYY-MM-DD.N matches more than one
+```
+
+This affects any later RC-branch push — most notably the force-push performed by `flowkit:release` step 3 after rebasing the RC onto `origin/main`. The fix is to use the fully qualified refspec form whenever pushing the RC branch in the presence of the matching tag:
+
+```bash
+git push --force-with-lease origin "refs/heads/$RC_BRANCH:refs/heads/$RC_BRANCH"
+```
+
+Both pushes above (the initial `-u` push of the branch and the tag push) already use the disambiguated form for consistency, even though only one of the two names exists at the moment of the first push. Renaming the tag to a separate namespace (e.g. `rc-tag/...`) would also resolve this but is out of scope here — the documentation route is preferred because it keeps the tag/branch pairing intact and the cost is one extra refspec qualifier at each push site.
 
 ### 4. Report
 

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -294,6 +294,32 @@ gh pr create \
 
 Capture the PR number from the URL output.
 
+### 5.5. Pre-merge divergence check
+
+Before attempting the merge, detect patch-id divergence between `origin/main` and the RC. Even with the unconditional rebase in step 3, a stale RC that was force-pushed elsewhere, an aborted prior rebase, or a missed back-merge can leave `main` carrying commits whose patch-id equivalents are absent on the RC (or vice versa). `gh pr merge --rebase` will fail mid-flight when that happens, leaving the release in a half-shipped state. Surface the divergence as an explicit precondition instead:
+
+```bash
+DUP_PATCHES=$(git rev-list --left-right --cherry-pick --count \
+  "origin/main...origin/$SOURCE" | awk '{print $1}')
+if [ "$DUP_PATCHES" -gt 0 ]; then
+  echo "release: detected $DUP_PATCHES commit(s) on origin/main with no patch-id equivalent on origin/$SOURCE." >&2
+  echo "release: this typically means a prior release rebase-merged into main and the back-merge never landed on develop," >&2
+  echo "release: leaving main with commits whose patch-id duplicates would now clash on rebase-merge." >&2
+  echo "release: remediate by rebasing the RC onto origin/main locally, then force-pushing with the disambiguated refspec:" >&2
+  echo "release:   git checkout $SOURCE" >&2
+  echo "release:   git rebase origin/main" >&2
+  echo "release:   git push --force-with-lease origin refs/heads/$SOURCE:refs/heads/$SOURCE" >&2
+  echo "release: the qualified refspec is required because cut creates a same-named tag (rc/YYYY-MM-DD.N)," >&2
+  echo "release: which makes the unqualified push form ambiguous (error: src refspec <name> matches more than one)." >&2
+  echo "release: confirm with the operator before auto-rebasing — re-run /release after the remediation." >&2
+  exit 1
+fi
+```
+
+The check uses `git rev-list --left-right --cherry-pick --count` against the symmetric difference `origin/main...origin/$SOURCE`. The left-side count (after `--cherry-pick` filters out patch-id-equivalent commits) is the set of commits on `main` whose changes are not represented on the RC by any commit, identical SHA or otherwise. Any non-zero value means the merge will not be clean, and the operator must rebase before continuing.
+
+Auto-rebase with operator confirmation is the preferred remediation; in interactive runs, prompt before executing the three remediation commands above on the operator's behalf. In non-interactive runs, abort with the message above and let the operator re-run after rebasing.
+
 ### 6. Merge the PR
 
 `gh pr merge --rebase --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. Wrap the call with the [`flowkit:with-clean-workspace`](../../with-clean-workspace/SKILL.md) script so any dirty state is auto-stashed and restored:
@@ -395,7 +421,11 @@ if [ -z "$RC_BRANCHES" ]; then
 else
   echo "$RC_BRANCHES" | while read rc; do
     echo "Deleting orphan RC branch: $rc"
-    git push origin --delete "$rc"
+    # Use the disambiguated refspec form — the same-named RC tag still exists on
+    # origin (cut/SKILL.md step 3 documents the collision), so the unqualified
+    # `git push origin --delete "$rc"` would fail with `src refspec matches more
+    # than one`. Deleting via `:refs/heads/<rc>` targets the branch unambiguously.
+    git push origin ":refs/heads/$rc"
   done
 fi
 ```

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -296,7 +296,7 @@ Capture the PR number from the URL output.
 
 ### 5.5. Pre-merge divergence check
 
-Before attempting the merge, detect patch-id divergence between `origin/main` and the RC. Even with the unconditional rebase in step 3, a stale RC that was force-pushed elsewhere, an aborted prior rebase, or a missed back-merge can leave `main` carrying commits whose patch-id equivalents are absent on the RC (or vice versa). `gh pr merge --rebase` will fail mid-flight when that happens, leaving the release in a half-shipped state. Surface the divergence as an explicit precondition instead:
+Before attempting the merge, detect commits on `origin/main` that have no patch-id equivalent on `origin/$SOURCE`. This typically fires after a prior release rebase-merged into `main` and the back-merge never landed on `develop` (and therefore never reached the RC) — leaving `main` with commits whose rebase-equivalent forms exist nowhere on the RC by either SHA or patch-id. Even with the unconditional rebase in step 3, a stale RC force-pushed elsewhere or an aborted prior rebase can produce the same shape. `gh pr merge --rebase` fails mid-flight when this divergence exists, leaving the release in a half-shipped state. Surface it as an explicit precondition instead:
 
 ```bash
 DUP_PATCHES=$(git rev-list --left-right --cherry-pick --count \
@@ -311,14 +311,14 @@ if [ "$DUP_PATCHES" -gt 0 ]; then
   echo "release:   git push --force-with-lease origin refs/heads/$SOURCE:refs/heads/$SOURCE" >&2
   echo "release: the qualified refspec is required because cut creates a same-named tag (rc/YYYY-MM-DD.N)," >&2
   echo "release: which makes the unqualified push form ambiguous (error: src refspec <name> matches more than one)." >&2
-  echo "release: confirm with the operator before auto-rebasing — re-run /release after the remediation." >&2
+  echo "release: re-run /release after the remediation has landed on origin/$SOURCE." >&2
   exit 1
 fi
 ```
 
-The check uses `git rev-list --left-right --cherry-pick --count` against the symmetric difference `origin/main...origin/$SOURCE`. The left-side count (after `--cherry-pick` filters out patch-id-equivalent commits) is the set of commits on `main` whose changes are not represented on the RC by any commit, identical SHA or otherwise. Any non-zero value means the merge will not be clean, and the operator must rebase before continuing.
+The check uses `git rev-list --left-right --cherry-pick --count` against the symmetric difference `origin/main...origin/$SOURCE`. The left-side count (after `--cherry-pick` filters out patch-id-equivalent commits) is the set of commits on `main` whose changes are not represented on the RC by any commit, identical SHA or otherwise. Any non-zero value means the merge will not be clean.
 
-Auto-rebase with operator confirmation is the preferred remediation; in interactive runs, prompt before executing the three remediation commands above on the operator's behalf. In non-interactive runs, abort with the message above and let the operator re-run after rebasing.
+The snippet aborts with the remediation message printed above and exits non-zero — the operator runs the three `git checkout` / `rebase` / `push` commands manually and then re-invokes `/release`. The skill does not auto-rebase on the operator's behalf, because a force-push to a release candidate that has already been advertised to other consumers deserves an explicit human decision rather than a wrapped prompt.
 
 ### 6. Merge the PR
 


### PR DESCRIPTION
## Summary

- Adds a pre-merge divergence check to `flowkit:release` that detects patch-id-duplicate commits between `origin/main` and the RC branch and instructs the operator to rebase the RC onto main + force-push using the disambiguated `refs/heads/<branch>:refs/heads/<branch>` refspec form.
- Documents the tag/branch refspec collision in `flowkit:cut` and recommends the disambiguated push form whenever an RC branch coexists with an identically-named tag.

## Changes

- `plugins/flowkit/skills/release/SKILL.md`: new step 5.5 ("Pre-merge divergence check") that runs `git rev-list --left-right --cherry-pick --count origin/main...origin/$SOURCE` before the merge, surfaces the duplicate-commit count, explains the trigger (prior rebase-merge release whose back-merge never landed on develop), and prints the disambiguated remediation commands. Step 10's orphan-RC-branch deletion also switched to the qualified `:refs/heads/<rc>` refspec to dodge the same tag/branch collision.
- `plugins/flowkit/skills/cut/SKILL.md`: step 3 now pushes the RC branch via the disambiguated `refs/heads/<branch>:refs/heads/<branch>` form for consistency, and a new "Refspec collision" note documents why every later RC-branch push (most notably `flowkit:release` step 3's force-push) must use the qualified form. Renaming the tag is explicitly called out as the rejected alternative.

## Test plan

- Trace through the edited `release/SKILL.md`: confirm the divergence check sits between the existing release-PR creation and the merge attempt, and that it surfaces the duplicate-commit count.
- Trace `cut/SKILL.md`: confirm the new doc note appears near the tag-creation step and references the disambiguated refspec form.
- Re-read against the reproduction in the issue (vorbis-player v2026.5.9): the check would have fired and the doc note would have given the operator the right push form.

Closes #939