### PR TITLE
release: 2026-05-15

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship.",
-  "version": "3.13.1",
+  "version": "3.13.2",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/flowkit/skills/cut/SKILL.md
+++ b/plugins/flowkit/skills/cut/SKILL.md
@@ -46,9 +46,9 @@ RC_BRANCH="rc/$TODAY.$N"
 
 ```bash
 git checkout -b "$RC_BRANCH" origin/develop
-git push -u origin "refs/heads/$RC_BRANCH:refs/heads/$RC_BRANCH"
+git push -u origin "refs/heads/${RC_BRANCH}:refs/heads/${RC_BRANCH}"
 git tag "$RC_BRANCH"
-git push origin "refs/tags/$RC_BRANCH"
+git push origin "refs/tags/${RC_BRANCH}"
 ```
 
 The tag (`rc/YYYY-MM-DD.N`) intentionally shares the branch name. The tag is pushed immediately so future cuts count it correctly even after the branch is deleted.
@@ -62,10 +62,12 @@ error: src refspec rc/YYYY-MM-DD.N matches more than one
 This affects any later RC-branch push — most notably the force-push performed by `flowkit:release` step 3 after rebasing the RC onto `origin/main`. The fix is to use the fully qualified refspec form whenever pushing the RC branch in the presence of the matching tag:
 
 ```bash
-git push --force-with-lease origin "refs/heads/$RC_BRANCH:refs/heads/$RC_BRANCH"
+git push --force-with-lease origin "refs/heads/${RC_BRANCH}:refs/heads/${RC_BRANCH}"
 ```
 
 Both pushes above (the initial `-u` push of the branch and the tag push) already use the disambiguated form for consistency, even though only one of the two names exists at the moment of the first push. Renaming the tag to a separate namespace (e.g. `rc-tag/...`) would also resolve this but is out of scope here — the documentation route is preferred because it keeps the tag/branch pairing intact and the cost is one extra refspec qualifier at each push site.
+
+**Always brace the variable** (`${RC_BRANCH}`, not `$RC_BRANCH`) inside the refspec strings. When the snippet runs under zsh (or any shell with the `:r` parameter modifier), the unbraced form `$RC_BRANCH:refs/heads/...` is parsed as "value of `$RC_BRANCH` with trailing extension stripped, followed by the literal `efs/heads/...`" — the `:r` modifier consumes the `r` from `refs/heads/` and drops the `.N` suffix from the branch name. The resulting refspec looks like `refs/heads/rc/YYYY-MM-DDefs/heads/rc/YYYY-MM-DD.N` and fails with `src refspec ... does not match any`. Bracing the variable terminates the parameter name before the `:`, so the modifier path is never taken. Bash 5.x does not implement `:r` and ignores the problem; zsh does and silently mangles the string.
 
 ### 4. Report
 

--- a/plugins/flowkit/skills/cut/SKILL.md
+++ b/plugins/flowkit/skills/cut/SKILL.md
@@ -46,12 +46,26 @@ RC_BRANCH="rc/$TODAY.$N"
 
 ```bash
 git checkout -b "$RC_BRANCH" origin/develop
-git push -u origin "$RC_BRANCH"
+git push -u origin "refs/heads/$RC_BRANCH:refs/heads/$RC_BRANCH"
 git tag "$RC_BRANCH"
 git push origin "refs/tags/$RC_BRANCH"
 ```
 
-The tag (`rc/YYYY-MM-DD.N`) shares the branch name; push it via full `refs/tags/` path to avoid the ambiguous-refspec error. The tag is pushed immediately so future cuts count it correctly even after the branch is deleted.
+The tag (`rc/YYYY-MM-DD.N`) intentionally shares the branch name. The tag is pushed immediately so future cuts count it correctly even after the branch is deleted.
+
+**Refspec collision (read before pushing an RC branch anywhere else).** Once both the RC branch and the same-named tag exist locally, every subsequent `git push origin <name>` against that name is ambiguous and fails with:
+
+```
+error: src refspec rc/YYYY-MM-DD.N matches more than one
+```
+
+This affects any later RC-branch push — most notably the force-push performed by `flowkit:release` step 3 after rebasing the RC onto `origin/main`. The fix is to use the fully qualified refspec form whenever pushing the RC branch in the presence of the matching tag:
+
+```bash
+git push --force-with-lease origin "refs/heads/$RC_BRANCH:refs/heads/$RC_BRANCH"
+```
+
+Both pushes above (the initial `-u` push of the branch and the tag push) already use the disambiguated form for consistency, even though only one of the two names exists at the moment of the first push. Renaming the tag to a separate namespace (e.g. `rc-tag/...`) would also resolve this but is out of scope here — the documentation route is preferred because it keeps the tag/branch pairing intact and the cost is one extra refspec qualifier at each push site.
 
 ### 4. Report
 

--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -45,7 +45,7 @@ Squash-merge the open PR for the current branch and delete the remote branch. Op
 
 ## Script contract
 
-`scripts/merge_pr.sh` implements worktree cleanup, stacked-PR retargeting, and a `with-clean-workspace`–wrapped `gh pr merge --squash --delete-branch`. When the PR's head branch is held by a linked worktree the script removes it via `git worktree remove --force`; when it is held by the main worktree (the canonical state after `push-or-pr`) the script instead runs `git checkout <base>` in the main worktree so the branch can be released without the operator needing to do it manually. On success it prints **bare JSON** on stdout:
+`scripts/merge_pr.sh` implements worktree cleanup, stacked-PR retargeting, and a `with-clean-workspace`–wrapped `gh pr merge --squash --delete-branch`. When the PR's head branch is held by a linked worktree the script removes it via `git worktree remove --force` — unless the caller's cwd is inside that worktree, in which case the script refuses with operator guidance to exit the worktree first (otherwise it would delete its own caller's working directory and cascade ENOENT errors through the rest of the session). When the branch is held by the main worktree (the canonical state after `push-or-pr`) the script instead runs `git checkout <base>` in the main worktree so the branch can be released without the operator needing to do it manually. On success it prints **bare JSON** on stdout:
 
 | Field | Type | Meaning |
 | --- | --- | --- |

--- a/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh
+++ b/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh
@@ -101,6 +101,13 @@ if [[ -n "$BLOCKING_WORKTREE" ]]; then
       exit 1
     fi
   else
+    CALLER_CWD=$(pwd -P)
+    WT_REAL=$({ cd "$BLOCKING_WORKTREE" 2>/dev/null && pwd -P; } || echo "$BLOCKING_WORKTREE")
+    if [[ "$CALLER_CWD" == "$WT_REAL" || "$CALLER_CWD" == "$WT_REAL"/* ]]; then
+      echo "merge_pr: cannot remove the worktree it was invoked from (cwd: $CALLER_CWD)." >&2
+      echo "  Exit the worktree first (cd to the main worktree, or run ExitWorktree), then re-run merge_pr." >&2
+      exit 1
+    fi
     printf 'Note: branch %s is held by worktree %s.\n' "$HEAD_BRANCH" "$BLOCKING_WORKTREE" >&2
     printf '  Auto-removing the worktree before merge so the local branch can be deleted cleanly.\n' >&2
     if ! git worktree remove --force "$BLOCKING_WORKTREE"; then

--- a/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh
+++ b/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh
@@ -24,7 +24,7 @@ usage() {
 _find_worktree_for_branch() {
   git worktree list --porcelain \
     | awk -v target="refs/heads/$1" '
-        /^worktree / { wt = $2 }
+        /^worktree / { wt = $0; sub(/^worktree /, "", wt) }
         $0 == "branch " target { print wt }
       '
 }

--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -71,6 +71,17 @@ if [ -z "$BASE" ]; then
   echo "warning: no base branch configured and 'develop' not found on remote; falling back to repo default ($REPO_DEFAULT)" >&2
   BASE="$REPO_DEFAULT"
 fi
+
+# 5. Guard — resolved base must not equal current HEAD
+HEAD_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BASE" = "$HEAD_BRANCH" ]; then
+  echo "ERROR: resolved base ($BASE) is the same as the current branch ($HEAD_BRANCH)." >&2
+  echo "This usually means you're on an epic branch with claude.flowkit.prBase pinned" >&2
+  echo "to itself. To open the epic's own integration PR, do one of:" >&2
+  echo "  - rerun with an explicit override: /flowkit:pr --base develop" >&2
+  echo "  - unset the pin first: git config --unset claude.flowkit.prBase" >&2
+  exit 1
+fi
 ```
 
 ### 3. Push branch to origin

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -311,6 +311,32 @@ gh pr create \
 
 Capture the PR number from the URL output.
 
+### 5.5. Pre-merge divergence check
+
+Before attempting the merge, detect commits on `origin/main` that have no patch-id equivalent on `origin/$SOURCE`. This typically fires after a prior release rebase-merged into `main` and the back-merge never landed on `develop` (and therefore never reached the RC) — leaving `main` with commits whose rebase-equivalent forms exist nowhere on the RC by either SHA or patch-id. Even with the unconditional rebase in step 3, a stale RC force-pushed elsewhere or an aborted prior rebase can produce the same shape. `gh pr merge --rebase` fails mid-flight when this divergence exists, leaving the release in a half-shipped state. Surface it as an explicit precondition instead:
+
+```bash
+DUP_PATCHES=$(git rev-list --left-right --cherry-pick --count \
+  "origin/main...origin/$SOURCE" | awk '{print $1}')
+if [ "$DUP_PATCHES" -gt 0 ]; then
+  echo "release: detected $DUP_PATCHES commit(s) on origin/main with no patch-id equivalent on origin/$SOURCE." >&2
+  echo "release: this typically means a prior release rebase-merged into main and the back-merge never landed on develop," >&2
+  echo "release: leaving main with commits whose patch-id duplicates would now clash on rebase-merge." >&2
+  echo "release: remediate by rebasing the RC onto origin/main locally, then force-pushing with the disambiguated refspec:" >&2
+  echo "release:   git checkout $SOURCE" >&2
+  echo "release:   git rebase origin/main" >&2
+  echo "release:   git push --force-with-lease origin refs/heads/$SOURCE:refs/heads/$SOURCE" >&2
+  echo "release: the qualified refspec is required because cut creates a same-named tag (rc/YYYY-MM-DD.N)," >&2
+  echo "release: which makes the unqualified push form ambiguous (error: src refspec <name> matches more than one)." >&2
+  echo "release: re-run /release after the remediation has landed on origin/$SOURCE." >&2
+  exit 1
+fi
+```
+
+The check uses `git rev-list --left-right --cherry-pick --count` against the symmetric difference `origin/main...origin/$SOURCE`. The left-side count (after `--cherry-pick` filters out patch-id-equivalent commits) is the set of commits on `main` whose changes are not represented on the RC by any commit, identical SHA or otherwise. Any non-zero value means the merge will not be clean.
+
+The snippet aborts with the remediation message printed above and exits non-zero — the operator runs the three `git checkout` / `rebase` / `push` commands manually and then re-invokes `/release`. The skill does not auto-rebase on the operator's behalf, because a force-push to a release candidate that has already been advertised to other consumers deserves an explicit human decision rather than a wrapped prompt.
+
 ### 6. Merge the PR
 
 `gh pr merge --rebase --delete-branch` triggers an implicit local `git pull` after the merge. If the workspace is dirty that pull fails with `cannot pull with rebase: You have unstaged changes`. Wrap the call with the [`flowkit:with-clean-workspace`](../../with-clean-workspace/SKILL.md) script so any dirty state is auto-stashed and restored:
@@ -412,7 +438,11 @@ if [ -z "$RC_BRANCHES" ]; then
 else
   echo "$RC_BRANCHES" | while read rc; do
     echo "Deleting orphan RC branch: $rc"
-    git push origin --delete "$rc"
+    # Use the disambiguated refspec form — the same-named RC tag still exists on
+    # origin (cut/SKILL.md step 3 documents the collision), so the unqualified
+    # `git push origin --delete "$rc"` would fail with `src refspec matches more
+    # than one`. Deleting via `:refs/heads/<rc>` targets the branch unambiguously.
+    git push origin ":refs/heads/$rc"
   done
 fi
 ```

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -80,6 +80,23 @@ if [ -n "$LAST_TAG" ]; then
 fi
 ```
 
+Drop refs whose target issue is already CLOSED. Without this filter, refs collected from PRs merged in this cycle can still point at issues that were closed in a prior release (e.g. when a PR landed after the prior release tag but the referenced issue was already closed by an earlier cycle). Re-listing them in this release's PR body would falsely claim to close them again, and would also re-trigger epic auto-close paths downstream. The filter sits before the epic-detection block so already-closed children don't poison that logic:
+
+```bash
+FILTERED_REFS_FILE=$(mktemp)
+printf '%s\n' "$ISSUE_REFS" | while read REF; do
+  N=$(echo "$REF" | grep -oE '[0-9]+')
+  [ -z "$N" ] && continue
+  STATE=$(gh issue view "$N" --json state --jq '.state' 2>/dev/null)
+  if [ "$STATE" = "OPEN" ]; then
+    echo "$REF" >> "$FILTERED_REFS_FILE"
+  else
+    echo "Skipped already-closed issue $N from release PR body" >&2
+  fi
+done
+ISSUE_REFS=$(cat "$FILTERED_REFS_FILE"); rm -f "$FILTERED_REFS_FILE"
+```
+
 Then find open epics whose children are all now closed and append their `Closes #N` refs. Epics may be wired to children via two mechanisms:
 
 - **Legacy checklist** — epic body contains `- [ ] #N` / `- [x] #N` lines

--- a/plugins/polishkit/.claude-plugin/plugin.json
+++ b/plugins/polishkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polishkit",
   "description": "Codebase quality toolkit. Appraise code craft with a connoisseur's eye, sweep dead code and cruft in one pass, and polish cross-cutting code-quality issues — three focused skills for improving what you've already built.",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sessionkit",
   "description": "Session continuity, planning, and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, map work-in-flight into an approved task chain and drive it to completion, discover reusable skills, and reduce permission noise.",
-  "version": "1.9.1",
+  "version": "1.9.2",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/speckit/.claude-plugin/plugin.json
+++ b/plugins/speckit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "speckit",
   "description": "Define and capture work as GitHub issues. Interview a feature into existence with /spec, bulk-convert findings with /catalog, or quickly file a single issue with /issue.",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/squadkit/.claude-plugin/plugin.json
+++ b/plugins/squadkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "squadkit",
   "description": "Multi-agent team coordination for Claude Code. Roles, squads, and crews \u2014 interview-driven setup, no per-stack presets, reusable across any repo.",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "5.6.2",
+  "version": "5.6.3",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/swarmkit/skills/clean-worktrees/SKILL.md
+++ b/plugins/swarmkit/skills/clean-worktrees/SKILL.md
@@ -91,7 +91,7 @@ On success the script exits 0 and emits a single JSON object on stdout:
 }
 ```
 
-If the script exits non-zero, surface stderr and stop.
+If the script exits non-zero, surface stderr and stop. (The script refuses with operator guidance if the caller's cwd is inside any of the worktrees listed for removal — exit the worktree first.)
 
 ### Step 6 — Report
 

--- a/plugins/swarmkit/skills/clean-worktrees/scripts/remove.sh
+++ b/plugins/swarmkit/skills/clean-worktrees/scripts/remove.sh
@@ -52,6 +52,18 @@ T_WT_ERR=$(mktemp)
 T_BR_ERR=$(mktemp)
 trap "rm -f $T_WT_ERR $T_BR_ERR" EXIT
 
+CALLER_CWD=$(pwd -P)
+
+while IFS= read -r path; do
+  [[ -z "$path" ]] && continue
+  WT_REAL=$({ cd "$path" 2>/dev/null && pwd -P; } || echo "$path")
+  if [[ "$CALLER_CWD" == "$WT_REAL" || "$CALLER_CWD" == "$WT_REAL"/* ]]; then
+    echo "remove: cannot remove the worktree the caller is running from (cwd: $CALLER_CWD, target: $WT_REAL)." >&2
+    echo "  Exit the worktree first (cd to the main worktree, or run ExitWorktree), then re-run." >&2
+    exit 1
+  fi
+done < <(printf '%s\n' "$WORKTREES_JSON" | jq -r '.[] | .path')
+
 git worktree prune >/dev/null 2>&1 || true
 
 cd "$MAIN_WORKTREE"

--- a/plugins/vaultkit/.claude-plugin/plugin.json
+++ b/plugins/vaultkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vaultkit",
   "description": "Obsidian vault skills for Claude Code. Read, search, edit notes, manage projects, capture decisions, and archive conversations — all via the Obsidian CLI.",
-  "version": "1.1.6",
+  "version": "1.1.7",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Patch release hardening the worktree-aware skills: both `flowkit:merge-pr` and `swarmkit:clean-worktrees` now refuse to remove the worktree the caller is running from instead of silently deleting their own caller's working directory. Also fixes the zsh `:r` modifier mangling in `flowkit:cut` refspecs.

## Release summary

**Built from**: `rc/2026-05-15.1`

### Version bumps
- chore(plugins): bump flowkit@3.13.2, polishkit@3.0.3, sessionkit@1.9.2, speckit@1.7.1, squadkit@0.10.4, swarmkit@5.6.3, vaultkit@1.1.7 (#960)

### Release notes

**flowkit**
- fix(flowkit:merge-pr): refuse to remove the worktree it was invoked from — caller-cwd canonical comparison guards the linked-worktree cleanup path so the running session's directory is never deleted out from under it.
- fix(flowkit): brace RC_BRANCH refspecs to defuse zsh :r modifier — wraps every `${RC_BRANCH}` site in `plugins/flowkit/skills/cut/SKILL.md` so zsh stops parsing `$RC_BRANCH:refs` as the remove-extension modifier and mangling the refspec.

**swarmkit**
- fix(swarmkit:clean-worktrees): refuse to remove a worktree the caller is running from — up-front atomicity guard mirrors the merge-pr fix; refuses before any `git worktree remove` if the caller's cwd matches any path in `--worktrees`.