### PR TITLE
sessionkit: tighten handoff and pickup SKILL.md against specs

### DIFF
--- a/plugins/sessionkit/skills/handoff/SKILL.md
+++ b/plugins/sessionkit/skills/handoff/SKILL.md
@@ -12,14 +12,6 @@ allowed-tools: Bash, Read, Write, TaskList, TaskGet, Skill, Agent
 
 # Handoff
 
-Capture the current session's goal, progress, git state, remaining work, and key context into `<working-dir>/.sessionkit/HANDOFF.md` so another agent can pick up without losing momentum.
-
-Synthesis has three paths, picked automatically based on what's actually changed:
-
-- **Delta mode** (no sub-agent, in-line surgical Edits) — the default fast path when a prior `HANDOFF.md` exists, its git fingerprint is an ancestor of HEAD, and only a handful of sections need updating. Median wall time well under 3s.
-- **Full regenerate via Haiku sub-agent** — used when no prior file exists, the prior file is structurally divergent, drift exceeds the delta threshold, or `--full` is passed. Skips synthesis for sections whose fingerprints still match.
-- **Both-fingerprints-match short-circuit** — if both fingerprints match, all four reusable sections come straight from the prior file and the sub-agent is skipped entirely (this case is unchanged from prior behavior).
-
 ## Input
 
 `$ARGUMENTS` — optional freeform notes to fold into the handoff (e.g. "focus on the auth refactor, skip the docs work"). If omitted, auto-infer everything from session state.
@@ -59,11 +51,7 @@ Compute both in shell (e.g. `git rev-parse HEAD`, `printf %s "$json" | shasum -a
 
 ### 1b. Skip-unchanged check
 
-If `.sessionkit/HANDOFF.md` already exists, Read it and look for an HTML comment header of the form:
-
-```
-<!-- handoff-meta gitFingerprint=<sha> taskFingerprint=<sha> -->
-```
+If `.sessionkit/HANDOFF.md` already exists, Read it and look for a first-line meta header `<!-- handoff-meta gitFingerprint=<sha> taskFingerprint=<sha> -->` (format shown in the step 2a template).
 
 Compare against the fingerprints from step 1a using two **independent** reuse decisions — each fingerprint governs its own pair of sections, with no cross-coupling:
 
@@ -83,7 +71,7 @@ After step 1b classifies which sections need to be regenerated, decide whether t
 **Pick delta mode when ALL of these hold:**
 
 1. A prior `.sessionkit/HANDOFF.md` exists and parsed cleanly in step 1b (meta header found, all six canonical sections present in the documented order, fenced `json` block in `## Task List` parses).
-2. The prior `gitFingerprint`'s HEAD-sha component is an ancestor of the current HEAD — verify with `git merge-base --is-ancestor <prior-head-sha> HEAD` (exit 0 = ancestor). This confirms session continuity rather than a branch swap. (The staged/unstaged drift is already captured by step 1b's fingerprint comparison; this ancestor check only guards against branch-swap or force-push scenarios where the commit graph has diverged.)
+2. The prior `gitFingerprint`'s HEAD-sha component is an ancestor of the current HEAD — verify with `git merge-base --is-ancestor <prior-head-sha> HEAD` (exit 0 = ancestor). This guards against branch-swap or force-push scenarios where session continuity has broken.
 3. At most **two** of the four reusable sections (`Git State`, `Progress`, `Task List`, `Remaining Work`) need regeneration. Goal and Context are always refreshed and don't count toward the threshold.
 4. `$ARGUMENTS` does not contain `--full` and does not look like a structural-rewrite directive (a freeform note longer than ~200 chars or one that explicitly mentions reframing/rewriting the goal/context counts as structural — when in doubt, fall back to full regenerate).
 
@@ -110,7 +98,7 @@ After all Edits land, skip step 2 entirely and proceed to step 3.
 
 ### 2. Synthesize via Haiku sub-agent
 
-Reached only when step 1c picked the `full` path. Delegate markdown synthesis to a sub-agent running on Haiku — the handoff document is structured output and does not need the main model.
+Delegate markdown synthesis to a sub-agent running on Haiku — the handoff document is structured output and does not need the main model.
 
 Invoke the `Agent` tool with:
 
@@ -226,8 +214,3 @@ Report the absolute path of the file written, the chosen mode and reuse outcome 
 
 > Start a new session and run `/pickup` to resume.
 
-## Constraints
-
-- Section order in HANDOFF.md is fixed: Goal → Progress → Git State → Remaining Work → Task List → Context
-- `.sessionkit/HANDOFF.md` in the working directory is the canonical location — never write elsewhere
-- Legacy HANDOFFs that lack a `## Task List` or meta header remain valid inputs to `/pickup` — their absence is not an error (the next run will simply regenerate everything)

--- a/plugins/sessionkit/skills/pickup/SKILL.md
+++ b/plugins/sessionkit/skills/pickup/SKILL.md
@@ -12,19 +12,11 @@ allowed-tools: Bash, Read, TaskCreate, TaskUpdate, TaskList, AskUserQuestion, Sk
 
 # Pickup
 
-Companion to `/handoff`. At the start of a new session, invoke `/pickup` to restore context written by the previous agent into `.sessionkit/HANDOFF.md`, so work can continue seamlessly.
-
 ## Process
 
 ### 1. Discover handoff file
 
-Check for `.sessionkit/HANDOFF.md` in the current working directory:
-
-```bash
-cat .sessionkit/HANDOFF.md 2>/dev/null
-```
-
-If the file does not exist, fail gracefully: report
+Check for `.sessionkit/HANDOFF.md` in the current working directory. If the file does not exist, fail gracefully: report
 
 > No handoff file found at `.sessionkit/HANDOFF.md`. Either `/handoff` was not run in the previous session, or you're in a different working directory.
 
@@ -32,7 +24,7 @@ Then stop — do not proceed with the remaining steps.
 
 ### 2. Read and parse
 
-Read the full content of `.sessionkit/HANDOFF.md`. Parse the standard sections: **Project**, **Date**, **Branch**, **Goal**, **Progress**, **Git State**, **Remaining Work**, **Context**. Unknown headings are passed through unmodified — section parsing is open-ended, so any future or legacy section names (including the legacy `## Team State` block emitted by sessionkit ≤ 1.5.0) are silently ignored.
+Read the full content of `.sessionkit/HANDOFF.md`. Parse the standard sections: **Project**, **Date**, **Branch**, **Goal**, **Progress**, **Git State**, **Remaining Work**, **Context**. Unknown headings are passed through unmodified — section parsing is open-ended, so any future or legacy section names are silently ignored.
 
 ### 3. Present orientation summary
 
@@ -74,13 +66,7 @@ Do not wire `blocks` — the inverse relationship is implicit and wiring both di
 
 ### 5. Restore git state (if needed)
 
-Compare the handoff's branch against the current branch:
-
-```bash
-git branch --show-current
-```
-
-If they differ, suggest:
+Compare the handoff's branch against the current branch. If they differ, suggest:
 
 ```bash
 git checkout <branch-from-handoff>
@@ -100,11 +86,7 @@ If `Remaining Work` has fewer than 2 actionable items, fall back to plain text:
 
 > Context loaded. Ready to continue work on: `<Goal>`. What would you like to tackle first?
 
-Do not pose this as a plain-text question when `AskUserQuestion` is viable — the structured prompt is the canonical end-of-pickup interaction.
-
 ## Constraints
 
 - Never modify `.sessionkit/HANDOFF.md` — this skill is read-only
-- Do not assume the handoff file always exists — always check first and fail gracefully
-- Keep the orientation summary concise — surface the essentials, not everything verbatim
 - Do not automatically re-execute any commands referenced in the handoff — the goal is to orient, not to act


### PR DESCRIPTION
## Summary

- Tightens `handoff/SKILL.md` (233 → 216, −17 lines) and `pickup/SKILL.md` (110 → 92, −18 lines) against their OpenSpec specs from PR #968.
- Total: −35 lines across two files, zero behavioral coverage lost.

## Changes

**handoff** (−17):
- Removed intro paragraph + three-paths overview — redundant with frontmatter description and step 1c's routing logic
- Compressed meta-header code block in step 1b to inline reference
- Removed "Reached only when step 1c…" preamble at step 2 heading
- Shortened ancestor-check explanation — dropped the parenthetical restating step 1b's scope
- Removed `## Constraints` section — all three bullets restate requirements already in the process body

**pickup** (−18):
- Removed "Companion to /handoff" opening paragraph — restates frontmatter description
- Removed bash code blocks in steps 1 and 5 (`cat` and `git branch --show-current`) — outcome-specified, not command-specified
- Dropped legacy sessionkit version callout from step 2 — "any future or legacy section names" already covers it
- Removed "Do not pose this as a plain-text question" note from step 6 — step 6's own directive is sufficient
- Trimmed constraints from 4 to 2 bullets: dropped "always check first" (restates step 1) and "keep summary concise" (restates step 3)

## Test plan

- [x] All spec scenarios in `openspec/specs/sessionkit-handoff/spec.md` still map to directives in the tightened `handoff/SKILL.md`
- [x] All spec scenarios in `openspec/specs/sessionkit-pickup/spec.md` still map to directives in the tightened `pickup/SKILL.md`