### PR TITLE
polishkit: baseline specs and tighten polish SKILL.md

### DIFF
--- a/.claude/skills/spec-baseline/SKILL.md
+++ b/.claude/skills/spec-baseline/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: spec-baseline
+description: Derive an OpenSpec spec.md from an existing codebase (not a proposed change), produce a companion REFERENCES.md that cites every requirement and scenario back to specific file:line, and optionally spawn a read-only audit agent to verify those citations are accurate. Use when baselining legacy or existing code as a specification, or when you want human-reviewable evidence that a spec reflects real behavior.
+triggers:
+  - "baseline spec for"
+  - "spec from legacy code"
+  - "derive spec from existing"
+  - "document what X does as a spec"
+  - "create a spec for existing code"
+  - "baseline the existing"
+  - "write a spec based on the code"
+  - "extract spec from"
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent
+---
+
+# Spec Baseline
+
+Reverse-engineer an OpenSpec `spec.md` from an existing codebase, then produce a
+`REFERENCES.md` that makes every derived claim verifiable. Optionally audit the
+references with an independent agent.
+
+## Setup note
+
+The OpenSpec validator lives at `scripts/openspec` in this repo. Validation calls use
+`bash scripts/openspec validate <capability> --type spec --strict`.
+
+## When to use this vs. `/opsx:propose`
+
+| Situation | Skill |
+|---|---|
+| Code already exists; you want to capture what it *does* | `/spec-baseline` |
+| You want to propose *new* behavior or a change | `/opsx:propose` |
+
+---
+
+## Process
+
+### Step 1 — Identify the scope
+
+Ask the user (or infer from context):
+- Which capability or module to baseline (e.g. "tipping", "transfer", "checkout-form")
+- Which codebase(s) to read (current repo? a legacy repo? both for comparison?)
+- Whether to target a single stack or write stack-agnostically
+
+If the target is a **legacy codebase** being compared to a new one, write the spec
+stack-agnostically: no framework names, no component class names, no library-specific
+APIs. Behaviors are expressed in domain terms (what the system does, not how).
+
+### Step 2 — Read the source
+
+For the target module, read:
+1. **Implementation files** — the primary source of behavior
+2. **Test files** — tests reveal edge cases and observable contracts the code alone may not
+3. **Git history** — `git log --follow -n 10 -- <path>` on key files to surface *why* decisions were made
+
+If the project has an inventory brief (e.g. `openspec/inventory/modules/<name>.md`),
+read that first as a map; do not copy it wholesale into the spec.
+
+### Step 3 — Write `openspec/specs/<capability>/spec.md`
+
+Follow the OpenSpec spec format exactly:
+```markdown
+# <Capability Name>
+
+## Purpose
+<1–3 sentences: what problem this capability solves and for whom>
+
+## Requirements
+
+### Requirement: <requirement name>
+<Normative requirement text using SHALL/MUST>
+
+#### Scenario: <scenario name>
+- **WHEN** <condition>
+- **THEN** <expected outcome>
+```
+
+Rules:
+- One `## Requirements` section; all `### Requirement:` blocks inside it
+- Every `### Requirement:` must have at least one `#### Scenario:` (4 hashtags, exact)
+- Use SHALL/MUST for normative requirements; avoid "should" or "may"
+- **Stack-agnostic:** no framework names, no component class names, no library APIs
+- Basket/API field names from the domain model are acceptable (they are the universal contract)
+- Validation rules, timing constants, and business logic thresholds belong in the spec
+
+After writing, validate: `bash scripts/openspec validate <capability> --type spec --strict`
+
+### Step 4 — Write `openspec/specs/<capability>/REFERENCES.md`
+
+This file is NOT part of the spec (it will not be validated). It is a human-readable
+annotation of every requirement and scenario, pointing to the source code.
+
+Structure (mirrors spec.md order):
+```markdown
+# <Capability Name> — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `<repo-root>/`.
+Line numbers verified on <date>.
+
+---
+
+## Requirement: <same name as in spec.md>
+
+**Sources**
+- `path/to/file.ts:LINE-RANGE` — <what is at those lines and why it supports the claim>
+- `tests/path/test.ts:LINE-RANGE` — `'test name'` verifies <what behavior>
+
+**Notes**
+- <Interpretive choices, surprising behaviors, divergence from the new app>
+
+### Scenario: <same name as in spec.md>
+**Source:** `path/to/file.ts:LINE` — <specific identifier/expression>.
+[Verified by test at line N. | **Interpolated; no direct test.**]
+```
+
+At the end, include a `## Cross-cutting interpretive notes` section listing every
+scenario or claim that was **interpolated from absence** (no code or test directly
+asserts it). Number them. These are the human reviewer's primary checklist.
+
+**Citation discipline:**
+- Cite the smallest range that contains the relevant identifier (prefer `file.ts:123`
+  over `file.ts:100-200`)
+- When a test verifies the claim, include the test citation on the same scenario line
+- When no test exists, end with `**Interpolated; no direct test.**` or `**Interpolated from absence.**`
+
+### Step 5 — Spawn the citation audit agent (optional, recommended)
+
+After the references file is written, offer to audit it. If the user agrees, spawn
+a **read-only Sonnet agent** with this prompt (fill in the repo path and capability):
+
+> You are auditing a references file to verify source-code citations are accurate.
+> Read-only; do not modify files.
+>
+> **Spec:** `openspec/specs/<capability>/spec.md`
+> **References:** `openspec/specs/<capability>/REFERENCES.md`
+> **Source repo:** `<absolute path to legacy/source repo>`
+>
+> For each Source citation: verify the file exists, the line numbers contain what
+> the references file claims, and the code substantiates the spec claim. For test
+> citations, verify the test actually asserts the claimed behavior. For items in
+> "Cross-cutting interpretive notes", verify no direct test coverage exists.
+>
+> Flag categories: WRONG_FILE, WRONG_LINE (>±5), DRIFT (≤±5), CLAIM_MISMATCH,
+> MISSING_CITATION, OVER_CLAIMED_TEST, OVER_FLAGGED_INTERPOLATION,
+> UNDER_FLAGGED_INTERPOLATION.
+>
+> Output: one-line summary (N citations checked / N flagged), then findings grouped
+> by category using this shape per finding:
+> > **Requirement:** "name" | **Scenario:** "name" (or —)
+> > **Citation:** `file.ts:LINE` — "what REFERENCES.md claims"
+> > **Issue:** what's actually there
+> > **Suggested fix:** corrected range or note
+>
+> Close with: "OK to trust" (only DRIFT/OVER_FLAGGED are present or none) or
+> "Needs revision" (any other category present).
+
+Apply the corrections the agent returns before declaring the references file done.
+
+---
+
+## Constraints
+
+- Never skip Step 4 (REFERENCES.md) — the spec alone is not reviewable without citations
+- Never mark a scenario "Verified by test" unless you have read the test and confirmed the assertion
+- Always label interpolated claims explicitly — do not present them as verified
+- Run `bash scripts/openspec validate --strict` before reporting the spec as complete
+- Stack-agnostic means: no React, no Ember, no Glimmer, no TanStack, no ember-concurrency, no framework-specific lifecycle names in the spec body
+- The spec is about behavior; the REFERENCES.md is about evidence — keep them separate
+- If a legacy codebase is being compared to a new implementation, add a comparison table at the end of the spec (or as a separate `COMPARISON.md`) noting behavioral differences — these are product decisions, not errors
+
+## Output checklist
+
+- [ ] `openspec/specs/<capability>/spec.md` — validates with `bash scripts/openspec validate --strict`
+- [ ] `openspec/specs/<capability>/REFERENCES.md` — one entry per requirement and scenario
+- [ ] Cross-cutting interpretive notes section present with numbered items
+- [ ] Citation audit run (or explicitly deferred with reason)
+- [ ] If audit returned "Needs revision", corrections applied

--- a/.claude/skills/tighten-to-spec/SKILL.md
+++ b/.claude/skills/tighten-to-spec/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: tighten-to-spec
+description: Audit an implementation artifact (typically a SKILL.md, README, or module file) against its written OpenSpec spec. Surface concrete findings across five categories — non-compliance, overreach, redundancy, bloat, overcomplication — each with file:line citations. Interview the user on which findings to apply, then refactor. The complement to spec-baseline.
+triggers:
+  - "audit X against the spec"
+  - "tighten X to match the spec"
+  - "does X conform to the spec"
+  - "find drift between spec and implementation"
+  - "spec compliance audit"
+  - "tighten the implementation"
+allowed-tools: Read, Edit, Write, Grep, Glob, Bash, AskUserQuestion
+---
+
+# Tighten to Spec
+
+Audit an implementation artifact against its written behavioral spec, surface
+concrete findings, interview on scope, then apply the approved tightening edits.
+The pair to [`spec-baseline`](../spec-baseline/SKILL.md) — baseline produces the
+spec, this skill enforces it.
+
+## When to use this
+
+| Situation | Skill |
+|---|---|
+| You have a spec and an impl, and want to know how well they align | `/tighten-to-spec` |
+| You have code but no spec yet | `/spec-baseline` |
+| You want a generic 5-dimension quality score (no spec input) | `/polishkit:appraise` |
+
+---
+
+## Process
+
+### Step 1 — Identify the spec and implementation
+
+Confirm (or infer from context):
+- **Spec path** — the OpenSpec `spec.md`, typically `openspec/specs/<capability>/spec.md`
+- **Implementation path** — the artifact to audit (SKILL.md, README, module file, etc.)
+
+If either is missing or ambiguous, ask before proceeding. Do not invent a spec.
+
+### Step 2 — Read both artifacts
+
+Read the spec end to end first to load the behavioral contract into context.
+Then read the implementation top to bottom, noting line numbers as you go —
+every finding in step 3 must cite a specific line range.
+
+### Step 3 — Audit across five categories
+
+Walk the spec requirement-by-requirement and scenario-by-scenario, comparing
+each to the implementation. Group findings:
+
+1. **Non-compliance** — places where the implementation contradicts, omits, or
+   under-specifies a spec requirement. Cite the spec requirement name + impl
+   file:line.
+2. **Overreach** — places where the implementation adds constraints or
+   behaviors not in the spec. For each, note whether the directive belongs in
+   project-wide rules (CLAUDE.md, `_shared/` docs) or is a legitimate
+   skill-specific extension worth preserving.
+3. **Redundancy** — repeated information across sections (the same warning
+   stated multiple times; a constraints section that restates the body; a
+   reference + inline duplication that drifts).
+4. **Bloat** — content that adds no signal (verbose code blocks that should
+   reference a canonical doc; sibling descriptions that belong in the README;
+   excessive examples; commentary that doesn't change reader behavior).
+5. **Overcomplication** — structure that could be simpler (too many labeled
+   sections, defensive checks that duplicate framework guarantees, multi-layer
+   warnings, prompt scaffolding heavier than the underlying directive).
+
+For every finding, include the implementation file:line. Vague critique is
+unactionable.
+
+### Step 4 — Surface suggestions in priority order
+
+After the categorized findings, list concrete tightening suggestions in
+priority order. Each suggestion should be actionable in one edit — not "reconsider
+the whole thing." Where possible, estimate line savings.
+
+A good suggestion has the shape:
+> N. **<one-line action>** — what to replace, what with, and what's saved.
+
+### Step 5 — Interview the user on scope
+
+Use `AskUserQuestion` (max 4 questions per call) for any ambiguous decisions:
+- For category findings with non-obvious tradeoffs, present both interpretations
+- For "is this overreach or appropriate implementation detail?" cases, ask
+- For "remove this restated content" calls, confirm if it might serve a purpose
+  (scannability, onboarding)
+
+Skip the interview if the user has already given clear scope ("apply all" /
+"apply the top 3" / "just the redundancy fixes").
+
+### Step 6 — Apply the approved changes
+
+- For small, scattered edits, use `Edit`
+- For substantial restructuring (more than ~30% of the file), `Write` the new
+  version
+
+After each edit, if a validator exists for the spec format, re-run it (e.g.
+`bash scripts/openspec validate <capability> --type spec --strict`). The
+implementation edit shouldn't touch the spec, but a passing validator confirms
+the alignment claim.
+
+Report the line delta (before → after) and confirm every spec scenario still
+maps to a directive in the tightened implementation.
+
+---
+
+## Constraints
+
+- Never refactor an artifact without a written spec — the spec is the contract.
+  If no spec exists, run `/spec-baseline` first.
+- Every finding MUST cite implementation file:line. Vague critique is rejected.
+- Never silently expand scope beyond the file under audit. If a sibling file
+  looks worse, surface that as a separate suggestion; do not modify it.
+- Preserve behavioral coverage. After refactoring, every spec scenario MUST
+  still map to a directive in the implementation. If the coverage map would
+  break, the edit is wrong.
+- Tightening removes; it does not add. Do not introduce new abstractions,
+  helper functions, or shared utilities during a tightening pass. Those are
+  separate features.
+- If the audit produces zero findings, say so explicitly and stop. Manufactured
+  churn is worse than a no-op pass.
+- Re-validate the spec after refactoring to confirm alignment (the impl edit
+  shouldn't touch the spec, but the validator check is the discipline that
+  catches accidental drift).
+
+## Output checklist
+
+- [ ] Audit findings grouped into the five categories with file:line citations
+- [ ] Priority-ordered suggestions with estimated line savings where applicable
+- [ ] Interview turn (or explicit acknowledgement that scope was pre-decided)
+- [ ] Edits applied; line delta reported (before → after)
+- [ ] Spec validator re-run (if applicable) and still passing
+- [ ] Coverage check: every spec scenario still maps to an impl directive

--- a/openspec/README.md
+++ b/openspec/README.md
@@ -1,0 +1,32 @@
+# OpenSpec
+
+Behavioral specifications for capabilities in this repository.
+
+## Layout
+
+```
+openspec/
+  specs/
+    <capability>/
+      spec.md         # The OpenSpec specification (machine-validated)
+      REFERENCES.md   # Source citations backing every requirement and scenario
+  inventory/
+    modules/
+      <name>.md       # Optional module inventory briefs (maps, not specs)
+```
+
+## Validate a spec
+
+```bash
+bash scripts/openspec validate <capability> --type spec --strict
+```
+
+## Authoring
+
+**Baselining existing capabilities** — use `/spec-baseline` to reverse-engineer a spec
+from code that already exists. The output includes a `REFERENCES.md` that cites every
+requirement back to specific file:line evidence.
+
+**Proposing changes** — once a capability is baselined, use `/opsx:propose` to draft
+changes against the existing spec rather than modifying it directly. Proposed changes
+go through a review and apply workflow before the spec is updated.

--- a/openspec/specs/polishkit-appraise/REFERENCES.md
+++ b/openspec/specs/polishkit-appraise/REFERENCES.md
@@ -1,0 +1,125 @@
+# Appraise — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `repo-root/`.
+Line numbers verified on 2026-05-22.
+
+---
+
+## Requirement: Scope survey
+
+**Sources**
+- `plugins/polishkit/skills/appraise/SKILL.md:195-212` — `## Workflow` section defines the three scope tiers (single file / pasted code, directory or module, full repo) and the representative-sampling approach for large scopes
+- `plugins/polishkit/skills/appraise/SKILL.md:200-204` — "For repo-wide or module assessments, start with a structural survey" — survey steps: directory tree, entry points, domain/infrastructure/test identification, read a representative sample
+
+**Notes**
+- The "representative sample — don't try to read every file" constraint is explicit and intentional
+
+### Scenario: Single file scope
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:197-198` — "If it's a single file or pasted code → assess that directly"
+**Interpolated; no direct test.**
+
+### Scenario: Repository or module scope
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:200-207` — full structural survey workflow for non-single-file scopes.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Language detection and idiomatic lens
+
+**Sources**
+- `plugins/polishkit/skills/appraise/SKILL.md:17-28` — `## Supported Languages` section lists C#, Go, Python, TypeScript, React, Next.js and states "applying both universal principles and language-specific idiomatic standards"
+- `plugins/polishkit/skills/appraise/SKILL.md:207` — `## Workflow` step 3: "Detect the language(s) in use and activate the appropriate idiomatic lens."
+
+**Notes**
+- The specific languages supported (C#, Go, Python, TypeScript, React, Next.js) are listed in the implementation; the spec abstracts these as "detected language + associated framework" to remain stack-agnostic. The enumeration belongs here in REFERENCES.md.
+
+### Scenario: Language detected
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:207` — "Detect the language(s) in use and activate the appropriate idiomatic lens."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Five-dimension scoring
+
+**Sources**
+- `plugins/polishkit/skills/appraise/SKILL.md:32-127` — `## The Five Dimensions` section defines all five dimensions with 1–10 score anchors
+- `plugins/polishkit/skills/appraise/SKILL.md:142-148` — `## Scoring Formula` section with the exact weighted formula and rounding instruction
+- `plugins/polishkit/skills/appraise/SKILL.md:150-161` — `## Overall Verdict Tiers` table mapping score ranges to verdicts
+
+**Notes**
+- Dimension weights: Architecture 30%, Naming 25%, Algorithmic Elegance 20%, Testability 15%, Idiomatic Consistency 10%
+
+### Scenario: Overall score computed
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:142-148` — the scoring formula block, rounding instruction included.
+**Interpolated; no direct test.**
+
+### Scenario: Verdict tier assigned
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:150-161` — the tier table with five ranges.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Always-flag violations
+
+**Sources**
+- `plugins/polishkit/skills/appraise/SKILL.md:128-139` — `## Always-Flag Violations` table listing five violation types: god classes, magic numbers/strings, comments that restate code, functions >~30 lines, files >~300 lines
+- `plugins/polishkit/skills/appraise/SKILL.md:183-188` — `### Violations` subsection of Report Structure: "List any always-flag violations found / Reference specific files/lines"
+
+### Scenario: God class present
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:131` — "God classes / god objects — A class doing too much is the antithesis of clean architecture."
+**Interpolated; no direct test.**
+
+### Scenario: Oversized function present
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:135` — "Functions exceeding ~30 lines — Long functions almost always do more than one thing."
+**Interpolated; no direct test.**
+
+### Scenario: No violations found
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:183-188` — the Violations section is always present in the report structure; content is the findings or absence thereof.
+**Interpolated from absence** — the SKILL.md does not explicitly state what to write when no violations are found; the spec's "states that no violations were found" behavior is inferred.
+
+---
+
+## Requirement: Report structure and length
+
+**Sources**
+- `plugins/polishkit/skills/appraise/SKILL.md:163-191` — `## Report Structure` defines the five-section order and content expectations for each
+- `plugins/polishkit/skills/appraise/SKILL.md:14-15` — length cap: "The entire report must stay under **500 lines**. Brevity is itself a form of elegance."
+- `plugins/polishkit/skills/appraise/SKILL.md:165-172` — `### Executive Summary` required elements: score, verdict, one-sentence characterization, most beautiful thing, most impactful improvement
+- `plugins/polishkit/skills/appraise/SKILL.md:173-177` — `### Beauty Highlights` 2–5 instances with principle named
+- `plugins/polishkit/skills/appraise/SKILL.md:218` — "Stay under 500 lines total. Be precise."
+
+### Scenario: Sections appear in prescribed order
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:163-191` — the five sections are listed in the prescribed order.
+**Interpolated; no direct test.**
+
+### Scenario: Report stays under length limit
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:14-15` and `plugins/polishkit/skills/appraise/SKILL.md:218` — two explicit 500-line cap statements.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Read-only operation
+
+**Sources**
+- `plugins/polishkit/skills/appraise/SKILL.md:1-3` — description frontmatter: "Produces a scored report" — no mention of file changes
+- `plugins/polishkit/skills/appraise/SKILL.md:193-218` — `## Workflow` section: all steps are read/survey/score/produce-report with no write, commit, push, or PR creation steps present
+
+**Notes**
+- The read-only constraint is interpolated from absence — the SKILL.md contains no write, edit, commit, or push instructions. There is no explicit "do not modify files" statement.
+
+### Scenario: Assessment completes
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:193-218` — the entire workflow has no file-write steps.
+**Interpolated from absence** — read-only behavior is defined by the absence of write operations in the workflow, not by an explicit prohibition.
+
+---
+
+## Cross-cutting interpretive notes
+
+1. **Read-only is interpolated from absence, not stated.** The SKILL.md never says "do not modify files" — the read-only constraint is inferred from the complete absence of write/edit/commit/push steps in the workflow. A future change adding a step with side effects would not contradict an explicit prohibition. This is the primary claim requiring human reviewer attention.
+
+2. **"No violations found" messaging is interpolated.** The SKILL.md specifies the Violations section must exist in the report structure and must reference specific files/lines, but does not define what to write when nothing is found. The spec's "states that no violations were found" wording is an interpretation of the intent.
+
+3. **No test coverage exists for any scenario.** Appraise has no test suite. All scenarios are interpolated from the skill's prompt instructions.
+
+4. **500-line cap is a behavioral commitment.** The cap appears twice (lines 14–15 and 218) with "brevity is itself a form of elegance" framing. This is a deliberate quality signal, not just a practicality — worth preserving in any future rewrites of the skill.

--- a/openspec/specs/polishkit-appraise/spec.md
+++ b/openspec/specs/polishkit-appraise/spec.md
@@ -1,0 +1,68 @@
+# Appraise
+
+## Purpose
+Appraise produces a scored, read-only quality assessment of code across five weighted dimensions — architecture, naming, algorithmic elegance, testability, and idiomatic consistency — with beauty highlights and violation flags. It is a connoisseur-style evaluation tool that leads with genuine craft observations before surfacing improvement opportunities.
+
+## Requirements
+
+### Requirement: Scope survey
+Appraise SHALL determine the target scope from user input and read enough representative code to support scoring. For a single file or pasted snippet, it reads that content directly. For a directory or module, it surveys the structure and reads key files. For a full repository, it surveys the project structure, identifies architectural boundaries, and samples representative files across layers. Appraise SHALL NOT attempt to read every file in a large scope; representative sampling is sufficient.
+
+#### Scenario: Single file scope
+- **WHEN** a single file path or code snippet is provided
+- **THEN** Appraise reads that content directly and bases its assessment on it
+
+#### Scenario: Repository or module scope
+- **WHEN** a directory, module path, or no scope is provided
+- **THEN** Appraise surveys the directory tree, identifies entry points and architectural layers, and reads a representative cross-section before scoring
+
+### Requirement: Language detection and idiomatic lens
+Appraise SHALL detect the primary language(s) present in the scope. For each detected language, Appraise SHALL apply that language's idiomatic standards when scoring the Idiomatic Consistency dimension alongside universal principles. Where a language has an associated application framework in widespread use, Appraise SHALL additionally apply that framework's conventions.
+
+#### Scenario: Language detected
+- **WHEN** a primary language is identifiable in the scope
+- **THEN** Appraise applies that language's idiomatic standards for the Idiomatic Consistency dimension
+
+### Requirement: Five-dimension scoring
+Appraise SHALL score the code across exactly five dimensions. Each dimension MUST be scored on a 1–10 scale. The overall score SHALL be the weighted sum: Architecture & Separation of Concerns (30%), Naming & Readability (25%), Algorithmic Elegance (20%), Testability & Test Design (15%), Idiomatic Consistency (10%), rounded to one decimal place.
+
+#### Scenario: Overall score computed
+- **WHEN** all five dimension scores are assigned
+- **THEN** overall score = (Architecture × 0.30) + (Naming × 0.25) + (Algorithmic Elegance × 0.20) + (Testability × 0.15) + (Idiomatic Consistency × 0.10), rounded to one decimal place
+
+#### Scenario: Verdict tier assigned
+- **WHEN** the overall score is computed
+- **THEN** a verdict tier is assigned: 9.0–10.0 Masterwork, 7.5–8.9 Polished, 6.0–7.4 Competent, 4.0–5.9 Rough, 1.0–3.9 Needs Rethinking
+
+### Requirement: Always-flag violations
+Regardless of dimension scores, Appraise SHALL flag any of the following when found: god classes or god objects; magic numbers or magic strings; comments that restate what the code does; functions exceeding approximately 30 lines; files exceeding approximately 300 lines. These SHALL appear in a dedicated Violations section.
+
+#### Scenario: God class present
+- **WHEN** a class, module, or file carries multiple unrelated responsibilities beyond a single clear purpose
+- **THEN** it is flagged in the Violations section with a file reference
+
+#### Scenario: Oversized function present
+- **WHEN** a function body exceeds approximately 30 lines
+- **THEN** it is flagged in the Violations section with a file:line reference
+
+#### Scenario: No violations found
+- **WHEN** none of the always-flag conditions are present
+- **THEN** the Violations section states that no violations were found
+
+### Requirement: Report structure and length
+Appraise SHALL produce its output in this section order: Executive Summary, Beauty Highlights, Dimension Breakdown, Violations, Closing Note. The report MUST stay under 500 lines total. The Executive Summary MUST include the overall score, verdict tier, a one-sentence characterization of the codebase, the single most beautiful thing observed, and the single most impactful improvement opportunity. The Beauty Highlights section MUST call out 2–5 specific instances of genuinely elegant code with the principle at work named.
+
+#### Scenario: Sections appear in prescribed order
+- **WHEN** Appraise produces its report
+- **THEN** sections appear in the order: Executive Summary → Beauty Highlights → Dimension Breakdown → Violations → Closing Note
+
+#### Scenario: Report stays under length limit
+- **WHEN** Appraise produces its report
+- **THEN** the total output is under 500 lines
+
+### Requirement: Read-only operation
+Appraise SHALL NOT modify, create, or delete any files. It SHALL NOT create branches or open pull requests. Its only output is the scored report delivered in the current conversation.
+
+#### Scenario: Assessment completes
+- **WHEN** Appraise finishes its assessment
+- **THEN** no files have been created, modified, or deleted and no branches or PRs exist as a result of the invocation

--- a/openspec/specs/polishkit-polish/REFERENCES.md
+++ b/openspec/specs/polishkit-polish/REFERENCES.md
@@ -1,0 +1,187 @@
+# Polish — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `repo-root/`.
+Line numbers verified on 2026-05-22.
+
+---
+
+## Requirement: Scope intake
+
+**Sources**
+- `plugins/polishkit/skills/polish/SKILL.md:27-43` — `## Input` section defines the three accepted scope forms (path, glob, cross-cutting concern) and the `--model`, `--agent`, `--max-files`, `--base`, `--dry-run` flags
+- `plugins/polishkit/skills/polish/SKILL.md:47-59` — `### 1. Resolve scope` specifies enumerate-and-pass-verbatim for path/glob, theme+boundary decomposition for concern, and the slug derivation
+- `plugins/polishkit/skills/polish/SKILL.md:42-43` — empty-scope prompt text: `"What scope should I polish? (path, glob, or cross-cutting concern + scope hint)"`
+
+**Notes**
+- The "pass file list verbatim" contract is explicit ("Pass the resolved file list to the agent verbatim so it doesn't re-discover scope")
+
+### Scenario: Path or glob scope provided
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:47-49` — "For a path/glob, list files that match." and the verbatim-pass instruction.
+**Interpolated; no direct test.**
+
+### Scenario: Cross-cutting concern scope provided
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:49-50` — "For a cross-cutting concern, treat the description as the agent's *theme* and the path/glob hint as the *file boundary* — pass both to the agent."
+**Interpolated; no direct test.**
+
+### Scenario: No scope provided
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:42-43` — the inline prompt string shown when `<scope>` is empty.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Verify command detection
+
+**Sources**
+- `plugins/polishkit/skills/polish/SKILL.md:61-75` — `### 2. Detect the project's verify commands` specifies the full priority order (CLAUDE.md → package.json → Makefile → language defaults) and the ask-user fallback
+- `plugins/polishkit/skills/polish/SKILL.md:73-74` — "If nothing matches, ask the user for the verify command before dispatching. Never invent a command the repo doesn't expose."
+
+**Notes**
+- Watch-mode exclusion is explicit: "Skip watch-mode scripts"
+
+### Scenario: Verify command found in package.json
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:67-69` — package.json scripts detection priority list: typecheck, test:run, test, lint.
+**Interpolated; no direct test.**
+
+### Scenario: No verify command detectable
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:73-74` — explicit ask-user fallback when nothing matches.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: PR base branch resolution
+
+**Sources**
+- `plugins/polishkit/skills/polish/SKILL.md:77-118` — `### 3. Resolve the PR base branch` — full 5-step resolution chain with inline bash pseudocode
+- `plugins/polishkit/skills/polish/SKILL.md:83-90` — step 1 (explicit `--base` arg extraction)
+- `plugins/polishkit/skills/polish/SKILL.md:92-94` — step 2 (`claude.polishkit.prBase`)
+- `plugins/polishkit/skills/polish/SKILL.md:96-99` — step 3 (`claude.flowkit.prBase` courtesy interop)
+- `plugins/polishkit/skills/polish/SKILL.md:101-105` — step 4 (develop if on remote)
+- `plugins/polishkit/skills/polish/SKILL.md:107-113` — step 5 (repo default with warning)
+- `plugins/polishkit/skills/polish/SKILL.md:116` — "The agent must use it for both the branch cut **and** the `gh pr create --base` argument."
+
+**Notes**
+- The flowkit interop is explicitly labeled best-effort: "The flowkit read at step 3 is best-effort interop only — polishkit works without flowkit installed."
+- This chain was introduced in commit `3469b50` (fix: resolve PR base via flowkit chain) and the canonical spec was extracted in `8a61f87` (refactor: extract canonical base-resolution spec)
+
+### Scenario: Explicit --base overrides all config
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:83-90` — step 1 bash block checks for `--base` first before any config read.
+**Interpolated; no direct test.**
+
+### Scenario: Polishkit config key present
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:92-94` — step 2 reads `claude.polishkit.prBase`.
+**Interpolated; no direct test.**
+
+### Scenario: Fallback to develop
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:101-105` — step 4 checks `git ls-remote --heads origin develop`.
+**Interpolated; no direct test.**
+
+### Scenario: Fallback to repo default with warning
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:107-113` — step 5 uses `gh repo view` for default branch and echoes warning to stderr.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Isolated single-agent dispatch
+
+**Sources**
+- `plugins/polishkit/skills/polish/SKILL.md:122-131` — `### 4. Dispatch the subagent` specifies `subagent_type: general-purpose`, `isolation: worktree`, `mode: bypassPermissions`, `run_in_background: true`
+- `plugins/polishkit/skills/polish/SKILL.md:186-187` — constraint: "One agent per invocation, one PR per agent. Never fan out multiple polish agents on the same scope."
+
+**Notes**
+- The `run_in_background: true` is the source of the "orchestrator does not block" behavior
+
+### Scenario: Agent dispatched
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:126-130` — Agent tool call shape with all four parameters specified.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Semantic fix application
+
+**Sources**
+- `plugins/polishkit/skills/polish/SKILL.md:136-143` — `**TASK**` section defines the three review heuristic categories: Reuse, Quality, Efficiency
+- `plugins/polishkit/skills/polish/SKILL.md:144-146` — "For a cross-cutting theme, prioritize fixes matching that theme; deprioritize everything else (mention as deferred findings, don't fix)."
+- `plugins/polishkit/skills/polish/SKILL.md:147-149` — `**RESPECT BEHAVIOR**` clause: public surfaces stay compatible; behavior-changing fixes go to deferred findings section
+
+### Scenario: Theme-filtered pass
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:144-146` — explicit theme priority instruction with deferred-findings disposition.
+**Interpolated; no direct test.**
+
+### Scenario: Public contract preserved
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:147-149` — "keep public surfaces compatible. If a fix would change a public contract, leave it untouched and surface in the PR's `## Findings deferred to issues` section with file:line refs."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: File cap enforcement
+
+**Sources**
+- `plugins/polishkit/skills/polish/SKILL.md:35-36` — `--max-files <N>` input flag definition with default of 15
+- `plugins/polishkit/skills/polish/SKILL.md:150-152` — `**SOFT CAP**` clause specifying cap behavior and deferred-findings disposition for excess
+- `plugins/polishkit/skills/polish/SKILL.md:187-188` — constraint restating the cap philosophy: "if scope is so large the agent wants to touch >50 files, it should narrow"
+
+### Scenario: Scope within cap
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:150` — implicit: cap only activates when exceeded.
+**Interpolated; no direct test.**
+
+### Scenario: Scope exceeds cap
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:150-152` — "If the scope clearly exceeds the cap, fix the highest-impact subset and list the rest under deferred findings."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Green-build gate
+
+**Sources**
+- `plugins/polishkit/skills/polish/SKILL.md:157-158` — workflow step 4: "Verify by running every command in `VERIFY_COMMANDS`... All MUST pass before push. If any fails, iterate until green or revert the breaking edit and list it as deferred."
+- `plugins/polishkit/skills/polish/SKILL.md:194` — constraint: "Verify must be green before push. Red builds are never acceptable, even for 'lightweight' passes."
+
+### Scenario: All verify commands pass
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:157-158` — "All MUST pass before push."
+**Interpolated; no direct test.**
+
+### Scenario: Verify command fails after an edit
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:158` — "If any fails, iterate until green or revert the breaking edit and list it as deferred."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Single PR delivery
+
+**Sources**
+- `plugins/polishkit/skills/polish/SKILL.md:159-160` — workflow step 5: push and open PR with `--base "$BASE_BRANCH"` explicitly; warning about omitting `--base`
+- `plugins/polishkit/skills/polish/SKILL.md:162-170` — `**PR BODY SHAPE**` clause defining the canonical four-section structure including the extra `## Findings deferred to issues`
+- `plugins/polishkit/skills/polish/SKILL.md:172-175` — `**NO-OP IS LEGITIMATE**` clause: "if the pass finds nothing actionable in the scope, open the PR anyway"
+
+### Scenario: Fixes applied and verified
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:159-160` — push and PR creation step, explicit `--base` requirement.
+**Interpolated; no direct test.**
+
+### Scenario: No actionable fixes found
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:172-175` — "open the PR anyway with `## Summary` stating `no actionable simplifications found`"
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Dry-run mode
+
+**Sources**
+- `plugins/polishkit/skills/polish/SKILL.md:38-39` — `--dry-run` flag definition in `## Input`
+- `plugins/polishkit/skills/polish/SKILL.md:177-179` — `### 5. Dry-run mode`: "the agent skips the apply/commit/push phase and instead returns a structured findings report inline (not as a PR)"
+
+### Scenario: Dry-run invocation
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:177-179` — dry-run mode definition.
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. **No test coverage exists for any scenario.** The SKILL.md is entirely prompt-based instruction; there is no test suite for polishkit skills. Every scenario in the spec is interpolated from the skill's written instructions rather than verified by an automated assertion.
+
+2. **"Isolated worktree" guarantee is structural, not tested.** The `isolation: worktree` parameter on the Agent call is the mechanism — the spec says the agent MUST run in a worktree, but whether the harness enforces this is outside the skill's own control.
+
+3. **Base-resolution chain order for flowkit interop.** The chain was authored with flowkit absent as a valid state. The courtesy read of `claude.flowkit.prBase` at step 3 is intentionally placed after polishkit's own key — this ordering was a deliberate product decision (commit `3469b50`, `8a61f87`).
+
+4. **No-op PR is the defined termination condition.** Polish explicitly rejects "manufactured churn" — the no-op PR is a first-class outcome, not a degenerate case. This is a behavioral commitment worth reviewing against any future changes to the skill.

--- a/openspec/specs/polishkit-polish/spec.md
+++ b/openspec/specs/polishkit-polish/spec.md
@@ -1,0 +1,97 @@
+# Polish
+
+## Purpose
+Polish applies semantic code-quality fixes — reuse, quality, and efficiency — across a user-specified scope in an isolated worktree and opens one PR. It is a lightweight, single-pass, single-agent cleanup tool for targeted cross-cutting improvements that preserves public contracts and gates on a green build before pushing.
+
+## Requirements
+
+### Requirement: Scope intake
+Polish SHALL accept a scope as a path, glob, or cross-cutting concern with a scope hint. For a path or glob, Polish SHALL enumerate matching files and pass them verbatim to the dispatched agent. For a cross-cutting concern, the description serves as the agent theme and the accompanying hint defines the file boundary. If no scope is provided, Polish SHALL prompt the user before proceeding.
+
+#### Scenario: Path or glob scope provided
+- **WHEN** the user provides a path or glob (e.g. `src/hooks/`)
+- **THEN** Polish resolves all matching files and passes the explicit list to the agent
+
+#### Scenario: Cross-cutting concern scope provided
+- **WHEN** the user provides a natural-language concern with a scope hint (e.g. `error handling in src/providers/`)
+- **THEN** Polish passes the concern description as the agent theme and the hint as the file boundary
+
+#### Scenario: No scope provided
+- **WHEN** the invocation includes no scope argument
+- **THEN** Polish prompts the user for a scope before dispatching any agent
+
+### Requirement: Verify command detection
+Before dispatching, Polish SHALL detect the project's canonical typecheck and test commands. If no command is found, Polish SHALL ask the user before dispatching.
+
+#### Scenario: Verify command found
+- **WHEN** at least one canonical typecheck or test command is detectable in the project
+- **THEN** Polish passes that command to the agent as the verify step
+
+#### Scenario: No verify command detectable
+- **WHEN** no verify command is found
+- **THEN** Polish asks the user for the verify command before dispatching
+
+### Requirement: PR base branch resolution
+Polish SHALL resolve a base branch before dispatching, preferring explicit arguments over configuration over remote defaults. The resolved base MUST be used for both the branch cut and the `gh pr create --base` argument.
+
+#### Scenario: Explicit --base overrides all
+- **WHEN** `--base <branch>` is present in the arguments
+- **THEN** that branch is used as the PR base, bypassing all other resolution
+
+#### Scenario: No resolvable configured base
+- **WHEN** no explicit arg, config key, or known remote branch resolves a base
+- **THEN** the repository default branch is used and a warning is emitted
+
+### Requirement: Isolated single-agent dispatch
+Polish SHALL dispatch exactly one agent per invocation. Polish MUST run all fix work in an isolated worktree, in bypassPermissions mode, and in the background. Polish MUST NOT dispatch more than one agent per invocation.
+
+#### Scenario: Agent dispatched
+- **WHEN** Polish is invoked with a valid scope
+- **THEN** exactly one agent runs in an isolated worktree and Polish returns without blocking on the agent's completion
+
+### Requirement: Semantic fix application
+Polish SHALL apply fixes across three categories: reuse (duplicated logic; inlined alternatives where an existing helper exists), quality (unclear naming, dead code, weak error handling, type hygiene gaps), and efficiency (quadratic loops where linear is possible, redundant async waits, unnecessary recomputations). When a cross-cutting theme is given, Polish SHALL prioritize only fixes matching that theme and defer all others to the PR's deferred findings section. Polish SHALL NOT change any public contract; such fixes MUST be deferred with a file:line reference.
+
+#### Scenario: Theme-filtered pass
+- **WHEN** a cross-cutting concern theme is provided
+- **THEN** Polish applies only fixes relevant to that theme and lists all other findings as deferred
+
+#### Scenario: Public contract preserved
+- **WHEN** a fix would alter an exported or public API surface
+- **THEN** Polish leaves the code unchanged and lists it in deferred findings with a file:line reference
+
+### Requirement: File cap enforcement
+Polish SHALL not touch more than the configured max-files limit (default: 15) in a single PR. If the actionable scope exceeds the cap, Polish SHALL fix the highest-impact subset and list the remainder as deferred findings.
+
+#### Scenario: Scope exceeds cap
+- **WHEN** the number of actionable files exceeds max-files
+- **THEN** Polish fixes the highest-impact subset up to the cap and lists remaining files as deferred findings
+
+### Requirement: Green-build gate
+Polish SHALL run every command in VERIFY_COMMANDS before pushing. All commands MUST pass. If a command fails after an edit, Polish SHALL iterate to fix the failure or revert that specific edit and list it as deferred. A failing build MUST NOT be pushed.
+
+#### Scenario: All verify commands pass
+- **WHEN** all VERIFY_COMMANDS pass after edits are applied
+- **THEN** Polish proceeds to push and open the PR
+
+#### Scenario: Verify command fails after an edit
+- **WHEN** a verify command fails following a specific edit
+- **THEN** Polish either resolves the failure or reverts that edit and adds it to deferred findings before pushing
+
+### Requirement: Single PR delivery
+Polish SHALL open exactly one PR per invocation targeting the resolved base branch. The PR body MUST follow the canonical shape (## Summary / ## Changes / ## Test plan / ## Findings deferred to issues). The `gh pr create` call MUST include `--base <BASE_BRANCH>` explicitly. A no-op result — scope examined but no actionable fixes found — is valid; Polish SHALL open a PR in that case stating no actionable simplifications were found.
+
+#### Scenario: Fixes applied and verified
+- **WHEN** Polish applies at least one edit that passes all verify commands
+- **THEN** exactly one PR is opened against the resolved base with a canonical body
+
+#### Scenario: No actionable fixes found
+- **WHEN** Polish finds nothing to change in the scope
+- **THEN** one PR is still opened with "no actionable simplifications found" in ## Summary
+
+### Requirement: Dry-run mode
+When `--dry-run` is provided, Polish SHALL report findings inline without applying any edits, committing, pushing, or opening a PR.
+
+#### Scenario: Dry-run invocation
+- **WHEN** `--dry-run` is present in the arguments
+- **THEN** Polish produces a structured findings report in the conversation and makes no file changes

--- a/openspec/specs/polishkit-sweep/REFERENCES.md
+++ b/openspec/specs/polishkit-sweep/REFERENCES.md
@@ -1,0 +1,133 @@
+# Sweep — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `repo-root/`.
+Line numbers verified on 2026-05-22.
+
+---
+
+## Requirement: Scope intake
+
+**Sources**
+- `plugins/polishkit/skills/sweep/SKILL.md:24-31` — `## Scope` section defines the three scope forms: path/glob, category hint, empty (full sweep)
+- `plugins/polishkit/skills/sweep/SKILL.md:35-36` — "Phases are independent — if scope restricts to one, skip the other."
+
+### Scenario: Full sweep (no scope)
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:26-27` — "Empty — run everything."
+**Interpolated; no direct test.**
+
+### Scenario: Path or glob scope
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:28-29` — "A path or glob (`src/components/`, `**/*.test.ts`) — restricts both phases to that subtree."
+**Interpolated; no direct test.**
+
+### Scenario: Category hint scope
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:30-31` — "A category hint (`dead-code-only`, `cruft-only`, `git-only`) — runs just the matching phase."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Dead code detection
+
+**Sources**
+- `plugins/polishkit/skills/sweep/SKILL.md:39-47` — `#### 1.1 Detect language and available tools` — TypeScript/JavaScript, Python, Go detection commands
+- `plugins/polishkit/skills/sweep/SKILL.md:49-95` — `#### 1.2 Scan for dead code` — per-language scan commands for unused exports, imports, dead variables, commented-out code
+- `plugins/polishkit/skills/sweep/SKILL.md:86-90` — exclusion list: node_modules/, dist/, build/, .next/, generated files (*.generated.ts, *.d.ts), test files
+
+**Notes**
+- The test-file exclusion rationale is stated explicitly: "dead code in tests can be intentional fixtures"
+
+### Scenario: TypeScript project scanned
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:63-68` — ts-prune for unused exports; `plugins/polishkit/skills/sweep/SKILL.md:72-73` — tsc --noEmit for noUnusedLocals/noUnusedParameters.
+**Interpolated; no direct test.**
+
+### Scenario: Test files excluded
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:89-90` — "Test files (dead code in tests can be intentional fixtures)" in the exclusion list.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Cruft detection
+
+**Sources**
+- `plugins/polishkit/skills/sweep/SKILL.md:105-165` — `### Phase 2 — Cruft & Hygiene` — full set of parallel checks
+- `plugins/polishkit/skills/sweep/SKILL.md:107-112` — stale documentation checks
+- `plugins/polishkit/skills/sweep/SKILL.md:113-117` — build artifacts and dead directories
+- `plugins/polishkit/skills/sweep/SKILL.md:118-123` — documentation gaps
+- `plugins/polishkit/skills/sweep/SKILL.md:124-127` — duplicate content
+- `plugins/polishkit/skills/sweep/SKILL.md:129-164` — git hygiene including the remote merged-branch classification loop
+
+**Notes**
+- The remote merged-PR branch classification was added in commit `d7f7836` (docs: cover remote merged PR branches). Prior to that commit only local branch hygiene was covered.
+- The `parked/*` prefix exemption in the remote branch filter is an implicit convention in this repo.
+
+### Scenario: Remote branch classification
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:133-151` — the bash loop that fetches, lists non-default/non-parked branches, and classifies each by PR state using `gh pr list`.
+**Interpolated; no direct test.**
+
+### Scenario: Only merged-PR branches proposed for deletion
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:153-161` — the deletion policy table: MERGED → propose deletion; CLOSED / OPEN / NO PR → preserve.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Remote branch deletion safety
+
+**Sources**
+- `plugins/polishkit/skills/sweep/SKILL.md:162-165` — "When deleting, **always use the disambiguated refspec form** (`git push origin :refs/heads/<branch>`). The unqualified `git push origin --delete <branch>` fails with `src refspec matches more than one` whenever a same-named tag exists"
+- `plugins/polishkit/skills/sweep/SKILL.md:164-167` — batch form: `git push origin :refs/heads/branch-a :refs/heads/branch-b`
+
+**Notes**
+- The motivation is explicit: the `rc/YYYY-MM-DD.N` tag shape from `flowkit:cut` is the canonical collision case. This was added in commit `d7f7836`.
+
+### Scenario: Single remote branch deletion
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:162-163` — disambiguated refspec instruction.
+**Interpolated; no direct test.**
+
+### Scenario: Multiple remote branch deletions
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:165-167` — batch push form shown explicitly.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Interactive confirmation
+
+**Sources**
+- `plugins/polishkit/skills/sweep/SKILL.md:168-181` — `### 3. Present findings and confirm each action` — combined Remove/Update/Keep summary, AskUserQuestion batching at most 4, grouping related items, wait-for-all-answers before step 4
+- `plugins/polishkit/skills/sweep/SKILL.md:176-180` — specific AskUserQuestion call conventions: batch ≤4, group related, default first option to recommended
+
+### Scenario: Confirmation collected before execution
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:181` — "Wait for all answers before proceeding to step 4."
+**Interpolated; no direct test.**
+
+### Scenario: Question batching
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:175` — "Use `AskUserQuestion` to confirm each proposed action, batched in groups of at most 4 questions per call."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Cleanup execution and commit
+
+**Sources**
+- `plugins/polishkit/skills/sweep/SKILL.md:182-191` — `### 4. Execute cleanup` — apply, tsc verify, re-run project verify, commit message `chore: sweep codebase`, PR targeting base branch with develop-then-default fallback
+
+### Scenario: Post-removal parse check
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:184-185` — "For dead-code removals, verify the file still parses — run `tsc --noEmit` or the language equivalent if available."
+**Interpolated; no direct test.**
+
+### Scenario: Commit and PR opened
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:187-191` — "Commit with `chore: sweep codebase` and open a PR targeting the project's base branch (auto-detect `develop` then fall back to `main`)."
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. **No test coverage exists for any scenario.** Sweep has no test suite. All scenarios are interpolated from the skill's prompt instructions.
+
+2. **Remote branch deletion safety was retroactively added.** The disambiguated refspec requirement was introduced in commit `d7f7836` specifically to prevent collisions with `rc/YYYY-MM-DD.N` tags created by `flowkit:cut`. Any revision to the sweep skill that touches the deletion path must preserve this form.
+
+3. **"Cruft detection" PR base branch fallback is simpler than polish's.** Sweep uses a two-step fallback (`develop` then repo default) without reading any git config keys. This is intentional — sweep is a maintenance operation that targets the integration branch directly rather than requiring explicit base configuration.
+
+4. **Parked branch exemption is implied, not documented inline.** The remote branch filter excludes `^(develop|main|gh-pages|parked/.*)$` — the `parked/*` prefix is an implicit repo convention not explained in the skill prose. A reviewer should verify this is the correct set of protected branch patterns for this repo.
+
+5. **Phase independence is stated but not enforced programmatically.** The skill says "Phases are independent — if scope restricts to one, skip the other," but there is no guard preventing both phases from running when a category hint is given. This is a behavioral claim interpolated from prose, not from any gate condition in the code.

--- a/openspec/specs/polishkit-sweep/spec.md
+++ b/openspec/specs/polishkit-sweep/spec.md
@@ -1,0 +1,76 @@
+# Sweep
+
+## Purpose
+Sweep removes accumulated cruft from a codebase in two coordinated phases — dead code (unused exports, imports, variables, unreachable branches) and stale artifacts (outdated docs, build leftovers, duplicate content, merged remote branches) — with interactive confirmation before any changes are applied. It is the hygiene counterpart to Polish, focused on safe removal with user control over every action.
+
+## Requirements
+
+### Requirement: Scope intake
+Sweep SHALL accept an optional scope argument that restricts processing. A path or glob restricts both phases to that subtree. A category hint (dead-code-only, cruft-only, git-only) restricts to the matching phase. An absent scope runs both phases across the full repository.
+
+#### Scenario: Full sweep (no scope)
+- **WHEN** no scope argument is provided
+- **THEN** both Phase 1 (dead code) and Phase 2 (cruft) run across the full repository
+
+#### Scenario: Path or glob scope
+- **WHEN** a path or glob is provided
+- **THEN** both phases are restricted to that subtree
+
+#### Scenario: Category hint scope
+- **WHEN** a category hint such as `dead-code-only`, `cruft-only`, or `git-only` is provided
+- **THEN** only the phase matching that hint runs
+
+### Requirement: Dead code detection
+Sweep SHALL detect the primary language(s) and available static analysis tools before scanning. It SHALL scan for unused exports, unused imports, dead variables, unreachable branches, and commented-out code blocks using the most capable tool available for each language. Findings SHALL be skipped for node_modules/, dist/, build/, .next/, generated files (*.generated.ts, *.d.ts), and test files.
+
+#### Scenario: TypeScript project scanned
+- **WHEN** a TypeScript project is detected
+- **THEN** Sweep uses ts-prune (if available) for unused exports and tsc --noEmit for unused locals and unreachable branches
+
+#### Scenario: Test files excluded
+- **WHEN** a dead-code candidate is located in a test file
+- **THEN** it is excluded from findings
+
+### Requirement: Cruft detection
+Sweep SHALL check for stale documentation (WIP or tracking files referencing completed work; PRDs for shipped features), build artifacts and dead directories (empty directories, committed build output not in .gitignore), documentation gaps (README or user-facing docs not reflecting current features), duplicate content (root-level files duplicating content already in docs/), and git hygiene (local merged branches, stale worktrees, orphaned remote-tracking branches, and remote branches tied to merged PRs).
+
+#### Scenario: Remote branch classification
+- **WHEN** Phase 2 runs
+- **THEN** Sweep fetches the remote, lists all non-default non-parked remote branches, and classifies each by its PR state: MERGED, CLOSED, OPEN, or NO PR
+
+#### Scenario: Only merged-PR branches proposed for deletion
+- **WHEN** remote branches are classified
+- **THEN** only MERGED branches are proposed for deletion; CLOSED, OPEN, and NO PR branches are preserved
+
+### Requirement: Remote branch deletion safety
+When deleting remote branches, Sweep SHALL use the disambiguated refspec form `git push origin :refs/heads/<branch>` rather than `git push origin --delete <branch>`. Multiple deletions SHALL be batched into a single push call. This prevents failures when a same-named tag exists.
+
+#### Scenario: Single remote branch deletion
+- **WHEN** one remote branch is confirmed for deletion
+- **THEN** deletion uses `git push origin :refs/heads/<branch>`
+
+#### Scenario: Multiple remote branch deletions
+- **WHEN** more than one remote branch is confirmed for deletion
+- **THEN** all are batched into a single `git push origin :refs/heads/<a> :refs/heads/<b>` call
+
+### Requirement: Interactive confirmation
+Before executing any changes, Sweep SHALL compile all findings from both phases into a combined Remove / Update / Keep summary and confirm each proposed action via AskUserQuestion. Questions SHALL be batched with at most 4 questions per call. Closely related items SHALL be grouped into a single question. Sweep SHALL wait for all answers before executing any change.
+
+#### Scenario: Confirmation collected before execution
+- **WHEN** findings are compiled
+- **THEN** Sweep presents all proposed actions and waits for complete user confirmation before modifying any file or running any command
+
+#### Scenario: Question batching
+- **WHEN** more than 4 independent confirmations are needed
+- **THEN** questions are spread across multiple AskUserQuestion calls with at most 4 questions each
+
+### Requirement: Cleanup execution and commit
+After confirmation, Sweep SHALL apply all approved removals and edits, verify that modified source files still parse (tsc --noEmit or language equivalent), re-run the project's verify command if one is available, commit with the message `chore: sweep codebase`, and open a PR targeting the project's base branch (develop if it exists on the remote, otherwise the repository default).
+
+#### Scenario: Post-removal parse check
+- **WHEN** dead code is removed from a source file
+- **THEN** Sweep verifies the file still parses before committing
+
+#### Scenario: Commit and PR opened
+- **WHEN** all approved changes are applied and verification passes
+- **THEN** Sweep commits with `chore: sweep codebase` and opens a PR targeting develop, or the repository default if develop does not exist

--- a/plugins/polishkit/skills/appraise/SKILL.md
+++ b/plugins/polishkit/skills/appraise/SKILL.md
@@ -11,21 +11,8 @@ You are a **code connoisseur** — an expert with refined taste who appreciates 
 
 - **Appreciative first.** Always lead with what is done well. Genuine beauty deserves recognition before any flaw is discussed.
 - **Precise, not pedantic.** Name the principle at stake. Don't nitpick semicolons or trailing whitespace — that's what formatters are for.
-- **Refined, not harsh.** Think wine critic, not drill sergeant. "This service layer has a lovely single-responsibility discipline" rather than "LGTM." And "This god class is shouldering burdens it shouldn't bear" rather than "BAD: too many responsibilities."
+- **Refined, not harsh.** Think wine critic, not drill sergeant. Prefer "This god class is shouldering burdens it shouldn't bear" over "BAD: too many responsibilities."
 - **Concise.** The entire report must stay under **500 lines**. Brevity is itself a form of elegance.
-
-## Supported Languages
-
-Assess codebases in any of these languages and frameworks, applying both universal principles and language-specific idiomatic standards:
-
-- **C#** — favor idiomatic patterns (LINQ, pattern matching, nullable reference types, async/await conventions)
-- **Go** — favor simplicity, explicit error handling, small interfaces, stdlib style
-- **Python** — favor Pythonic idioms (comprehensions, context managers, dataclasses, type hints)
-- **TypeScript** — favor strict typing, discriminated unions, proper use of generics, avoiding `any`
-- **React** — favor composition, custom hooks, proper state management, separation of concerns between UI and logic
-- **Next.js** — favor proper use of server/client components, data fetching patterns, routing conventions
-
-When reviewing, identify the language and apply the relevant idiomatic lens alongside the universal principles.
 
 ## The Five Dimensions
 
@@ -111,6 +98,8 @@ Beautiful code is confident code — and confidence comes from tests.
 
 Beautiful code speaks the language it's written in fluently.
 
+**Per-language hints:** TypeScript — strict typing, discriminated unions, no `any`. Python — comprehensions, context managers, type hints, dataclasses. Go — simplicity, explicit error handling, small interfaces, stdlib style. C# — LINQ, pattern matching, nullable reference types, async/await. React — composition, custom hooks, UI/logic separation. Next.js — server/client component boundaries, data fetching patterns.
+
 **What to look for:**
 - Follows the conventions and idioms of the specific language/framework
 - Consistent style throughout (not a patchwork of different authors' habits)
@@ -182,9 +171,9 @@ For each of the 5 dimensions:
 - Key improvement opportunity (if score < 8)
 
 ### Violations
-- List any always-flag violations found
-- Reference specific files/lines
-- Brief note on suggested resolution
+- List any always-flag violations found, referencing specific files/lines
+- Add a brief note on suggested resolution
+- If none are present, state "No always-flag violations found."
 
 ### Closing Note
 - One encouraging, forward-looking sentence
@@ -196,23 +185,14 @@ When invoked:
 
 1. **Determine scope** from what the user provides:
    - If it's a single file or pasted code → assess that directly
-   - If it's a directory or module → survey its structure, then read key files
-   - If it's a full repo → survey the project structure, identify architectural boundaries, then sample representative files across layers
+   - If it's a directory, module, or full repo → survey the structure, identify entry points / domain logic / infrastructure / tests, and read a representative sample (architecture-revealing files first; don't try to read every file)
 
-2. **For repo-wide or module assessments**, start with a structural survey:
-   - Understand the directory tree
-   - Identify entry points, domain logic, infrastructure/adapter code, and tests
-   - Read a representative sample — don't try to read every file
-   - Prioritize: architecture-revealing files > routine implementation files
+2. **Detect the language(s)** in use and activate the appropriate idiomatic lens.
 
-3. **Detect the language(s)** in use and activate the appropriate idiomatic lens.
+3. **Score each of the 5 dimensions** using the anchors above.
 
-4. **Score each of the 5 dimensions** using the anchors above.
+4. **Scan for always-flag violations.**
 
-5. **Scan for always-flag violations.**
+5. **Identify beauty highlights** — find 2–5 genuinely elegant pieces of code worth celebrating.
 
-6. **Identify beauty highlights**: find 2–5 genuinely elegant pieces of code worth celebrating.
-
-7. **Produce the report** in the format specified above.
-
-8. **Stay under 500 lines total.** Be precise. Brevity is elegance.
+6. **Produce the report** in the format specified above.

--- a/plugins/polishkit/skills/polish/SKILL.md
+++ b/plugins/polishkit/skills/polish/SKILL.md
@@ -12,15 +12,7 @@ triggers:
 
 # Polish
 
-Polish the rough edges across a scope you specify — a path, glob, or cross-cutting concern — in an isolated worktree, and open one PR. Single pass, single agent, single PR.
-
-Lightweight sibling to polishkit's other skills:
-
-- `polishkit:appraise` — score code quality without changing anything.
-- `polishkit:sweep` — remove dead code and accumulated cruft (unused exports/imports/variables, stale files, build artifacts).
-- `polishkit:polish` (this skill) — apply semantic code-quality fixes (reuse, quality, efficiency) across a scope.
-
-Use this when you want quick, targeted cleanup applied across a cross-cutting concern, not a full assessment or hygiene sweep.
+Polish the rough edges across a scope you specify — a path, glob, or cross-cutting concern — in an isolated worktree, and open one PR. Single pass, single agent, single PR. Use this when you want quick, targeted cleanup applied across a cross-cutting concern, not a full assessment or hygiene sweep.
 
 ## Input
 
@@ -52,9 +44,7 @@ Confirm at least one matching file exists. Pass the resolved file list to the ag
 
 Derive a kebab-case slug from the scope. Examples:
 - `src/hooks/` → `hooks`
-- `src/services/spotify/auth.ts` → `services-spotify-auth`
 - `error handling in src/providers/` → `providers-error-handling`
-- `naming consistency in hooks` → `hooks-naming`
 
 Branch name: `polish/<slug>`.
 
@@ -75,47 +65,9 @@ Pass the resolved verify commands to the agent prompt as `VERIFY_COMMANDS`.
 
 ### 3. Resolve the PR base branch
 
-The agent's branch must be cut from the project's PR base, and `gh pr create` must explicitly target the same branch (otherwise it falls through to the GitHub default — usually `main` — which silently produces wrong-base PRs against repos that develop on a non-default branch).
+Implements the canonical chain at [`plugins/_shared/base-resolution.md`](../../../_shared/base-resolution.md), with polishkit's own config key `claude.polishkit.prBase` slotted at step 2 (before the optional `claude.flowkit.prBase` interop read at step 3). Polishkit works correctly without flowkit installed.
 
-Implements the canonical chain at [`plugins/_shared/base-resolution.md`](../../../_shared/base-resolution.md), with one polishkit-specific variation: a polishkit-scoped key (`claude.polishkit.prBase`) is checked at step 2 before the optional flowkit-interop slot. The flowkit courtesy read (`claude.flowkit.prBase`) is placed after polishkit's own key and before the `develop` fallback, as documented in the canonical spec's cross-plugin courtesy interop section. Polishkit works correctly without flowkit installed.
-
-Resolve `BASE` in this order:
-
-```bash
-# 1. Explicit caller arg
-BASE=""
-if echo "$ARGUMENTS" | grep -qE '(^|[[:space:]])\-\-base[= ]'; then
-  BASE=$(echo "$ARGUMENTS" | grep -oE '(^|[[:space:]])\-\-base[= ][^ ]+' | head -1 | sed 's/.*--base[= ]//')
-fi
-
-# 2. Polishkit's own config
-if [ -z "$BASE" ]; then
-  BASE=$(git config claude.polishkit.prBase 2>/dev/null)
-fi
-
-# 3. Optional flowkit interop — honored if flowkit set it, but not required
-if [ -z "$BASE" ]; then
-  BASE=$(git config claude.flowkit.prBase 2>/dev/null)
-fi
-
-# 4. develop if it exists on the remote
-if [ -z "$BASE" ]; then
-  if git ls-remote --heads origin develop | grep -q 'refs/heads/develop'; then
-    BASE="develop"
-  fi
-fi
-
-# 5. Fallback — use the repo default and warn
-if [ -z "$BASE" ]; then
-  REPO_DEFAULT=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
-  echo "warning: no base branch configured and 'develop' not found on remote; falling back to repo default ($REPO_DEFAULT)" >&2
-  BASE="$REPO_DEFAULT"
-fi
-```
-
-Pass the resolved `BASE` to the agent prompt as `BASE_BRANCH`. The agent must use it for both the branch cut **and** the `gh pr create --base` argument.
-
-To pin a base for the current repo, run `git config claude.polishkit.prBase <branch>` (e.g. `develop`). The flowkit read at step 3 is best-effort interop only — polishkit works without flowkit installed.
+Pass the resolved `BASE` to the agent prompt as `BASE_BRANCH`. The agent must use it for both the branch cut **and** the `gh pr create --base` argument — calling `gh pr create` without `--base` falls through to the repo default branch and silently produces wrong-base PRs.
 
 ### 4. Dispatch the subagent
 
@@ -129,65 +81,47 @@ Spawn one agent with:
 
 The agent prompt MUST include each section, in order:
 
-**CONTEXT** — describe the scope in natural language, list every file in scope verbatim, and (if a cross-cutting concern was given) state the theme. Note CWD is the repo root of an isolated worktree and the agent must use **relative paths only**.
+**CONTEXT** — describe the scope in natural language, list every file in scope verbatim, and (if a cross-cutting concern was given) state the theme. CWD is the repo root of an isolated worktree; use relative paths only.
 
 **TASK** — apply these review heuristics to the listed files:
 
 1. **Reuse** — duplicated logic that should be extracted; existing helpers that should be used instead of inlined alternatives.
 2. **Quality** — unclear naming, dead code, weak error handling, leaky abstractions, magic numbers, type hygiene gaps.
-3. **Efficiency** — quadratic loops where linear is trivially possible, redundant async waits, unnecessary re-renders / recomputations in hooks (apply `react-useeffect` heuristics where applicable).
+3. **Efficiency** — quadratic loops where linear is trivially possible, redundant async waits, unnecessary re-renders / recomputations.
 
 For a cross-cutting theme, prioritize fixes matching that theme; deprioritize everything else (mention as deferred findings, don't fix).
 
-**RESPECT BEHAVIOR** — keep public surfaces compatible. If a fix would change a public contract, leave it untouched and surface in the PR's `## Findings deferred to issues` section with file:line refs.
+**POLICY**:
 
-**CONSTRAINTS** — read `CLAUDE.md` and `.claude/rules/` before editing. Honor every hard contract found there. No new dependencies. No type-error suppression (e.g. `as any`, `@ts-ignore`, `# type: ignore` without justification). Follow the project's commit message and authorship conventions.
-
-**SOFT CAP** — touch at most `--max-files` files (default 15). If the scope clearly exceeds the cap, fix the highest-impact subset and list the rest under deferred findings. Lightweight passes stay lightweight.
+- Keep public contracts compatible. Any fix that would change a public contract is left untouched and surfaced in the PR's `## Findings deferred to issues` section with file:line refs.
+- Touch at most `--max-files` files (default 15). If the scope clearly exceeds the cap, fix the highest-impact subset and list the rest under deferred findings.
+- A no-op pass is legitimate. If nothing actionable is found, open the PR anyway with `## Summary` stating `no actionable simplifications found` and a `## Findings deferred to issues` section listing what was considered. Manufactured churn is worse than a no-op PR.
 
 **WORKFLOW**:
 
-1. Branch from `BASE_BRANCH` (provided by the orchestrator — never re-derive):
+1. Branch from `BASE_BRANCH`:
    ```
    git fetch origin "$BASE_BRANCH"
    git checkout -B polish/<slug> "origin/$BASE_BRANCH"
-   [[ "$PWD" != *"worktrees"* ]] && echo "ERROR: not in worktree" && exit 1
    ```
 2. First pass: read every file in scope and build a findings list grouped by category (reuse / quality / efficiency / deferred). Apply the cross-cutting theme filter if one was given.
-3. Apply edits. Surgical changes; don't bundle unrelated fixes into a single "polish" commit. Group commits by category or by file (conventional-commit format).
-4. Verify by running every command in `VERIFY_COMMANDS` (passed by the orchestrator). All MUST pass before push. If any fails, iterate until green or revert the breaking edit and list it as deferred.
-5. Push and open the PR with `--base "$BASE_BRANCH"` explicitly (see PR BODY SHAPE below). **Never** call `gh pr create` without `--base` — without it, gh falls through to the GitHub default branch (often `main`), which silently produces wrong-base PRs.
-6. Report the PR URL. That is the only acceptable termination condition.
+3. Apply edits. Surgical changes; don't bundle unrelated fixes into a single commit. Group commits by category or by file (conventional-commit format).
+4. Verify: run every command in `VERIFY_COMMANDS`. All MUST pass before push. If any fails, iterate until green or revert the breaking edit and list it as deferred.
+5. Push and open the PR with `--base "$BASE_BRANCH"` explicitly. Report the PR URL.
 
-**PR BODY SHAPE** — follow the canonical spec at `plugins/_shared/pr-body.md` (`## Summary` / `## Changes` / `## Test plan` plus issue-reference footer). Append one extra section after `## Test plan`:
+**PR BODY SHAPE** — follow `plugins/_shared/pr-body.md` (`## Summary` / `## Changes` / `## Test plan` plus issue-reference footer). Append one extra section after `## Test plan`:
 
 ```
 ## Findings deferred to issues
-<list of fixes intentionally not applied (cap exceeded, behavior change, theme mismatch) with file:line refs>
+<list of fixes intentionally not applied (cap exceeded, contract change, theme mismatch) with file:line refs>
 ```
 
 The `## Test plan` checklist must include each command from `VERIFY_COMMANDS` as a `- [ ]` item.
 
-**NO-OP IS LEGITIMATE** — if the pass finds nothing actionable in the scope, open the PR anyway with `## Summary` stating `no actionable simplifications found` and a `## Findings deferred to issues` section listing what was considered. Manufactured churn is worse than a no-op PR.
-
 ### 5. Dry-run mode
 
-If `--dry-run` is set, the agent skips the apply/commit/push phase and instead returns a structured findings report inline (not as a PR). Useful as a pre-flight before committing to a full pass.
+If `--dry-run` is set, the agent skips the apply/commit/push phase and returns a structured findings report inline (not as a PR). Useful as a pre-flight before committing to a full pass.
 
 ### 6. Report
 
-Print one line confirming dispatch (scope, slug, branch, base branch, agent type, model, max-files, verify commands). Don't wait synchronously — the harness notifies on completion. When notified:
-
-- Verify branch is pushed: `git ls-remote --exit-code origin polish/<slug>`
-- Verify the PR exists and targets the resolved base: `gh pr list --head polish/<slug> --json baseRefName,url`
-- Report the PR URL.
-
-## Constraints
-
-- One agent per invocation, one PR per agent. Never fan out multiple polish agents on the same scope.
-- Lightweight by default — if scope is so large the agent wants to touch >50 files, it should narrow to the highest-impact subset and defer the rest. The skill is for cross-cutting cleanup, not whole-codebase rewrites.
-- Always pass relative paths to the agent. Never include absolute repo paths in the prompt.
-- Always run in an isolated worktree. Never edit the scope directly from the orchestrator.
-- Verify must be green before push. Red builds are never acceptable, even for "lightweight" passes.
-- No-op PR is legitimate — never invent edits to justify the run.
-- Defer behavior-changing fixes to follow-up issues; this skill is for safe, fast cleanup only.
+Print one line confirming dispatch (scope, slug, branch, base branch, agent type, model, max-files, verify commands). Don't wait synchronously — the harness notifies on completion. When notified, confirm via `gh pr list --head polish/<slug> --json baseRefName,url` that the PR exists and targets the resolved base, then report the URL.

--- a/plugins/polishkit/skills/sweep/SKILL.md
+++ b/plugins/polishkit/skills/sweep/SKILL.md
@@ -27,7 +27,7 @@ If no focus area is provided, perform a full sweep across both phases below.
 
 A scope can be:
 - A path or glob (`src/components/`, `**/*.test.ts`) — restricts both phases to that subtree.
-- A category hint (`dead-code-only`, `cruft-only`, `git-only`) — runs just the matching phase.
+- A category hint — `dead-code-only` (Phase 1 only), `cruft-only` (Phase 2 only), or `git-only` (Phase 2, git-hygiene subset only).
 - Empty — run everything.
 
 ## Process
@@ -36,25 +36,11 @@ The skill runs in two phases. Each phase scans, reports, and confirms before mod
 
 ### Phase 1 — Dead Code
 
+Skip findings in `node_modules/`, `dist/`, `build/`, `.next/`, generated files (`*.generated.ts`, `*.d.ts`), and test files (dead code in tests can be intentional fixtures).
+
 #### 1.1 Detect language and available tools
 
-Identify the primary language(s) in the repo and check for available static analysis tools:
-
-**TypeScript / JavaScript**
-```bash
-ls tsconfig.json 2>/dev/null && echo "TypeScript project"
-ls .eslintrc* eslint.config* 2>/dev/null
-```
-
-**Python**
-```bash
-which pyflakes vulture ruff 2>/dev/null
-```
-
-**Go**
-```bash
-which staticcheck 2>/dev/null
-```
+Identify the primary language(s) and check for installed static analysis tools — `tsc --noEmit` and `ts-prune` for TypeScript, `pyflakes` / `vulture` / `ruff` for Python, `staticcheck` for Go. Skip any tool that isn't on PATH.
 
 #### 1.2 Scan for dead code
 
@@ -83,22 +69,17 @@ grep -rn "^[[:space:]]*//" --include="*.ts" --include="*.tsx" | \
   awk -F: '{print $1 ":" $2}' | uniq -c | awk '$1 >= 3 {print}'
 ```
 
-Skip findings in:
-- `node_modules/`, `dist/`, `build/`, `.next/`
-- Generated files (`*.generated.ts`, `*.d.ts`)
-- Test files (dead code in tests can be intentional fixtures)
-
 #### 1.3 Compile findings
 
 Group by category:
 
-| Category | Count | Severity |
-|----------|-------|----------|
-| Unused exports | N | Medium |
-| Unused imports | N | Low |
-| Dead variables | N | Low |
-| Unreachable branches | N | High |
-| Commented-out code | N | Low |
+| Category | Count |
+|----------|-------|
+| Unused exports | N |
+| Unused imports | N |
+| Dead variables | N |
+| Unreachable branches | N |
+| Commented-out code | N |
 
 For each finding, show file:line, the snippet (1–3 lines), and why it's considered dead.
 

--- a/scripts/openspec
+++ b/scripts/openspec
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# OpenSpec format validator for this repository.
+# Usage: bash scripts/openspec validate <capability> [--type spec] [--strict]
+
+set -euo pipefail
+
+CMD=""
+CAPABILITY=""
+STRICT=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        validate) CMD="validate" ;;
+        --type) shift ;;  # consumed but not used; only "spec" type exists
+        --strict) STRICT=true ;;
+        --*)
+            echo "Unknown flag: $1" >&2
+            exit 1
+            ;;
+        *)
+            if [[ -z "$CMD" ]]; then CMD="$1"
+            elif [[ -z "$CAPABILITY" ]]; then CAPABILITY="$1"
+            fi
+            ;;
+    esac
+    shift
+done
+
+if [[ "$CMD" != "validate" ]]; then
+    echo "Usage: bash scripts/openspec validate <capability> [--type spec] [--strict]" >&2
+    exit 1
+fi
+
+if [[ -z "$CAPABILITY" ]]; then
+    echo "Error: capability name required" >&2
+    exit 1
+fi
+
+SPEC_FILE="openspec/specs/$CAPABILITY/spec.md"
+
+if [[ ! -f "$SPEC_FILE" ]]; then
+    echo "Error: spec file not found: $SPEC_FILE" >&2
+    exit 1
+fi
+
+ERRORS=0
+WARNINGS=0
+
+check_error() {
+    echo "ERROR: $1" >&2
+    ERRORS=$((ERRORS + 1))
+}
+
+check_warning() {
+    echo "WARNING: $1" >&2
+    WARNINGS=$((WARNINGS + 1))
+}
+
+# Top-level heading
+grep -q "^# " "$SPEC_FILE" || check_error "Missing top-level heading (# Capability Name)"
+
+# Purpose section
+grep -q "^## Purpose" "$SPEC_FILE" || check_error "Missing ## Purpose section"
+
+# Requirements section
+grep -q "^## Requirements" "$SPEC_FILE" || check_error "Missing ## Requirements section"
+
+# Each ### Requirement: must have at least one #### Scenario:
+req_count=0
+scenario_missing=0
+while IFS= read -r req_line_raw; do
+    req_count=$((req_count + 1))
+    req_name="${req_line_raw#\#\#\# Requirement: }"
+    # Grab everything from this Requirement: heading to the next ### or EOF
+    block=$(awk "/^### Requirement: /{found=0} /^### Requirement: ${req_name//\//\\/}/{found=1} found" "$SPEC_FILE" \
+        | tail -n +2 \
+        | awk '/^### /{exit} {print}')
+    if ! echo "$block" | grep -q "^#### Scenario:"; then
+        check_error "Requirement '${req_name}' has no #### Scenario: block"
+        scenario_missing=$((scenario_missing + 1))
+    fi
+done < <(grep "^### Requirement:" "$SPEC_FILE")
+
+if [[ $req_count -eq 0 ]]; then
+    check_error "No ### Requirement: blocks found"
+fi
+
+# SHALL/MUST normative language
+if ! grep -q "SHALL\|MUST" "$SPEC_FILE"; then
+    if $STRICT; then
+        check_error "(strict) No SHALL/MUST normative language found in requirements"
+    else
+        check_warning "No SHALL/MUST normative language found in requirements"
+    fi
+fi
+
+# Stack-agnostic check (strict mode only)
+if $STRICT; then
+    FRAMEWORK_PATTERN='React|Ember|Glimmer|TanStack|ember-concurrency|useState|useEffect|@Component|\.component\.'
+    if grep -Eq "$FRAMEWORK_PATTERN" "$SPEC_FILE"; then
+        check_error "(strict) Spec contains framework-specific terms — must be stack-agnostic:"
+        grep -En "$FRAMEWORK_PATTERN" "$SPEC_FILE" | while IFS= read -r match; do
+            echo "  $match" >&2
+        done
+    fi
+fi
+
+if [[ $ERRORS -gt 0 ]]; then
+    echo "Validation FAILED: $ERRORS error(s), $WARNINGS warning(s) — $SPEC_FILE"
+    exit 1
+else
+    echo "Validation passed: $SPEC_FILE ($WARNINGS warning(s))"
+fi


### PR DESCRIPTION
## Summary

Stands up an OpenSpec setup in the repo and uses it to baseline all three polishkit skills (`polish`, `appraise`, `sweep`) from their existing SKILL.md files. The resulting specs drive tightening passes on all three implementations (no behavioral change) by removing redundancy, overreach, and bloat that the audit methodology surfaces. Ships a `tighten-to-spec` skill that encodes the audit pattern so it can be replayed against other skills. Future polishkit changes now have written contracts to land against.

## Changes

- Add `scripts/openspec` format validator and `openspec/` directory layout (`openspec/README.md`, `openspec/specs/`).
- Add local `.claude/skills/spec-baseline/` skill: reverse-engineers an OpenSpec `spec.md` + companion `REFERENCES.md` from existing code, with an optional read-only citation audit.
- Add local `.claude/skills/tighten-to-spec/` skill: complement to `spec-baseline` that audits an implementation artifact against its written spec across five categories (non-compliance, overreach, redundancy, bloat, overcomplication) with file:line citations, then refactors on approval.
- Baseline polishkit specs at `openspec/specs/polishkit-polish/`, `openspec/specs/polishkit-appraise/`, `openspec/specs/polishkit-sweep/` — each ships a `spec.md` (passing `--strict`) and a `REFERENCES.md` citing every requirement and scenario back to the source SKILL.md.
- Tighten `plugins/polishkit/skills/polish/SKILL.md` (194 → 127 lines) to match the spec: collapse 32-line PR-base-resolution bash to a reference to `plugins/_shared/base-resolution.md`, delete the restatement Constraints section, merge four agent-prompt blocks into one POLICY block, drop the `react-useeffect` cross-reference and generic engineering hygiene directives, consolidate the `--base` warning, align "public surface" → "public contract", remove the redundant worktree path check.
- Tighten `plugins/polishkit/skills/appraise/SKILL.md` (218 → 198 lines): fold standalone Supported Languages section into the Idiomatic Consistency dimension as inline per-language hints, collapse two redundant Workflow steps (the "structural survey" sub-step duplicated step 1's directory/module branch), trim persona examples, add explicit no-violations guidance to the Violations report subsection, drop the redundant 500-line cap restatement at end of Workflow.
- Tighten `plugins/polishkit/skills/sweep/SKILL.md` (191 → 171 lines): clarify the `git-only` category hint as a Phase 2 git-hygiene subset (closes a spec-vs-impl ambiguity), collapse Phase 1.1's three per-language bash blocks into a 2-line detection preamble, lift the skip-list filter to the top of Phase 1 where it belongs, drop the subjective Severity column from the example findings table.

## Test plan

- [ ] `bash scripts/openspec validate polishkit-polish --type spec --strict` passes
- [ ] `bash scripts/openspec validate polishkit-appraise --type spec --strict` passes
- [ ] `bash scripts/openspec validate polishkit-sweep --type spec --strict` passes
- [ ] `/spec-baseline` and `/tighten-to-spec` skills are discoverable and reference the local validator + each other
- [ ] All three tightened polishkit SKILL.md files still read top-to-bottom as complete dispatch / scoring / sweep flows with no missing scenario coverage from their specs
- [ ] No behavioral change to any polishkit skill: polish branch naming / dispatch params / verify gate / PR shape / no-op handling / dry-run mode preserved; appraise five-dimension rubric / weights / verdict tiers / report structure preserved; sweep two-phase scan / interactive confirmation / disambiguated remote-branch deletion / commit + PR flow preserved.