### PR TITLE
fix(swarmkit:clean-worktrees): refuse to remove a worktree the caller is running from

### DIFF
--- a/plugins/swarmkit/skills/clean-worktrees/SKILL.md
+++ b/plugins/swarmkit/skills/clean-worktrees/SKILL.md
@@ -91,7 +91,7 @@ On success the script exits 0 and emits a single JSON object on stdout:
 }
 ```
 
-If the script exits non-zero, surface stderr and stop.
+If the script exits non-zero, surface stderr and stop. (The script refuses with operator guidance if the caller's cwd is inside any of the worktrees listed for removal — exit the worktree first.)
 
 ### Step 6 — Report
 

--- a/plugins/swarmkit/skills/clean-worktrees/scripts/remove.sh
+++ b/plugins/swarmkit/skills/clean-worktrees/scripts/remove.sh
@@ -52,6 +52,18 @@ T_WT_ERR=$(mktemp)
 T_BR_ERR=$(mktemp)
 trap "rm -f $T_WT_ERR $T_BR_ERR" EXIT
 
+CALLER_CWD=$(pwd -P)
+
+while IFS= read -r path; do
+  [[ -z "$path" ]] && continue
+  WT_REAL=$({ cd "$path" 2>/dev/null && pwd -P; } || echo "$path")
+  if [[ "$CALLER_CWD" == "$WT_REAL" || "$CALLER_CWD" == "$WT_REAL"/* ]]; then
+    echo "remove: cannot remove the worktree the caller is running from (cwd: $CALLER_CWD, target: $WT_REAL)." >&2
+    echo "  Exit the worktree first (cd to the main worktree, or run ExitWorktree), then re-run." >&2
+    exit 1
+  fi
+done < <(printf '%s\n' "$WORKTREES_JSON" | jq -r '.[] | .path')
+
 git worktree prune >/dev/null 2>&1 || true
 
 cd "$MAIN_WORKTREE"


### PR DESCRIPTION
## Summary

`clean-worktrees/remove.sh` calls `git worktree remove "$path" -f -f` on every entry in the `--worktrees` JSON without checking whether the caller's session cwd is inside any of those paths. When it is — common with `/swarmkit:clean-worktrees` invoked from inside an agent worktree — the script deletes its own caller's working directory, cascading `ENOENT: posix_spawn '/bin/sh'` through the rest of the session. Mirrors the analogous hazard fixed in #957 for `flowkit:merge-pr`.

## Changes

- `plugins/swarmkit/skills/clean-worktrees/scripts/remove.sh`: before `cd "$MAIN_WORKTREE"`, capture `CALLER_CWD=$(pwd -P)` and scan every `worktrees_to_remove` entry for an exact match or `/`-bounded subdirectory match. Exit 1 with operator guidance ("exit the worktree first") if any match — preserves atomicity (no partial removal before the error fires).
- `plugins/swarmkit/skills/clean-worktrees/SKILL.md`: one-sentence note documenting the new refusal mode.

## Test plan

- [x] `bash -n` syntax check on the modified script
- [x] Manual logic check across exact-match, subdirectory, sibling, unrelated-dir, and sibling-with-shared-prefix cases — all pass
- [ ] Operator smoke test: invoke `/swarmkit:clean-worktrees` from inside `.claude/worktrees/worktree-agent-<N>/` and confirm the script exits with the guidance message instead of removing the worktree

Closes #958