### PR TITLE
sessionkit: baseline specs and tighten SKILL.md files

### DIFF
--- a/openspec/specs/sessionkit-drive/REFERENCES.md
+++ b/openspec/specs/sessionkit-drive/REFERENCES.md
@@ -1,0 +1,133 @@
+# Drive — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `smallorbit-plugins/`.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Pre-flight chain validation
+
+**Sources**
+- `plugins/sessionkit/skills/drive/SKILL.md:27-32` — Step 1 checks `TaskList` for no pending/in_progress tasks and stops with a message
+- `plugins/sessionkit/skills/drive/SKILL.md:33` — Step 1 checks for broken `blockedBy` edges pointing at non-existent IDs
+
+**Notes**
+- The broken-graph check (all tasks blocked by non-existent IDs) is explicitly called out as a stop condition
+
+### Scenario: Task list is empty
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:27-29` — "If the result has no `pending` or `in_progress` tasks, stop with: > Nothing to drive…"
+Verified by presence in the guard clause. **Interpolated; no direct test.**
+
+### Scenario: Broken dependency graph
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:31-33` — "If there are tasks but they all have unresolved `blockedBy` edges pointing at non-existent IDs, report the broken state and stop."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Single driving preamble
+
+**Sources**
+- `plugins/sessionkit/skills/drive/SKILL.md:35-39` — Step 2 defines a verbatim preamble and states "Do not narrate again until you finish"
+
+### Scenario: Driving starts
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:37-38` — verbatim preamble text with starting task ID and silence contract.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Task-state discipline
+
+**Sources**
+- `plugins/sessionkit/skills/drive/SKILL.md:51` — "Mark `completed`. Immediately after the task's outcome is achieved… Never batch."
+- `plugins/sessionkit/skills/drive/SKILL.md:89` — Constraints: "One task `in_progress` at a time."
+- `plugins/sessionkit/skills/drive/SKILL.md:89` — "Mark `in_progress` before starting, `completed` immediately after, never batch."
+
+### Scenario: Task lifecycle
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:47-52` — Steps 2 (mark in_progress before work) and 4 (mark completed immediately after).
+**Interpolated; no direct test.**
+
+### Scenario: Multiple in_progress tasks
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:45` — "If multiple `in_progress` tasks exist, finish them before picking a new one."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Task selection order
+
+**Sources**
+- `plugins/sessionkit/skills/drive/SKILL.md:45` — "take the lowest-ID task whose `status` is `pending` and whose `blockedBy` array is empty (or whose blockers are already `completed`). Ties broken by ID."
+
+### Scenario: Next unblocked task
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:45` — lowest-ID pending task with empty or completed `blockedBy`.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Task execution dispatch
+
+**Sources**
+- `plugins/sessionkit/skills/drive/SKILL.md:47-51` — Step 3 defines three execution shapes: named skill, explicit command, open-ended work
+
+### Scenario: Named skill task
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:48` — "Named skill — description references a skill (e.g. 'Run `/flowkit:merge-pr`'): invoke it via the `Skill` tool."
+**Interpolated; no direct test.**
+
+### Scenario: Shell command task
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:49` — "Explicit command — description gives a shell command or sequence: run via `Bash`."
+**Interpolated; no direct test.**
+
+### Scenario: Outcome-based task
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:50` — "Open-ended work — description describes an outcome… perform the work using whatever tools fit."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Controlled surface conditions
+
+**Sources**
+- `plugins/sessionkit/skills/drive/SKILL.md:56-63` — Step 4 table defines four and only four surface conditions
+- `plugins/sessionkit/skills/drive/SKILL.md:65-69` — "What does not count as a surface condition" list
+
+### Scenario: Unrecoverable blocker
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:60` — "A tool failed in a way you cannot recover from… Plain text: state what failed, what you tried, what's needed. Leave the task `in_progress`. Stop."
+**Interpolated; no direct test.**
+
+### Scenario: Executive decision required
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:61` — "`AskUserQuestion` with 2–4 options and your recommendation labeled `(Recommended)`. Resume on answer."
+**Interpolated; no direct test.**
+
+### Scenario: Risky or destructive action
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:62` — "Plain text confirmation prompt — describe the action and ask permission. Do not bury it inside an `AskUserQuestion`."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Scope integrity
+
+**Sources**
+- `plugins/sessionkit/skills/drive/SKILL.md:92` — "No silent scope expansion… add it via `TaskCreate` (with appropriate `blockedBy`) so it's visible"
+- `plugins/sessionkit/skills/drive/SKILL.md:95` — "Never modify task subjects/descriptions to make them easier."
+
+### Scenario: Unplanned sub-work discovered
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:92` — TaskCreate with blockedBy for unplanned sub-tasks.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Final report
+
+**Sources**
+- `plugins/sessionkit/skills/drive/SKILL.md:73-85` — Step 5 defines the completion report format with task count, elapsed time, highlights, and outstanding items
+
+### Scenario: Chain completed
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:73-84` — "When the chain is fully completed (no pending or in_progress tasks remain), output a tight report."
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. All scenarios are **interpolated** — Drive has no test suite. The behavior is encoded entirely in the SKILL.md directive and validated by the consistency of the directive language.
+2. The "one preamble then silence" contract relies on the model following the directive; no runtime enforcement mechanism exists.
+3. The distinction between "blocker" and "executive decision" requires model judgment on what constitutes "irrecoverable" vs. "a genuine fork" — this is intentionally left to context.

--- a/openspec/specs/sessionkit-drive/spec.md
+++ b/openspec/specs/sessionkit-drive/spec.md
@@ -1,0 +1,86 @@
+# Drive
+
+## Purpose
+Drive executes an approved task chain autonomously from start to finish. It manages task state throughout, surfaces to the user only for blockers or executive decisions, and produces a final report on completion.
+
+## Requirements
+
+### Requirement: Pre-flight chain validation
+Drive SHALL verify a runnable chain exists before starting. If no `pending` or `in_progress` tasks exist, Drive MUST stop and report that the task list is empty. If all tasks have unresolved `blockedBy` edges pointing at non-existent IDs, Drive MUST report the broken state and stop.
+
+#### Scenario: Task list is empty
+- **WHEN** `TaskList` returns no `pending` or `in_progress` tasks
+- **THEN** Drive stops with a message directing the user to add tasks or run `/sessionkit:roadmap`
+
+#### Scenario: Broken dependency graph
+- **WHEN** all pending tasks have `blockedBy` entries referencing non-existent task IDs
+- **THEN** Drive reports the broken state and stops without starting any work
+
+### Requirement: Single driving preamble
+Drive SHALL emit exactly one short preamble before the first tool call, stating the starting task ID and the driving contract. Drive MUST NOT narrate individual task progress beyond that initial preamble.
+
+#### Scenario: Driving starts
+- **WHEN** a runnable chain is confirmed
+- **THEN** Drive emits one preamble (starting task, silence contract, Esc-to-interrupt note) and then works silently
+
+### Requirement: Task-state discipline
+For each task, Drive SHALL mark it `in_progress` before doing any work, and `completed` immediately after the outcome is achieved. Drive MUST NOT have more than one task in `in_progress` at a time. Drive MUST NOT batch completions.
+
+#### Scenario: Task lifecycle
+- **WHEN** Drive picks a task to execute
+- **THEN** `in_progress` is set before the first tool call for that task, and `completed` is set as soon as the outcome is achieved — never deferred
+
+#### Scenario: Multiple in_progress tasks
+- **WHEN** multiple tasks are found in `in_progress` state at loop entry
+- **THEN** Drive finishes them before picking any new pending task
+
+### Requirement: Task selection order
+Drive SHALL pick the lowest-ID `pending` task whose `blockedBy` array is empty or fully completed. Drive MUST NOT start a task whose blockers are unresolved.
+
+#### Scenario: Next unblocked task
+- **WHEN** multiple pending tasks exist
+- **THEN** Drive picks the lowest-ID task with no unresolved `blockedBy` dependencies
+
+### Requirement: Task execution dispatch
+Drive SHALL dispatch each task according to its description. A description referencing a skill SHALL be invoked via the skill tool. A description giving a shell command SHALL be run via the shell. An open-ended outcome description SHALL be executed using whatever tools fit the described outcome.
+
+#### Scenario: Named skill task
+- **WHEN** a task description references a skill (e.g. "Run `/flowkit:merge-pr`")
+- **THEN** Drive invokes that skill, passing any arguments mentioned in the description
+
+#### Scenario: Shell command task
+- **WHEN** a task description provides an explicit shell command
+- **THEN** Drive runs that command via the shell
+
+#### Scenario: Outcome-based task
+- **WHEN** a task description states an outcome without specifying a skill or command
+- **THEN** Drive uses any appropriate tools to achieve the described outcome
+
+### Requirement: Controlled surface conditions
+Drive SHALL surface to the user only for blockers, executive decisions, risky actions, or completion. Drive MUST NOT surface for routine failures with obvious remediation, cosmetic choices, or "just to confirm" moments.
+
+#### Scenario: Unrecoverable blocker
+- **WHEN** a tool fails in a way Drive cannot recover from (auth missing, network down, irreversible state required)
+- **THEN** Drive emits plain text describing the failure, leaves the task `in_progress`, and stops
+
+#### Scenario: Executive decision required
+- **WHEN** a genuine fork in approach emerges that the task description does not resolve
+- **THEN** Drive presents options via `AskUserQuestion` with a recommendation, then resumes on the user's answer
+
+#### Scenario: Risky or destructive action
+- **WHEN** the next step would delete data, force-push, rewrite shared history, or send messages on the user's behalf
+- **THEN** Drive presents a plain-text confirmation prompt before proceeding — not an `AskUserQuestion`
+
+### Requirement: Scope integrity
+Drive SHALL NOT silently expand scope beyond the task list. If a task requires sub-work not in the plan, Drive MUST create a visible task via `TaskCreate` with appropriate `blockedBy` rather than absorbing the work into an existing task. Drive MUST NOT modify task subjects or descriptions to make them easier.
+
+#### Scenario: Unplanned sub-work discovered
+- **WHEN** executing a task reveals necessary work not in the plan
+- **THEN** Drive creates a new task (with `blockedBy` wiring) and surfaces it as an executive decision if scope is affected
+
+### Requirement: Final report
+Drive SHALL emit a tight completion report when the chain is fully done. The report SHALL list artifacts produced (PR URLs, tags, files modified) and any outstanding items the user should know about. Drive MUST NOT reproduce the task list verbatim in the report.
+
+#### Scenario: Chain completed
+- **WHEN** no `pending` or `in_progress` tasks remain
+- **THEN** Drive emits a report with task count, elapsed time, artifact highlights, and any outstanding items

--- a/openspec/specs/sessionkit-handoff/REFERENCES.md
+++ b/openspec/specs/sessionkit-handoff/REFERENCES.md
@@ -1,0 +1,142 @@
+# Handoff — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `smallorbit-plugins/`.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Context collection
+
+**Sources**
+- `plugins/sessionkit/skills/handoff/SKILL.md:37-50` — Step 1 runs git commands in parallel and calls `TaskList` + `TaskGet` per task "in parallel with the bash commands above"
+
+### Scenario: Context gathered
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:37-50` — "Run these commands in parallel."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Fingerprint-based section reuse
+
+**Sources**
+- `plugins/sessionkit/skills/handoff/SKILL.md:52-77` — Steps 1a and 1b define fingerprint computation and the two-independent-decision reuse logic
+
+### Scenario: Git fingerprint matches
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:69-70` — "If `gitFingerprint` matches the prior header: reuse `## Git State` and `## Progress` verbatim."
+**Interpolated; no direct test.**
+
+### Scenario: Task fingerprint matches
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:71-72` — "If `taskFingerprint` matches the prior header: reuse `## Task List` and `## Remaining Work` verbatim."
+**Interpolated; no direct test.**
+
+### Scenario: Both fingerprints match
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:74-77` — "When both fingerprints match, all four reusable sections come straight from the prior file."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Routing to delta or full path
+
+**Sources**
+- `plugins/sessionkit/skills/handoff/SKILL.md:79-108` — Step 1c defines the four delta conditions and the routing decision
+
+### Scenario: Delta path selected
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:84-88` — all four conditions enumerated; "Pick delta mode when ALL of these hold."
+**Interpolated; no direct test.**
+
+### Scenario: Full path selected
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:90` — "Otherwise, use the full Haiku regenerate path."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Document structure
+
+**Sources**
+- `plugins/sessionkit/skills/handoff/SKILL.md:140-188` — Step 2a defines the strict template including section order and inference rules
+- `plugins/sessionkit/skills/handoff/SKILL.md:229-230` — Constraints: "Section order in HANDOFF.md is fixed: Goal → Progress → Git State → Remaining Work → Task List → Context"
+
+### Scenario: Section order
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:229` — fixed section order constraint.
+**Interpolated; no direct test.**
+
+### Scenario: Bullet-only sections
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:141` — "Bullets only in Progress / Remaining Work / Context — no narrative paragraphs."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Task list serialization
+
+**Sources**
+- `plugins/sessionkit/skills/handoff/SKILL.md:193-195` — inference rule for Task List: "Include only `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, `blocks`. Exclude `owner`, `metadata`, and deleted tasks… Preserve original task `id`."
+
+### Scenario: Task list in JSON block
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:168-182` — template shows fenced `json` block; `plugins/sessionkit/skills/handoff/SKILL.md:193-195` — serialization rules.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Sub-agent synthesis
+
+**Sources**
+- `plugins/sessionkit/skills/handoff/SKILL.md:111-136` — Step 2 defines the Haiku sub-agent invocation and the failure fallback with warning comment
+
+### Scenario: Sub-agent succeeds
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:114-128` — Agent tool call with model `"claude-haiku-4-5"`.
+**Interpolated; no direct test.**
+
+### Scenario: Sub-agent fails
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:130-135` — "if the Agent call fails, returns empty output, or produces output that does not contain the required `## Task List` heading, fall back to in-line synthesis."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Gitignore coverage
+
+**Sources**
+- `plugins/sessionkit/skills/handoff/SKILL.md:201-213` — Step 3 defines the three-branch `.gitignore` check
+
+### Scenario: Gitignore absent
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:206-207` — "`.gitignore` absent: ask 'No `.gitignore` found…'"
+**Interpolated; no direct test.**
+
+### Scenario: Gitignore present but uncovered
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:208-209` — "`.gitignore` present but not covered: ask '`.gitignore` doesn't cover `.sessionkit/`…'"
+**Interpolated; no direct test.**
+
+### Scenario: Already covered
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:210` — "Already covered: proceed silently."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Canonical output location
+
+**Sources**
+- `plugins/sessionkit/skills/handoff/SKILL.md:231` — Constraints: "`.sessionkit/HANDOFF.md` in the working directory is the canonical location — never write elsewhere"
+
+### Scenario: Document written
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:15` — "into `<working-dir>/.sessionkit/HANDOFF.md`".
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Completion report
+
+**Sources**
+- `plugins/sessionkit/skills/handoff/SKILL.md:224-226` — Step 4 defines what to report: path, mode, reuse outcome, and `/pickup` suggestion
+
+### Scenario: Handoff confirmed
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:224-226` — verbatim step 4 text.
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. All scenarios are **interpolated from the SKILL.md directive** — no test suite exists for handoff behavior.
+2. The `gitFingerprint` ancestor check (`git merge-base --is-ancestor`) is distinct from the section reuse decision — it guards against branch-swap scenarios, not just content drift.
+3. The "at most two reusable sections" delta threshold is an implementation detail that is not observable from outside the skill; it is captured in the spec as an approximation of the routing intent.
+4. The strict template at step 2a is the canonical source of truth for section order — the constraint at line 229 restates it.

--- a/openspec/specs/sessionkit-handoff/spec.md
+++ b/openspec/specs/sessionkit-handoff/spec.md
@@ -1,0 +1,97 @@
+# Handoff
+
+## Purpose
+Handoff captures the current session's goal, progress, git state, task list, remaining work, and key context into `.sessionkit/HANDOFF.md` so another agent can resume the work without losing momentum. It minimizes cost by reusing unchanged sections from a prior handoff via fingerprint-based caching.
+
+## Requirements
+
+### Requirement: Context collection
+Handoff SHALL gather git state (HEAD SHA, branch, staged files, unstaged files, recent commits) and task list in parallel before synthesizing the document.
+
+#### Scenario: Context gathered
+- **WHEN** Handoff is invoked
+- **THEN** git state and task list are collected in parallel before any synthesis begins
+
+### Requirement: Fingerprint-based section reuse
+Handoff SHALL compute a `gitFingerprint` (HEAD SHA + sorted staged/unstaged file hashes) and a `taskFingerprint` (SHA-1 of the canonicalized task list JSON). Each fingerprint governs its own pair of sections independently: `gitFingerprint` controls `## Git State` and `## Progress`; `taskFingerprint` controls `## Task List` and `## Remaining Work`. Sections whose fingerprint matches the prior header SHALL be reused byte-for-byte. `## Goal` and `## Context` SHALL always be regenerated.
+
+#### Scenario: Git fingerprint matches
+- **WHEN** the prior handoff's `gitFingerprint` matches the current one
+- **THEN** `## Git State` and `## Progress` are reused verbatim; only `## Goal` and `## Context` are regenerated
+
+#### Scenario: Task fingerprint matches
+- **WHEN** the prior handoff's `taskFingerprint` matches the current one
+- **THEN** `## Task List` and `## Remaining Work` are reused verbatim
+
+#### Scenario: Both fingerprints match
+- **WHEN** both fingerprints match the prior header
+- **THEN** all four reusable sections come straight from the prior file and no sub-agent is dispatched
+
+### Requirement: Routing to delta or full path
+Handoff SHALL use the delta path when all four conditions hold: a prior HANDOFF.md parsed cleanly, the prior HEAD is an ancestor of the current HEAD, at most two reusable sections need regeneration, and `--full` is not present. Otherwise Handoff SHALL use the full regenerate path.
+
+#### Scenario: Delta path selected
+- **WHEN** all four delta-mode conditions hold
+- **THEN** Handoff surgically edits the existing file in place without dispatching a sub-agent
+
+#### Scenario: Full path selected
+- **WHEN** any delta-mode condition fails or `--full` is passed
+- **THEN** Handoff dispatches a sub-agent for full synthesis
+
+### Requirement: Document structure
+The handoff document SHALL follow a fixed section order: meta header → Goal → Progress → Git State → Remaining Work → Task List → Context. All content in Progress, Remaining Work, and Context SHALL be bullets only — no narrative paragraphs. The meta header SHALL be the first line and SHALL contain both fingerprints.
+
+#### Scenario: Section order
+- **WHEN** a handoff document is written (delta or full)
+- **THEN** sections appear in the canonical order: Goal → Progress → Git State → Remaining Work → Task List → Context
+
+#### Scenario: Bullet-only sections
+- **WHEN** Progress, Remaining Work, or Context content is generated
+- **THEN** every entry is a bullet — no narrative paragraphs
+
+### Requirement: Task list serialization
+The `## Task List` section SHALL contain a single fenced `json` code block. Each task object SHALL include only `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, and `blocks`. Deleted tasks SHALL be excluded. The original task `id` SHALL be preserved so `/pickup` can wire `blockedBy` relationships.
+
+#### Scenario: Task list in JSON block
+- **WHEN** the document is written
+- **THEN** `## Task List` contains a fenced `json` block with one object per non-deleted task, using the original task IDs
+
+### Requirement: Sub-agent synthesis
+When the full path is selected, Handoff SHALL delegate document synthesis to a Haiku-class sub-agent. If the sub-agent call fails or returns output missing `## Task List`, Handoff SHALL fall back to inline synthesis and prepend a warning comment to the document.
+
+#### Scenario: Sub-agent succeeds
+- **WHEN** the full path is selected and the sub-agent returns a valid document
+- **THEN** the synthesized document is written to disk
+
+#### Scenario: Sub-agent fails
+- **WHEN** the sub-agent call fails or returns output missing `## Task List`
+- **THEN** Handoff synthesizes the document inline and prepends `<!-- handoff-warning: haiku sub-agent unavailable, synthesized in-line -->`
+
+### Requirement: Gitignore coverage
+Before writing, Handoff SHALL check whether `.sessionkit/` is covered by `.gitignore`. If `.gitignore` is absent or does not cover `.sessionkit/`, Handoff SHALL ask the user before adding coverage. Handoff MUST NOT modify `.gitignore` without user confirmation.
+
+#### Scenario: Gitignore absent
+- **WHEN** no `.gitignore` file exists
+- **THEN** Handoff asks the user whether to create one with `.sessionkit/`
+
+#### Scenario: Gitignore present but uncovered
+- **WHEN** `.gitignore` exists but does not cover `.sessionkit/`
+- **THEN** Handoff asks the user whether to append `.sessionkit/`
+
+#### Scenario: Already covered
+- **WHEN** `.gitignore` already covers `.sessionkit/`
+- **THEN** Handoff proceeds silently
+
+### Requirement: Canonical output location
+Handoff SHALL write the document exclusively to `<working-dir>/.sessionkit/HANDOFF.md`. Handoff MUST NOT write the document to any other path.
+
+#### Scenario: Document written
+- **WHEN** synthesis completes
+- **THEN** the document is at `.sessionkit/HANDOFF.md` in the current working directory
+
+### Requirement: Completion report
+After writing, Handoff SHALL report the absolute file path, the chosen mode (delta or full), which sections were regenerated vs. reused, and suggest running `/pickup` to resume.
+
+#### Scenario: Handoff confirmed
+- **WHEN** the document is written
+- **THEN** Handoff reports the path, mode, section reuse outcome, and suggests `/pickup`

--- a/openspec/specs/sessionkit-pickup/REFERENCES.md
+++ b/openspec/specs/sessionkit-pickup/REFERENCES.md
@@ -1,0 +1,112 @@
+# Pickup — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `smallorbit-plugins/`.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Graceful absent-file handling
+
+**Sources**
+- `plugins/sessionkit/skills/pickup/SKILL.md:19-31` — Step 1 checks for the file and stops with a graceful message if absent
+
+### Scenario: Handoff file absent
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:27-31` — "If the file does not exist, fail gracefully: report > No handoff file found… Then stop."
+**Interpolated; no direct test.**
+
+### Scenario: Handoff file present
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:19-26` — `cat .sessionkit/HANDOFF.md 2>/dev/null` followed by remaining steps.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Open-ended section parsing
+
+**Sources**
+- `plugins/sessionkit/skills/pickup/SKILL.md:33-36` — "Unknown headings are passed through unmodified — section parsing is open-ended, so any future or legacy section names… are silently ignored."
+
+### Scenario: Unknown heading encountered
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:34-36` — explicit open-ended parsing rule.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Orientation summary
+
+**Sources**
+- `plugins/sessionkit/skills/pickup/SKILL.md:39-46` — Step 3 lists the five areas: Goal, Progress, Git State, Remaining Work, Context
+- `plugins/sessionkit/skills/pickup/SKILL.md:108` — Constraints: "Keep the orientation summary concise — surface the essentials, not everything verbatim"
+
+### Scenario: Orientation presented
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:39-46` — five-area summary format.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Task list hydration — two-pass
+
+**Sources**
+- `plugins/sessionkit/skills/pickup/SKILL.md:49-73` — Step 4 defines the full two-pass hydration: locate JSON block, create tasks (pass 1), wire blockedBy (pass 2)
+
+### Scenario: Task list present and parseable
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:56-73` — pass 1 (TaskCreate per pending/in_progress task) + pass 2 (TaskUpdate addBlockedBy).
+**Interpolated; no direct test.**
+
+### Scenario: Task list absent or unparseable
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:51-54` — "If no `## Task List` section exists, or the JSON block is absent or unparseable, emit exactly one line… Then skip."
+**Interpolated; no direct test.**
+
+### Scenario: Completed tasks skipped
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:64` — "Skip tasks whose `status` is `completed` — they are history."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Branch mismatch detection
+
+**Sources**
+- `plugins/sessionkit/skills/pickup/SKILL.md:75-89` — Step 5 compares branch and suggests checkout without switching automatically
+
+### Scenario: Branch matches
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:87-88` — "Only suggest this when there's a mismatch."
+**Interpolated from absence; no direct test.**
+
+### Scenario: Branch mismatch
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:83-86` — "suggest: `git checkout <branch-from-handoff>`" and "Do not switch branches automatically."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Readiness confirmation via structured prompt
+
+**Sources**
+- `plugins/sessionkit/skills/pickup/SKILL.md:91-103` — Step 6 defines the AskUserQuestion format: question text, header, options from Remaining Work, fallback to plain text
+
+### Scenario: Multiple remaining items
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:93-98` — AskUserQuestion with options derived from Remaining Work when 2+ items exist.
+**Interpolated; no direct test.**
+
+### Scenario: Fewer than two actionable items
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:99-101` — "If `Remaining Work` has fewer than 2 actionable items, fall back to plain text."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Read-only operation
+
+**Sources**
+- `plugins/sessionkit/skills/pickup/SKILL.md:107` — Constraints: "Never modify `.sessionkit/HANDOFF.md` — this skill is read-only"
+- `plugins/sessionkit/skills/pickup/SKILL.md:110` — "Do not automatically re-execute any commands referenced in the handoff — the goal is to orient, not to act"
+
+### Scenario: Handoff file untouched
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:107` — explicit constraint.
+**Interpolated from absence; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. All scenarios are **interpolated** — no test suite covers pickup behavior directly.
+2. The "do not wire `blocks`" rule (line 72) prevents double-writing the dependency graph; only `blockedBy` is wired in pass 2.
+3. The old-ID → new-ID mapping must be maintained in memory across all `TaskCreate` calls before any `TaskUpdate` call in pass 2 — this ordering is implicit in the sequential pass structure.

--- a/openspec/specs/sessionkit-pickup/spec.md
+++ b/openspec/specs/sessionkit-pickup/spec.md
@@ -1,0 +1,75 @@
+# Pickup
+
+## Purpose
+Pickup loads `.sessionkit/HANDOFF.md` at the start of a new session, orients the agent by summarizing its contents, hydrates the task list from the snapshot, checks for branch mismatches, and asks what to tackle first. It is the complement to Handoff.
+
+## Requirements
+
+### Requirement: Graceful absent-file handling
+Pickup SHALL check for `.sessionkit/HANDOFF.md` before proceeding. If the file does not exist, Pickup MUST report the absence and stop — it MUST NOT attempt to orient, hydrate tasks, or ask what to do next.
+
+#### Scenario: Handoff file absent
+- **WHEN** `.sessionkit/HANDOFF.md` does not exist
+- **THEN** Pickup reports the file is missing with a guidance message and stops
+
+#### Scenario: Handoff file present
+- **WHEN** `.sessionkit/HANDOFF.md` exists
+- **THEN** Pickup reads and parses it, then continues with the remaining steps
+
+### Requirement: Open-ended section parsing
+Pickup SHALL parse all standard sections (Project, Date, Branch, Goal, Progress, Git State, Remaining Work, Context). Unknown headings SHALL be silently ignored — section parsing is open-ended. Legacy section names from prior versions SHALL not cause errors.
+
+#### Scenario: Unknown heading encountered
+- **WHEN** the handoff file contains a heading not in the standard section list
+- **THEN** Pickup ignores it without error and continues parsing
+
+### Requirement: Orientation summary
+Pickup SHALL produce a structured orientation summary from the parsed content. The summary SHALL cover: Goal (restated clearly), Progress (what was done and decided), Git State (branch, staged/unstaged, recent commits), Remaining Work (in priority order), and Context (gotchas and notes). The summary SHALL be concise — it MUST NOT reproduce the document verbatim.
+
+#### Scenario: Orientation presented
+- **WHEN** the handoff file is successfully parsed
+- **THEN** Pickup outputs a structured summary covering all five areas without reproducing the document verbatim
+
+### Requirement: Task list hydration — two-pass
+Pickup SHALL locate the fenced `json` block following `## Task List`. If the block is absent or unparseable, Pickup SHALL emit one line noting the skip and continue. For tasks with `status` `pending` or `in_progress`, Pickup SHALL create new tasks via `TaskCreate` (pass 1), record old-ID → new-ID mappings, then restore `blockedBy` edges via `TaskUpdate` using remapped IDs (pass 2). Completed tasks SHALL be skipped. Pickup MUST NOT wire the `blocks` direction — only `blockedBy`.
+
+#### Scenario: Task list present and parseable
+- **WHEN** `## Task List` contains a valid JSON array
+- **THEN** Pickup creates tasks for `pending`/`in_progress` entries (pass 1), then wires `blockedBy` using remapped IDs (pass 2)
+
+#### Scenario: Task list absent or unparseable
+- **WHEN** the JSON block is missing or cannot be parsed
+- **THEN** Pickup emits "No task list snapshot — skipping hydration" and continues to step 5
+
+#### Scenario: Completed tasks skipped
+- **WHEN** a task in the snapshot has `status: completed`
+- **THEN** Pickup skips creating that task — it is surfaced only in the orientation summary
+
+### Requirement: Branch mismatch detection
+Pickup SHALL compare the handoff branch against the current branch. If they differ, Pickup MUST suggest the checkout command. Pickup MUST NOT switch branches automatically.
+
+#### Scenario: Branch matches
+- **WHEN** the current branch matches the handoff branch
+- **THEN** Pickup makes no branch suggestion
+
+#### Scenario: Branch mismatch
+- **WHEN** the current branch differs from the handoff branch
+- **THEN** Pickup suggests `git checkout <branch-from-handoff>` and does not switch automatically
+
+### Requirement: Readiness confirmation via structured prompt
+Pickup SHALL end by asking the user what to tackle first via `AskUserQuestion`. The question SHALL reference the handoff Goal. Options SHALL be derived from the top items in Remaining Work (highest-priority first), up to four options. If fewer than two actionable items exist in Remaining Work, Pickup SHALL fall back to plain text.
+
+#### Scenario: Multiple remaining items
+- **WHEN** Remaining Work has two or more actionable items
+- **THEN** Pickup presents them as structured options via `AskUserQuestion`
+
+#### Scenario: Fewer than two actionable items
+- **WHEN** Remaining Work has fewer than two actionable items
+- **THEN** Pickup asks what to do next in plain text
+
+### Requirement: Read-only operation
+Pickup SHALL NOT modify `.sessionkit/HANDOFF.md` under any circumstances. Pickup MUST NOT re-execute commands referenced in the handoff.
+
+#### Scenario: Handoff file untouched
+- **WHEN** Pickup runs to completion
+- **THEN** `.sessionkit/HANDOFF.md` is byte-identical to when Pickup started

--- a/openspec/specs/sessionkit-retro/REFERENCES.md
+++ b/openspec/specs/sessionkit-retro/REFERENCES.md
@@ -1,0 +1,108 @@
+# Retro — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `smallorbit-plugins/`.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Parallel signal collection
+
+**Sources**
+- `plugins/sessionkit/skills/retro/SKILL.md:26-56` — Step 1 collects git activity, JSONL events, task list, and conversation transcript, with "Run all data-collection commands in parallel. Tolerate missing outputs gracefully."
+
+### Scenario: All surfaces available
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:27` — "Run all data-collection commands in parallel."
+**Interpolated; no direct test.**
+
+### Scenario: A surface is unavailable
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:27` — "Tolerate missing outputs gracefully — an empty surface is itself a signal."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Three-bucket synthesis
+
+**Sources**
+- `plugins/sessionkit/skills/retro/SKILL.md:59-88` — Step 2 defines the three buckets with bullet counts and citation discipline
+- `plugins/sessionkit/skills/retro/SKILL.md:150-151` — Constraints: "Always identify at least one item per `## What went well` and `## What didn't go well`"
+
+### Scenario: Friction observed
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:67-71` — "What didn't go well" bullets: repeated corrections, hook-blocked, failed commands, stalled tasks.
+**Interpolated; no direct test.**
+
+### Scenario: No friction observed
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:68` — "If no friction surfaces at all, emit: _No friction observed this session._"
+**Interpolated; no direct test.**
+
+### Scenario: Positive patterns found
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:63-66` — "What went well" bullets. Constraints line 151 requires at least one even for low-friction sessions.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Recommended actions with delegation targets
+
+**Sources**
+- `plugins/sessionkit/skills/retro/SKILL.md:74-88` — delegation table and cap-at-4 rule with 4th-slot reservation
+
+### Scenario: More than three actionable items
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:88` — "Cap the list at 4 options. If more than 4 items qualify, keep the highest-signal ones. Reserve the 4th option slot for 'Other — I'll handle this manually.'"
+**Interpolated; no direct test.**
+
+### Scenario: No matching skill for a pattern
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:83` — "No matching skill | Surface as plain-text guidance only"
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Inline-only output
+
+**Sources**
+- `plugins/sessionkit/skills/retro/SKILL.md:18` — "Output stays entirely inline. No files are written."
+- `plugins/sessionkit/skills/retro/SKILL.md:149` — Constraints: "Never write files."
+
+### Scenario: Output is inline
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:18` — explicit no-file constraint.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: User-gated action menu
+
+**Sources**
+- `plugins/sessionkit/skills/retro/SKILL.md:112-122` — Step 4 defines the AskUserQuestion call with multiSelect and "None — I'm done" option
+- `plugins/sessionkit/skills/retro/SKILL.md:122` — "Do not proceed to step 5 until the user answers via `AskUserQuestion`."
+- `plugins/sessionkit/skills/retro/SKILL.md:151-152` — Constraints: "Never run delegated skills without explicit user selection."
+
+### Scenario: Action menu presented
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:114-121` — AskUserQuestion with multiSelect: true and "None — I'm done" option.
+**Interpolated; no direct test.**
+
+### Scenario: User selects actions
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:126-143` — Step 5 announces and invokes each selected skill.
+**Interpolated; no direct test.**
+
+### Scenario: User selects none
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:144-145` — "If the user selects 'None — I'm done', skip all invocations and close the retro with a one-line acknowledgement."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Skill delegation — no absorption
+
+**Sources**
+- `plugins/sessionkit/skills/retro/SKILL.md:153-154` — Constraints: "`retro` is a thin reflective layer. It does not absorb `skillit`'s encoding logic."
+- `plugins/sessionkit/skills/retro/SKILL.md:155` — "Do not modify `skillit` or any other existing skill."
+
+### Scenario: Skill invoked
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:132-143` — delegation table maps each action to a `Skill(...)` call.
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. All scenarios are **interpolated** — Retro has no test suite.
+2. The 4th-slot reservation for "Other — I'll handle this manually" is required only when more than 3 actionable items exist — it is not always present.
+3. The delegation table (line 78-86) is the authoritative mapping between pattern types and skill invocations; retro's role ends at delegation.

--- a/openspec/specs/sessionkit-retro/spec.md
+++ b/openspec/specs/sessionkit-retro/spec.md
@@ -1,0 +1,72 @@
+# Retro
+
+## Purpose
+Retro runs a lightweight session retrospective. It scans four input surfaces — conversation transcript, task list, git activity, and hook/tool-denial events — then produces an inline summary and a one-keystroke action menu that delegates findings to the appropriate downstream skills.
+
+## Requirements
+
+### Requirement: Parallel signal collection
+Retro SHALL gather all raw signals in parallel: git activity (recent commits, branch, stash, open PRs), session JSONL files (tool-denial and hook-blocked events), task list (all non-deleted tasks), and conversation transcript. Missing or empty surfaces SHALL be tolerated without error.
+
+#### Scenario: All surfaces available
+- **WHEN** all four input surfaces are accessible
+- **THEN** Retro collects them in parallel and proceeds to synthesis
+
+#### Scenario: A surface is unavailable
+- **WHEN** one or more surfaces are missing or empty
+- **THEN** Retro treats absence as a signal (e.g. no tool denials = no friction of that type) and continues
+
+### Requirement: Three-bucket synthesis
+Retro SHALL organize findings into exactly three sections: **What went well** (2–5 bullets), **What didn't go well** (2–5 bullets or the explicit empty-state line), and **Recommended actions** (1–4 items). Every finding SHALL cite concrete evidence — a turn, PR number, file name, or task subject. Retro SHALL NOT emit vague critique.
+
+#### Scenario: Friction observed
+- **WHEN** one or more friction signals are found (repeated corrections, hook blocks, failed commands, stalled tasks)
+- **THEN** each is included in "What didn't go well" with a concrete citation
+
+#### Scenario: No friction observed
+- **WHEN** no friction signals are found across all surfaces
+- **THEN** Retro emits the explicit empty-state line "No friction observed this session." in "What didn't go well"
+
+#### Scenario: Positive patterns found
+- **WHEN** cleanly executed workflows or early-caught mistakes are found
+- **THEN** at least one bullet appears in "What went well" even for low-friction sessions
+
+### Requirement: Recommended actions with delegation targets
+Retro SHALL map each friction signal or repeatable pattern to a downstream delegation target. Recommended actions SHALL be capped at 4. The 4th slot SHALL be reserved for "Other — I'll handle this manually" when more than 3 actionable items exist.
+
+#### Scenario: More than three actionable items
+- **WHEN** four or more patterns map to delegation targets
+- **THEN** only the three highest-signal items are listed, and the 4th slot is "Other — I'll handle this manually"
+
+#### Scenario: No matching skill for a pattern
+- **WHEN** a finding does not map to any delegation target
+- **THEN** it is surfaced as plain-text guidance only in the recommended actions list
+
+### Requirement: Inline-only output
+Retro SHALL emit the three sections as inline markdown. Retro MUST NOT write any file — no retro file, no `.sessionkit/RETRO.md`, no artifact of any kind.
+
+#### Scenario: Output is inline
+- **WHEN** Retro completes synthesis
+- **THEN** the three-section markdown appears directly in the conversation; no file is created
+
+### Requirement: User-gated action menu
+Retro SHALL present the recommended actions as a multi-select `AskUserQuestion` after the inline summary. Retro MUST NOT invoke any downstream skill before the user answers. A "None — I'm done" option SHALL always be included.
+
+#### Scenario: Action menu presented
+- **WHEN** synthesis is complete
+- **THEN** Retro calls `AskUserQuestion` with multi-select enabled, one option per recommended action, plus "None — I'm done"
+
+#### Scenario: User selects actions
+- **WHEN** the user selects one or more actions
+- **THEN** Retro announces the actions to run, then invokes each selected skill sequentially
+
+#### Scenario: User selects none
+- **WHEN** the user selects "None — I'm done"
+- **THEN** Retro closes with a one-line acknowledgement and invokes no skills
+
+### Requirement: Skill delegation — no absorption
+Retro SHALL delegate to skills via the skill tool. Retro MUST NOT absorb or re-implement the logic of any delegated skill. When "encode as a skill" is recommended, Retro delegates to `sessionkit:skillit` — it does not author the skill file itself.
+
+#### Scenario: Skill invoked
+- **WHEN** the user selects a skill-backed action
+- **THEN** Retro invokes that skill via the skill tool, passing relevant context from the findings as arguments where accepted

--- a/openspec/specs/sessionkit-roadmap/REFERENCES.md
+++ b/openspec/specs/sessionkit-roadmap/REFERENCES.md
@@ -1,0 +1,106 @@
+# Roadmap — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `smallorbit-plugins/`.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Read-only survey
+
+**Sources**
+- `plugins/sessionkit/skills/roadmap/SKILL.md:26-60` — Step 1 lists all survey commands in parallel
+- `plugins/sessionkit/skills/roadmap/SKILL.md:153` — Constraints: "Read-only during steps 1–3. Never mutate the repo, branches, tags, or PRs while planning."
+
+### Scenario: Survey phase
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:26-27` — "Read-only. Run these in parallel."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: State classification
+
+**Sources**
+- `plugins/sessionkit/skills/roadmap/SKILL.md:64-78` — Step 2 table mapping each signal to a sub-chain entry point with "composable, not exclusive" note
+
+### Scenario: Multiple signals apply
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:64` — "Identify every state signal that applies (composable, not exclusive)."
+**Interpolated; no direct test.**
+
+### Scenario: Nothing to ship
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:77` — "Latest release shipped, develop in sync | 'Nothing to ship' — surface and offer alternatives."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Task chain synthesis
+
+**Sources**
+- `plugins/sessionkit/skills/roadmap/SKILL.md:80-115` — Step 3 defines the step library, blockedBy wiring, and task field requirements
+- `plugins/sessionkit/skills/roadmap/SKILL.md:158` — Constraints: "Use named skills, not raw commands, where possible."
+
+### Scenario: Linear chain produced
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:110-114` — per-task field spec: subject, description, activeForm, blockedBy.
+**Interpolated; no direct test.**
+
+### Scenario: Named skill available
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:158` — "A task description that says 'Run `/flowkit:cut`' is unambiguous to drive; a description that pastes the cut script is brittle."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Single-thread planning
+
+**Sources**
+- `plugins/sessionkit/skills/roadmap/SKILL.md:156-159` — Constraints: "One chain per invocation. If the survey turns up two unrelated work threads… ask which one to plan."
+
+### Scenario: Two unrelated threads found
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:156-158` — single-thread constraint with example.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Plan presentation and approval gate
+
+**Sources**
+- `plugins/sessionkit/skills/roadmap/SKILL.md:117-151` — Steps 4 and 5 define the plan summary format, AskUserQuestion options, and per-answer actions
+- `plugins/sessionkit/skills/roadmap/SKILL.md:154` — Constraints: "Tasks created before approval are provisional. If the user picks 'Cancel', delete every task this invocation created."
+
+### Scenario: Approval requested
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:134-143` — AskUserQuestion with four options.
+**Interpolated; no direct test.**
+
+### Scenario: User approves and drives
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:148` — "Drive it for me → invoke `Skill('sessionkit:drive')`."
+**Interpolated; no direct test.**
+
+### Scenario: User approves manually
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:149` — "I'll drive → print the task IDs and a one-line reminder."
+**Interpolated; no direct test.**
+
+### Scenario: User modifies
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:150` — "Modify → prompt the user for what to change. Update the task list. Re-present from step 4."
+**Interpolated; no direct test.**
+
+### Scenario: User cancels
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:151` — "`TaskUpdate` with `status: deleted` for every task created. Confirm and exit."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Canonical release sequence
+
+**Sources**
+- `plugins/sessionkit/skills/roadmap/SKILL.md:101-107` — defines the bubble-free release sequence and explains why ship aborts if worktree-agent PRs remain
+
+### Scenario: Epic in flight
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:103-104` — "standard chain is: `/swarmkit:merge-stack → verify (manual) → /flowkit:ship-epic → /flowkit:ship`"
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. All scenarios are **interpolated** — Roadmap has no test suite.
+2. The `flowkit:pipeline-status` preference (line 62-63) is an optimization hint — if not installed, the raw survey commands are used directly.
+3. The single-thread constraint (step 1c) means the survey might reveal more than one thread but Roadmap only plans one per invocation; the user runs Roadmap again for other threads.

--- a/openspec/specs/sessionkit-roadmap/spec.md
+++ b/openspec/specs/sessionkit-roadmap/spec.md
@@ -1,0 +1,72 @@
+# Roadmap
+
+## Purpose
+Roadmap surveys the current work-in-flight, synthesizes a linear task chain that takes the work to its natural completion state, presents it for user approval, and then either hands it off to Drive for autonomous execution or returns it for manual execution.
+
+## Requirements
+
+### Requirement: Read-only survey
+During planning, Roadmap SHALL only read — it MUST NOT mutate the repository, branches, tags, or PRs during steps 1 through 3. Work-in-flight signals collected SHALL include: uncommitted state, branch/upstream relationship, open PRs (current branch and peers), epic mode configuration, release pipeline state (RC branches, latest tag), in-flight worktrees, and existing tasks.
+
+#### Scenario: Survey phase
+- **WHEN** Roadmap is invoked
+- **THEN** all survey commands run in parallel and no mutations occur before the plan is approved
+
+### Requirement: State classification
+Roadmap SHALL identify every applicable state signal and map each to a sub-chain entry point. Signals are composable — multiple may apply simultaneously. The canonical signals include: uncommitted changes, local commits ahead of upstream, pushed branch with no PR, open PR for current branch, peer PRs on the same base, epic mode active, develop ahead of main, RC branch exists, and nothing-to-ship state.
+
+#### Scenario: Multiple signals apply
+- **WHEN** more than one state signal is present (e.g. uncommitted changes AND an open peer PR)
+- **THEN** each signal contributes its sub-chain entry point to the composed plan
+
+#### Scenario: Nothing to ship
+- **WHEN** the latest release is shipped and develop is in sync with main
+- **THEN** Roadmap surfaces the nothing-to-ship state and offers alternatives instead of an empty plan
+
+### Requirement: Task chain synthesis
+Roadmap SHALL compose the sub-chains into a single ordered task chain. Each task SHALL have an imperative subject, an unambiguous description (exact skill invocation or concrete outcome), an `activeForm` label, and `blockedBy` wiring to its predecessor. Roadmap SHALL use named skills in task descriptions where available, not raw command pastes.
+
+#### Scenario: Linear chain produced
+- **WHEN** the state signals compose into a sequential plan
+- **THEN** tasks are created with `blockedBy` wiring so each step is unblocked only after its predecessor completes
+
+#### Scenario: Named skill available
+- **WHEN** a step maps to a known installed skill
+- **THEN** the task description references the skill by name (e.g. "Run `/flowkit:merge-pr`")
+
+### Requirement: Single-thread planning
+Roadmap SHALL plan one work thread per invocation. If the survey reveals two unrelated in-flight threads, Roadmap MUST ask the user which to plan and defer the other.
+
+#### Scenario: Two unrelated threads found
+- **WHEN** the survey reveals e.g. an in-flight PR and a separate untracked feature branch
+- **THEN** Roadmap asks which thread to plan and does not produce a forked plan
+
+### Requirement: Plan presentation and approval gate
+Roadmap SHALL present the plan as a compact summary before creating any tasks, then present it for approval via `AskUserQuestion`. Options SHALL include: drive autonomously (recommended), drive manually, modify, and cancel. Tasks created before approval are provisional — if the user cancels, Roadmap MUST delete every task created in that invocation.
+
+#### Scenario: Approval requested
+- **WHEN** the plan is ready
+- **THEN** Roadmap outputs the plan summary and calls `AskUserQuestion` with the four approval options
+
+#### Scenario: User approves and drives
+- **WHEN** the user selects "Drive it for me"
+- **THEN** Roadmap invokes `/sessionkit:drive` immediately and exits
+
+#### Scenario: User approves manually
+- **WHEN** the user selects "I'll drive"
+- **THEN** Roadmap prints the task IDs and a one-line reminder, then exits
+
+#### Scenario: User modifies
+- **WHEN** the user selects "Modify"
+- **THEN** Roadmap prompts for changes, updates the task list, and re-presents from the plan summary step
+
+#### Scenario: User cancels
+- **WHEN** the user selects "Cancel"
+- **THEN** Roadmap deletes every task it created and exits
+
+### Requirement: Canonical release sequence
+When an epic is in flight (open worktree-agent-* PRs targeting a feature branch), Roadmap SHALL include the canonical bubble-free sequence: merge-stack → verify → ship-epic → ship. Roadmap MUST NOT collapse this into a single step.
+
+#### Scenario: Epic in flight
+- **WHEN** open worktree-agent-* PRs target the current feature branch
+- **THEN** the plan includes merge-stack, a manual verify step, ship-epic, and ship — in that order

--- a/openspec/specs/sessionkit-skillit/REFERENCES.md
+++ b/openspec/specs/sessionkit-skillit/REFERENCES.md
@@ -1,0 +1,79 @@
+# Skillit — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `smallorbit-plugins/`.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Session reflection
+
+**Sources**
+- `plugins/sessionkit/skills/skillit/SKILL.md:19-31` — Step 1 reviews conversation history for five pattern types and requires identifying at least one candidate
+- `plugins/sessionkit/skills/skillit/SKILL.md:79` — Constraints: "Identify at least one candidate before concluding — never report 'nothing found'"
+
+### Scenario: Candidate identified
+**Source:** `plugins/sessionkit/skills/skillit/SKILL.md:79` — explicit constraint requiring at least one candidate.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Existing library survey
+
+**Sources**
+- `plugins/sessionkit/skills/skillit/SKILL.md:33-44` — Step 2 scans three paths for existing skills and reads name/description front matter
+
+### Scenario: Overlap found
+**Source:** `plugins/sessionkit/skills/skillit/SKILL.md:43` — "Surface any close matches to the user before proposing something new."
+**Interpolated; no direct test.**
+
+### Scenario: No overlap found
+**Source:** `plugins/sessionkit/skills/skillit/SKILL.md:43` — absence of close match implies creating a new skill (step 3 option 1).
+**Interpolated from absence; no direct test.**
+
+---
+
+## Requirement: Findings presentation
+
+**Sources**
+- `plugins/sessionkit/skills/skillit/SKILL.md:46-57` — Step 3 defines the three-part description (what/why/overlap) and the three options
+
+### Scenario: Findings presented
+**Source:** `plugins/sessionkit/skills/skillit/SKILL.md:46-56` — per-candidate description format and create/modify/skip options.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Approval-gated skill creation
+
+**Sources**
+- `plugins/sessionkit/skills/skillit/SKILL.md:59-73` — Step 4 creates file only on user agreement, at user-specified path, with required sections
+- `plugins/sessionkit/skills/skillit/SKILL.md:80` — Constraints: "Never create a skill file without user approval"
+- `plugins/sessionkit/skills/skillit/SKILL.md:83` — Constraints: "Skill names must be lowercase kebab-case"
+
+### Scenario: User approves creation
+**Source:** `plugins/sessionkit/skills/skillit/SKILL.md:59-73` — "On user agreement, create the skill file."
+**Interpolated; no direct test.**
+
+### Scenario: User declines
+**Source:** `plugins/sessionkit/skills/skillit/SKILL.md:55` — "3. Skip — not worth encoding yet" — step 4 is not reached.
+**Interpolated from absence; no direct test.**
+
+---
+
+## Requirement: Completion confirmation
+
+**Sources**
+- `plugins/sessionkit/skills/skillit/SKILL.md:75-76` — Step 5 reports the absolute path and suggests running again
+
+### Scenario: Skill written
+**Source:** `plugins/sessionkit/skills/skillit/SKILL.md:75` — "Report the absolute path of the file written."
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. All scenarios are **interpolated** — Skillit has no test suite.
+2. The "at least one candidate" requirement (constraint line 79) means Skillit will surface something even if the session was routine — this is intentional to keep the habit of skill library growth.
+3. The skill file must paths (line 63-64) offer both user-global (`~/.claude/skills/`) and project-local (`.claude/skills/`) as valid targets; the user chooses or is prompted.

--- a/openspec/specs/sessionkit-skillit/spec.md
+++ b/openspec/specs/sessionkit-skillit/spec.md
@@ -1,0 +1,49 @@
+# Skillit
+
+## Purpose
+Skillit reflects on the current session to identify repeatable patterns worth encoding as skills. It checks the existing skill library for overlap before offering to create a new skill or extend an existing one, and writes the skill file only on explicit user approval.
+
+## Requirements
+
+### Requirement: Session reflection
+Skillit SHALL review the conversation history and identify at least one candidate pattern — repeated instructions, step-by-step workflows, applied heuristics, fixed tool sequences, or explicit "always do this" directives from the user. Skillit MUST NOT conclude with "nothing found."
+
+#### Scenario: Candidate identified
+- **WHEN** Skillit reviews the session
+- **THEN** at least one candidate pattern is surfaced
+
+### Requirement: Existing library survey
+Before proposing anything new, Skillit SHALL scan the skill library (user-global and project-local) for potential overlaps with each candidate. Skillit SHALL read the `name` and `description` front matter of any relevant candidates.
+
+#### Scenario: Overlap found
+- **WHEN** an existing skill covers the same ground as a candidate
+- **THEN** Skillit surfaces the overlap before proposing the new skill, and offers to extend the existing one instead
+
+#### Scenario: No overlap found
+- **WHEN** no existing skill is close to the candidate
+- **THEN** Skillit proposes creating a new skill
+
+### Requirement: Findings presentation
+Skillit SHALL describe each candidate with: what it would do (one sentence), why it's worth encoding (friction removed), and overlap risk. Skillit SHALL offer the user explicit options: create a new skill, modify an existing skill, or skip.
+
+#### Scenario: Findings presented
+- **WHEN** candidates and overlap analysis are ready
+- **THEN** Skillit presents each candidate with its three-part description and the create/modify/skip options
+
+### Requirement: Approval-gated skill creation
+Skillit MUST NOT create or modify any skill file without explicit user approval. On approval, Skillit SHALL write the skill file to the user-specified path (or prompt for one). The file MUST include: YAML front matter with `name`, `description`, `triggers` (at least two), and `allowed-tools`; a `## Process` section with numbered steps; and a `## Constraints` section. Skill names SHALL be lowercase kebab-case.
+
+#### Scenario: User approves creation
+- **WHEN** the user selects "Create new skill" or "Modify existing"
+- **THEN** Skillit writes (or edits) the skill file and reports the absolute path
+
+#### Scenario: User declines
+- **WHEN** the user selects "Skip"
+- **THEN** Skillit makes no file changes
+
+### Requirement: Completion confirmation
+After writing the skill file, Skillit SHALL report the absolute path written. Skillit SHOULD suggest running `/skillit` again at the end of future sessions.
+
+#### Scenario: Skill written
+- **WHEN** the file is written
+- **THEN** Skillit reports the absolute path

--- a/openspec/specs/sessionkit-suggest-permissions/REFERENCES.md
+++ b/openspec/specs/sessionkit-suggest-permissions/REFERENCES.md
@@ -1,0 +1,109 @@
+# Suggest Permissions — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `smallorbit-plugins/`.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Session history location
+
+**Sources**
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:20-29` — Step 1 defines the encoded-cwd path and reads the five most recent JSONL files
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:82` — Constraints: "If session history is unavailable or empty, say so and stop"
+
+### Scenario: History files found
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:24-28` — `ls -t ~/.claude/projects/${PROJECT_PATH}/*.jsonl 2>/dev/null | head -5`
+**Interpolated; no direct test.**
+
+### Scenario: History unavailable
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:82` — explicit stop constraint.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Pattern identification across three categories
+
+**Sources**
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:32-39` — Step 2 defines three categories and the 2+ appearances threshold
+
+### Scenario: Bash command pattern
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:33` — "Bash commands — package managers, VCS, language runtimes, project-specific scripts."
+**Interpolated; no direct test.**
+
+### Scenario: File edit pattern
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:34` — "File edits — source directories, file globs, config files."
+**Interpolated; no direct test.**
+
+### Scenario: MCP tool pattern
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:35` — "MCP tools — any MCP tool approved more than once."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Scoped suggestions
+
+**Sources**
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:56-59` — Step 3 formats suggestions with one-line rationale, grouped by category
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:80` — Constraints: "Do not suggest wildcard patterns broader than what the evidence supports"
+
+### Scenario: Evidence-bounded suggestion
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:80` — explicit no-over-wildcard constraint with `Bash(*:*)` counter-example.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Approval gate before applying
+
+**Sources**
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:60-61` — Step 3 ends with AskUserQuestion; step 4 reached only after answer
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:77` — Constraints: "Never write to settings files without explicit user approval"
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:78-79` — "always request approval via the `AskUserQuestion` tool — not prose. A silent wait with no tool call is a defect."
+
+### Scenario: Approval requested
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:60-61` — "call the `AskUserQuestion` tool to request approval."
+**Interpolated; no direct test.**
+
+### Scenario: User approves
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:63-69` — "If the user approves some or all suggestions: 1. Read… 2. Merge… 3. Write…"
+**Interpolated; no direct test.**
+
+### Scenario: User cancels
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:60` — options include Cancel; step 4 not reached.
+**Interpolated from absence; no direct test.**
+
+---
+
+## Requirement: Settings file target
+
+**Sources**
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:63-69` — Step 4 reads existing file, merges, writes back
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:68-69` — "If no `.claude/settings.json` exists, create it with the minimal structure needed."
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:79` — Constraints: "Suggest project-level `.claude/settings.json` by default; offer `settings.local.json` as an alternative"
+
+### Scenario: Settings file absent
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:68-69` — creation with minimal structure.
+**Interpolated; no direct test.**
+
+### Scenario: Settings file present
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:63-67` — read + merge + write workflow.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Completion report
+
+**Sources**
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:72-74` — Step 5 reports what was added and suggests running again
+
+### Scenario: Permissions applied
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:72` — "Report what was added and where."
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. All scenarios are **interpolated** — no test suite covers suggest-permissions behavior.
+2. The "approved without hesitation" qualifier (line 39) alongside the 2+ threshold is deliberately subjective — it allows the skill to surface patterns from a single session where the approval cadence indicates strong user intent.
+3. The `settings.local.json` alternative (constraint line 79) is the mechanism for keeping personal permissions out of committed project settings.

--- a/openspec/specs/sessionkit-suggest-permissions/spec.md
+++ b/openspec/specs/sessionkit-suggest-permissions/spec.md
@@ -1,0 +1,72 @@
+# Suggest Permissions
+
+## Purpose
+Suggest Permissions scans recent session history to surface Bash commands, file edits, and MCP tools the user repeatedly approved, then proposes additions to `.claude/settings.json` so the user stops seeing the same permission prompts.
+
+## Requirements
+
+### Requirement: Session history location
+Suggest Permissions SHALL locate session JSONL files at `~/.claude/projects/<encoded-cwd>/`, where `<encoded-cwd>` is `$PWD` with every `/` replaced by `-`. It SHALL read the five most recent files. If session history is unavailable or empty, Suggest Permissions MUST report the absence and stop.
+
+#### Scenario: History files found
+- **WHEN** JSONL files exist in the project history directory
+- **THEN** the five most recent are read and scanned for approval events
+
+#### Scenario: History unavailable
+- **WHEN** no JSONL files exist in the history directory
+- **THEN** Suggest Permissions reports the absence and stops
+
+### Requirement: Pattern identification across three categories
+Suggest Permissions SHALL identify repeated approvals across three categories: Bash commands (package managers, VCS, language runtimes, project scripts), file edits (source directories, file globs, config files), and MCP tools. A pattern qualifies if it appears two or more times across recent sessions, or if the user approved it without hesitation.
+
+#### Scenario: Bash command pattern
+- **WHEN** a Bash command or command class is approved two or more times
+- **THEN** it appears as a Bash permission suggestion
+
+#### Scenario: File edit pattern
+- **WHEN** edits to a path or glob pattern are approved two or more times
+- **THEN** it appears as an Edit permission suggestion
+
+#### Scenario: MCP tool pattern
+- **WHEN** an MCP tool is approved two or more times
+- **THEN** it appears as an MCP tool permission suggestion
+
+### Requirement: Scoped suggestions
+Suggest Permissions SHALL NOT suggest wildcard patterns broader than the evidence supports. Each suggestion SHALL include a one-line rationale. Suggestions SHALL be grouped by category (Bash / Edit / MCP).
+
+#### Scenario: Evidence-bounded suggestion
+- **WHEN** only `git status` and `git log` are repeatedly approved
+- **THEN** the suggestion is scoped (e.g. `Bash(git:*)` or narrower) — not `Bash(*:*)`
+
+### Requirement: Approval gate before applying
+After presenting suggestions, Suggest Permissions SHALL call `AskUserQuestion` to request approval. It MUST NOT write to any settings file before the user answers. Options SHALL include at least: apply all, select individually, and cancel.
+
+#### Scenario: Approval requested
+- **WHEN** suggestions are ready
+- **THEN** `AskUserQuestion` is called before any file is written
+
+#### Scenario: User approves
+- **WHEN** the user selects "Apply all" or confirms individual items
+- **THEN** Suggest Permissions merges the approved entries into `permissions.allow` and writes the settings file
+
+#### Scenario: User cancels
+- **WHEN** the user selects "Cancel"
+- **THEN** no settings file is written or modified
+
+### Requirement: Settings file target
+By default, Suggest Permissions SHALL target the project-level `.claude/settings.json`. It SHALL offer `settings.local.json` as an alternative for personal preferences that should not be committed. If `.claude/settings.json` does not exist, Suggest Permissions SHALL create it with the minimal required structure.
+
+#### Scenario: Settings file absent
+- **WHEN** `.claude/settings.json` does not exist
+- **THEN** Suggest Permissions creates it with the minimal structure containing the approved permissions
+
+#### Scenario: Settings file present
+- **WHEN** `.claude/settings.json` already exists
+- **THEN** Suggest Permissions merges new entries into the existing `permissions.allow` array
+
+### Requirement: Completion report
+After writing, Suggest Permissions SHALL report what was added and where, and suggest running it again after a few sessions to catch new patterns.
+
+#### Scenario: Permissions applied
+- **WHEN** the settings file is written
+- **THEN** Suggest Permissions reports the added entries and the file path

--- a/plugins/sessionkit/skills/drive/SKILL.md
+++ b/plugins/sessionkit/skills/drive/SKILL.md
@@ -13,13 +13,6 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TaskList, TaskGet, TaskCreat
 
 # Drive
 
-Take an approved task chain and run it to completion. You are now responsible for getting the plan done end-to-end. The user has signed off on the roadmap; your job is to execute it without further narration of routine steps.
-
-## When to invoke
-
-- After `/sessionkit:roadmap` produces an approved plan and the user picks "drive it for me".
-- Standalone, when the task list is already populated by other means and the user says "drive it" / "you're driving" / "execute the plan".
-
 ## Process
 
 ### 1. Confirm there's a chain to drive

--- a/plugins/sessionkit/skills/retro/SKILL.md
+++ b/plugins/sessionkit/skills/retro/SKILL.md
@@ -127,18 +127,7 @@ Announce the actions that will be executed in order:
 
 > Running: <action 1>, then <action 2>, ...
 
-Then invoke each selected skill one at a time using the `Skill` tool. Pass any relevant context from the retro findings as arguments where the target skill accepts them.
-
-**Delegation targets and how to invoke them:**
-
-| Delegation target | Skill tool invocation |
-|-------------------|-----------------------|
-| `sessionkit:skillit` | `Skill("sessionkit:skillit")` |
-| `sessionkit:suggest-permissions` | `Skill("sessionkit:suggest-permissions")` |
-| `sessionkit:handoff` | `Skill("sessionkit:handoff")` |
-| `hookify:hookify` | `Skill("hookify:hookify")` |
-| `speckit:issue` | `Skill("speckit:issue")` |
-| `update-config` | `Skill("update-config")` |
+Then invoke each selected skill one at a time using the `Skill` tool, passing the skill's name from the delegation target column in step 2. Pass any relevant context from the retro findings as arguments where the target skill accepts them.
 
 For options the user selected that carry no delegation target (plain-text guidance), surface them as a brief summary after the skill invocations complete.
 

--- a/plugins/sessionkit/skills/roadmap/SKILL.md
+++ b/plugins/sessionkit/skills/roadmap/SKILL.md
@@ -15,11 +15,6 @@ allowed-tools: Bash, Read, Grep, Glob, TaskList, TaskGet, TaskCreate, TaskUpdate
 
 Map the route from "where we are now" to "fully shipped" — or whatever the natural completion state is for the current work — and materialize it as an approved task chain. After approval, hand off to `/sessionkit:drive` for autonomous execution, or hand the chain back to the user to drive manually.
 
-Companion to `/sessionkit:drive`:
-
-- `/sessionkit:roadmap` (this skill) — surveys + plans + approves.
-- `/sessionkit:drive` — executes an approved chain.
-
 ## Process
 
 ### 1. Survey current work-in-flight
@@ -58,8 +53,6 @@ git worktree list
 ```
 
 Then call `TaskList` to see what's already tracked.
-
-If `flowkit:pipeline-status` is available in this repo, prefer invoking it once via the `Skill` tool for the canonical pipeline view — it summarizes the data above into a single block.
 
 ### 2. Classify the state
 


### PR DESCRIPTION
## Summary

- Baselines OpenSpec `spec.md` + `REFERENCES.md` for all 7 sessionkit skills (drive, handoff, pickup, retro, roadmap, skillit, suggest-permissions). All 7 specs validate clean under `scripts/openspec validate --strict`.
- Tightens three SKILL.md files (drive, retro, roadmap) against their new specs: 916 → 891 lines (−25).

## Changes

**New specs** (`openspec/specs/sessionkit-*/`):
- `spec.md` — behavioral requirements in SHALL/MUST language with Scenario blocks
- `REFERENCES.md` — per-requirement citations back to SKILL.md file:line

**Tightened SKILL.md files**:
- `drive` (−7): removed intro paragraph and "When to invoke" section, both redundant with frontmatter `description`
- `retro` (−11): collapsed step-5 delegation table; references step-2 table instead of duplicating `skill → Skill()` mappings
- `roadmap` (−7): removed "Companion to" context block and `flowkit:pipeline-status` conditional hint

`handoff`, `pickup`, `skillit`, `suggest-permissions` untouched — already tight.

## Test plan

- [x] All 7 specs pass `bash scripts/openspec validate <cap> --type spec --strict`
- [x] Coverage check: every spec scenario still maps to a directive in the tightened SKILL.md files

Closes no issues — continuation of the OpenSpec rollout started in #967.