### PR TITLE
chore(plugins): bump flowkit@3.13.3, polishkit@3.0.4

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Branch, commit, open PRs, merge, cut releases, and ship.",
-  "version": "3.13.2",
+  "version": "3.13.3",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/polishkit/.claude-plugin/plugin.json
+++ b/plugins/polishkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polishkit",
   "description": "Codebase quality toolkit. Appraise code craft with a connoisseur's eye, sweep dead code and cruft in one pass, and polish cross-cutting code-quality issues — three focused skills for improving what you've already built.",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary
Bump plugin.json versions for plugins changed since their last release.

## Changes

- flowkit@3.13.3
- polishkit@3.0.4

## Test plan

- [ ] Confirm each `plugin.json` version bump matches the per-plugin tag that will be created after merge.