### PR TITLE
fix(flowkit:merge-pr): refuse to remove the worktree it was invoked from

### DIFF
--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -45,7 +45,7 @@ Squash-merge the open PR for the current branch and delete the remote branch. Op
 
 ## Script contract
 
-`scripts/merge_pr.sh` implements worktree cleanup, stacked-PR retargeting, and a `with-clean-workspace`–wrapped `gh pr merge --squash --delete-branch`. When the PR's head branch is held by a linked worktree the script removes it via `git worktree remove --force`; when it is held by the main worktree (the canonical state after `push-or-pr`) the script instead runs `git checkout <base>` in the main worktree so the branch can be released without the operator needing to do it manually. On success it prints **bare JSON** on stdout:
+`scripts/merge_pr.sh` implements worktree cleanup, stacked-PR retargeting, and a `with-clean-workspace`–wrapped `gh pr merge --squash --delete-branch`. When the PR's head branch is held by a linked worktree the script removes it via `git worktree remove --force` — unless the caller's cwd is inside that worktree, in which case the script refuses with operator guidance to exit the worktree first (otherwise it would delete its own caller's working directory and cascade ENOENT errors through the rest of the session). When the branch is held by the main worktree (the canonical state after `push-or-pr`) the script instead runs `git checkout <base>` in the main worktree so the branch can be released without the operator needing to do it manually. On success it prints **bare JSON** on stdout:
 
 | Field | Type | Meaning |
 | --- | --- | --- |

--- a/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh
+++ b/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh
@@ -101,7 +101,7 @@ if [[ -n "$BLOCKING_WORKTREE" ]]; then
       exit 1
     fi
   else
-    CALLER_CWD=$({ cd "$PWD" 2>/dev/null && pwd -P; } || echo "$PWD")
+    CALLER_CWD=$(pwd -P)
     WT_REAL=$({ cd "$BLOCKING_WORKTREE" 2>/dev/null && pwd -P; } || echo "$BLOCKING_WORKTREE")
     if [[ "$CALLER_CWD" == "$WT_REAL" || "$CALLER_CWD" == "$WT_REAL"/* ]]; then
       echo "merge_pr: cannot remove the worktree it was invoked from (cwd: $CALLER_CWD)." >&2

--- a/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh
+++ b/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh
@@ -101,6 +101,13 @@ if [[ -n "$BLOCKING_WORKTREE" ]]; then
       exit 1
     fi
   else
+    CALLER_CWD=$({ cd "$PWD" 2>/dev/null && pwd -P; } || echo "$PWD")
+    WT_REAL=$({ cd "$BLOCKING_WORKTREE" 2>/dev/null && pwd -P; } || echo "$BLOCKING_WORKTREE")
+    if [[ "$CALLER_CWD" == "$WT_REAL" || "$CALLER_CWD" == "$WT_REAL"/* ]]; then
+      echo "merge_pr: cannot remove the worktree it was invoked from (cwd: $CALLER_CWD)." >&2
+      echo "  Exit the worktree first (cd to the main worktree, or run ExitWorktree), then re-run merge_pr." >&2
+      exit 1
+    fi
     printf 'Note: branch %s is held by worktree %s.\n' "$HEAD_BRANCH" "$BLOCKING_WORKTREE" >&2
     printf '  Auto-removing the worktree before merge so the local branch can be deleted cleanly.\n' >&2
     if ! git worktree remove --force "$BLOCKING_WORKTREE"; then


### PR DESCRIPTION
## Summary

`merge-pr`'s linked-worktree cleanup path auto-removes the worktree holding the PR's head branch (`git worktree remove --force`) so the local branch can be deleted cleanly. When the caller's shell session is running inside that worktree, this deletes its own cwd — every subsequent shell spawn fails with `ENOENT: posix_spawn '/bin/sh'` (the ENOENT is the dead cwd, not `/bin/sh`), cascading through PostToolUse/PreToolUse hook errors until the operator manually leaves the worktree.

Fix follows option (a) from the issue: detect "caller is inside the worktree I'm about to remove" and fail fast with operator guidance to exit the worktree first. Matches the fail-fast pattern the main-worktree branch already uses for its analogous case.

## Changes

- `plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh`: before `git worktree remove --force "$BLOCKING_WORKTREE"`, canonicalize both `$PWD` and the worktree path via `pwd -P` and compare; exit 1 with operator guidance if the caller's cwd equals the worktree path or is a subdirectory of it. The `"$WT_REAL"/*` guard requires a slash boundary, so a sibling worktree whose name shares a prefix (e.g. `wt1-sibling` vs `wt1`) is not mistakenly flagged.
- `plugins/flowkit/skills/merge-pr/SKILL.md`: document the new fail-fast behavior in the Script contract section.

## Test plan

- [x] `bash -n` syntax check passes
- [x] Manual unit check of the comparison logic across five cases: exact match, subdirectory, sibling worktree, unrelated dir, and sibling-with-shared-prefix — all behave as expected
- [ ] Operator smoke test: invoke `/flowkit:merge-pr` from inside `.claude/worktrees/<name>/` for a branch with an open PR and confirm the script exits with the guidance message instead of removing the worktree

Refs #955