### PR TITLE
feat(epic): ship flowkit-cleanup-872

### DIFF
--- a/plugins/flowkit/skills/cut/SKILL.md
+++ b/plugins/flowkit/skills/cut/SKILL.md
@@ -46,12 +46,26 @@ RC_BRANCH="rc/$TODAY.$N"
 
 ```bash
 git checkout -b "$RC_BRANCH" origin/develop
-git push -u origin "$RC_BRANCH"
+git push -u origin "refs/heads/$RC_BRANCH:refs/heads/$RC_BRANCH"
 git tag "$RC_BRANCH"
 git push origin "refs/tags/$RC_BRANCH"
 ```
 
-The tag (`rc/YYYY-MM-DD.N`) shares the branch name; push it via full `refs/tags/` path to avoid the ambiguous-refspec error. The tag is pushed immediately so future cuts count it correctly even after the branch is deleted.
+The tag (`rc/YYYY-MM-DD.N`) intentionally shares the branch name. The tag is pushed immediately so future cuts count it correctly even after the branch is deleted.
+
+**Refspec collision (read before pushing an RC branch anywhere else).** Once both the RC branch and the same-named tag exist locally, every subsequent `git push origin <name>` against that name is ambiguous and fails with:
+
+```
+error: src refspec rc/YYYY-MM-DD.N matches more than one
+```
+
+This affects any later RC-branch push — most notably the force-push performed by `flowkit:release` step 3 after rebasing the RC onto `origin/main`. The fix is to use the fully qualified refspec form whenever pushing the RC branch in the presence of the matching tag:
+
+```bash
+git push --force-with-lease origin "refs/heads/$RC_BRANCH:refs/heads/$RC_BRANCH"
+```
+
+Both pushes above (the initial `-u` push of the branch and the tag push) already use the disambiguated form for consistency, even though only one of the two names exists at the moment of the first push. Renaming the tag to a separate namespace (e.g. `rc-tag/...`) would also resolve this but is out of scope here — the documentation route is preferred because it keeps the tag/branch pairing intact and the cost is one extra refspec qualifier at each push site.
 
 ### 4. Report
 

--- a/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh
+++ b/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh
@@ -24,7 +24,7 @@ usage() {
 _find_worktree_for_branch() {
   git worktree list --porcelain \
     | awk -v target="refs/heads/$1" '
-        /^worktree / { wt = $2 }
+        /^worktree / { wt = $0; sub(/^worktree /, "", wt) }
         $0 == "branch " target { print wt }
       '
 }

--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -71,6 +71,17 @@ if [ -z "$BASE" ]; then
   echo "warning: no base branch configured and 'develop' not found on remote; falling back to repo default ($REPO_DEFAULT)" >&2
   BASE="$REPO_DEFAULT"
 fi
+
+# 5. Guard — resolved base must not equal current HEAD
+HEAD_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BASE" = "$HEAD_BRANCH" ]; then
+  echo "ERROR: resolved base ($BASE) is the same as the current branch ($HEAD_BRANCH)." >&2
+  echo "This usually means you're on an epic branch with claude.flowkit.prBase pinned" >&2
+  echo "to itself. To open the epic's own integration PR, do one of:" >&2
+  echo "  - rerun with an explicit override: /flowkit:pr --base develop" >&2
+  echo "  - unset the pin first: git config --unset claude.flowkit.prBase" >&2
+  exit 1
+fi
 ```
 
 ### 3. Push branch to origin

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -311,6 +311,32 @@ gh pr create \
 
 Capture the PR number from the URL output.
 
+### 5.5. Pre-merge divergence check
+
+Before attempting the merge, detect commits on `origin/main` that have no patch-id equivalent on `origin/$SOURCE`. This typically fires after a prior release rebase-merged into `main` and the back-merge never landed on `develop` (and therefore never reached the RC) — leaving `main` with commits whose rebase-equivalent forms exist nowhere on the RC by either SHA or patch-id. Even with the unconditional rebase in step 3, a stale RC force-pushed elsewhere or an aborted prior rebase can produce the same shape. `gh pr merge --rebase` fails mid-flight when this divergence exists, leaving the release in a half-shipped state. Surface it as an explicit precondition instead:
+
+```bash
+DUP_PATCHES=$(git rev-list --left-right --cherry-pick --count \
+  "origin/main...origin/$SOURCE" | awk '{print $1}')
+if [ "$DUP_PATCHES" -gt 0 ]; then
+  echo "release: detected $DUP_PATCHES commit(s) on origin/main with no patch-id equivalent on origin/$SOURCE." >&2
+  echo "release: this typically means a prior release rebase-merged into main and the back-merge never landed on develop," >&2
+  echo "release: leaving main with commits whose patch-id duplicates would now clash on rebase-merge." >&2
+  echo "release: remediate by rebasing the RC onto origin/main locally, then force-pushing with the disambiguated refspec:" >&2
+  echo "release:   git checkout $SOURCE" >&2
+  echo "release:   git rebase origin/main" >&2
+  echo "release:   git push --force-with-lease origin refs/heads/$SOURCE:refs/heads/$SOURCE" >&2
+  echo "release: the qualified refspec is required because cut creates a same-named tag (rc/YYYY-MM-DD.N)," >&2
+  echo "release: which makes the unqualified push form ambiguous (error: src refspec <name> matches more than one)." >&2
+  echo "release: re-run /release after the remediation has landed on origin/$SOURCE." >&2
+  exit 1
+fi
+```
+
+The check uses `git rev-list --left-right --cherry-pick --count` against the symmetric difference `origin/main...origin/$SOURCE`. The left-side count (after `--cherry-pick` filters out patch-id-equivalent commits) is the set of commits on `main` whose changes are not represented on the RC by any commit, identical SHA or otherwise. Any non-zero value means the merge will not be clean.
+
+The snippet aborts with the remediation message printed above and exits non-zero — the operator runs the three `git checkout` / `rebase` / `push` commands manually and then re-invokes `/release`. The skill does not auto-rebase on the operator's behalf, because a force-push to a release candidate that has already been advertised to other consumers deserves an explicit human decision rather than a wrapped prompt.
+
 ### 6. Merge the PR
 
 `gh pr merge --rebase --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. Wrap the call with the [`flowkit:with-clean-workspace`](../../with-clean-workspace/SKILL.md) script so any dirty state is auto-stashed and restored:
@@ -412,7 +438,11 @@ if [ -z "$RC_BRANCHES" ]; then
 else
   echo "$RC_BRANCHES" | while read rc; do
     echo "Deleting orphan RC branch: $rc"
-    git push origin --delete "$rc"
+    # Use the disambiguated refspec form — the same-named RC tag still exists on
+    # origin (cut/SKILL.md step 3 documents the collision), so the unqualified
+    # `git push origin --delete "$rc"` would fail with `src refspec matches more
+    # than one`. Deleting via `:refs/heads/<rc>` targets the branch unambiguously.
+    git push origin ":refs/heads/$rc"
   done
 fi
 ```

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -80,6 +80,23 @@ if [ -n "$LAST_TAG" ]; then
 fi
 ```
 
+Drop refs whose target issue is already CLOSED. Without this filter, refs collected from PRs merged in this cycle can still point at issues that were closed in a prior release (e.g. when a PR landed after the prior release tag but the referenced issue was already closed by an earlier cycle). Re-listing them in this release's PR body would falsely claim to close them again, and would also re-trigger epic auto-close paths downstream. The filter sits before the epic-detection block so already-closed children don't poison that logic:
+
+```bash
+FILTERED_REFS_FILE=$(mktemp)
+printf '%s\n' "$ISSUE_REFS" | while read REF; do
+  N=$(echo "$REF" | grep -oE '[0-9]+')
+  [ -z "$N" ] && continue
+  STATE=$(gh issue view "$N" --json state --jq '.state' 2>/dev/null)
+  if [ "$STATE" = "OPEN" ]; then
+    echo "$REF" >> "$FILTERED_REFS_FILE"
+  else
+    echo "Skipped already-closed issue $N from release PR body" >&2
+  fi
+done
+ISSUE_REFS=$(cat "$FILTERED_REFS_FILE"); rm -f "$FILTERED_REFS_FILE"
+```
+
 Then find open epics whose children are all now closed and append their `Closes #N` refs. Epics may be wired to children via two mechanisms:
 
 - **Legacy checklist** — epic body contains `- [ ] #N` / `- [x] #N` lines


### PR DESCRIPTION
## Summary

Ship epic `feature/flowkit-cleanup-872` to develop via rebase-merge. This branch contains 4 squashed child commit(s) that will replay linearly onto develop's first-parent line.

## Changes

- Rebase-merge promotes 4 squashed child PR(s) onto develop linearly.
- `claude.flowkit.prBase` will be unset after merge; epic branch deleted.

## Test plan

- [ ] Verify `git log --first-parent origin/develop` shows 4 new commit(s) with no merge bubbles.
- [ ] Verify `git config --get claude.flowkit.prBase` is empty after ship.

Closes #939
Closes #940
Closes #935
Closes #872
Refs #872