### PR TITLE
docs(polishkit:sweep): cover remote merged PR branches

### DIFF
--- a/plugins/polishkit/skills/sweep/SKILL.md
+++ b/plugins/polishkit/skills/sweep/SKILL.md
@@ -130,6 +130,39 @@ Run these checks in parallel and compile findings:
 - Local branches whose upstream has been merged (`git branch --merged main` cross-referenced with remote)
 - Stale worktrees (`git worktree list` — flag any where the branch no longer exists or has been merged)
 - Orphaned remote-tracking branches (`git remote prune origin --dry-run`)
+- **Remote branches tied to merged PRs** — origin-side branches the local prune can't touch. List every remote head except the default branches and any explicitly parked prefix (`parked/*`); for each, classify via the PR it heads:
+
+  ```bash
+  git fetch --prune --quiet
+  git ls-remote --heads origin \
+    | awk '{print $2}' | sed 's|refs/heads/||' \
+    | grep -v -E '^(develop|main|gh-pages|parked/.*)$' \
+    | while read B; do
+        PR=$(gh pr list --head "$B" --state all --json number,state,title --limit 1 --jq '.[0]' 2>/dev/null)
+        if [ -z "$PR" ] || [ "$PR" = "null" ]; then
+          echo "[NO PR] $B"
+        else
+          STATE=$(echo "$PR" | jq -r '.state')
+          NUM=$(echo "$PR" | jq -r '.number')
+          echo "[$STATE PR #$NUM] $B"
+        fi
+      done
+  ```
+
+  Deletion policy — surface only the **MERGED** bucket for removal. Preserve the rest:
+
+  | Bucket | Action | Why |
+  |--------|--------|-----|
+  | MERGED | Propose deletion | Work landed; branch is pure cruft. |
+  | CLOSED (not merged) | Preserve | Branch contains rejected work that persists nowhere else. |
+  | OPEN | Preserve | Active PR; deleting would close the PR. |
+  | NO PR | Preserve, flag for manual inspection | No record of intent; easy to lose work. |
+
+  When deleting, **always use the disambiguated refspec form** (`git push origin :refs/heads/<branch>`). The unqualified `git push origin --delete <branch>` fails with `src refspec matches more than one` whenever a same-named tag exists (the `rc/YYYY-MM-DD.N` shape from `flowkit:cut` is the canonical example). Batch into a single push:
+
+  ```bash
+  git push origin :refs/heads/branch-a :refs/heads/branch-b
+  ```
 
 ### 3. Present findings and confirm each action
 


### PR DESCRIPTION
## Summary

`polishkit:sweep` Phase 2's Git hygiene section only covered local branch pruning, local worktrees, and orphaned remote-tracking refs. Remote branches on origin tied to merged PRs were outside the skill, so consumers had to fall back to bespoke `gh`/`git` pipelines (or to `swarmkit:clean-remote-worktrees`, which is scoped to the `worktree-agent-*` prefix). This PR extends `sweep` to cover that gap with the same preservation policy.

## Changes

- `plugins/polishkit/skills/sweep/SKILL.md`: add a remote-head classification loop under Phase 2's Git hygiene section. Skips default branches (`develop`, `main`, `gh-pages`) and any `parked/*` prefix; classifies the rest via `gh pr list --head` into MERGED / CLOSED / OPEN / NO PR buckets.
- Add a deletion-policy table that surfaces only MERGED for removal and preserves CLOSED-not-merged (rejected work), OPEN (active PR), and NO PR (manual inspection) — mirroring `swarmkit:clean-remote-worktrees`'s policy but generalized to any prefix.
- Document the disambiguated refspec form (`git push origin :refs/heads/<branch>`) with a one-liner explaining why the unqualified form fails when a same-named tag exists (the `rc/YYYY-MM-DD.N` shape from `flowkit:cut` is the canonical example).

## Test plan

- [ ] Invoke `/sweep` on a repo with at least one MERGED remote branch and confirm it surfaces under the Git hygiene section's new bucket.
- [ ] Confirm `parked/*` branches and the repo's default branches are excluded from the candidate list.
- [ ] Confirm CLOSED-not-merged and NO PR branches appear in the Keep section with the documented rationale, not in Remove.
- [ ] Confirm batch deletion uses the disambiguated refspec form rather than `--delete`.