### PR TITLE
fix(flowkit): brace RC_BRANCH refspecs to defuse zsh :r modifier

### DIFF
--- a/plugins/flowkit/skills/cut/SKILL.md
+++ b/plugins/flowkit/skills/cut/SKILL.md
@@ -46,9 +46,9 @@ RC_BRANCH="rc/$TODAY.$N"
 
 ```bash
 git checkout -b "$RC_BRANCH" origin/develop
-git push -u origin "refs/heads/$RC_BRANCH:refs/heads/$RC_BRANCH"
+git push -u origin "refs/heads/${RC_BRANCH}:refs/heads/${RC_BRANCH}"
 git tag "$RC_BRANCH"
-git push origin "refs/tags/$RC_BRANCH"
+git push origin "refs/tags/${RC_BRANCH}"
 ```
 
 The tag (`rc/YYYY-MM-DD.N`) intentionally shares the branch name. The tag is pushed immediately so future cuts count it correctly even after the branch is deleted.
@@ -62,10 +62,12 @@ error: src refspec rc/YYYY-MM-DD.N matches more than one
 This affects any later RC-branch push — most notably the force-push performed by `flowkit:release` step 3 after rebasing the RC onto `origin/main`. The fix is to use the fully qualified refspec form whenever pushing the RC branch in the presence of the matching tag:
 
 ```bash
-git push --force-with-lease origin "refs/heads/$RC_BRANCH:refs/heads/$RC_BRANCH"
+git push --force-with-lease origin "refs/heads/${RC_BRANCH}:refs/heads/${RC_BRANCH}"
 ```
 
 Both pushes above (the initial `-u` push of the branch and the tag push) already use the disambiguated form for consistency, even though only one of the two names exists at the moment of the first push. Renaming the tag to a separate namespace (e.g. `rc-tag/...`) would also resolve this but is out of scope here — the documentation route is preferred because it keeps the tag/branch pairing intact and the cost is one extra refspec qualifier at each push site.
+
+**Always brace the variable** (`${RC_BRANCH}`, not `$RC_BRANCH`) inside the refspec strings. When the snippet runs under zsh (or any shell with the `:r` parameter modifier), the unbraced form `$RC_BRANCH:refs/heads/...` is parsed as "value of `$RC_BRANCH` with trailing extension stripped, followed by the literal `efs/heads/...`" — the `:r` modifier consumes the `r` from `refs/heads/` and drops the `.N` suffix from the branch name. The resulting refspec looks like `refs/heads/rc/YYYY-MM-DDefs/heads/rc/YYYY-MM-DD.N` and fails with `src refspec ... does not match any`. Bracing the variable terminates the parameter name before the `:`, so the modifier path is never taken. Bash 5.x does not implement `:r` and ignores the problem; zsh does and silently mangles the string.
 
 ### 4. Report
 


### PR DESCRIPTION
## Summary

- Brace `\${RC_BRANCH}` at every refspec site in `plugins/flowkit/skills/cut/SKILL.md` (two push sites in step 3, one in the refspec-collision documentation block)
- Add a note in the docs section explaining the zsh `:r` modifier hazard so future edits don't reintroduce the unbraced form

## Root cause

Under zsh, the unbraced form `\"refs/heads/\$RC_BRANCH:refs/heads/\$RC_BRANCH\"` is parsed as the zsh modifier ``\$RC_BRANCH:r``  ("strip trailing extension"), consuming the `r` from the literal `refs/heads/` that follows and dropping the `.N` from the branch name. The push then fails with:

\`\`\`
error: src refspec refs/heads/rc/YYYY-MM-DDefs/heads/rc/YYYY-MM-DD.N does not match any
\`\`\`

Bash 5.x ignores `:r`, so the bug only fires through zsh. But the Claude Code Bash tool dispatches through the user's login shell, so any operator on zsh (the macOS default since Catalina) hits it on every `\$RC_BRANCH` with a `.N` suffix — i.e., every RC cut.

## Reproduction

Run the existing cut SKILL.md snippet inside a zsh session with `RC_BRANCH=\"rc/2026-05-15.1\"`:

\`\`\`zsh
RC_BRANCH=\"rc/2026-05-15.1\"
echo \"refs/heads/\$RC_BRANCH:refs/heads/\$RC_BRANCH\"
# → refs/heads/rc/2026-05-15efs/heads/rc/2026-05-15.1
\`\`\`

With braces:

\`\`\`zsh
echo \"refs/heads/\${RC_BRANCH}:refs/heads/\${RC_BRANCH}\"
# → refs/heads/rc/2026-05-15.1:refs/heads/rc/2026-05-15.1
\`\`\`

## Related

Surfaced during a vorbis-player release cycle today; companion bug to smallorbit-plugins#955 (flowkit:merge-pr cwd-deletion). Both filed against the same flowkit plugin, both observed in the same session.

## Test plan

- [x] Reproduce the bug under zsh with the existing unbraced form
- [x] Confirm the braced form expands correctly under zsh
- [ ] Cut a fresh RC after this lands (downstream consumer can verify on next release)