### PR TITLE
sessionkit: tighten skillit and suggest-permissions SKILL.md against specs

### DIFF
--- a/plugins/sessionkit/skills/skillit/SKILL.md
+++ b/plugins/sessionkit/skills/skillit/SKILL.md
@@ -13,8 +13,6 @@ allowed-tools: AskUserQuestion, Read, Glob, Grep, Write, Edit
 
 # Skillit
 
-Reflect on the current session and identify reusable patterns worth encoding as skills. Reviews the existing skill library to avoid duplication, then offers to create a new skill or improve an existing one.
-
 ## Process
 
 ### 1. Reflect on the session
@@ -31,15 +29,7 @@ Identify at least one candidate pattern.
 
 ### 2. Survey existing skills
 
-Scan the skill library for potential overlap:
-
-```bash
-find ~/.claude/skills -name "SKILL.md" 2>/dev/null
-find .claude/skills -name "SKILL.md" 2>/dev/null
-find ~/.claude/commands -name "*.md" 2>/dev/null
-```
-
-Read the `name` and `description` front matter of any candidates that seem relevant. Surface any close matches to the user before proposing something new.
+Scan the skill library (user-global `~/.claude/skills` and project-local `.claude/skills`) for all skill definitions. Read the `name` and `description` front matter of any candidates that seem relevant. Surface any close matches to the user before proposing something new.
 
 ### 3. Present findings
 
@@ -49,34 +39,15 @@ For each candidate skill identified, describe:
 - **Why it's worth encoding** — what friction it removes
 - **Overlap risk** — does it duplicate or extend an existing skill?
 
-Then offer the user a choice:
-
-> I found [N] potential skill(s). Options:
-> 1. Create new skill: `<name>` — <description>
-> 2. Modify existing skill: `<name>` — extend to cover <gap>
-> 3. Skip — not worth encoding yet
+Then offer the user explicit options: create a new skill, modify an existing skill, or skip.
 
 ### 4. Generate the skill file
 
-On user agreement, create the skill file at the path they specify (or prompt for one):
-
-```
-~/.claude/skills/<name>/SKILL.md          # user-global
-.claude/skills/<name>/SKILL.md            # project-local
-```
+On user agreement, create the skill file at the path they specify (or prompt for one). Skill names must be lowercase kebab-case.
 
 The skill file must include:
 - Front matter: `name`, `description`, `triggers` (at least two), `allowed-tools`
 - A clear ## Process section with numbered steps
 - A ## Constraints section listing hard rules
 
-### 5. Confirm
-
-Report the absolute path of the file written. Suggest running `/skillit` again at the end of future sessions to keep the library growing.
-
-## Constraints
-
-- Identify at least one candidate before concluding — never report "nothing found"
-- Never create a skill file without user approval
-- Always check for existing skills before proposing something new
-- Skill names must be lowercase kebab-case
+Report the absolute path of the file written. Suggest running `/skillit` again at the end of future sessions.

--- a/plugins/sessionkit/skills/suggest-permissions/SKILL.md
+++ b/plugins/sessionkit/skills/suggest-permissions/SKILL.md
@@ -13,20 +13,11 @@ allowed-tools: Bash, Read, Glob, Grep, Write, Edit
 
 # Suggest Permissions
 
-Scan recent Claude Code session history to surface permission patterns — Bash commands, file edits, and MCP tools you approved repeatedly — and propose additions to `.claude/settings.json` so you stop seeing the same prompts.
-
 ## Process
 
 ### 1. Locate session history
 
-Claude Code stores per-session `.jsonl` files under `~/.claude/projects/<encoded-cwd>/`, where `<encoded-cwd>` is `$PWD` with every `/` replaced by `-`. List the five most recent files in that directory:
-
-```bash
-PROJECT_PATH=$(echo "$PWD" | sed 's|/|-|g')
-ls -t ~/.claude/projects/${PROJECT_PATH}/*.jsonl 2>/dev/null | head -5
-```
-
-Read the most recent session files and extract tool approval events.
+Claude Code stores per-session `.jsonl` files under `~/.claude/projects/<encoded-cwd>/`, where `<encoded-cwd>` is `$PWD` with every `/` replaced by `-`. Locate the directory, list JSONL files sorted by modification time (most recent first), and read the five most recent. Extract tool approval events from each.
 
 ### 2. Identify patterns
 
@@ -39,21 +30,6 @@ Scan for repeatedly approved operations across three categories:
 A pattern qualifies if it appears 2+ times across recent sessions, or if the user approved it without hesitation.
 
 ### 3. Propose additions
-
-Format suggestions as a `permissions.allow` block for `.claude/settings.json`:
-
-```json
-{
-  "permissions": {
-    "allow": [
-      "Bash(npm:*)",
-      "Bash(git:*)",
-      "Edit(src/**)",
-      "Edit(*.ts)"
-    ]
-  }
-}
-```
 
 For each suggestion, provide a one-line rationale so the user can make an informed decision. Group by category (Bash / Edit / MCP).
 


### PR DESCRIPTION
## Summary

- Tightens `skillit/SKILL.md` (82 → 53, −29 lines) and `suggest-permissions/SKILL.md` (82 → 58, −24 lines) against their OpenSpec specs from PR #968.
- Total: −53 lines across two files, zero behavioral coverage lost.
- Completes the sessionkit tighten pass (drive, retro, roadmap in #968; handoff, pickup in #969; skillit, suggest-permissions here).

## Changes

**skillit** (−29):
- Removed orientation prose after heading — restates frontmatter description
- Replaced bash `find` commands in step 2 with functional description — outcome-specified, not command-specified
- Replaced prescriptive choice-format quote block in step 3 — "offer the user explicit options" is sufficient
- Removed path template code block in step 4 — paths are user-specified; examples add prescriptive detail not in spec
- Merged step 5 (Confirm) into step 4 and removed `## Constraints` section — all four constraints restate process directives verbatim; kebab-case rule folded into step 4 prose

**suggest-permissions** (−24):
- Removed orientation prose after heading — restates frontmatter description
- Replaced bash code block in step 1 with functional description — algorithm-specified, not command-specified
- Removed JSON example block in step 3 — `permissions.allow` format is implicit in the spec requirement; rationale and grouping instruction retained as prose
- Constraints section kept — four of five bullets add genuine enforcement directives not derivable from the process steps alone

## Test plan

- [x] All spec scenarios in `openspec/specs/sessionkit-skillit/spec.md` still map to directives in the tightened `skillit/SKILL.md`
- [x] All spec scenarios in `openspec/specs/sessionkit-suggest-permissions/spec.md` still map to directives in the tightened `suggest-permissions/SKILL.md`