### PR TITLE
release: 2026-05-23

### DIFF
--- a/.claude/skills/spec-baseline/SKILL.md
+++ b/.claude/skills/spec-baseline/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: spec-baseline
+description: Derive an OpenSpec spec.md from an existing codebase (not a proposed change), produce a companion REFERENCES.md that cites every requirement and scenario back to specific file:line, and optionally spawn a read-only audit agent to verify those citations are accurate. Use when baselining legacy or existing code as a specification, or when you want human-reviewable evidence that a spec reflects real behavior.
+triggers:
+  - "baseline spec for"
+  - "spec from legacy code"
+  - "derive spec from existing"
+  - "document what X does as a spec"
+  - "create a spec for existing code"
+  - "baseline the existing"
+  - "write a spec based on the code"
+  - "extract spec from"
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Agent
+---
+
+# Spec Baseline
+
+Reverse-engineer an OpenSpec `spec.md` from an existing codebase, then produce a
+`REFERENCES.md` that makes every derived claim verifiable. Optionally audit the
+references with an independent agent.
+
+## Setup note
+
+The OpenSpec validator lives at `scripts/openspec` in this repo. Validation calls use
+`bash scripts/openspec validate <capability> --type spec --strict`.
+
+## When to use this vs. `/opsx:propose`
+
+| Situation | Skill |
+|---|---|
+| Code already exists; you want to capture what it *does* | `/spec-baseline` |
+| You want to propose *new* behavior or a change | `/opsx:propose` |
+
+---
+
+## Process
+
+### Step 1 — Identify the scope
+
+Ask the user (or infer from context):
+- Which capability or module to baseline (e.g. "tipping", "transfer", "checkout-form")
+- Which codebase(s) to read (current repo? a legacy repo? both for comparison?)
+- Whether to target a single stack or write stack-agnostically
+
+If the target is a **legacy codebase** being compared to a new one, write the spec
+stack-agnostically: no framework names, no component class names, no library-specific
+APIs. Behaviors are expressed in domain terms (what the system does, not how).
+
+### Step 2 — Read the source
+
+For the target module, read:
+1. **Implementation files** — the primary source of behavior
+2. **Test files** — tests reveal edge cases and observable contracts the code alone may not
+3. **Git history** — `git log --follow -n 10 -- <path>` on key files to surface *why* decisions were made
+
+If the project has an inventory brief (e.g. `openspec/inventory/modules/<name>.md`),
+read that first as a map; do not copy it wholesale into the spec.
+
+### Step 3 — Write `openspec/specs/<capability>/spec.md`
+
+Follow the OpenSpec spec format exactly:
+```markdown
+# <Capability Name>
+
+## Purpose
+<1–3 sentences: what problem this capability solves and for whom>
+
+## Requirements
+
+### Requirement: <requirement name>
+<Normative requirement text using SHALL/MUST>
+
+#### Scenario: <scenario name>
+- **WHEN** <condition>
+- **THEN** <expected outcome>
+```
+
+Rules:
+- One `## Requirements` section; all `### Requirement:` blocks inside it
+- Every `### Requirement:` must have at least one `#### Scenario:` (4 hashtags, exact)
+- Use SHALL/MUST for normative requirements; avoid "should" or "may"
+- **Stack-agnostic:** no framework names, no component class names, no library APIs
+- Basket/API field names from the domain model are acceptable (they are the universal contract)
+- Validation rules, timing constants, and business logic thresholds belong in the spec
+
+After writing, validate: `bash scripts/openspec validate <capability> --type spec --strict`
+
+### Step 4 — Write `openspec/specs/<capability>/REFERENCES.md`
+
+This file is NOT part of the spec (it will not be validated). It is a human-readable
+annotation of every requirement and scenario, pointing to the source code.
+
+Structure (mirrors spec.md order):
+```markdown
+# <Capability Name> — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `<repo-root>/`.
+Line numbers verified on <date>.
+
+---
+
+## Requirement: <same name as in spec.md>
+
+**Sources**
+- `path/to/file.ts:LINE-RANGE` — <what is at those lines and why it supports the claim>
+- `tests/path/test.ts:LINE-RANGE` — `'test name'` verifies <what behavior>
+
+**Notes**
+- <Interpretive choices, surprising behaviors, divergence from the new app>
+
+### Scenario: <same name as in spec.md>
+**Source:** `path/to/file.ts:LINE` — <specific identifier/expression>.
+[Verified by test at line N. | **Interpolated; no direct test.**]
+```
+
+At the end, include a `## Cross-cutting interpretive notes` section listing every
+scenario or claim that was **interpolated from absence** (no code or test directly
+asserts it). Number them. These are the human reviewer's primary checklist.
+
+**Citation discipline:**
+- Cite the smallest range that contains the relevant identifier (prefer `file.ts:123`
+  over `file.ts:100-200`)
+- When a test verifies the claim, include the test citation on the same scenario line
+- When no test exists, end with `**Interpolated; no direct test.**` or `**Interpolated from absence.**`
+
+### Step 5 — Spawn the citation audit agent (optional, recommended)
+
+After the references file is written, offer to audit it. If the user agrees, spawn
+a **read-only Sonnet agent** with this prompt (fill in the repo path and capability):
+
+> You are auditing a references file to verify source-code citations are accurate.
+> Read-only; do not modify files.
+>
+> **Spec:** `openspec/specs/<capability>/spec.md`
+> **References:** `openspec/specs/<capability>/REFERENCES.md`
+> **Source repo:** `<absolute path to legacy/source repo>`
+>
+> For each Source citation: verify the file exists, the line numbers contain what
+> the references file claims, and the code substantiates the spec claim. For test
+> citations, verify the test actually asserts the claimed behavior. For items in
+> "Cross-cutting interpretive notes", verify no direct test coverage exists.
+>
+> Flag categories: WRONG_FILE, WRONG_LINE (>±5), DRIFT (≤±5), CLAIM_MISMATCH,
+> MISSING_CITATION, OVER_CLAIMED_TEST, OVER_FLAGGED_INTERPOLATION,
+> UNDER_FLAGGED_INTERPOLATION.
+>
+> Output: one-line summary (N citations checked / N flagged), then findings grouped
+> by category using this shape per finding:
+> > **Requirement:** "name" | **Scenario:** "name" (or —)
+> > **Citation:** `file.ts:LINE` — "what REFERENCES.md claims"
+> > **Issue:** what's actually there
+> > **Suggested fix:** corrected range or note
+>
+> Close with: "OK to trust" (only DRIFT/OVER_FLAGGED are present or none) or
+> "Needs revision" (any other category present).
+
+Apply the corrections the agent returns before declaring the references file done.
+
+---
+
+## Constraints
+
+- Never skip Step 4 (REFERENCES.md) — the spec alone is not reviewable without citations
+- Never mark a scenario "Verified by test" unless you have read the test and confirmed the assertion
+- Always label interpolated claims explicitly — do not present them as verified
+- Run `bash scripts/openspec validate --strict` before reporting the spec as complete
+- Stack-agnostic means: no React, no Ember, no Glimmer, no TanStack, no ember-concurrency, no framework-specific lifecycle names in the spec body
+- The spec is about behavior; the REFERENCES.md is about evidence — keep them separate
+- If a legacy codebase is being compared to a new implementation, add a comparison table at the end of the spec (or as a separate `COMPARISON.md`) noting behavioral differences — these are product decisions, not errors
+
+## Output checklist
+
+- [ ] `openspec/specs/<capability>/spec.md` — validates with `bash scripts/openspec validate --strict`
+- [ ] `openspec/specs/<capability>/REFERENCES.md` — one entry per requirement and scenario
+- [ ] Cross-cutting interpretive notes section present with numbered items
+- [ ] Citation audit run (or explicitly deferred with reason)
+- [ ] If audit returned "Needs revision", corrections applied

--- a/.claude/skills/tighten-to-spec/SKILL.md
+++ b/.claude/skills/tighten-to-spec/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: tighten-to-spec
+description: Audit an implementation artifact (typically a SKILL.md, README, or module file) against its written OpenSpec spec. Surface concrete findings across five categories — non-compliance, overreach, redundancy, bloat, overcomplication — each with file:line citations. Interview the user on which findings to apply, then refactor. The complement to spec-baseline.
+triggers:
+  - "audit X against the spec"
+  - "tighten X to match the spec"
+  - "does X conform to the spec"
+  - "find drift between spec and implementation"
+  - "spec compliance audit"
+  - "tighten the implementation"
+allowed-tools: Read, Edit, Write, Grep, Glob, Bash, AskUserQuestion
+---
+
+# Tighten to Spec
+
+Audit an implementation artifact against its written behavioral spec, surface
+concrete findings, interview on scope, then apply the approved tightening edits.
+The pair to [`spec-baseline`](../spec-baseline/SKILL.md) — baseline produces the
+spec, this skill enforces it.
+
+## When to use this
+
+| Situation | Skill |
+|---|---|
+| You have a spec and an impl, and want to know how well they align | `/tighten-to-spec` |
+| You have code but no spec yet | `/spec-baseline` |
+| You want a generic 5-dimension quality score (no spec input) | `/polishkit:appraise` |
+
+---
+
+## Process
+
+### Step 1 — Identify the spec and implementation
+
+Confirm (or infer from context):
+- **Spec path** — the OpenSpec `spec.md`, typically `openspec/specs/<capability>/spec.md`
+- **Implementation path** — the artifact to audit (SKILL.md, README, module file, etc.)
+
+If either is missing or ambiguous, ask before proceeding. Do not invent a spec.
+
+### Step 2 — Read both artifacts
+
+Read the spec end to end first to load the behavioral contract into context.
+Then read the implementation top to bottom, noting line numbers as you go —
+every finding in step 3 must cite a specific line range.
+
+### Step 3 — Audit across five categories
+
+Walk the spec requirement-by-requirement and scenario-by-scenario, comparing
+each to the implementation. Group findings:
+
+1. **Non-compliance** — places where the implementation contradicts, omits, or
+   under-specifies a spec requirement. Cite the spec requirement name + impl
+   file:line.
+2. **Overreach** — places where the implementation adds constraints or
+   behaviors not in the spec. For each, note whether the directive belongs in
+   project-wide rules (CLAUDE.md, `_shared/` docs) or is a legitimate
+   skill-specific extension worth preserving.
+3. **Redundancy** — repeated information across sections (the same warning
+   stated multiple times; a constraints section that restates the body; a
+   reference + inline duplication that drifts).
+4. **Bloat** — content that adds no signal (verbose code blocks that should
+   reference a canonical doc; sibling descriptions that belong in the README;
+   excessive examples; commentary that doesn't change reader behavior).
+5. **Overcomplication** — structure that could be simpler (too many labeled
+   sections, defensive checks that duplicate framework guarantees, multi-layer
+   warnings, prompt scaffolding heavier than the underlying directive).
+
+For every finding, include the implementation file:line. Vague critique is
+unactionable.
+
+### Step 4 — Surface suggestions in priority order
+
+After the categorized findings, list concrete tightening suggestions in
+priority order. Each suggestion should be actionable in one edit — not "reconsider
+the whole thing." Where possible, estimate line savings.
+
+A good suggestion has the shape:
+> N. **<one-line action>** — what to replace, what with, and what's saved.
+
+### Step 5 — Interview the user on scope
+
+Use `AskUserQuestion` (max 4 questions per call) for any ambiguous decisions:
+- For category findings with non-obvious tradeoffs, present both interpretations
+- For "is this overreach or appropriate implementation detail?" cases, ask
+- For "remove this restated content" calls, confirm if it might serve a purpose
+  (scannability, onboarding)
+
+Skip the interview if the user has already given clear scope ("apply all" /
+"apply the top 3" / "just the redundancy fixes").
+
+### Step 6 — Apply the approved changes
+
+- For small, scattered edits, use `Edit`
+- For substantial restructuring (more than ~30% of the file), `Write` the new
+  version
+
+After each edit, if a validator exists for the spec format, re-run it (e.g.
+`bash scripts/openspec validate <capability> --type spec --strict`). The
+implementation edit shouldn't touch the spec, but a passing validator confirms
+the alignment claim.
+
+Report the line delta (before → after) and confirm every spec scenario still
+maps to a directive in the tightened implementation.
+
+---
+
+## Constraints
+
+- Never refactor an artifact without a written spec — the spec is the contract.
+  If no spec exists, run `/spec-baseline` first.
+- Every finding MUST cite implementation file:line. Vague critique is rejected.
+- Never silently expand scope beyond the file under audit. If a sibling file
+  looks worse, surface that as a separate suggestion; do not modify it.
+- Preserve behavioral coverage. After refactoring, every spec scenario MUST
+  still map to a directive in the implementation. If the coverage map would
+  break, the edit is wrong.
+- Tightening removes; it does not add. Do not introduce new abstractions,
+  helper functions, or shared utilities during a tightening pass. Those are
+  separate features.
+- If the audit produces zero findings, say so explicitly and stop. Manufactured
+  churn is worse than a no-op pass.
+- Re-validate the spec after refactoring to confirm alignment (the impl edit
+  shouldn't touch the spec, but the validator check is the discipline that
+  catches accidental drift).
+
+## Output checklist
+
+- [ ] Audit findings grouped into the five categories with file:line citations
+- [ ] Priority-ordered suggestions with estimated line savings where applicable
+- [ ] Interview turn (or explicit acknowledgement that scope was pre-decided)
+- [ ] Edits applied; line delta reported (before → after)
+- [ ] Spec validator re-run (if applicable) and still passing
+- [ ] Coverage check: every spec scenario still maps to an impl directive

--- a/openspec/README.md
+++ b/openspec/README.md
@@ -1,0 +1,32 @@
+# OpenSpec
+
+Behavioral specifications for capabilities in this repository.
+
+## Layout
+
+```
+openspec/
+  specs/
+    <capability>/
+      spec.md         # The OpenSpec specification (machine-validated)
+      REFERENCES.md   # Source citations backing every requirement and scenario
+  inventory/
+    modules/
+      <name>.md       # Optional module inventory briefs (maps, not specs)
+```
+
+## Validate a spec
+
+```bash
+bash scripts/openspec validate <capability> --type spec --strict
+```
+
+## Authoring
+
+**Baselining existing capabilities** — use `/spec-baseline` to reverse-engineer a spec
+from code that already exists. The output includes a `REFERENCES.md` that cites every
+requirement back to specific file:line evidence.
+
+**Proposing changes** — once a capability is baselined, use `/opsx:propose` to draft
+changes against the existing spec rather than modifying it directly. Proposed changes
+go through a review and apply workflow before the spec is updated.

--- a/openspec/specs/polishkit-appraise/REFERENCES.md
+++ b/openspec/specs/polishkit-appraise/REFERENCES.md
@@ -1,0 +1,125 @@
+# Appraise — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `repo-root/`.
+Line numbers verified on 2026-05-22.
+
+---
+
+## Requirement: Scope survey
+
+**Sources**
+- `plugins/polishkit/skills/appraise/SKILL.md:195-212` — `## Workflow` section defines the three scope tiers (single file / pasted code, directory or module, full repo) and the representative-sampling approach for large scopes
+- `plugins/polishkit/skills/appraise/SKILL.md:200-204` — "For repo-wide or module assessments, start with a structural survey" — survey steps: directory tree, entry points, domain/infrastructure/test identification, read a representative sample
+
+**Notes**
+- The "representative sample — don't try to read every file" constraint is explicit and intentional
+
+### Scenario: Single file scope
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:197-198` — "If it's a single file or pasted code → assess that directly"
+**Interpolated; no direct test.**
+
+### Scenario: Repository or module scope
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:200-207` — full structural survey workflow for non-single-file scopes.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Language detection and idiomatic lens
+
+**Sources**
+- `plugins/polishkit/skills/appraise/SKILL.md:17-28` — `## Supported Languages` section lists C#, Go, Python, TypeScript, React, Next.js and states "applying both universal principles and language-specific idiomatic standards"
+- `plugins/polishkit/skills/appraise/SKILL.md:207` — `## Workflow` step 3: "Detect the language(s) in use and activate the appropriate idiomatic lens."
+
+**Notes**
+- The specific languages supported (C#, Go, Python, TypeScript, React, Next.js) are listed in the implementation; the spec abstracts these as "detected language + associated framework" to remain stack-agnostic. The enumeration belongs here in REFERENCES.md.
+
+### Scenario: Language detected
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:207` — "Detect the language(s) in use and activate the appropriate idiomatic lens."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Five-dimension scoring
+
+**Sources**
+- `plugins/polishkit/skills/appraise/SKILL.md:32-127` — `## The Five Dimensions` section defines all five dimensions with 1–10 score anchors
+- `plugins/polishkit/skills/appraise/SKILL.md:142-148` — `## Scoring Formula` section with the exact weighted formula and rounding instruction
+- `plugins/polishkit/skills/appraise/SKILL.md:150-161` — `## Overall Verdict Tiers` table mapping score ranges to verdicts
+
+**Notes**
+- Dimension weights: Architecture 30%, Naming 25%, Algorithmic Elegance 20%, Testability 15%, Idiomatic Consistency 10%
+
+### Scenario: Overall score computed
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:142-148` — the scoring formula block, rounding instruction included.
+**Interpolated; no direct test.**
+
+### Scenario: Verdict tier assigned
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:150-161` — the tier table with five ranges.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Always-flag violations
+
+**Sources**
+- `plugins/polishkit/skills/appraise/SKILL.md:128-139` — `## Always-Flag Violations` table listing five violation types: god classes, magic numbers/strings, comments that restate code, functions >~30 lines, files >~300 lines
+- `plugins/polishkit/skills/appraise/SKILL.md:183-188` — `### Violations` subsection of Report Structure: "List any always-flag violations found / Reference specific files/lines"
+
+### Scenario: God class present
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:131` — "God classes / god objects — A class doing too much is the antithesis of clean architecture."
+**Interpolated; no direct test.**
+
+### Scenario: Oversized function present
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:135` — "Functions exceeding ~30 lines — Long functions almost always do more than one thing."
+**Interpolated; no direct test.**
+
+### Scenario: No violations found
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:183-188` — the Violations section is always present in the report structure; content is the findings or absence thereof.
+**Interpolated from absence** — the SKILL.md does not explicitly state what to write when no violations are found; the spec's "states that no violations were found" behavior is inferred.
+
+---
+
+## Requirement: Report structure and length
+
+**Sources**
+- `plugins/polishkit/skills/appraise/SKILL.md:163-191` — `## Report Structure` defines the five-section order and content expectations for each
+- `plugins/polishkit/skills/appraise/SKILL.md:14-15` — length cap: "The entire report must stay under **500 lines**. Brevity is itself a form of elegance."
+- `plugins/polishkit/skills/appraise/SKILL.md:165-172` — `### Executive Summary` required elements: score, verdict, one-sentence characterization, most beautiful thing, most impactful improvement
+- `plugins/polishkit/skills/appraise/SKILL.md:173-177` — `### Beauty Highlights` 2–5 instances with principle named
+- `plugins/polishkit/skills/appraise/SKILL.md:218` — "Stay under 500 lines total. Be precise."
+
+### Scenario: Sections appear in prescribed order
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:163-191` — the five sections are listed in the prescribed order.
+**Interpolated; no direct test.**
+
+### Scenario: Report stays under length limit
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:14-15` and `plugins/polishkit/skills/appraise/SKILL.md:218` — two explicit 500-line cap statements.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Read-only operation
+
+**Sources**
+- `plugins/polishkit/skills/appraise/SKILL.md:1-3` — description frontmatter: "Produces a scored report" — no mention of file changes
+- `plugins/polishkit/skills/appraise/SKILL.md:193-218` — `## Workflow` section: all steps are read/survey/score/produce-report with no write, commit, push, or PR creation steps present
+
+**Notes**
+- The read-only constraint is interpolated from absence — the SKILL.md contains no write, edit, commit, or push instructions. There is no explicit "do not modify files" statement.
+
+### Scenario: Assessment completes
+**Source:** `plugins/polishkit/skills/appraise/SKILL.md:193-218` — the entire workflow has no file-write steps.
+**Interpolated from absence** — read-only behavior is defined by the absence of write operations in the workflow, not by an explicit prohibition.
+
+---
+
+## Cross-cutting interpretive notes
+
+1. **Read-only is interpolated from absence, not stated.** The SKILL.md never says "do not modify files" — the read-only constraint is inferred from the complete absence of write/edit/commit/push steps in the workflow. A future change adding a step with side effects would not contradict an explicit prohibition. This is the primary claim requiring human reviewer attention.
+
+2. **"No violations found" messaging is interpolated.** The SKILL.md specifies the Violations section must exist in the report structure and must reference specific files/lines, but does not define what to write when nothing is found. The spec's "states that no violations were found" wording is an interpretation of the intent.
+
+3. **No test coverage exists for any scenario.** Appraise has no test suite. All scenarios are interpolated from the skill's prompt instructions.
+
+4. **500-line cap is a behavioral commitment.** The cap appears twice (lines 14–15 and 218) with "brevity is itself a form of elegance" framing. This is a deliberate quality signal, not just a practicality — worth preserving in any future rewrites of the skill.

--- a/openspec/specs/polishkit-appraise/spec.md
+++ b/openspec/specs/polishkit-appraise/spec.md
@@ -1,0 +1,68 @@
+# Appraise
+
+## Purpose
+Appraise produces a scored, read-only quality assessment of code across five weighted dimensions — architecture, naming, algorithmic elegance, testability, and idiomatic consistency — with beauty highlights and violation flags. It is a connoisseur-style evaluation tool that leads with genuine craft observations before surfacing improvement opportunities.
+
+## Requirements
+
+### Requirement: Scope survey
+Appraise SHALL determine the target scope from user input and read enough representative code to support scoring. For a single file or pasted snippet, it reads that content directly. For a directory or module, it surveys the structure and reads key files. For a full repository, it surveys the project structure, identifies architectural boundaries, and samples representative files across layers. Appraise SHALL NOT attempt to read every file in a large scope; representative sampling is sufficient.
+
+#### Scenario: Single file scope
+- **WHEN** a single file path or code snippet is provided
+- **THEN** Appraise reads that content directly and bases its assessment on it
+
+#### Scenario: Repository or module scope
+- **WHEN** a directory, module path, or no scope is provided
+- **THEN** Appraise surveys the directory tree, identifies entry points and architectural layers, and reads a representative cross-section before scoring
+
+### Requirement: Language detection and idiomatic lens
+Appraise SHALL detect the primary language(s) present in the scope. For each detected language, Appraise SHALL apply that language's idiomatic standards when scoring the Idiomatic Consistency dimension alongside universal principles. Where a language has an associated application framework in widespread use, Appraise SHALL additionally apply that framework's conventions.
+
+#### Scenario: Language detected
+- **WHEN** a primary language is identifiable in the scope
+- **THEN** Appraise applies that language's idiomatic standards for the Idiomatic Consistency dimension
+
+### Requirement: Five-dimension scoring
+Appraise SHALL score the code across exactly five dimensions. Each dimension MUST be scored on a 1–10 scale. The overall score SHALL be the weighted sum: Architecture & Separation of Concerns (30%), Naming & Readability (25%), Algorithmic Elegance (20%), Testability & Test Design (15%), Idiomatic Consistency (10%), rounded to one decimal place.
+
+#### Scenario: Overall score computed
+- **WHEN** all five dimension scores are assigned
+- **THEN** overall score = (Architecture × 0.30) + (Naming × 0.25) + (Algorithmic Elegance × 0.20) + (Testability × 0.15) + (Idiomatic Consistency × 0.10), rounded to one decimal place
+
+#### Scenario: Verdict tier assigned
+- **WHEN** the overall score is computed
+- **THEN** a verdict tier is assigned: 9.0–10.0 Masterwork, 7.5–8.9 Polished, 6.0–7.4 Competent, 4.0–5.9 Rough, 1.0–3.9 Needs Rethinking
+
+### Requirement: Always-flag violations
+Regardless of dimension scores, Appraise SHALL flag any of the following when found: god classes or god objects; magic numbers or magic strings; comments that restate what the code does; functions exceeding approximately 30 lines; files exceeding approximately 300 lines. These SHALL appear in a dedicated Violations section.
+
+#### Scenario: God class present
+- **WHEN** a class, module, or file carries multiple unrelated responsibilities beyond a single clear purpose
+- **THEN** it is flagged in the Violations section with a file reference
+
+#### Scenario: Oversized function present
+- **WHEN** a function body exceeds approximately 30 lines
+- **THEN** it is flagged in the Violations section with a file:line reference
+
+#### Scenario: No violations found
+- **WHEN** none of the always-flag conditions are present
+- **THEN** the Violations section states that no violations were found
+
+### Requirement: Report structure and length
+Appraise SHALL produce its output in this section order: Executive Summary, Beauty Highlights, Dimension Breakdown, Violations, Closing Note. The report MUST stay under 500 lines total. The Executive Summary MUST include the overall score, verdict tier, a one-sentence characterization of the codebase, the single most beautiful thing observed, and the single most impactful improvement opportunity. The Beauty Highlights section MUST call out 2–5 specific instances of genuinely elegant code with the principle at work named.
+
+#### Scenario: Sections appear in prescribed order
+- **WHEN** Appraise produces its report
+- **THEN** sections appear in the order: Executive Summary → Beauty Highlights → Dimension Breakdown → Violations → Closing Note
+
+#### Scenario: Report stays under length limit
+- **WHEN** Appraise produces its report
+- **THEN** the total output is under 500 lines
+
+### Requirement: Read-only operation
+Appraise SHALL NOT modify, create, or delete any files. It SHALL NOT create branches or open pull requests. Its only output is the scored report delivered in the current conversation.
+
+#### Scenario: Assessment completes
+- **WHEN** Appraise finishes its assessment
+- **THEN** no files have been created, modified, or deleted and no branches or PRs exist as a result of the invocation

--- a/openspec/specs/polishkit-polish/REFERENCES.md
+++ b/openspec/specs/polishkit-polish/REFERENCES.md
@@ -1,0 +1,187 @@
+# Polish — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `repo-root/`.
+Line numbers verified on 2026-05-22.
+
+---
+
+## Requirement: Scope intake
+
+**Sources**
+- `plugins/polishkit/skills/polish/SKILL.md:27-43` — `## Input` section defines the three accepted scope forms (path, glob, cross-cutting concern) and the `--model`, `--agent`, `--max-files`, `--base`, `--dry-run` flags
+- `plugins/polishkit/skills/polish/SKILL.md:47-59` — `### 1. Resolve scope` specifies enumerate-and-pass-verbatim for path/glob, theme+boundary decomposition for concern, and the slug derivation
+- `plugins/polishkit/skills/polish/SKILL.md:42-43` — empty-scope prompt text: `"What scope should I polish? (path, glob, or cross-cutting concern + scope hint)"`
+
+**Notes**
+- The "pass file list verbatim" contract is explicit ("Pass the resolved file list to the agent verbatim so it doesn't re-discover scope")
+
+### Scenario: Path or glob scope provided
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:47-49` — "For a path/glob, list files that match." and the verbatim-pass instruction.
+**Interpolated; no direct test.**
+
+### Scenario: Cross-cutting concern scope provided
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:49-50` — "For a cross-cutting concern, treat the description as the agent's *theme* and the path/glob hint as the *file boundary* — pass both to the agent."
+**Interpolated; no direct test.**
+
+### Scenario: No scope provided
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:42-43` — the inline prompt string shown when `<scope>` is empty.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Verify command detection
+
+**Sources**
+- `plugins/polishkit/skills/polish/SKILL.md:61-75` — `### 2. Detect the project's verify commands` specifies the full priority order (CLAUDE.md → package.json → Makefile → language defaults) and the ask-user fallback
+- `plugins/polishkit/skills/polish/SKILL.md:73-74` — "If nothing matches, ask the user for the verify command before dispatching. Never invent a command the repo doesn't expose."
+
+**Notes**
+- Watch-mode exclusion is explicit: "Skip watch-mode scripts"
+
+### Scenario: Verify command found in package.json
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:67-69` — package.json scripts detection priority list: typecheck, test:run, test, lint.
+**Interpolated; no direct test.**
+
+### Scenario: No verify command detectable
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:73-74` — explicit ask-user fallback when nothing matches.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: PR base branch resolution
+
+**Sources**
+- `plugins/polishkit/skills/polish/SKILL.md:77-118` — `### 3. Resolve the PR base branch` — full 5-step resolution chain with inline bash pseudocode
+- `plugins/polishkit/skills/polish/SKILL.md:83-90` — step 1 (explicit `--base` arg extraction)
+- `plugins/polishkit/skills/polish/SKILL.md:92-94` — step 2 (`claude.polishkit.prBase`)
+- `plugins/polishkit/skills/polish/SKILL.md:96-99` — step 3 (`claude.flowkit.prBase` courtesy interop)
+- `plugins/polishkit/skills/polish/SKILL.md:101-105` — step 4 (develop if on remote)
+- `plugins/polishkit/skills/polish/SKILL.md:107-113` — step 5 (repo default with warning)
+- `plugins/polishkit/skills/polish/SKILL.md:116` — "The agent must use it for both the branch cut **and** the `gh pr create --base` argument."
+
+**Notes**
+- The flowkit interop is explicitly labeled best-effort: "The flowkit read at step 3 is best-effort interop only — polishkit works without flowkit installed."
+- This chain was introduced in commit `3469b50` (fix: resolve PR base via flowkit chain) and the canonical spec was extracted in `8a61f87` (refactor: extract canonical base-resolution spec)
+
+### Scenario: Explicit --base overrides all config
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:83-90` — step 1 bash block checks for `--base` first before any config read.
+**Interpolated; no direct test.**
+
+### Scenario: Polishkit config key present
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:92-94` — step 2 reads `claude.polishkit.prBase`.
+**Interpolated; no direct test.**
+
+### Scenario: Fallback to develop
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:101-105` — step 4 checks `git ls-remote --heads origin develop`.
+**Interpolated; no direct test.**
+
+### Scenario: Fallback to repo default with warning
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:107-113` — step 5 uses `gh repo view` for default branch and echoes warning to stderr.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Isolated single-agent dispatch
+
+**Sources**
+- `plugins/polishkit/skills/polish/SKILL.md:122-131` — `### 4. Dispatch the subagent` specifies `subagent_type: general-purpose`, `isolation: worktree`, `mode: bypassPermissions`, `run_in_background: true`
+- `plugins/polishkit/skills/polish/SKILL.md:186-187` — constraint: "One agent per invocation, one PR per agent. Never fan out multiple polish agents on the same scope."
+
+**Notes**
+- The `run_in_background: true` is the source of the "orchestrator does not block" behavior
+
+### Scenario: Agent dispatched
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:126-130` — Agent tool call shape with all four parameters specified.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Semantic fix application
+
+**Sources**
+- `plugins/polishkit/skills/polish/SKILL.md:136-143` — `**TASK**` section defines the three review heuristic categories: Reuse, Quality, Efficiency
+- `plugins/polishkit/skills/polish/SKILL.md:144-146` — "For a cross-cutting theme, prioritize fixes matching that theme; deprioritize everything else (mention as deferred findings, don't fix)."
+- `plugins/polishkit/skills/polish/SKILL.md:147-149` — `**RESPECT BEHAVIOR**` clause: public surfaces stay compatible; behavior-changing fixes go to deferred findings section
+
+### Scenario: Theme-filtered pass
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:144-146` — explicit theme priority instruction with deferred-findings disposition.
+**Interpolated; no direct test.**
+
+### Scenario: Public contract preserved
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:147-149` — "keep public surfaces compatible. If a fix would change a public contract, leave it untouched and surface in the PR's `## Findings deferred to issues` section with file:line refs."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: File cap enforcement
+
+**Sources**
+- `plugins/polishkit/skills/polish/SKILL.md:35-36` — `--max-files <N>` input flag definition with default of 15
+- `plugins/polishkit/skills/polish/SKILL.md:150-152` — `**SOFT CAP**` clause specifying cap behavior and deferred-findings disposition for excess
+- `plugins/polishkit/skills/polish/SKILL.md:187-188` — constraint restating the cap philosophy: "if scope is so large the agent wants to touch >50 files, it should narrow"
+
+### Scenario: Scope within cap
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:150` — implicit: cap only activates when exceeded.
+**Interpolated; no direct test.**
+
+### Scenario: Scope exceeds cap
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:150-152` — "If the scope clearly exceeds the cap, fix the highest-impact subset and list the rest under deferred findings."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Green-build gate
+
+**Sources**
+- `plugins/polishkit/skills/polish/SKILL.md:157-158` — workflow step 4: "Verify by running every command in `VERIFY_COMMANDS`... All MUST pass before push. If any fails, iterate until green or revert the breaking edit and list it as deferred."
+- `plugins/polishkit/skills/polish/SKILL.md:194` — constraint: "Verify must be green before push. Red builds are never acceptable, even for 'lightweight' passes."
+
+### Scenario: All verify commands pass
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:157-158` — "All MUST pass before push."
+**Interpolated; no direct test.**
+
+### Scenario: Verify command fails after an edit
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:158` — "If any fails, iterate until green or revert the breaking edit and list it as deferred."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Single PR delivery
+
+**Sources**
+- `plugins/polishkit/skills/polish/SKILL.md:159-160` — workflow step 5: push and open PR with `--base "$BASE_BRANCH"` explicitly; warning about omitting `--base`
+- `plugins/polishkit/skills/polish/SKILL.md:162-170` — `**PR BODY SHAPE**` clause defining the canonical four-section structure including the extra `## Findings deferred to issues`
+- `plugins/polishkit/skills/polish/SKILL.md:172-175` — `**NO-OP IS LEGITIMATE**` clause: "if the pass finds nothing actionable in the scope, open the PR anyway"
+
+### Scenario: Fixes applied and verified
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:159-160` — push and PR creation step, explicit `--base` requirement.
+**Interpolated; no direct test.**
+
+### Scenario: No actionable fixes found
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:172-175` — "open the PR anyway with `## Summary` stating `no actionable simplifications found`"
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Dry-run mode
+
+**Sources**
+- `plugins/polishkit/skills/polish/SKILL.md:38-39` — `--dry-run` flag definition in `## Input`
+- `plugins/polishkit/skills/polish/SKILL.md:177-179` — `### 5. Dry-run mode`: "the agent skips the apply/commit/push phase and instead returns a structured findings report inline (not as a PR)"
+
+### Scenario: Dry-run invocation
+**Source:** `plugins/polishkit/skills/polish/SKILL.md:177-179` — dry-run mode definition.
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. **No test coverage exists for any scenario.** The SKILL.md is entirely prompt-based instruction; there is no test suite for polishkit skills. Every scenario in the spec is interpolated from the skill's written instructions rather than verified by an automated assertion.
+
+2. **"Isolated worktree" guarantee is structural, not tested.** The `isolation: worktree` parameter on the Agent call is the mechanism — the spec says the agent MUST run in a worktree, but whether the harness enforces this is outside the skill's own control.
+
+3. **Base-resolution chain order for flowkit interop.** The chain was authored with flowkit absent as a valid state. The courtesy read of `claude.flowkit.prBase` at step 3 is intentionally placed after polishkit's own key — this ordering was a deliberate product decision (commit `3469b50`, `8a61f87`).
+
+4. **No-op PR is the defined termination condition.** Polish explicitly rejects "manufactured churn" — the no-op PR is a first-class outcome, not a degenerate case. This is a behavioral commitment worth reviewing against any future changes to the skill.

--- a/openspec/specs/polishkit-polish/spec.md
+++ b/openspec/specs/polishkit-polish/spec.md
@@ -1,0 +1,97 @@
+# Polish
+
+## Purpose
+Polish applies semantic code-quality fixes — reuse, quality, and efficiency — across a user-specified scope in an isolated worktree and opens one PR. It is a lightweight, single-pass, single-agent cleanup tool for targeted cross-cutting improvements that preserves public contracts and gates on a green build before pushing.
+
+## Requirements
+
+### Requirement: Scope intake
+Polish SHALL accept a scope as a path, glob, or cross-cutting concern with a scope hint. For a path or glob, Polish SHALL enumerate matching files and pass them verbatim to the dispatched agent. For a cross-cutting concern, the description serves as the agent theme and the accompanying hint defines the file boundary. If no scope is provided, Polish SHALL prompt the user before proceeding.
+
+#### Scenario: Path or glob scope provided
+- **WHEN** the user provides a path or glob (e.g. `src/hooks/`)
+- **THEN** Polish resolves all matching files and passes the explicit list to the agent
+
+#### Scenario: Cross-cutting concern scope provided
+- **WHEN** the user provides a natural-language concern with a scope hint (e.g. `error handling in src/providers/`)
+- **THEN** Polish passes the concern description as the agent theme and the hint as the file boundary
+
+#### Scenario: No scope provided
+- **WHEN** the invocation includes no scope argument
+- **THEN** Polish prompts the user for a scope before dispatching any agent
+
+### Requirement: Verify command detection
+Before dispatching, Polish SHALL detect the project's canonical typecheck and test commands. If no command is found, Polish SHALL ask the user before dispatching.
+
+#### Scenario: Verify command found
+- **WHEN** at least one canonical typecheck or test command is detectable in the project
+- **THEN** Polish passes that command to the agent as the verify step
+
+#### Scenario: No verify command detectable
+- **WHEN** no verify command is found
+- **THEN** Polish asks the user for the verify command before dispatching
+
+### Requirement: PR base branch resolution
+Polish SHALL resolve a base branch before dispatching, preferring explicit arguments over configuration over remote defaults. The resolved base MUST be used for both the branch cut and the `gh pr create --base` argument.
+
+#### Scenario: Explicit --base overrides all
+- **WHEN** `--base <branch>` is present in the arguments
+- **THEN** that branch is used as the PR base, bypassing all other resolution
+
+#### Scenario: No resolvable configured base
+- **WHEN** no explicit arg, config key, or known remote branch resolves a base
+- **THEN** the repository default branch is used and a warning is emitted
+
+### Requirement: Isolated single-agent dispatch
+Polish SHALL dispatch exactly one agent per invocation. Polish MUST run all fix work in an isolated worktree, in bypassPermissions mode, and in the background. Polish MUST NOT dispatch more than one agent per invocation.
+
+#### Scenario: Agent dispatched
+- **WHEN** Polish is invoked with a valid scope
+- **THEN** exactly one agent runs in an isolated worktree and Polish returns without blocking on the agent's completion
+
+### Requirement: Semantic fix application
+Polish SHALL apply fixes across three categories: reuse (duplicated logic; inlined alternatives where an existing helper exists), quality (unclear naming, dead code, weak error handling, type hygiene gaps), and efficiency (quadratic loops where linear is possible, redundant async waits, unnecessary recomputations). When a cross-cutting theme is given, Polish SHALL prioritize only fixes matching that theme and defer all others to the PR's deferred findings section. Polish SHALL NOT change any public contract; such fixes MUST be deferred with a file:line reference.
+
+#### Scenario: Theme-filtered pass
+- **WHEN** a cross-cutting concern theme is provided
+- **THEN** Polish applies only fixes relevant to that theme and lists all other findings as deferred
+
+#### Scenario: Public contract preserved
+- **WHEN** a fix would alter an exported or public API surface
+- **THEN** Polish leaves the code unchanged and lists it in deferred findings with a file:line reference
+
+### Requirement: File cap enforcement
+Polish SHALL not touch more than the configured max-files limit (default: 15) in a single PR. If the actionable scope exceeds the cap, Polish SHALL fix the highest-impact subset and list the remainder as deferred findings.
+
+#### Scenario: Scope exceeds cap
+- **WHEN** the number of actionable files exceeds max-files
+- **THEN** Polish fixes the highest-impact subset up to the cap and lists remaining files as deferred findings
+
+### Requirement: Green-build gate
+Polish SHALL run every command in VERIFY_COMMANDS before pushing. All commands MUST pass. If a command fails after an edit, Polish SHALL iterate to fix the failure or revert that specific edit and list it as deferred. A failing build MUST NOT be pushed.
+
+#### Scenario: All verify commands pass
+- **WHEN** all VERIFY_COMMANDS pass after edits are applied
+- **THEN** Polish proceeds to push and open the PR
+
+#### Scenario: Verify command fails after an edit
+- **WHEN** a verify command fails following a specific edit
+- **THEN** Polish either resolves the failure or reverts that edit and adds it to deferred findings before pushing
+
+### Requirement: Single PR delivery
+Polish SHALL open exactly one PR per invocation targeting the resolved base branch. The PR body MUST follow the canonical shape (## Summary / ## Changes / ## Test plan / ## Findings deferred to issues). The `gh pr create` call MUST include `--base <BASE_BRANCH>` explicitly. A no-op result — scope examined but no actionable fixes found — is valid; Polish SHALL open a PR in that case stating no actionable simplifications were found.
+
+#### Scenario: Fixes applied and verified
+- **WHEN** Polish applies at least one edit that passes all verify commands
+- **THEN** exactly one PR is opened against the resolved base with a canonical body
+
+#### Scenario: No actionable fixes found
+- **WHEN** Polish finds nothing to change in the scope
+- **THEN** one PR is still opened with "no actionable simplifications found" in ## Summary
+
+### Requirement: Dry-run mode
+When `--dry-run` is provided, Polish SHALL report findings inline without applying any edits, committing, pushing, or opening a PR.
+
+#### Scenario: Dry-run invocation
+- **WHEN** `--dry-run` is present in the arguments
+- **THEN** Polish produces a structured findings report in the conversation and makes no file changes

--- a/openspec/specs/polishkit-sweep/REFERENCES.md
+++ b/openspec/specs/polishkit-sweep/REFERENCES.md
@@ -1,0 +1,133 @@
+# Sweep — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `repo-root/`.
+Line numbers verified on 2026-05-22.
+
+---
+
+## Requirement: Scope intake
+
+**Sources**
+- `plugins/polishkit/skills/sweep/SKILL.md:24-31` — `## Scope` section defines the three scope forms: path/glob, category hint, empty (full sweep)
+- `plugins/polishkit/skills/sweep/SKILL.md:35-36` — "Phases are independent — if scope restricts to one, skip the other."
+
+### Scenario: Full sweep (no scope)
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:26-27` — "Empty — run everything."
+**Interpolated; no direct test.**
+
+### Scenario: Path or glob scope
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:28-29` — "A path or glob (`src/components/`, `**/*.test.ts`) — restricts both phases to that subtree."
+**Interpolated; no direct test.**
+
+### Scenario: Category hint scope
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:30-31` — "A category hint (`dead-code-only`, `cruft-only`, `git-only`) — runs just the matching phase."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Dead code detection
+
+**Sources**
+- `plugins/polishkit/skills/sweep/SKILL.md:39-47` — `#### 1.1 Detect language and available tools` — TypeScript/JavaScript, Python, Go detection commands
+- `plugins/polishkit/skills/sweep/SKILL.md:49-95` — `#### 1.2 Scan for dead code` — per-language scan commands for unused exports, imports, dead variables, commented-out code
+- `plugins/polishkit/skills/sweep/SKILL.md:86-90` — exclusion list: node_modules/, dist/, build/, .next/, generated files (*.generated.ts, *.d.ts), test files
+
+**Notes**
+- The test-file exclusion rationale is stated explicitly: "dead code in tests can be intentional fixtures"
+
+### Scenario: TypeScript project scanned
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:63-68` — ts-prune for unused exports; `plugins/polishkit/skills/sweep/SKILL.md:72-73` — tsc --noEmit for noUnusedLocals/noUnusedParameters.
+**Interpolated; no direct test.**
+
+### Scenario: Test files excluded
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:89-90` — "Test files (dead code in tests can be intentional fixtures)" in the exclusion list.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Cruft detection
+
+**Sources**
+- `plugins/polishkit/skills/sweep/SKILL.md:105-165` — `### Phase 2 — Cruft & Hygiene` — full set of parallel checks
+- `plugins/polishkit/skills/sweep/SKILL.md:107-112` — stale documentation checks
+- `plugins/polishkit/skills/sweep/SKILL.md:113-117` — build artifacts and dead directories
+- `plugins/polishkit/skills/sweep/SKILL.md:118-123` — documentation gaps
+- `plugins/polishkit/skills/sweep/SKILL.md:124-127` — duplicate content
+- `plugins/polishkit/skills/sweep/SKILL.md:129-164` — git hygiene including the remote merged-branch classification loop
+
+**Notes**
+- The remote merged-PR branch classification was added in commit `d7f7836` (docs: cover remote merged PR branches). Prior to that commit only local branch hygiene was covered.
+- The `parked/*` prefix exemption in the remote branch filter is an implicit convention in this repo.
+
+### Scenario: Remote branch classification
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:133-151` — the bash loop that fetches, lists non-default/non-parked branches, and classifies each by PR state using `gh pr list`.
+**Interpolated; no direct test.**
+
+### Scenario: Only merged-PR branches proposed for deletion
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:153-161` — the deletion policy table: MERGED → propose deletion; CLOSED / OPEN / NO PR → preserve.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Remote branch deletion safety
+
+**Sources**
+- `plugins/polishkit/skills/sweep/SKILL.md:162-165` — "When deleting, **always use the disambiguated refspec form** (`git push origin :refs/heads/<branch>`). The unqualified `git push origin --delete <branch>` fails with `src refspec matches more than one` whenever a same-named tag exists"
+- `plugins/polishkit/skills/sweep/SKILL.md:164-167` — batch form: `git push origin :refs/heads/branch-a :refs/heads/branch-b`
+
+**Notes**
+- The motivation is explicit: the `rc/YYYY-MM-DD.N` tag shape from `flowkit:cut` is the canonical collision case. This was added in commit `d7f7836`.
+
+### Scenario: Single remote branch deletion
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:162-163` — disambiguated refspec instruction.
+**Interpolated; no direct test.**
+
+### Scenario: Multiple remote branch deletions
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:165-167` — batch push form shown explicitly.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Interactive confirmation
+
+**Sources**
+- `plugins/polishkit/skills/sweep/SKILL.md:168-181` — `### 3. Present findings and confirm each action` — combined Remove/Update/Keep summary, AskUserQuestion batching at most 4, grouping related items, wait-for-all-answers before step 4
+- `plugins/polishkit/skills/sweep/SKILL.md:176-180` — specific AskUserQuestion call conventions: batch ≤4, group related, default first option to recommended
+
+### Scenario: Confirmation collected before execution
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:181` — "Wait for all answers before proceeding to step 4."
+**Interpolated; no direct test.**
+
+### Scenario: Question batching
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:175` — "Use `AskUserQuestion` to confirm each proposed action, batched in groups of at most 4 questions per call."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Cleanup execution and commit
+
+**Sources**
+- `plugins/polishkit/skills/sweep/SKILL.md:182-191` — `### 4. Execute cleanup` — apply, tsc verify, re-run project verify, commit message `chore: sweep codebase`, PR targeting base branch with develop-then-default fallback
+
+### Scenario: Post-removal parse check
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:184-185` — "For dead-code removals, verify the file still parses — run `tsc --noEmit` or the language equivalent if available."
+**Interpolated; no direct test.**
+
+### Scenario: Commit and PR opened
+**Source:** `plugins/polishkit/skills/sweep/SKILL.md:187-191` — "Commit with `chore: sweep codebase` and open a PR targeting the project's base branch (auto-detect `develop` then fall back to `main`)."
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. **No test coverage exists for any scenario.** Sweep has no test suite. All scenarios are interpolated from the skill's prompt instructions.
+
+2. **Remote branch deletion safety was retroactively added.** The disambiguated refspec requirement was introduced in commit `d7f7836` specifically to prevent collisions with `rc/YYYY-MM-DD.N` tags created by `flowkit:cut`. Any revision to the sweep skill that touches the deletion path must preserve this form.
+
+3. **"Cruft detection" PR base branch fallback is simpler than polish's.** Sweep uses a two-step fallback (`develop` then repo default) without reading any git config keys. This is intentional — sweep is a maintenance operation that targets the integration branch directly rather than requiring explicit base configuration.
+
+4. **Parked branch exemption is implied, not documented inline.** The remote branch filter excludes `^(develop|main|gh-pages|parked/.*)$` — the `parked/*` prefix is an implicit repo convention not explained in the skill prose. A reviewer should verify this is the correct set of protected branch patterns for this repo.
+
+5. **Phase independence is stated but not enforced programmatically.** The skill says "Phases are independent — if scope restricts to one, skip the other," but there is no guard preventing both phases from running when a category hint is given. This is a behavioral claim interpolated from prose, not from any gate condition in the code.

--- a/openspec/specs/polishkit-sweep/spec.md
+++ b/openspec/specs/polishkit-sweep/spec.md
@@ -1,0 +1,76 @@
+# Sweep
+
+## Purpose
+Sweep removes accumulated cruft from a codebase in two coordinated phases — dead code (unused exports, imports, variables, unreachable branches) and stale artifacts (outdated docs, build leftovers, duplicate content, merged remote branches) — with interactive confirmation before any changes are applied. It is the hygiene counterpart to Polish, focused on safe removal with user control over every action.
+
+## Requirements
+
+### Requirement: Scope intake
+Sweep SHALL accept an optional scope argument that restricts processing. A path or glob restricts both phases to that subtree. A category hint (dead-code-only, cruft-only, git-only) restricts to the matching phase. An absent scope runs both phases across the full repository.
+
+#### Scenario: Full sweep (no scope)
+- **WHEN** no scope argument is provided
+- **THEN** both Phase 1 (dead code) and Phase 2 (cruft) run across the full repository
+
+#### Scenario: Path or glob scope
+- **WHEN** a path or glob is provided
+- **THEN** both phases are restricted to that subtree
+
+#### Scenario: Category hint scope
+- **WHEN** a category hint such as `dead-code-only`, `cruft-only`, or `git-only` is provided
+- **THEN** only the phase matching that hint runs
+
+### Requirement: Dead code detection
+Sweep SHALL detect the primary language(s) and available static analysis tools before scanning. It SHALL scan for unused exports, unused imports, dead variables, unreachable branches, and commented-out code blocks using the most capable tool available for each language. Findings SHALL be skipped for node_modules/, dist/, build/, .next/, generated files (*.generated.ts, *.d.ts), and test files.
+
+#### Scenario: TypeScript project scanned
+- **WHEN** a TypeScript project is detected
+- **THEN** Sweep uses ts-prune (if available) for unused exports and tsc --noEmit for unused locals and unreachable branches
+
+#### Scenario: Test files excluded
+- **WHEN** a dead-code candidate is located in a test file
+- **THEN** it is excluded from findings
+
+### Requirement: Cruft detection
+Sweep SHALL check for stale documentation (WIP or tracking files referencing completed work; PRDs for shipped features), build artifacts and dead directories (empty directories, committed build output not in .gitignore), documentation gaps (README or user-facing docs not reflecting current features), duplicate content (root-level files duplicating content already in docs/), and git hygiene (local merged branches, stale worktrees, orphaned remote-tracking branches, and remote branches tied to merged PRs).
+
+#### Scenario: Remote branch classification
+- **WHEN** Phase 2 runs
+- **THEN** Sweep fetches the remote, lists all non-default non-parked remote branches, and classifies each by its PR state: MERGED, CLOSED, OPEN, or NO PR
+
+#### Scenario: Only merged-PR branches proposed for deletion
+- **WHEN** remote branches are classified
+- **THEN** only MERGED branches are proposed for deletion; CLOSED, OPEN, and NO PR branches are preserved
+
+### Requirement: Remote branch deletion safety
+When deleting remote branches, Sweep SHALL use the disambiguated refspec form `git push origin :refs/heads/<branch>` rather than `git push origin --delete <branch>`. Multiple deletions SHALL be batched into a single push call. This prevents failures when a same-named tag exists.
+
+#### Scenario: Single remote branch deletion
+- **WHEN** one remote branch is confirmed for deletion
+- **THEN** deletion uses `git push origin :refs/heads/<branch>`
+
+#### Scenario: Multiple remote branch deletions
+- **WHEN** more than one remote branch is confirmed for deletion
+- **THEN** all are batched into a single `git push origin :refs/heads/<a> :refs/heads/<b>` call
+
+### Requirement: Interactive confirmation
+Before executing any changes, Sweep SHALL compile all findings from both phases into a combined Remove / Update / Keep summary and confirm each proposed action via AskUserQuestion. Questions SHALL be batched with at most 4 questions per call. Closely related items SHALL be grouped into a single question. Sweep SHALL wait for all answers before executing any change.
+
+#### Scenario: Confirmation collected before execution
+- **WHEN** findings are compiled
+- **THEN** Sweep presents all proposed actions and waits for complete user confirmation before modifying any file or running any command
+
+#### Scenario: Question batching
+- **WHEN** more than 4 independent confirmations are needed
+- **THEN** questions are spread across multiple AskUserQuestion calls with at most 4 questions each
+
+### Requirement: Cleanup execution and commit
+After confirmation, Sweep SHALL apply all approved removals and edits, verify that modified source files still parse (tsc --noEmit or language equivalent), re-run the project's verify command if one is available, commit with the message `chore: sweep codebase`, and open a PR targeting the project's base branch (develop if it exists on the remote, otherwise the repository default).
+
+#### Scenario: Post-removal parse check
+- **WHEN** dead code is removed from a source file
+- **THEN** Sweep verifies the file still parses before committing
+
+#### Scenario: Commit and PR opened
+- **WHEN** all approved changes are applied and verification passes
+- **THEN** Sweep commits with `chore: sweep codebase` and opens a PR targeting develop, or the repository default if develop does not exist

--- a/openspec/specs/sessionkit-drive/REFERENCES.md
+++ b/openspec/specs/sessionkit-drive/REFERENCES.md
@@ -1,0 +1,133 @@
+# Drive — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `smallorbit-plugins/`.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Pre-flight chain validation
+
+**Sources**
+- `plugins/sessionkit/skills/drive/SKILL.md:27-32` — Step 1 checks `TaskList` for no pending/in_progress tasks and stops with a message
+- `plugins/sessionkit/skills/drive/SKILL.md:33` — Step 1 checks for broken `blockedBy` edges pointing at non-existent IDs
+
+**Notes**
+- The broken-graph check (all tasks blocked by non-existent IDs) is explicitly called out as a stop condition
+
+### Scenario: Task list is empty
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:27-29` — "If the result has no `pending` or `in_progress` tasks, stop with: > Nothing to drive…"
+Verified by presence in the guard clause. **Interpolated; no direct test.**
+
+### Scenario: Broken dependency graph
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:31-33` — "If there are tasks but they all have unresolved `blockedBy` edges pointing at non-existent IDs, report the broken state and stop."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Single driving preamble
+
+**Sources**
+- `plugins/sessionkit/skills/drive/SKILL.md:35-39` — Step 2 defines a verbatim preamble and states "Do not narrate again until you finish"
+
+### Scenario: Driving starts
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:37-38` — verbatim preamble text with starting task ID and silence contract.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Task-state discipline
+
+**Sources**
+- `plugins/sessionkit/skills/drive/SKILL.md:51` — "Mark `completed`. Immediately after the task's outcome is achieved… Never batch."
+- `plugins/sessionkit/skills/drive/SKILL.md:89` — Constraints: "One task `in_progress` at a time."
+- `plugins/sessionkit/skills/drive/SKILL.md:89` — "Mark `in_progress` before starting, `completed` immediately after, never batch."
+
+### Scenario: Task lifecycle
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:47-52` — Steps 2 (mark in_progress before work) and 4 (mark completed immediately after).
+**Interpolated; no direct test.**
+
+### Scenario: Multiple in_progress tasks
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:45` — "If multiple `in_progress` tasks exist, finish them before picking a new one."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Task selection order
+
+**Sources**
+- `plugins/sessionkit/skills/drive/SKILL.md:45` — "take the lowest-ID task whose `status` is `pending` and whose `blockedBy` array is empty (or whose blockers are already `completed`). Ties broken by ID."
+
+### Scenario: Next unblocked task
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:45` — lowest-ID pending task with empty or completed `blockedBy`.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Task execution dispatch
+
+**Sources**
+- `plugins/sessionkit/skills/drive/SKILL.md:47-51` — Step 3 defines three execution shapes: named skill, explicit command, open-ended work
+
+### Scenario: Named skill task
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:48` — "Named skill — description references a skill (e.g. 'Run `/flowkit:merge-pr`'): invoke it via the `Skill` tool."
+**Interpolated; no direct test.**
+
+### Scenario: Shell command task
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:49` — "Explicit command — description gives a shell command or sequence: run via `Bash`."
+**Interpolated; no direct test.**
+
+### Scenario: Outcome-based task
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:50` — "Open-ended work — description describes an outcome… perform the work using whatever tools fit."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Controlled surface conditions
+
+**Sources**
+- `plugins/sessionkit/skills/drive/SKILL.md:56-63` — Step 4 table defines four and only four surface conditions
+- `plugins/sessionkit/skills/drive/SKILL.md:65-69` — "What does not count as a surface condition" list
+
+### Scenario: Unrecoverable blocker
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:60` — "A tool failed in a way you cannot recover from… Plain text: state what failed, what you tried, what's needed. Leave the task `in_progress`. Stop."
+**Interpolated; no direct test.**
+
+### Scenario: Executive decision required
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:61` — "`AskUserQuestion` with 2–4 options and your recommendation labeled `(Recommended)`. Resume on answer."
+**Interpolated; no direct test.**
+
+### Scenario: Risky or destructive action
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:62` — "Plain text confirmation prompt — describe the action and ask permission. Do not bury it inside an `AskUserQuestion`."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Scope integrity
+
+**Sources**
+- `plugins/sessionkit/skills/drive/SKILL.md:92` — "No silent scope expansion… add it via `TaskCreate` (with appropriate `blockedBy`) so it's visible"
+- `plugins/sessionkit/skills/drive/SKILL.md:95` — "Never modify task subjects/descriptions to make them easier."
+
+### Scenario: Unplanned sub-work discovered
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:92` — TaskCreate with blockedBy for unplanned sub-tasks.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Final report
+
+**Sources**
+- `plugins/sessionkit/skills/drive/SKILL.md:73-85` — Step 5 defines the completion report format with task count, elapsed time, highlights, and outstanding items
+
+### Scenario: Chain completed
+**Source:** `plugins/sessionkit/skills/drive/SKILL.md:73-84` — "When the chain is fully completed (no pending or in_progress tasks remain), output a tight report."
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. All scenarios are **interpolated** — Drive has no test suite. The behavior is encoded entirely in the SKILL.md directive and validated by the consistency of the directive language.
+2. The "one preamble then silence" contract relies on the model following the directive; no runtime enforcement mechanism exists.
+3. The distinction between "blocker" and "executive decision" requires model judgment on what constitutes "irrecoverable" vs. "a genuine fork" — this is intentionally left to context.

--- a/openspec/specs/sessionkit-drive/spec.md
+++ b/openspec/specs/sessionkit-drive/spec.md
@@ -1,0 +1,86 @@
+# Drive
+
+## Purpose
+Drive executes an approved task chain autonomously from start to finish. It manages task state throughout, surfaces to the user only for blockers or executive decisions, and produces a final report on completion.
+
+## Requirements
+
+### Requirement: Pre-flight chain validation
+Drive SHALL verify a runnable chain exists before starting. If no `pending` or `in_progress` tasks exist, Drive MUST stop and report that the task list is empty. If all tasks have unresolved `blockedBy` edges pointing at non-existent IDs, Drive MUST report the broken state and stop.
+
+#### Scenario: Task list is empty
+- **WHEN** `TaskList` returns no `pending` or `in_progress` tasks
+- **THEN** Drive stops with a message directing the user to add tasks or run `/sessionkit:roadmap`
+
+#### Scenario: Broken dependency graph
+- **WHEN** all pending tasks have `blockedBy` entries referencing non-existent task IDs
+- **THEN** Drive reports the broken state and stops without starting any work
+
+### Requirement: Single driving preamble
+Drive SHALL emit exactly one short preamble before the first tool call, stating the starting task ID and the driving contract. Drive MUST NOT narrate individual task progress beyond that initial preamble.
+
+#### Scenario: Driving starts
+- **WHEN** a runnable chain is confirmed
+- **THEN** Drive emits one preamble (starting task, silence contract, Esc-to-interrupt note) and then works silently
+
+### Requirement: Task-state discipline
+For each task, Drive SHALL mark it `in_progress` before doing any work, and `completed` immediately after the outcome is achieved. Drive MUST NOT have more than one task in `in_progress` at a time. Drive MUST NOT batch completions.
+
+#### Scenario: Task lifecycle
+- **WHEN** Drive picks a task to execute
+- **THEN** `in_progress` is set before the first tool call for that task, and `completed` is set as soon as the outcome is achieved — never deferred
+
+#### Scenario: Multiple in_progress tasks
+- **WHEN** multiple tasks are found in `in_progress` state at loop entry
+- **THEN** Drive finishes them before picking any new pending task
+
+### Requirement: Task selection order
+Drive SHALL pick the lowest-ID `pending` task whose `blockedBy` array is empty or fully completed. Drive MUST NOT start a task whose blockers are unresolved.
+
+#### Scenario: Next unblocked task
+- **WHEN** multiple pending tasks exist
+- **THEN** Drive picks the lowest-ID task with no unresolved `blockedBy` dependencies
+
+### Requirement: Task execution dispatch
+Drive SHALL dispatch each task according to its description. A description referencing a skill SHALL be invoked via the skill tool. A description giving a shell command SHALL be run via the shell. An open-ended outcome description SHALL be executed using whatever tools fit the described outcome.
+
+#### Scenario: Named skill task
+- **WHEN** a task description references a skill (e.g. "Run `/flowkit:merge-pr`")
+- **THEN** Drive invokes that skill, passing any arguments mentioned in the description
+
+#### Scenario: Shell command task
+- **WHEN** a task description provides an explicit shell command
+- **THEN** Drive runs that command via the shell
+
+#### Scenario: Outcome-based task
+- **WHEN** a task description states an outcome without specifying a skill or command
+- **THEN** Drive uses any appropriate tools to achieve the described outcome
+
+### Requirement: Controlled surface conditions
+Drive SHALL surface to the user only for blockers, executive decisions, risky actions, or completion. Drive MUST NOT surface for routine failures with obvious remediation, cosmetic choices, or "just to confirm" moments.
+
+#### Scenario: Unrecoverable blocker
+- **WHEN** a tool fails in a way Drive cannot recover from (auth missing, network down, irreversible state required)
+- **THEN** Drive emits plain text describing the failure, leaves the task `in_progress`, and stops
+
+#### Scenario: Executive decision required
+- **WHEN** a genuine fork in approach emerges that the task description does not resolve
+- **THEN** Drive presents options via `AskUserQuestion` with a recommendation, then resumes on the user's answer
+
+#### Scenario: Risky or destructive action
+- **WHEN** the next step would delete data, force-push, rewrite shared history, or send messages on the user's behalf
+- **THEN** Drive presents a plain-text confirmation prompt before proceeding — not an `AskUserQuestion`
+
+### Requirement: Scope integrity
+Drive SHALL NOT silently expand scope beyond the task list. If a task requires sub-work not in the plan, Drive MUST create a visible task via `TaskCreate` with appropriate `blockedBy` rather than absorbing the work into an existing task. Drive MUST NOT modify task subjects or descriptions to make them easier.
+
+#### Scenario: Unplanned sub-work discovered
+- **WHEN** executing a task reveals necessary work not in the plan
+- **THEN** Drive creates a new task (with `blockedBy` wiring) and surfaces it as an executive decision if scope is affected
+
+### Requirement: Final report
+Drive SHALL emit a tight completion report when the chain is fully done. The report SHALL list artifacts produced (PR URLs, tags, files modified) and any outstanding items the user should know about. Drive MUST NOT reproduce the task list verbatim in the report.
+
+#### Scenario: Chain completed
+- **WHEN** no `pending` or `in_progress` tasks remain
+- **THEN** Drive emits a report with task count, elapsed time, artifact highlights, and any outstanding items

--- a/openspec/specs/sessionkit-handoff/REFERENCES.md
+++ b/openspec/specs/sessionkit-handoff/REFERENCES.md
@@ -1,0 +1,142 @@
+# Handoff — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `smallorbit-plugins/`.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Context collection
+
+**Sources**
+- `plugins/sessionkit/skills/handoff/SKILL.md:37-50` — Step 1 runs git commands in parallel and calls `TaskList` + `TaskGet` per task "in parallel with the bash commands above"
+
+### Scenario: Context gathered
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:37-50` — "Run these commands in parallel."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Fingerprint-based section reuse
+
+**Sources**
+- `plugins/sessionkit/skills/handoff/SKILL.md:52-77` — Steps 1a and 1b define fingerprint computation and the two-independent-decision reuse logic
+
+### Scenario: Git fingerprint matches
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:69-70` — "If `gitFingerprint` matches the prior header: reuse `## Git State` and `## Progress` verbatim."
+**Interpolated; no direct test.**
+
+### Scenario: Task fingerprint matches
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:71-72` — "If `taskFingerprint` matches the prior header: reuse `## Task List` and `## Remaining Work` verbatim."
+**Interpolated; no direct test.**
+
+### Scenario: Both fingerprints match
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:74-77` — "When both fingerprints match, all four reusable sections come straight from the prior file."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Routing to delta or full path
+
+**Sources**
+- `plugins/sessionkit/skills/handoff/SKILL.md:79-108` — Step 1c defines the four delta conditions and the routing decision
+
+### Scenario: Delta path selected
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:84-88` — all four conditions enumerated; "Pick delta mode when ALL of these hold."
+**Interpolated; no direct test.**
+
+### Scenario: Full path selected
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:90` — "Otherwise, use the full Haiku regenerate path."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Document structure
+
+**Sources**
+- `plugins/sessionkit/skills/handoff/SKILL.md:140-188` — Step 2a defines the strict template including section order and inference rules
+- `plugins/sessionkit/skills/handoff/SKILL.md:229-230` — Constraints: "Section order in HANDOFF.md is fixed: Goal → Progress → Git State → Remaining Work → Task List → Context"
+
+### Scenario: Section order
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:229` — fixed section order constraint.
+**Interpolated; no direct test.**
+
+### Scenario: Bullet-only sections
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:141` — "Bullets only in Progress / Remaining Work / Context — no narrative paragraphs."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Task list serialization
+
+**Sources**
+- `plugins/sessionkit/skills/handoff/SKILL.md:193-195` — inference rule for Task List: "Include only `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, `blocks`. Exclude `owner`, `metadata`, and deleted tasks… Preserve original task `id`."
+
+### Scenario: Task list in JSON block
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:168-182` — template shows fenced `json` block; `plugins/sessionkit/skills/handoff/SKILL.md:193-195` — serialization rules.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Sub-agent synthesis
+
+**Sources**
+- `plugins/sessionkit/skills/handoff/SKILL.md:111-136` — Step 2 defines the Haiku sub-agent invocation and the failure fallback with warning comment
+
+### Scenario: Sub-agent succeeds
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:114-128` — Agent tool call with model `"claude-haiku-4-5"`.
+**Interpolated; no direct test.**
+
+### Scenario: Sub-agent fails
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:130-135` — "if the Agent call fails, returns empty output, or produces output that does not contain the required `## Task List` heading, fall back to in-line synthesis."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Gitignore coverage
+
+**Sources**
+- `plugins/sessionkit/skills/handoff/SKILL.md:201-213` — Step 3 defines the three-branch `.gitignore` check
+
+### Scenario: Gitignore absent
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:206-207` — "`.gitignore` absent: ask 'No `.gitignore` found…'"
+**Interpolated; no direct test.**
+
+### Scenario: Gitignore present but uncovered
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:208-209` — "`.gitignore` present but not covered: ask '`.gitignore` doesn't cover `.sessionkit/`…'"
+**Interpolated; no direct test.**
+
+### Scenario: Already covered
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:210` — "Already covered: proceed silently."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Canonical output location
+
+**Sources**
+- `plugins/sessionkit/skills/handoff/SKILL.md:231` — Constraints: "`.sessionkit/HANDOFF.md` in the working directory is the canonical location — never write elsewhere"
+
+### Scenario: Document written
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:15` — "into `<working-dir>/.sessionkit/HANDOFF.md`".
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Completion report
+
+**Sources**
+- `plugins/sessionkit/skills/handoff/SKILL.md:224-226` — Step 4 defines what to report: path, mode, reuse outcome, and `/pickup` suggestion
+
+### Scenario: Handoff confirmed
+**Source:** `plugins/sessionkit/skills/handoff/SKILL.md:224-226` — verbatim step 4 text.
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. All scenarios are **interpolated from the SKILL.md directive** — no test suite exists for handoff behavior.
+2. The `gitFingerprint` ancestor check (`git merge-base --is-ancestor`) is distinct from the section reuse decision — it guards against branch-swap scenarios, not just content drift.
+3. The "at most two reusable sections" delta threshold is an implementation detail that is not observable from outside the skill; it is captured in the spec as an approximation of the routing intent.
+4. The strict template at step 2a is the canonical source of truth for section order — the constraint at line 229 restates it.

--- a/openspec/specs/sessionkit-handoff/spec.md
+++ b/openspec/specs/sessionkit-handoff/spec.md
@@ -1,0 +1,97 @@
+# Handoff
+
+## Purpose
+Handoff captures the current session's goal, progress, git state, task list, remaining work, and key context into `.sessionkit/HANDOFF.md` so another agent can resume the work without losing momentum. It minimizes cost by reusing unchanged sections from a prior handoff via fingerprint-based caching.
+
+## Requirements
+
+### Requirement: Context collection
+Handoff SHALL gather git state (HEAD SHA, branch, staged files, unstaged files, recent commits) and task list in parallel before synthesizing the document.
+
+#### Scenario: Context gathered
+- **WHEN** Handoff is invoked
+- **THEN** git state and task list are collected in parallel before any synthesis begins
+
+### Requirement: Fingerprint-based section reuse
+Handoff SHALL compute a `gitFingerprint` (HEAD SHA + sorted staged/unstaged file hashes) and a `taskFingerprint` (SHA-1 of the canonicalized task list JSON). Each fingerprint governs its own pair of sections independently: `gitFingerprint` controls `## Git State` and `## Progress`; `taskFingerprint` controls `## Task List` and `## Remaining Work`. Sections whose fingerprint matches the prior header SHALL be reused byte-for-byte. `## Goal` and `## Context` SHALL always be regenerated.
+
+#### Scenario: Git fingerprint matches
+- **WHEN** the prior handoff's `gitFingerprint` matches the current one
+- **THEN** `## Git State` and `## Progress` are reused verbatim; only `## Goal` and `## Context` are regenerated
+
+#### Scenario: Task fingerprint matches
+- **WHEN** the prior handoff's `taskFingerprint` matches the current one
+- **THEN** `## Task List` and `## Remaining Work` are reused verbatim
+
+#### Scenario: Both fingerprints match
+- **WHEN** both fingerprints match the prior header
+- **THEN** all four reusable sections come straight from the prior file and no sub-agent is dispatched
+
+### Requirement: Routing to delta or full path
+Handoff SHALL use the delta path when all four conditions hold: a prior HANDOFF.md parsed cleanly, the prior HEAD is an ancestor of the current HEAD, at most two reusable sections need regeneration, and `--full` is not present. Otherwise Handoff SHALL use the full regenerate path.
+
+#### Scenario: Delta path selected
+- **WHEN** all four delta-mode conditions hold
+- **THEN** Handoff surgically edits the existing file in place without dispatching a sub-agent
+
+#### Scenario: Full path selected
+- **WHEN** any delta-mode condition fails or `--full` is passed
+- **THEN** Handoff dispatches a sub-agent for full synthesis
+
+### Requirement: Document structure
+The handoff document SHALL follow a fixed section order: meta header → Goal → Progress → Git State → Remaining Work → Task List → Context. All content in Progress, Remaining Work, and Context SHALL be bullets only — no narrative paragraphs. The meta header SHALL be the first line and SHALL contain both fingerprints.
+
+#### Scenario: Section order
+- **WHEN** a handoff document is written (delta or full)
+- **THEN** sections appear in the canonical order: Goal → Progress → Git State → Remaining Work → Task List → Context
+
+#### Scenario: Bullet-only sections
+- **WHEN** Progress, Remaining Work, or Context content is generated
+- **THEN** every entry is a bullet — no narrative paragraphs
+
+### Requirement: Task list serialization
+The `## Task List` section SHALL contain a single fenced `json` code block. Each task object SHALL include only `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, and `blocks`. Deleted tasks SHALL be excluded. The original task `id` SHALL be preserved so `/pickup` can wire `blockedBy` relationships.
+
+#### Scenario: Task list in JSON block
+- **WHEN** the document is written
+- **THEN** `## Task List` contains a fenced `json` block with one object per non-deleted task, using the original task IDs
+
+### Requirement: Sub-agent synthesis
+When the full path is selected, Handoff SHALL delegate document synthesis to a Haiku-class sub-agent. If the sub-agent call fails or returns output missing `## Task List`, Handoff SHALL fall back to inline synthesis and prepend a warning comment to the document.
+
+#### Scenario: Sub-agent succeeds
+- **WHEN** the full path is selected and the sub-agent returns a valid document
+- **THEN** the synthesized document is written to disk
+
+#### Scenario: Sub-agent fails
+- **WHEN** the sub-agent call fails or returns output missing `## Task List`
+- **THEN** Handoff synthesizes the document inline and prepends `<!-- handoff-warning: haiku sub-agent unavailable, synthesized in-line -->`
+
+### Requirement: Gitignore coverage
+Before writing, Handoff SHALL check whether `.sessionkit/` is covered by `.gitignore`. If `.gitignore` is absent or does not cover `.sessionkit/`, Handoff SHALL ask the user before adding coverage. Handoff MUST NOT modify `.gitignore` without user confirmation.
+
+#### Scenario: Gitignore absent
+- **WHEN** no `.gitignore` file exists
+- **THEN** Handoff asks the user whether to create one with `.sessionkit/`
+
+#### Scenario: Gitignore present but uncovered
+- **WHEN** `.gitignore` exists but does not cover `.sessionkit/`
+- **THEN** Handoff asks the user whether to append `.sessionkit/`
+
+#### Scenario: Already covered
+- **WHEN** `.gitignore` already covers `.sessionkit/`
+- **THEN** Handoff proceeds silently
+
+### Requirement: Canonical output location
+Handoff SHALL write the document exclusively to `<working-dir>/.sessionkit/HANDOFF.md`. Handoff MUST NOT write the document to any other path.
+
+#### Scenario: Document written
+- **WHEN** synthesis completes
+- **THEN** the document is at `.sessionkit/HANDOFF.md` in the current working directory
+
+### Requirement: Completion report
+After writing, Handoff SHALL report the absolute file path, the chosen mode (delta or full), which sections were regenerated vs. reused, and suggest running `/pickup` to resume.
+
+#### Scenario: Handoff confirmed
+- **WHEN** the document is written
+- **THEN** Handoff reports the path, mode, section reuse outcome, and suggests `/pickup`

--- a/openspec/specs/sessionkit-pickup/REFERENCES.md
+++ b/openspec/specs/sessionkit-pickup/REFERENCES.md
@@ -1,0 +1,112 @@
+# Pickup — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `smallorbit-plugins/`.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Graceful absent-file handling
+
+**Sources**
+- `plugins/sessionkit/skills/pickup/SKILL.md:19-31` — Step 1 checks for the file and stops with a graceful message if absent
+
+### Scenario: Handoff file absent
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:27-31` — "If the file does not exist, fail gracefully: report > No handoff file found… Then stop."
+**Interpolated; no direct test.**
+
+### Scenario: Handoff file present
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:19-26` — `cat .sessionkit/HANDOFF.md 2>/dev/null` followed by remaining steps.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Open-ended section parsing
+
+**Sources**
+- `plugins/sessionkit/skills/pickup/SKILL.md:33-36` — "Unknown headings are passed through unmodified — section parsing is open-ended, so any future or legacy section names… are silently ignored."
+
+### Scenario: Unknown heading encountered
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:34-36` — explicit open-ended parsing rule.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Orientation summary
+
+**Sources**
+- `plugins/sessionkit/skills/pickup/SKILL.md:39-46` — Step 3 lists the five areas: Goal, Progress, Git State, Remaining Work, Context
+- `plugins/sessionkit/skills/pickup/SKILL.md:108` — Constraints: "Keep the orientation summary concise — surface the essentials, not everything verbatim"
+
+### Scenario: Orientation presented
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:39-46` — five-area summary format.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Task list hydration — two-pass
+
+**Sources**
+- `plugins/sessionkit/skills/pickup/SKILL.md:49-73` — Step 4 defines the full two-pass hydration: locate JSON block, create tasks (pass 1), wire blockedBy (pass 2)
+
+### Scenario: Task list present and parseable
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:56-73` — pass 1 (TaskCreate per pending/in_progress task) + pass 2 (TaskUpdate addBlockedBy).
+**Interpolated; no direct test.**
+
+### Scenario: Task list absent or unparseable
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:51-54` — "If no `## Task List` section exists, or the JSON block is absent or unparseable, emit exactly one line… Then skip."
+**Interpolated; no direct test.**
+
+### Scenario: Completed tasks skipped
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:64` — "Skip tasks whose `status` is `completed` — they are history."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Branch mismatch detection
+
+**Sources**
+- `plugins/sessionkit/skills/pickup/SKILL.md:75-89` — Step 5 compares branch and suggests checkout without switching automatically
+
+### Scenario: Branch matches
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:87-88` — "Only suggest this when there's a mismatch."
+**Interpolated from absence; no direct test.**
+
+### Scenario: Branch mismatch
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:83-86` — "suggest: `git checkout <branch-from-handoff>`" and "Do not switch branches automatically."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Readiness confirmation via structured prompt
+
+**Sources**
+- `plugins/sessionkit/skills/pickup/SKILL.md:91-103` — Step 6 defines the AskUserQuestion format: question text, header, options from Remaining Work, fallback to plain text
+
+### Scenario: Multiple remaining items
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:93-98` — AskUserQuestion with options derived from Remaining Work when 2+ items exist.
+**Interpolated; no direct test.**
+
+### Scenario: Fewer than two actionable items
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:99-101` — "If `Remaining Work` has fewer than 2 actionable items, fall back to plain text."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Read-only operation
+
+**Sources**
+- `plugins/sessionkit/skills/pickup/SKILL.md:107` — Constraints: "Never modify `.sessionkit/HANDOFF.md` — this skill is read-only"
+- `plugins/sessionkit/skills/pickup/SKILL.md:110` — "Do not automatically re-execute any commands referenced in the handoff — the goal is to orient, not to act"
+
+### Scenario: Handoff file untouched
+**Source:** `plugins/sessionkit/skills/pickup/SKILL.md:107` — explicit constraint.
+**Interpolated from absence; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. All scenarios are **interpolated** — no test suite covers pickup behavior directly.
+2. The "do not wire `blocks`" rule (line 72) prevents double-writing the dependency graph; only `blockedBy` is wired in pass 2.
+3. The old-ID → new-ID mapping must be maintained in memory across all `TaskCreate` calls before any `TaskUpdate` call in pass 2 — this ordering is implicit in the sequential pass structure.

--- a/openspec/specs/sessionkit-pickup/spec.md
+++ b/openspec/specs/sessionkit-pickup/spec.md
@@ -1,0 +1,75 @@
+# Pickup
+
+## Purpose
+Pickup loads `.sessionkit/HANDOFF.md` at the start of a new session, orients the agent by summarizing its contents, hydrates the task list from the snapshot, checks for branch mismatches, and asks what to tackle first. It is the complement to Handoff.
+
+## Requirements
+
+### Requirement: Graceful absent-file handling
+Pickup SHALL check for `.sessionkit/HANDOFF.md` before proceeding. If the file does not exist, Pickup MUST report the absence and stop — it MUST NOT attempt to orient, hydrate tasks, or ask what to do next.
+
+#### Scenario: Handoff file absent
+- **WHEN** `.sessionkit/HANDOFF.md` does not exist
+- **THEN** Pickup reports the file is missing with a guidance message and stops
+
+#### Scenario: Handoff file present
+- **WHEN** `.sessionkit/HANDOFF.md` exists
+- **THEN** Pickup reads and parses it, then continues with the remaining steps
+
+### Requirement: Open-ended section parsing
+Pickup SHALL parse all standard sections (Project, Date, Branch, Goal, Progress, Git State, Remaining Work, Context). Unknown headings SHALL be silently ignored — section parsing is open-ended. Legacy section names from prior versions SHALL not cause errors.
+
+#### Scenario: Unknown heading encountered
+- **WHEN** the handoff file contains a heading not in the standard section list
+- **THEN** Pickup ignores it without error and continues parsing
+
+### Requirement: Orientation summary
+Pickup SHALL produce a structured orientation summary from the parsed content. The summary SHALL cover: Goal (restated clearly), Progress (what was done and decided), Git State (branch, staged/unstaged, recent commits), Remaining Work (in priority order), and Context (gotchas and notes). The summary SHALL be concise — it MUST NOT reproduce the document verbatim.
+
+#### Scenario: Orientation presented
+- **WHEN** the handoff file is successfully parsed
+- **THEN** Pickup outputs a structured summary covering all five areas without reproducing the document verbatim
+
+### Requirement: Task list hydration — two-pass
+Pickup SHALL locate the fenced `json` block following `## Task List`. If the block is absent or unparseable, Pickup SHALL emit one line noting the skip and continue. For tasks with `status` `pending` or `in_progress`, Pickup SHALL create new tasks via `TaskCreate` (pass 1), record old-ID → new-ID mappings, then restore `blockedBy` edges via `TaskUpdate` using remapped IDs (pass 2). Completed tasks SHALL be skipped. Pickup MUST NOT wire the `blocks` direction — only `blockedBy`.
+
+#### Scenario: Task list present and parseable
+- **WHEN** `## Task List` contains a valid JSON array
+- **THEN** Pickup creates tasks for `pending`/`in_progress` entries (pass 1), then wires `blockedBy` using remapped IDs (pass 2)
+
+#### Scenario: Task list absent or unparseable
+- **WHEN** the JSON block is missing or cannot be parsed
+- **THEN** Pickup emits "No task list snapshot — skipping hydration" and continues to step 5
+
+#### Scenario: Completed tasks skipped
+- **WHEN** a task in the snapshot has `status: completed`
+- **THEN** Pickup skips creating that task — it is surfaced only in the orientation summary
+
+### Requirement: Branch mismatch detection
+Pickup SHALL compare the handoff branch against the current branch. If they differ, Pickup MUST suggest the checkout command. Pickup MUST NOT switch branches automatically.
+
+#### Scenario: Branch matches
+- **WHEN** the current branch matches the handoff branch
+- **THEN** Pickup makes no branch suggestion
+
+#### Scenario: Branch mismatch
+- **WHEN** the current branch differs from the handoff branch
+- **THEN** Pickup suggests `git checkout <branch-from-handoff>` and does not switch automatically
+
+### Requirement: Readiness confirmation via structured prompt
+Pickup SHALL end by asking the user what to tackle first via `AskUserQuestion`. The question SHALL reference the handoff Goal. Options SHALL be derived from the top items in Remaining Work (highest-priority first), up to four options. If fewer than two actionable items exist in Remaining Work, Pickup SHALL fall back to plain text.
+
+#### Scenario: Multiple remaining items
+- **WHEN** Remaining Work has two or more actionable items
+- **THEN** Pickup presents them as structured options via `AskUserQuestion`
+
+#### Scenario: Fewer than two actionable items
+- **WHEN** Remaining Work has fewer than two actionable items
+- **THEN** Pickup asks what to do next in plain text
+
+### Requirement: Read-only operation
+Pickup SHALL NOT modify `.sessionkit/HANDOFF.md` under any circumstances. Pickup MUST NOT re-execute commands referenced in the handoff.
+
+#### Scenario: Handoff file untouched
+- **WHEN** Pickup runs to completion
+- **THEN** `.sessionkit/HANDOFF.md` is byte-identical to when Pickup started

--- a/openspec/specs/sessionkit-retro/REFERENCES.md
+++ b/openspec/specs/sessionkit-retro/REFERENCES.md
@@ -1,0 +1,108 @@
+# Retro — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `smallorbit-plugins/`.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Parallel signal collection
+
+**Sources**
+- `plugins/sessionkit/skills/retro/SKILL.md:26-56` — Step 1 collects git activity, JSONL events, task list, and conversation transcript, with "Run all data-collection commands in parallel. Tolerate missing outputs gracefully."
+
+### Scenario: All surfaces available
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:27` — "Run all data-collection commands in parallel."
+**Interpolated; no direct test.**
+
+### Scenario: A surface is unavailable
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:27` — "Tolerate missing outputs gracefully — an empty surface is itself a signal."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Three-bucket synthesis
+
+**Sources**
+- `plugins/sessionkit/skills/retro/SKILL.md:59-88` — Step 2 defines the three buckets with bullet counts and citation discipline
+- `plugins/sessionkit/skills/retro/SKILL.md:150-151` — Constraints: "Always identify at least one item per `## What went well` and `## What didn't go well`"
+
+### Scenario: Friction observed
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:67-71` — "What didn't go well" bullets: repeated corrections, hook-blocked, failed commands, stalled tasks.
+**Interpolated; no direct test.**
+
+### Scenario: No friction observed
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:68` — "If no friction surfaces at all, emit: _No friction observed this session._"
+**Interpolated; no direct test.**
+
+### Scenario: Positive patterns found
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:63-66` — "What went well" bullets. Constraints line 151 requires at least one even for low-friction sessions.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Recommended actions with delegation targets
+
+**Sources**
+- `plugins/sessionkit/skills/retro/SKILL.md:74-88` — delegation table and cap-at-4 rule with 4th-slot reservation
+
+### Scenario: More than three actionable items
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:88` — "Cap the list at 4 options. If more than 4 items qualify, keep the highest-signal ones. Reserve the 4th option slot for 'Other — I'll handle this manually.'"
+**Interpolated; no direct test.**
+
+### Scenario: No matching skill for a pattern
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:83` — "No matching skill | Surface as plain-text guidance only"
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Inline-only output
+
+**Sources**
+- `plugins/sessionkit/skills/retro/SKILL.md:18` — "Output stays entirely inline. No files are written."
+- `plugins/sessionkit/skills/retro/SKILL.md:149` — Constraints: "Never write files."
+
+### Scenario: Output is inline
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:18` — explicit no-file constraint.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: User-gated action menu
+
+**Sources**
+- `plugins/sessionkit/skills/retro/SKILL.md:112-122` — Step 4 defines the AskUserQuestion call with multiSelect and "None — I'm done" option
+- `plugins/sessionkit/skills/retro/SKILL.md:122` — "Do not proceed to step 5 until the user answers via `AskUserQuestion`."
+- `plugins/sessionkit/skills/retro/SKILL.md:151-152` — Constraints: "Never run delegated skills without explicit user selection."
+
+### Scenario: Action menu presented
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:114-121` — AskUserQuestion with multiSelect: true and "None — I'm done" option.
+**Interpolated; no direct test.**
+
+### Scenario: User selects actions
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:126-143` — Step 5 announces and invokes each selected skill.
+**Interpolated; no direct test.**
+
+### Scenario: User selects none
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:144-145` — "If the user selects 'None — I'm done', skip all invocations and close the retro with a one-line acknowledgement."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Skill delegation — no absorption
+
+**Sources**
+- `plugins/sessionkit/skills/retro/SKILL.md:153-154` — Constraints: "`retro` is a thin reflective layer. It does not absorb `skillit`'s encoding logic."
+- `plugins/sessionkit/skills/retro/SKILL.md:155` — "Do not modify `skillit` or any other existing skill."
+
+### Scenario: Skill invoked
+**Source:** `plugins/sessionkit/skills/retro/SKILL.md:132-143` — delegation table maps each action to a `Skill(...)` call.
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. All scenarios are **interpolated** — Retro has no test suite.
+2. The 4th-slot reservation for "Other — I'll handle this manually" is required only when more than 3 actionable items exist — it is not always present.
+3. The delegation table (line 78-86) is the authoritative mapping between pattern types and skill invocations; retro's role ends at delegation.

--- a/openspec/specs/sessionkit-retro/spec.md
+++ b/openspec/specs/sessionkit-retro/spec.md
@@ -1,0 +1,72 @@
+# Retro
+
+## Purpose
+Retro runs a lightweight session retrospective. It scans four input surfaces — conversation transcript, task list, git activity, and hook/tool-denial events — then produces an inline summary and a one-keystroke action menu that delegates findings to the appropriate downstream skills.
+
+## Requirements
+
+### Requirement: Parallel signal collection
+Retro SHALL gather all raw signals in parallel: git activity (recent commits, branch, stash, open PRs), session JSONL files (tool-denial and hook-blocked events), task list (all non-deleted tasks), and conversation transcript. Missing or empty surfaces SHALL be tolerated without error.
+
+#### Scenario: All surfaces available
+- **WHEN** all four input surfaces are accessible
+- **THEN** Retro collects them in parallel and proceeds to synthesis
+
+#### Scenario: A surface is unavailable
+- **WHEN** one or more surfaces are missing or empty
+- **THEN** Retro treats absence as a signal (e.g. no tool denials = no friction of that type) and continues
+
+### Requirement: Three-bucket synthesis
+Retro SHALL organize findings into exactly three sections: **What went well** (2–5 bullets), **What didn't go well** (2–5 bullets or the explicit empty-state line), and **Recommended actions** (1–4 items). Every finding SHALL cite concrete evidence — a turn, PR number, file name, or task subject. Retro SHALL NOT emit vague critique.
+
+#### Scenario: Friction observed
+- **WHEN** one or more friction signals are found (repeated corrections, hook blocks, failed commands, stalled tasks)
+- **THEN** each is included in "What didn't go well" with a concrete citation
+
+#### Scenario: No friction observed
+- **WHEN** no friction signals are found across all surfaces
+- **THEN** Retro emits the explicit empty-state line "No friction observed this session." in "What didn't go well"
+
+#### Scenario: Positive patterns found
+- **WHEN** cleanly executed workflows or early-caught mistakes are found
+- **THEN** at least one bullet appears in "What went well" even for low-friction sessions
+
+### Requirement: Recommended actions with delegation targets
+Retro SHALL map each friction signal or repeatable pattern to a downstream delegation target. Recommended actions SHALL be capped at 4. The 4th slot SHALL be reserved for "Other — I'll handle this manually" when more than 3 actionable items exist.
+
+#### Scenario: More than three actionable items
+- **WHEN** four or more patterns map to delegation targets
+- **THEN** only the three highest-signal items are listed, and the 4th slot is "Other — I'll handle this manually"
+
+#### Scenario: No matching skill for a pattern
+- **WHEN** a finding does not map to any delegation target
+- **THEN** it is surfaced as plain-text guidance only in the recommended actions list
+
+### Requirement: Inline-only output
+Retro SHALL emit the three sections as inline markdown. Retro MUST NOT write any file — no retro file, no `.sessionkit/RETRO.md`, no artifact of any kind.
+
+#### Scenario: Output is inline
+- **WHEN** Retro completes synthesis
+- **THEN** the three-section markdown appears directly in the conversation; no file is created
+
+### Requirement: User-gated action menu
+Retro SHALL present the recommended actions as a multi-select `AskUserQuestion` after the inline summary. Retro MUST NOT invoke any downstream skill before the user answers. A "None — I'm done" option SHALL always be included.
+
+#### Scenario: Action menu presented
+- **WHEN** synthesis is complete
+- **THEN** Retro calls `AskUserQuestion` with multi-select enabled, one option per recommended action, plus "None — I'm done"
+
+#### Scenario: User selects actions
+- **WHEN** the user selects one or more actions
+- **THEN** Retro announces the actions to run, then invokes each selected skill sequentially
+
+#### Scenario: User selects none
+- **WHEN** the user selects "None — I'm done"
+- **THEN** Retro closes with a one-line acknowledgement and invokes no skills
+
+### Requirement: Skill delegation — no absorption
+Retro SHALL delegate to skills via the skill tool. Retro MUST NOT absorb or re-implement the logic of any delegated skill. When "encode as a skill" is recommended, Retro delegates to `sessionkit:skillit` — it does not author the skill file itself.
+
+#### Scenario: Skill invoked
+- **WHEN** the user selects a skill-backed action
+- **THEN** Retro invokes that skill via the skill tool, passing relevant context from the findings as arguments where accepted

--- a/openspec/specs/sessionkit-roadmap/REFERENCES.md
+++ b/openspec/specs/sessionkit-roadmap/REFERENCES.md
@@ -1,0 +1,106 @@
+# Roadmap — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `smallorbit-plugins/`.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Read-only survey
+
+**Sources**
+- `plugins/sessionkit/skills/roadmap/SKILL.md:26-60` — Step 1 lists all survey commands in parallel
+- `plugins/sessionkit/skills/roadmap/SKILL.md:153` — Constraints: "Read-only during steps 1–3. Never mutate the repo, branches, tags, or PRs while planning."
+
+### Scenario: Survey phase
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:26-27` — "Read-only. Run these in parallel."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: State classification
+
+**Sources**
+- `plugins/sessionkit/skills/roadmap/SKILL.md:64-78` — Step 2 table mapping each signal to a sub-chain entry point with "composable, not exclusive" note
+
+### Scenario: Multiple signals apply
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:64` — "Identify every state signal that applies (composable, not exclusive)."
+**Interpolated; no direct test.**
+
+### Scenario: Nothing to ship
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:77` — "Latest release shipped, develop in sync | 'Nothing to ship' — surface and offer alternatives."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Task chain synthesis
+
+**Sources**
+- `plugins/sessionkit/skills/roadmap/SKILL.md:80-115` — Step 3 defines the step library, blockedBy wiring, and task field requirements
+- `plugins/sessionkit/skills/roadmap/SKILL.md:158` — Constraints: "Use named skills, not raw commands, where possible."
+
+### Scenario: Linear chain produced
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:110-114` — per-task field spec: subject, description, activeForm, blockedBy.
+**Interpolated; no direct test.**
+
+### Scenario: Named skill available
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:158` — "A task description that says 'Run `/flowkit:cut`' is unambiguous to drive; a description that pastes the cut script is brittle."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Single-thread planning
+
+**Sources**
+- `plugins/sessionkit/skills/roadmap/SKILL.md:156-159` — Constraints: "One chain per invocation. If the survey turns up two unrelated work threads… ask which one to plan."
+
+### Scenario: Two unrelated threads found
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:156-158` — single-thread constraint with example.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Plan presentation and approval gate
+
+**Sources**
+- `plugins/sessionkit/skills/roadmap/SKILL.md:117-151` — Steps 4 and 5 define the plan summary format, AskUserQuestion options, and per-answer actions
+- `plugins/sessionkit/skills/roadmap/SKILL.md:154` — Constraints: "Tasks created before approval are provisional. If the user picks 'Cancel', delete every task this invocation created."
+
+### Scenario: Approval requested
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:134-143` — AskUserQuestion with four options.
+**Interpolated; no direct test.**
+
+### Scenario: User approves and drives
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:148` — "Drive it for me → invoke `Skill('sessionkit:drive')`."
+**Interpolated; no direct test.**
+
+### Scenario: User approves manually
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:149` — "I'll drive → print the task IDs and a one-line reminder."
+**Interpolated; no direct test.**
+
+### Scenario: User modifies
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:150` — "Modify → prompt the user for what to change. Update the task list. Re-present from step 4."
+**Interpolated; no direct test.**
+
+### Scenario: User cancels
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:151` — "`TaskUpdate` with `status: deleted` for every task created. Confirm and exit."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Canonical release sequence
+
+**Sources**
+- `plugins/sessionkit/skills/roadmap/SKILL.md:101-107` — defines the bubble-free release sequence and explains why ship aborts if worktree-agent PRs remain
+
+### Scenario: Epic in flight
+**Source:** `plugins/sessionkit/skills/roadmap/SKILL.md:103-104` — "standard chain is: `/swarmkit:merge-stack → verify (manual) → /flowkit:ship-epic → /flowkit:ship`"
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. All scenarios are **interpolated** — Roadmap has no test suite.
+2. The `flowkit:pipeline-status` preference (line 62-63) is an optimization hint — if not installed, the raw survey commands are used directly.
+3. The single-thread constraint (step 1c) means the survey might reveal more than one thread but Roadmap only plans one per invocation; the user runs Roadmap again for other threads.

--- a/openspec/specs/sessionkit-roadmap/spec.md
+++ b/openspec/specs/sessionkit-roadmap/spec.md
@@ -1,0 +1,72 @@
+# Roadmap
+
+## Purpose
+Roadmap surveys the current work-in-flight, synthesizes a linear task chain that takes the work to its natural completion state, presents it for user approval, and then either hands it off to Drive for autonomous execution or returns it for manual execution.
+
+## Requirements
+
+### Requirement: Read-only survey
+During planning, Roadmap SHALL only read — it MUST NOT mutate the repository, branches, tags, or PRs during steps 1 through 3. Work-in-flight signals collected SHALL include: uncommitted state, branch/upstream relationship, open PRs (current branch and peers), epic mode configuration, release pipeline state (RC branches, latest tag), in-flight worktrees, and existing tasks.
+
+#### Scenario: Survey phase
+- **WHEN** Roadmap is invoked
+- **THEN** all survey commands run in parallel and no mutations occur before the plan is approved
+
+### Requirement: State classification
+Roadmap SHALL identify every applicable state signal and map each to a sub-chain entry point. Signals are composable — multiple may apply simultaneously. The canonical signals include: uncommitted changes, local commits ahead of upstream, pushed branch with no PR, open PR for current branch, peer PRs on the same base, epic mode active, develop ahead of main, RC branch exists, and nothing-to-ship state.
+
+#### Scenario: Multiple signals apply
+- **WHEN** more than one state signal is present (e.g. uncommitted changes AND an open peer PR)
+- **THEN** each signal contributes its sub-chain entry point to the composed plan
+
+#### Scenario: Nothing to ship
+- **WHEN** the latest release is shipped and develop is in sync with main
+- **THEN** Roadmap surfaces the nothing-to-ship state and offers alternatives instead of an empty plan
+
+### Requirement: Task chain synthesis
+Roadmap SHALL compose the sub-chains into a single ordered task chain. Each task SHALL have an imperative subject, an unambiguous description (exact skill invocation or concrete outcome), an `activeForm` label, and `blockedBy` wiring to its predecessor. Roadmap SHALL use named skills in task descriptions where available, not raw command pastes.
+
+#### Scenario: Linear chain produced
+- **WHEN** the state signals compose into a sequential plan
+- **THEN** tasks are created with `blockedBy` wiring so each step is unblocked only after its predecessor completes
+
+#### Scenario: Named skill available
+- **WHEN** a step maps to a known installed skill
+- **THEN** the task description references the skill by name (e.g. "Run `/flowkit:merge-pr`")
+
+### Requirement: Single-thread planning
+Roadmap SHALL plan one work thread per invocation. If the survey reveals two unrelated in-flight threads, Roadmap MUST ask the user which to plan and defer the other.
+
+#### Scenario: Two unrelated threads found
+- **WHEN** the survey reveals e.g. an in-flight PR and a separate untracked feature branch
+- **THEN** Roadmap asks which thread to plan and does not produce a forked plan
+
+### Requirement: Plan presentation and approval gate
+Roadmap SHALL present the plan as a compact summary before creating any tasks, then present it for approval via `AskUserQuestion`. Options SHALL include: drive autonomously (recommended), drive manually, modify, and cancel. Tasks created before approval are provisional — if the user cancels, Roadmap MUST delete every task created in that invocation.
+
+#### Scenario: Approval requested
+- **WHEN** the plan is ready
+- **THEN** Roadmap outputs the plan summary and calls `AskUserQuestion` with the four approval options
+
+#### Scenario: User approves and drives
+- **WHEN** the user selects "Drive it for me"
+- **THEN** Roadmap invokes `/sessionkit:drive` immediately and exits
+
+#### Scenario: User approves manually
+- **WHEN** the user selects "I'll drive"
+- **THEN** Roadmap prints the task IDs and a one-line reminder, then exits
+
+#### Scenario: User modifies
+- **WHEN** the user selects "Modify"
+- **THEN** Roadmap prompts for changes, updates the task list, and re-presents from the plan summary step
+
+#### Scenario: User cancels
+- **WHEN** the user selects "Cancel"
+- **THEN** Roadmap deletes every task it created and exits
+
+### Requirement: Canonical release sequence
+When an epic is in flight (open worktree-agent-* PRs targeting a feature branch), Roadmap SHALL include the canonical bubble-free sequence: merge-stack → verify → ship-epic → ship. Roadmap MUST NOT collapse this into a single step.
+
+#### Scenario: Epic in flight
+- **WHEN** open worktree-agent-* PRs target the current feature branch
+- **THEN** the plan includes merge-stack, a manual verify step, ship-epic, and ship — in that order

--- a/openspec/specs/sessionkit-skillit/REFERENCES.md
+++ b/openspec/specs/sessionkit-skillit/REFERENCES.md
@@ -1,0 +1,79 @@
+# Skillit — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `smallorbit-plugins/`.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Session reflection
+
+**Sources**
+- `plugins/sessionkit/skills/skillit/SKILL.md:19-31` — Step 1 reviews conversation history for five pattern types and requires identifying at least one candidate
+- `plugins/sessionkit/skills/skillit/SKILL.md:79` — Constraints: "Identify at least one candidate before concluding — never report 'nothing found'"
+
+### Scenario: Candidate identified
+**Source:** `plugins/sessionkit/skills/skillit/SKILL.md:79` — explicit constraint requiring at least one candidate.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Existing library survey
+
+**Sources**
+- `plugins/sessionkit/skills/skillit/SKILL.md:33-44` — Step 2 scans three paths for existing skills and reads name/description front matter
+
+### Scenario: Overlap found
+**Source:** `plugins/sessionkit/skills/skillit/SKILL.md:43` — "Surface any close matches to the user before proposing something new."
+**Interpolated; no direct test.**
+
+### Scenario: No overlap found
+**Source:** `plugins/sessionkit/skills/skillit/SKILL.md:43` — absence of close match implies creating a new skill (step 3 option 1).
+**Interpolated from absence; no direct test.**
+
+---
+
+## Requirement: Findings presentation
+
+**Sources**
+- `plugins/sessionkit/skills/skillit/SKILL.md:46-57` — Step 3 defines the three-part description (what/why/overlap) and the three options
+
+### Scenario: Findings presented
+**Source:** `plugins/sessionkit/skills/skillit/SKILL.md:46-56` — per-candidate description format and create/modify/skip options.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Approval-gated skill creation
+
+**Sources**
+- `plugins/sessionkit/skills/skillit/SKILL.md:59-73` — Step 4 creates file only on user agreement, at user-specified path, with required sections
+- `plugins/sessionkit/skills/skillit/SKILL.md:80` — Constraints: "Never create a skill file without user approval"
+- `plugins/sessionkit/skills/skillit/SKILL.md:83` — Constraints: "Skill names must be lowercase kebab-case"
+
+### Scenario: User approves creation
+**Source:** `plugins/sessionkit/skills/skillit/SKILL.md:59-73` — "On user agreement, create the skill file."
+**Interpolated; no direct test.**
+
+### Scenario: User declines
+**Source:** `plugins/sessionkit/skills/skillit/SKILL.md:55` — "3. Skip — not worth encoding yet" — step 4 is not reached.
+**Interpolated from absence; no direct test.**
+
+---
+
+## Requirement: Completion confirmation
+
+**Sources**
+- `plugins/sessionkit/skills/skillit/SKILL.md:75-76` — Step 5 reports the absolute path and suggests running again
+
+### Scenario: Skill written
+**Source:** `plugins/sessionkit/skills/skillit/SKILL.md:75` — "Report the absolute path of the file written."
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. All scenarios are **interpolated** — Skillit has no test suite.
+2. The "at least one candidate" requirement (constraint line 79) means Skillit will surface something even if the session was routine — this is intentional to keep the habit of skill library growth.
+3. The skill file must paths (line 63-64) offer both user-global (`~/.claude/skills/`) and project-local (`.claude/skills/`) as valid targets; the user chooses or is prompted.

--- a/openspec/specs/sessionkit-skillit/spec.md
+++ b/openspec/specs/sessionkit-skillit/spec.md
@@ -1,0 +1,49 @@
+# Skillit
+
+## Purpose
+Skillit reflects on the current session to identify repeatable patterns worth encoding as skills. It checks the existing skill library for overlap before offering to create a new skill or extend an existing one, and writes the skill file only on explicit user approval.
+
+## Requirements
+
+### Requirement: Session reflection
+Skillit SHALL review the conversation history and identify at least one candidate pattern — repeated instructions, step-by-step workflows, applied heuristics, fixed tool sequences, or explicit "always do this" directives from the user. Skillit MUST NOT conclude with "nothing found."
+
+#### Scenario: Candidate identified
+- **WHEN** Skillit reviews the session
+- **THEN** at least one candidate pattern is surfaced
+
+### Requirement: Existing library survey
+Before proposing anything new, Skillit SHALL scan the skill library (user-global and project-local) for potential overlaps with each candidate. Skillit SHALL read the `name` and `description` front matter of any relevant candidates.
+
+#### Scenario: Overlap found
+- **WHEN** an existing skill covers the same ground as a candidate
+- **THEN** Skillit surfaces the overlap before proposing the new skill, and offers to extend the existing one instead
+
+#### Scenario: No overlap found
+- **WHEN** no existing skill is close to the candidate
+- **THEN** Skillit proposes creating a new skill
+
+### Requirement: Findings presentation
+Skillit SHALL describe each candidate with: what it would do (one sentence), why it's worth encoding (friction removed), and overlap risk. Skillit SHALL offer the user explicit options: create a new skill, modify an existing skill, or skip.
+
+#### Scenario: Findings presented
+- **WHEN** candidates and overlap analysis are ready
+- **THEN** Skillit presents each candidate with its three-part description and the create/modify/skip options
+
+### Requirement: Approval-gated skill creation
+Skillit MUST NOT create or modify any skill file without explicit user approval. On approval, Skillit SHALL write the skill file to the user-specified path (or prompt for one). The file MUST include: YAML front matter with `name`, `description`, `triggers` (at least two), and `allowed-tools`; a `## Process` section with numbered steps; and a `## Constraints` section. Skill names SHALL be lowercase kebab-case.
+
+#### Scenario: User approves creation
+- **WHEN** the user selects "Create new skill" or "Modify existing"
+- **THEN** Skillit writes (or edits) the skill file and reports the absolute path
+
+#### Scenario: User declines
+- **WHEN** the user selects "Skip"
+- **THEN** Skillit makes no file changes
+
+### Requirement: Completion confirmation
+After writing the skill file, Skillit SHALL report the absolute path written. Skillit SHOULD suggest running `/skillit` again at the end of future sessions.
+
+#### Scenario: Skill written
+- **WHEN** the file is written
+- **THEN** Skillit reports the absolute path

--- a/openspec/specs/sessionkit-suggest-permissions/REFERENCES.md
+++ b/openspec/specs/sessionkit-suggest-permissions/REFERENCES.md
@@ -1,0 +1,109 @@
+# Suggest Permissions — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `smallorbit-plugins/`.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Session history location
+
+**Sources**
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:20-29` — Step 1 defines the encoded-cwd path and reads the five most recent JSONL files
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:82` — Constraints: "If session history is unavailable or empty, say so and stop"
+
+### Scenario: History files found
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:24-28` — `ls -t ~/.claude/projects/${PROJECT_PATH}/*.jsonl 2>/dev/null | head -5`
+**Interpolated; no direct test.**
+
+### Scenario: History unavailable
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:82` — explicit stop constraint.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Pattern identification across three categories
+
+**Sources**
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:32-39` — Step 2 defines three categories and the 2+ appearances threshold
+
+### Scenario: Bash command pattern
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:33` — "Bash commands — package managers, VCS, language runtimes, project-specific scripts."
+**Interpolated; no direct test.**
+
+### Scenario: File edit pattern
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:34` — "File edits — source directories, file globs, config files."
+**Interpolated; no direct test.**
+
+### Scenario: MCP tool pattern
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:35` — "MCP tools — any MCP tool approved more than once."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Scoped suggestions
+
+**Sources**
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:56-59` — Step 3 formats suggestions with one-line rationale, grouped by category
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:80` — Constraints: "Do not suggest wildcard patterns broader than what the evidence supports"
+
+### Scenario: Evidence-bounded suggestion
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:80` — explicit no-over-wildcard constraint with `Bash(*:*)` counter-example.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Approval gate before applying
+
+**Sources**
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:60-61` — Step 3 ends with AskUserQuestion; step 4 reached only after answer
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:77` — Constraints: "Never write to settings files without explicit user approval"
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:78-79` — "always request approval via the `AskUserQuestion` tool — not prose. A silent wait with no tool call is a defect."
+
+### Scenario: Approval requested
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:60-61` — "call the `AskUserQuestion` tool to request approval."
+**Interpolated; no direct test.**
+
+### Scenario: User approves
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:63-69` — "If the user approves some or all suggestions: 1. Read… 2. Merge… 3. Write…"
+**Interpolated; no direct test.**
+
+### Scenario: User cancels
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:60` — options include Cancel; step 4 not reached.
+**Interpolated from absence; no direct test.**
+
+---
+
+## Requirement: Settings file target
+
+**Sources**
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:63-69` — Step 4 reads existing file, merges, writes back
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:68-69` — "If no `.claude/settings.json` exists, create it with the minimal structure needed."
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:79` — Constraints: "Suggest project-level `.claude/settings.json` by default; offer `settings.local.json` as an alternative"
+
+### Scenario: Settings file absent
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:68-69` — creation with minimal structure.
+**Interpolated; no direct test.**
+
+### Scenario: Settings file present
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:63-67` — read + merge + write workflow.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Completion report
+
+**Sources**
+- `plugins/sessionkit/skills/suggest-permissions/SKILL.md:72-74` — Step 5 reports what was added and suggests running again
+
+### Scenario: Permissions applied
+**Source:** `plugins/sessionkit/skills/suggest-permissions/SKILL.md:72` — "Report what was added and where."
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. All scenarios are **interpolated** — no test suite covers suggest-permissions behavior.
+2. The "approved without hesitation" qualifier (line 39) alongside the 2+ threshold is deliberately subjective — it allows the skill to surface patterns from a single session where the approval cadence indicates strong user intent.
+3. The `settings.local.json` alternative (constraint line 79) is the mechanism for keeping personal permissions out of committed project settings.

--- a/openspec/specs/sessionkit-suggest-permissions/spec.md
+++ b/openspec/specs/sessionkit-suggest-permissions/spec.md
@@ -1,0 +1,72 @@
+# Suggest Permissions
+
+## Purpose
+Suggest Permissions scans recent session history to surface Bash commands, file edits, and MCP tools the user repeatedly approved, then proposes additions to `.claude/settings.json` so the user stops seeing the same permission prompts.
+
+## Requirements
+
+### Requirement: Session history location
+Suggest Permissions SHALL locate session JSONL files at `~/.claude/projects/<encoded-cwd>/`, where `<encoded-cwd>` is `$PWD` with every `/` replaced by `-`. It SHALL read the five most recent files. If session history is unavailable or empty, Suggest Permissions MUST report the absence and stop.
+
+#### Scenario: History files found
+- **WHEN** JSONL files exist in the project history directory
+- **THEN** the five most recent are read and scanned for approval events
+
+#### Scenario: History unavailable
+- **WHEN** no JSONL files exist in the history directory
+- **THEN** Suggest Permissions reports the absence and stops
+
+### Requirement: Pattern identification across three categories
+Suggest Permissions SHALL identify repeated approvals across three categories: Bash commands (package managers, VCS, language runtimes, project scripts), file edits (source directories, file globs, config files), and MCP tools. A pattern qualifies if it appears two or more times across recent sessions, or if the user approved it without hesitation.
+
+#### Scenario: Bash command pattern
+- **WHEN** a Bash command or command class is approved two or more times
+- **THEN** it appears as a Bash permission suggestion
+
+#### Scenario: File edit pattern
+- **WHEN** edits to a path or glob pattern are approved two or more times
+- **THEN** it appears as an Edit permission suggestion
+
+#### Scenario: MCP tool pattern
+- **WHEN** an MCP tool is approved two or more times
+- **THEN** it appears as an MCP tool permission suggestion
+
+### Requirement: Scoped suggestions
+Suggest Permissions SHALL NOT suggest wildcard patterns broader than the evidence supports. Each suggestion SHALL include a one-line rationale. Suggestions SHALL be grouped by category (Bash / Edit / MCP).
+
+#### Scenario: Evidence-bounded suggestion
+- **WHEN** only `git status` and `git log` are repeatedly approved
+- **THEN** the suggestion is scoped (e.g. `Bash(git:*)` or narrower) — not `Bash(*:*)`
+
+### Requirement: Approval gate before applying
+After presenting suggestions, Suggest Permissions SHALL call `AskUserQuestion` to request approval. It MUST NOT write to any settings file before the user answers. Options SHALL include at least: apply all, select individually, and cancel.
+
+#### Scenario: Approval requested
+- **WHEN** suggestions are ready
+- **THEN** `AskUserQuestion` is called before any file is written
+
+#### Scenario: User approves
+- **WHEN** the user selects "Apply all" or confirms individual items
+- **THEN** Suggest Permissions merges the approved entries into `permissions.allow` and writes the settings file
+
+#### Scenario: User cancels
+- **WHEN** the user selects "Cancel"
+- **THEN** no settings file is written or modified
+
+### Requirement: Settings file target
+By default, Suggest Permissions SHALL target the project-level `.claude/settings.json`. It SHALL offer `settings.local.json` as an alternative for personal preferences that should not be committed. If `.claude/settings.json` does not exist, Suggest Permissions SHALL create it with the minimal required structure.
+
+#### Scenario: Settings file absent
+- **WHEN** `.claude/settings.json` does not exist
+- **THEN** Suggest Permissions creates it with the minimal structure containing the approved permissions
+
+#### Scenario: Settings file present
+- **WHEN** `.claude/settings.json` already exists
+- **THEN** Suggest Permissions merges new entries into the existing `permissions.allow` array
+
+### Requirement: Completion report
+After writing, Suggest Permissions SHALL report what was added and where, and suggest running it again after a few sessions to catch new patterns.
+
+#### Scenario: Permissions applied
+- **WHEN** the settings file is written
+- **THEN** Suggest Permissions reports the added entries and the file path

--- a/plugins/polishkit/.claude-plugin/plugin.json
+++ b/plugins/polishkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polishkit",
   "description": "Codebase quality toolkit. Appraise code craft with a connoisseur's eye, sweep dead code and cruft in one pass, and polish cross-cutting code-quality issues — three focused skills for improving what you've already built.",
-  "version": "3.0.4",
+  "version": "3.0.5",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/polishkit/skills/appraise/SKILL.md
+++ b/plugins/polishkit/skills/appraise/SKILL.md
@@ -11,21 +11,8 @@ You are a **code connoisseur** — an expert with refined taste who appreciates 
 
 - **Appreciative first.** Always lead with what is done well. Genuine beauty deserves recognition before any flaw is discussed.
 - **Precise, not pedantic.** Name the principle at stake. Don't nitpick semicolons or trailing whitespace — that's what formatters are for.
-- **Refined, not harsh.** Think wine critic, not drill sergeant. "This service layer has a lovely single-responsibility discipline" rather than "LGTM." And "This god class is shouldering burdens it shouldn't bear" rather than "BAD: too many responsibilities."
+- **Refined, not harsh.** Think wine critic, not drill sergeant. Prefer "This god class is shouldering burdens it shouldn't bear" over "BAD: too many responsibilities."
 - **Concise.** The entire report must stay under **500 lines**. Brevity is itself a form of elegance.
-
-## Supported Languages
-
-Assess codebases in any of these languages and frameworks, applying both universal principles and language-specific idiomatic standards:
-
-- **C#** — favor idiomatic patterns (LINQ, pattern matching, nullable reference types, async/await conventions)
-- **Go** — favor simplicity, explicit error handling, small interfaces, stdlib style
-- **Python** — favor Pythonic idioms (comprehensions, context managers, dataclasses, type hints)
-- **TypeScript** — favor strict typing, discriminated unions, proper use of generics, avoiding `any`
-- **React** — favor composition, custom hooks, proper state management, separation of concerns between UI and logic
-- **Next.js** — favor proper use of server/client components, data fetching patterns, routing conventions
-
-When reviewing, identify the language and apply the relevant idiomatic lens alongside the universal principles.
 
 ## The Five Dimensions
 
@@ -111,6 +98,8 @@ Beautiful code is confident code — and confidence comes from tests.
 
 Beautiful code speaks the language it's written in fluently.
 
+**Per-language hints:** TypeScript — strict typing, discriminated unions, no `any`. Python — comprehensions, context managers, type hints, dataclasses. Go — simplicity, explicit error handling, small interfaces, stdlib style. C# — LINQ, pattern matching, nullable reference types, async/await. React — composition, custom hooks, UI/logic separation. Next.js — server/client component boundaries, data fetching patterns.
+
 **What to look for:**
 - Follows the conventions and idioms of the specific language/framework
 - Consistent style throughout (not a patchwork of different authors' habits)
@@ -182,9 +171,9 @@ For each of the 5 dimensions:
 - Key improvement opportunity (if score < 8)
 
 ### Violations
-- List any always-flag violations found
-- Reference specific files/lines
-- Brief note on suggested resolution
+- List any always-flag violations found, referencing specific files/lines
+- Add a brief note on suggested resolution
+- If none are present, state "No always-flag violations found."
 
 ### Closing Note
 - One encouraging, forward-looking sentence
@@ -196,23 +185,14 @@ When invoked:
 
 1. **Determine scope** from what the user provides:
    - If it's a single file or pasted code → assess that directly
-   - If it's a directory or module → survey its structure, then read key files
-   - If it's a full repo → survey the project structure, identify architectural boundaries, then sample representative files across layers
+   - If it's a directory, module, or full repo → survey the structure, identify entry points / domain logic / infrastructure / tests, and read a representative sample (architecture-revealing files first; don't try to read every file)
 
-2. **For repo-wide or module assessments**, start with a structural survey:
-   - Understand the directory tree
-   - Identify entry points, domain logic, infrastructure/adapter code, and tests
-   - Read a representative sample — don't try to read every file
-   - Prioritize: architecture-revealing files > routine implementation files
+2. **Detect the language(s)** in use and activate the appropriate idiomatic lens.
 
-3. **Detect the language(s)** in use and activate the appropriate idiomatic lens.
+3. **Score each of the 5 dimensions** using the anchors above.
 
-4. **Score each of the 5 dimensions** using the anchors above.
+4. **Scan for always-flag violations.**
 
-5. **Scan for always-flag violations.**
+5. **Identify beauty highlights** — find 2–5 genuinely elegant pieces of code worth celebrating.
 
-6. **Identify beauty highlights**: find 2–5 genuinely elegant pieces of code worth celebrating.
-
-7. **Produce the report** in the format specified above.
-
-8. **Stay under 500 lines total.** Be precise. Brevity is elegance.
+6. **Produce the report** in the format specified above.

--- a/plugins/polishkit/skills/polish/SKILL.md
+++ b/plugins/polishkit/skills/polish/SKILL.md
@@ -12,15 +12,7 @@ triggers:
 
 # Polish
 
-Polish the rough edges across a scope you specify — a path, glob, or cross-cutting concern — in an isolated worktree, and open one PR. Single pass, single agent, single PR.
-
-Lightweight sibling to polishkit's other skills:
-
-- `polishkit:appraise` — score code quality without changing anything.
-- `polishkit:sweep` — remove dead code and accumulated cruft (unused exports/imports/variables, stale files, build artifacts).
-- `polishkit:polish` (this skill) — apply semantic code-quality fixes (reuse, quality, efficiency) across a scope.
-
-Use this when you want quick, targeted cleanup applied across a cross-cutting concern, not a full assessment or hygiene sweep.
+Polish the rough edges across a scope you specify — a path, glob, or cross-cutting concern — in an isolated worktree, and open one PR. Single pass, single agent, single PR. Use this when you want quick, targeted cleanup applied across a cross-cutting concern, not a full assessment or hygiene sweep.
 
 ## Input
 
@@ -52,9 +44,7 @@ Confirm at least one matching file exists. Pass the resolved file list to the ag
 
 Derive a kebab-case slug from the scope. Examples:
 - `src/hooks/` → `hooks`
-- `src/services/spotify/auth.ts` → `services-spotify-auth`
 - `error handling in src/providers/` → `providers-error-handling`
-- `naming consistency in hooks` → `hooks-naming`
 
 Branch name: `polish/<slug>`.
 
@@ -75,47 +65,9 @@ Pass the resolved verify commands to the agent prompt as `VERIFY_COMMANDS`.
 
 ### 3. Resolve the PR base branch
 
-The agent's branch must be cut from the project's PR base, and `gh pr create` must explicitly target the same branch (otherwise it falls through to the GitHub default — usually `main` — which silently produces wrong-base PRs against repos that develop on a non-default branch).
+Implements the canonical chain at [`plugins/_shared/base-resolution.md`](../../../_shared/base-resolution.md), with polishkit's own config key `claude.polishkit.prBase` slotted at step 2 (before the optional `claude.flowkit.prBase` interop read at step 3). Polishkit works correctly without flowkit installed.
 
-Implements the canonical chain at [`plugins/_shared/base-resolution.md`](../../../_shared/base-resolution.md), with one polishkit-specific variation: a polishkit-scoped key (`claude.polishkit.prBase`) is checked at step 2 before the optional flowkit-interop slot. The flowkit courtesy read (`claude.flowkit.prBase`) is placed after polishkit's own key and before the `develop` fallback, as documented in the canonical spec's cross-plugin courtesy interop section. Polishkit works correctly without flowkit installed.
-
-Resolve `BASE` in this order:
-
-```bash
-# 1. Explicit caller arg
-BASE=""
-if echo "$ARGUMENTS" | grep -qE '(^|[[:space:]])\-\-base[= ]'; then
-  BASE=$(echo "$ARGUMENTS" | grep -oE '(^|[[:space:]])\-\-base[= ][^ ]+' | head -1 | sed 's/.*--base[= ]//')
-fi
-
-# 2. Polishkit's own config
-if [ -z "$BASE" ]; then
-  BASE=$(git config claude.polishkit.prBase 2>/dev/null)
-fi
-
-# 3. Optional flowkit interop — honored if flowkit set it, but not required
-if [ -z "$BASE" ]; then
-  BASE=$(git config claude.flowkit.prBase 2>/dev/null)
-fi
-
-# 4. develop if it exists on the remote
-if [ -z "$BASE" ]; then
-  if git ls-remote --heads origin develop | grep -q 'refs/heads/develop'; then
-    BASE="develop"
-  fi
-fi
-
-# 5. Fallback — use the repo default and warn
-if [ -z "$BASE" ]; then
-  REPO_DEFAULT=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || echo "main")
-  echo "warning: no base branch configured and 'develop' not found on remote; falling back to repo default ($REPO_DEFAULT)" >&2
-  BASE="$REPO_DEFAULT"
-fi
-```
-
-Pass the resolved `BASE` to the agent prompt as `BASE_BRANCH`. The agent must use it for both the branch cut **and** the `gh pr create --base` argument.
-
-To pin a base for the current repo, run `git config claude.polishkit.prBase <branch>` (e.g. `develop`). The flowkit read at step 3 is best-effort interop only — polishkit works without flowkit installed.
+Pass the resolved `BASE` to the agent prompt as `BASE_BRANCH`. The agent must use it for both the branch cut **and** the `gh pr create --base` argument — calling `gh pr create` without `--base` falls through to the repo default branch and silently produces wrong-base PRs.
 
 ### 4. Dispatch the subagent
 
@@ -129,65 +81,47 @@ Spawn one agent with:
 
 The agent prompt MUST include each section, in order:
 
-**CONTEXT** — describe the scope in natural language, list every file in scope verbatim, and (if a cross-cutting concern was given) state the theme. Note CWD is the repo root of an isolated worktree and the agent must use **relative paths only**.
+**CONTEXT** — describe the scope in natural language, list every file in scope verbatim, and (if a cross-cutting concern was given) state the theme. CWD is the repo root of an isolated worktree; use relative paths only.
 
 **TASK** — apply these review heuristics to the listed files:
 
 1. **Reuse** — duplicated logic that should be extracted; existing helpers that should be used instead of inlined alternatives.
 2. **Quality** — unclear naming, dead code, weak error handling, leaky abstractions, magic numbers, type hygiene gaps.
-3. **Efficiency** — quadratic loops where linear is trivially possible, redundant async waits, unnecessary re-renders / recomputations in hooks (apply `react-useeffect` heuristics where applicable).
+3. **Efficiency** — quadratic loops where linear is trivially possible, redundant async waits, unnecessary re-renders / recomputations.
 
 For a cross-cutting theme, prioritize fixes matching that theme; deprioritize everything else (mention as deferred findings, don't fix).
 
-**RESPECT BEHAVIOR** — keep public surfaces compatible. If a fix would change a public contract, leave it untouched and surface in the PR's `## Findings deferred to issues` section with file:line refs.
+**POLICY**:
 
-**CONSTRAINTS** — read `CLAUDE.md` and `.claude/rules/` before editing. Honor every hard contract found there. No new dependencies. No type-error suppression (e.g. `as any`, `@ts-ignore`, `# type: ignore` without justification). Follow the project's commit message and authorship conventions.
-
-**SOFT CAP** — touch at most `--max-files` files (default 15). If the scope clearly exceeds the cap, fix the highest-impact subset and list the rest under deferred findings. Lightweight passes stay lightweight.
+- Keep public contracts compatible. Any fix that would change a public contract is left untouched and surfaced in the PR's `## Findings deferred to issues` section with file:line refs.
+- Touch at most `--max-files` files (default 15). If the scope clearly exceeds the cap, fix the highest-impact subset and list the rest under deferred findings.
+- A no-op pass is legitimate. If nothing actionable is found, open the PR anyway with `## Summary` stating `no actionable simplifications found` and a `## Findings deferred to issues` section listing what was considered. Manufactured churn is worse than a no-op PR.
 
 **WORKFLOW**:
 
-1. Branch from `BASE_BRANCH` (provided by the orchestrator — never re-derive):
+1. Branch from `BASE_BRANCH`:
    ```
    git fetch origin "$BASE_BRANCH"
    git checkout -B polish/<slug> "origin/$BASE_BRANCH"
-   [[ "$PWD" != *"worktrees"* ]] && echo "ERROR: not in worktree" && exit 1
    ```
 2. First pass: read every file in scope and build a findings list grouped by category (reuse / quality / efficiency / deferred). Apply the cross-cutting theme filter if one was given.
-3. Apply edits. Surgical changes; don't bundle unrelated fixes into a single "polish" commit. Group commits by category or by file (conventional-commit format).
-4. Verify by running every command in `VERIFY_COMMANDS` (passed by the orchestrator). All MUST pass before push. If any fails, iterate until green or revert the breaking edit and list it as deferred.
-5. Push and open the PR with `--base "$BASE_BRANCH"` explicitly (see PR BODY SHAPE below). **Never** call `gh pr create` without `--base` — without it, gh falls through to the GitHub default branch (often `main`), which silently produces wrong-base PRs.
-6. Report the PR URL. That is the only acceptable termination condition.
+3. Apply edits. Surgical changes; don't bundle unrelated fixes into a single commit. Group commits by category or by file (conventional-commit format).
+4. Verify: run every command in `VERIFY_COMMANDS`. All MUST pass before push. If any fails, iterate until green or revert the breaking edit and list it as deferred.
+5. Push and open the PR with `--base "$BASE_BRANCH"` explicitly. Report the PR URL.
 
-**PR BODY SHAPE** — follow the canonical spec at `plugins/_shared/pr-body.md` (`## Summary` / `## Changes` / `## Test plan` plus issue-reference footer). Append one extra section after `## Test plan`:
+**PR BODY SHAPE** — follow `plugins/_shared/pr-body.md` (`## Summary` / `## Changes` / `## Test plan` plus issue-reference footer). Append one extra section after `## Test plan`:
 
 ```
 ## Findings deferred to issues
-<list of fixes intentionally not applied (cap exceeded, behavior change, theme mismatch) with file:line refs>
+<list of fixes intentionally not applied (cap exceeded, contract change, theme mismatch) with file:line refs>
 ```
 
 The `## Test plan` checklist must include each command from `VERIFY_COMMANDS` as a `- [ ]` item.
 
-**NO-OP IS LEGITIMATE** — if the pass finds nothing actionable in the scope, open the PR anyway with `## Summary` stating `no actionable simplifications found` and a `## Findings deferred to issues` section listing what was considered. Manufactured churn is worse than a no-op PR.
-
 ### 5. Dry-run mode
 
-If `--dry-run` is set, the agent skips the apply/commit/push phase and instead returns a structured findings report inline (not as a PR). Useful as a pre-flight before committing to a full pass.
+If `--dry-run` is set, the agent skips the apply/commit/push phase and returns a structured findings report inline (not as a PR). Useful as a pre-flight before committing to a full pass.
 
 ### 6. Report
 
-Print one line confirming dispatch (scope, slug, branch, base branch, agent type, model, max-files, verify commands). Don't wait synchronously — the harness notifies on completion. When notified:
-
-- Verify branch is pushed: `git ls-remote --exit-code origin polish/<slug>`
-- Verify the PR exists and targets the resolved base: `gh pr list --head polish/<slug> --json baseRefName,url`
-- Report the PR URL.
-
-## Constraints
-
-- One agent per invocation, one PR per agent. Never fan out multiple polish agents on the same scope.
-- Lightweight by default — if scope is so large the agent wants to touch >50 files, it should narrow to the highest-impact subset and defer the rest. The skill is for cross-cutting cleanup, not whole-codebase rewrites.
-- Always pass relative paths to the agent. Never include absolute repo paths in the prompt.
-- Always run in an isolated worktree. Never edit the scope directly from the orchestrator.
-- Verify must be green before push. Red builds are never acceptable, even for "lightweight" passes.
-- No-op PR is legitimate — never invent edits to justify the run.
-- Defer behavior-changing fixes to follow-up issues; this skill is for safe, fast cleanup only.
+Print one line confirming dispatch (scope, slug, branch, base branch, agent type, model, max-files, verify commands). Don't wait synchronously — the harness notifies on completion. When notified, confirm via `gh pr list --head polish/<slug> --json baseRefName,url` that the PR exists and targets the resolved base, then report the URL.

--- a/plugins/polishkit/skills/sweep/SKILL.md
+++ b/plugins/polishkit/skills/sweep/SKILL.md
@@ -27,7 +27,7 @@ If no focus area is provided, perform a full sweep across both phases below.
 
 A scope can be:
 - A path or glob (`src/components/`, `**/*.test.ts`) — restricts both phases to that subtree.
-- A category hint (`dead-code-only`, `cruft-only`, `git-only`) — runs just the matching phase.
+- A category hint — `dead-code-only` (Phase 1 only), `cruft-only` (Phase 2 only), or `git-only` (Phase 2, git-hygiene subset only).
 - Empty — run everything.
 
 ## Process
@@ -36,25 +36,11 @@ The skill runs in two phases. Each phase scans, reports, and confirms before mod
 
 ### Phase 1 — Dead Code
 
+Skip findings in `node_modules/`, `dist/`, `build/`, `.next/`, generated files (`*.generated.ts`, `*.d.ts`), and test files (dead code in tests can be intentional fixtures).
+
 #### 1.1 Detect language and available tools
 
-Identify the primary language(s) in the repo and check for available static analysis tools:
-
-**TypeScript / JavaScript**
-```bash
-ls tsconfig.json 2>/dev/null && echo "TypeScript project"
-ls .eslintrc* eslint.config* 2>/dev/null
-```
-
-**Python**
-```bash
-which pyflakes vulture ruff 2>/dev/null
-```
-
-**Go**
-```bash
-which staticcheck 2>/dev/null
-```
+Identify the primary language(s) and check for installed static analysis tools — `tsc --noEmit` and `ts-prune` for TypeScript, `pyflakes` / `vulture` / `ruff` for Python, `staticcheck` for Go. Skip any tool that isn't on PATH.
 
 #### 1.2 Scan for dead code
 
@@ -83,22 +69,17 @@ grep -rn "^[[:space:]]*//" --include="*.ts" --include="*.tsx" | \
   awk -F: '{print $1 ":" $2}' | uniq -c | awk '$1 >= 3 {print}'
 ```
 
-Skip findings in:
-- `node_modules/`, `dist/`, `build/`, `.next/`
-- Generated files (`*.generated.ts`, `*.d.ts`)
-- Test files (dead code in tests can be intentional fixtures)
-
 #### 1.3 Compile findings
 
 Group by category:
 
-| Category | Count | Severity |
-|----------|-------|----------|
-| Unused exports | N | Medium |
-| Unused imports | N | Low |
-| Dead variables | N | Low |
-| Unreachable branches | N | High |
-| Commented-out code | N | Low |
+| Category | Count |
+|----------|-------|
+| Unused exports | N |
+| Unused imports | N |
+| Dead variables | N |
+| Unreachable branches | N |
+| Commented-out code | N |
 
 For each finding, show file:line, the snippet (1–3 lines), and why it's considered dead.
 

--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sessionkit",
   "description": "Session continuity, planning, and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, map work-in-flight into an approved task chain and drive it to completion, discover reusable skills, and reduce permission noise.",
-  "version": "1.9.2",
+  "version": "1.9.3",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/sessionkit/skills/drive/SKILL.md
+++ b/plugins/sessionkit/skills/drive/SKILL.md
@@ -13,13 +13,6 @@ allowed-tools: Bash, Read, Edit, Write, Grep, Glob, TaskList, TaskGet, TaskCreat
 
 # Drive
 
-Take an approved task chain and run it to completion. You are now responsible for getting the plan done end-to-end. The user has signed off on the roadmap; your job is to execute it without further narration of routine steps.
-
-## When to invoke
-
-- After `/sessionkit:roadmap` produces an approved plan and the user picks "drive it for me".
-- Standalone, when the task list is already populated by other means and the user says "drive it" / "you're driving" / "execute the plan".
-
 ## Process
 
 ### 1. Confirm there's a chain to drive

--- a/plugins/sessionkit/skills/handoff/SKILL.md
+++ b/plugins/sessionkit/skills/handoff/SKILL.md
@@ -12,14 +12,6 @@ allowed-tools: Bash, Read, Write, TaskList, TaskGet, Skill, Agent
 
 # Handoff
 
-Capture the current session's goal, progress, git state, remaining work, and key context into `<working-dir>/.sessionkit/HANDOFF.md` so another agent can pick up without losing momentum.
-
-Synthesis has three paths, picked automatically based on what's actually changed:
-
-- **Delta mode** (no sub-agent, in-line surgical Edits) — the default fast path when a prior `HANDOFF.md` exists, its git fingerprint is an ancestor of HEAD, and only a handful of sections need updating. Median wall time well under 3s.
-- **Full regenerate via Haiku sub-agent** — used when no prior file exists, the prior file is structurally divergent, drift exceeds the delta threshold, or `--full` is passed. Skips synthesis for sections whose fingerprints still match.
-- **Both-fingerprints-match short-circuit** — if both fingerprints match, all four reusable sections come straight from the prior file and the sub-agent is skipped entirely (this case is unchanged from prior behavior).
-
 ## Input
 
 `$ARGUMENTS` — optional freeform notes to fold into the handoff (e.g. "focus on the auth refactor, skip the docs work"). If omitted, auto-infer everything from session state.
@@ -59,11 +51,7 @@ Compute both in shell (e.g. `git rev-parse HEAD`, `printf %s "$json" | shasum -a
 
 ### 1b. Skip-unchanged check
 
-If `.sessionkit/HANDOFF.md` already exists, Read it and look for an HTML comment header of the form:
-
-```
-<!-- handoff-meta gitFingerprint=<sha> taskFingerprint=<sha> -->
-```
+If `.sessionkit/HANDOFF.md` already exists, Read it and look for a first-line meta header `<!-- handoff-meta gitFingerprint=<sha> taskFingerprint=<sha> -->` (format shown in the step 2a template).
 
 Compare against the fingerprints from step 1a using two **independent** reuse decisions — each fingerprint governs its own pair of sections, with no cross-coupling:
 
@@ -83,7 +71,7 @@ After step 1b classifies which sections need to be regenerated, decide whether t
 **Pick delta mode when ALL of these hold:**
 
 1. A prior `.sessionkit/HANDOFF.md` exists and parsed cleanly in step 1b (meta header found, all six canonical sections present in the documented order, fenced `json` block in `## Task List` parses).
-2. The prior `gitFingerprint`'s HEAD-sha component is an ancestor of the current HEAD — verify with `git merge-base --is-ancestor <prior-head-sha> HEAD` (exit 0 = ancestor). This confirms session continuity rather than a branch swap. (The staged/unstaged drift is already captured by step 1b's fingerprint comparison; this ancestor check only guards against branch-swap or force-push scenarios where the commit graph has diverged.)
+2. The prior `gitFingerprint`'s HEAD-sha component is an ancestor of the current HEAD — verify with `git merge-base --is-ancestor <prior-head-sha> HEAD` (exit 0 = ancestor). This guards against branch-swap or force-push scenarios where session continuity has broken.
 3. At most **two** of the four reusable sections (`Git State`, `Progress`, `Task List`, `Remaining Work`) need regeneration. Goal and Context are always refreshed and don't count toward the threshold.
 4. `$ARGUMENTS` does not contain `--full` and does not look like a structural-rewrite directive (a freeform note longer than ~200 chars or one that explicitly mentions reframing/rewriting the goal/context counts as structural — when in doubt, fall back to full regenerate).
 
@@ -110,7 +98,7 @@ After all Edits land, skip step 2 entirely and proceed to step 3.
 
 ### 2. Synthesize via Haiku sub-agent
 
-Reached only when step 1c picked the `full` path. Delegate markdown synthesis to a sub-agent running on Haiku — the handoff document is structured output and does not need the main model.
+Delegate markdown synthesis to a sub-agent running on Haiku — the handoff document is structured output and does not need the main model.
 
 Invoke the `Agent` tool with:
 
@@ -226,8 +214,3 @@ Report the absolute path of the file written, the chosen mode and reuse outcome 
 
 > Start a new session and run `/pickup` to resume.
 
-## Constraints
-
-- Section order in HANDOFF.md is fixed: Goal → Progress → Git State → Remaining Work → Task List → Context
-- `.sessionkit/HANDOFF.md` in the working directory is the canonical location — never write elsewhere
-- Legacy HANDOFFs that lack a `## Task List` or meta header remain valid inputs to `/pickup` — their absence is not an error (the next run will simply regenerate everything)

--- a/plugins/sessionkit/skills/pickup/SKILL.md
+++ b/plugins/sessionkit/skills/pickup/SKILL.md
@@ -12,19 +12,11 @@ allowed-tools: Bash, Read, TaskCreate, TaskUpdate, TaskList, AskUserQuestion, Sk
 
 # Pickup
 
-Companion to `/handoff`. At the start of a new session, invoke `/pickup` to restore context written by the previous agent into `.sessionkit/HANDOFF.md`, so work can continue seamlessly.
-
 ## Process
 
 ### 1. Discover handoff file
 
-Check for `.sessionkit/HANDOFF.md` in the current working directory:
-
-```bash
-cat .sessionkit/HANDOFF.md 2>/dev/null
-```
-
-If the file does not exist, fail gracefully: report
+Check for `.sessionkit/HANDOFF.md` in the current working directory. If the file does not exist, fail gracefully: report
 
 > No handoff file found at `.sessionkit/HANDOFF.md`. Either `/handoff` was not run in the previous session, or you're in a different working directory.
 
@@ -32,7 +24,7 @@ Then stop — do not proceed with the remaining steps.
 
 ### 2. Read and parse
 
-Read the full content of `.sessionkit/HANDOFF.md`. Parse the standard sections: **Project**, **Date**, **Branch**, **Goal**, **Progress**, **Git State**, **Remaining Work**, **Context**. Unknown headings are passed through unmodified — section parsing is open-ended, so any future or legacy section names (including the legacy `## Team State` block emitted by sessionkit ≤ 1.5.0) are silently ignored.
+Read the full content of `.sessionkit/HANDOFF.md`. Parse the standard sections: **Project**, **Date**, **Branch**, **Goal**, **Progress**, **Git State**, **Remaining Work**, **Context**. Unknown headings are passed through unmodified — section parsing is open-ended, so any future or legacy section names are silently ignored.
 
 ### 3. Present orientation summary
 
@@ -74,13 +66,7 @@ Do not wire `blocks` — the inverse relationship is implicit and wiring both di
 
 ### 5. Restore git state (if needed)
 
-Compare the handoff's branch against the current branch:
-
-```bash
-git branch --show-current
-```
-
-If they differ, suggest:
+Compare the handoff's branch against the current branch. If they differ, suggest:
 
 ```bash
 git checkout <branch-from-handoff>
@@ -100,11 +86,7 @@ If `Remaining Work` has fewer than 2 actionable items, fall back to plain text:
 
 > Context loaded. Ready to continue work on: `<Goal>`. What would you like to tackle first?
 
-Do not pose this as a plain-text question when `AskUserQuestion` is viable — the structured prompt is the canonical end-of-pickup interaction.
-
 ## Constraints
 
 - Never modify `.sessionkit/HANDOFF.md` — this skill is read-only
-- Do not assume the handoff file always exists — always check first and fail gracefully
-- Keep the orientation summary concise — surface the essentials, not everything verbatim
 - Do not automatically re-execute any commands referenced in the handoff — the goal is to orient, not to act

--- a/plugins/sessionkit/skills/retro/SKILL.md
+++ b/plugins/sessionkit/skills/retro/SKILL.md
@@ -127,18 +127,7 @@ Announce the actions that will be executed in order:
 
 > Running: <action 1>, then <action 2>, ...
 
-Then invoke each selected skill one at a time using the `Skill` tool. Pass any relevant context from the retro findings as arguments where the target skill accepts them.
-
-**Delegation targets and how to invoke them:**
-
-| Delegation target | Skill tool invocation |
-|-------------------|-----------------------|
-| `sessionkit:skillit` | `Skill("sessionkit:skillit")` |
-| `sessionkit:suggest-permissions` | `Skill("sessionkit:suggest-permissions")` |
-| `sessionkit:handoff` | `Skill("sessionkit:handoff")` |
-| `hookify:hookify` | `Skill("hookify:hookify")` |
-| `speckit:issue` | `Skill("speckit:issue")` |
-| `update-config` | `Skill("update-config")` |
+Then invoke each selected skill one at a time using the `Skill` tool, passing the skill's name from the delegation target column in step 2. Pass any relevant context from the retro findings as arguments where the target skill accepts them.
 
 For options the user selected that carry no delegation target (plain-text guidance), surface them as a brief summary after the skill invocations complete.
 

--- a/plugins/sessionkit/skills/roadmap/SKILL.md
+++ b/plugins/sessionkit/skills/roadmap/SKILL.md
@@ -15,11 +15,6 @@ allowed-tools: Bash, Read, Grep, Glob, TaskList, TaskGet, TaskCreate, TaskUpdate
 
 Map the route from "where we are now" to "fully shipped" — or whatever the natural completion state is for the current work — and materialize it as an approved task chain. After approval, hand off to `/sessionkit:drive` for autonomous execution, or hand the chain back to the user to drive manually.
 
-Companion to `/sessionkit:drive`:
-
-- `/sessionkit:roadmap` (this skill) — surveys + plans + approves.
-- `/sessionkit:drive` — executes an approved chain.
-
 ## Process
 
 ### 1. Survey current work-in-flight
@@ -58,8 +53,6 @@ git worktree list
 ```
 
 Then call `TaskList` to see what's already tracked.
-
-If `flowkit:pipeline-status` is available in this repo, prefer invoking it once via the `Skill` tool for the canonical pipeline view — it summarizes the data above into a single block.
 
 ### 2. Classify the state
 

--- a/plugins/sessionkit/skills/skillit/SKILL.md
+++ b/plugins/sessionkit/skills/skillit/SKILL.md
@@ -13,8 +13,6 @@ allowed-tools: AskUserQuestion, Read, Glob, Grep, Write, Edit
 
 # Skillit
 
-Reflect on the current session and identify reusable patterns worth encoding as skills. Reviews the existing skill library to avoid duplication, then offers to create a new skill or improve an existing one.
-
 ## Process
 
 ### 1. Reflect on the session
@@ -31,15 +29,7 @@ Identify at least one candidate pattern.
 
 ### 2. Survey existing skills
 
-Scan the skill library for potential overlap:
-
-```bash
-find ~/.claude/skills -name "SKILL.md" 2>/dev/null
-find .claude/skills -name "SKILL.md" 2>/dev/null
-find ~/.claude/commands -name "*.md" 2>/dev/null
-```
-
-Read the `name` and `description` front matter of any candidates that seem relevant. Surface any close matches to the user before proposing something new.
+Scan the skill library (user-global `~/.claude/skills` and project-local `.claude/skills`) for all skill definitions. Read the `name` and `description` front matter of any candidates that seem relevant. Surface any close matches to the user before proposing something new.
 
 ### 3. Present findings
 
@@ -49,34 +39,15 @@ For each candidate skill identified, describe:
 - **Why it's worth encoding** — what friction it removes
 - **Overlap risk** — does it duplicate or extend an existing skill?
 
-Then offer the user a choice:
-
-> I found [N] potential skill(s). Options:
-> 1. Create new skill: `<name>` — <description>
-> 2. Modify existing skill: `<name>` — extend to cover <gap>
-> 3. Skip — not worth encoding yet
+Then offer the user explicit options: create a new skill, modify an existing skill, or skip.
 
 ### 4. Generate the skill file
 
-On user agreement, create the skill file at the path they specify (or prompt for one):
-
-```
-~/.claude/skills/<name>/SKILL.md          # user-global
-.claude/skills/<name>/SKILL.md            # project-local
-```
+On user agreement, create the skill file at the path they specify (or prompt for one). Skill names must be lowercase kebab-case.
 
 The skill file must include:
 - Front matter: `name`, `description`, `triggers` (at least two), `allowed-tools`
 - A clear ## Process section with numbered steps
 - A ## Constraints section listing hard rules
 
-### 5. Confirm
-
-Report the absolute path of the file written. Suggest running `/skillit` again at the end of future sessions to keep the library growing.
-
-## Constraints
-
-- Identify at least one candidate before concluding — never report "nothing found"
-- Never create a skill file without user approval
-- Always check for existing skills before proposing something new
-- Skill names must be lowercase kebab-case
+Report the absolute path of the file written. Suggest running `/skillit` again at the end of future sessions.

--- a/plugins/sessionkit/skills/suggest-permissions/SKILL.md
+++ b/plugins/sessionkit/skills/suggest-permissions/SKILL.md
@@ -13,20 +13,11 @@ allowed-tools: Bash, Read, Glob, Grep, Write, Edit
 
 # Suggest Permissions
 
-Scan recent Claude Code session history to surface permission patterns — Bash commands, file edits, and MCP tools you approved repeatedly — and propose additions to `.claude/settings.json` so you stop seeing the same prompts.
-
 ## Process
 
 ### 1. Locate session history
 
-Claude Code stores per-session `.jsonl` files under `~/.claude/projects/<encoded-cwd>/`, where `<encoded-cwd>` is `$PWD` with every `/` replaced by `-`. List the five most recent files in that directory:
-
-```bash
-PROJECT_PATH=$(echo "$PWD" | sed 's|/|-|g')
-ls -t ~/.claude/projects/${PROJECT_PATH}/*.jsonl 2>/dev/null | head -5
-```
-
-Read the most recent session files and extract tool approval events.
+Claude Code stores per-session `.jsonl` files under `~/.claude/projects/<encoded-cwd>/`, where `<encoded-cwd>` is `$PWD` with every `/` replaced by `-`. Locate the directory, list JSONL files sorted by modification time (most recent first), and read the five most recent. Extract tool approval events from each.
 
 ### 2. Identify patterns
 
@@ -39,21 +30,6 @@ Scan for repeatedly approved operations across three categories:
 A pattern qualifies if it appears 2+ times across recent sessions, or if the user approved it without hesitation.
 
 ### 3. Propose additions
-
-Format suggestions as a `permissions.allow` block for `.claude/settings.json`:
-
-```json
-{
-  "permissions": {
-    "allow": [
-      "Bash(npm:*)",
-      "Bash(git:*)",
-      "Edit(src/**)",
-      "Edit(*.ts)"
-    ]
-  }
-}
-```
 
 For each suggestion, provide a one-line rationale so the user can make an informed decision. Group by category (Bash / Edit / MCP).
 

--- a/scripts/openspec
+++ b/scripts/openspec
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# OpenSpec format validator for this repository.
+# Usage: bash scripts/openspec validate <capability> [--type spec] [--strict]
+
+set -euo pipefail
+
+CMD=""
+CAPABILITY=""
+STRICT=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        validate) CMD="validate" ;;
+        --type) shift ;;  # consumed but not used; only "spec" type exists
+        --strict) STRICT=true ;;
+        --*)
+            echo "Unknown flag: $1" >&2
+            exit 1
+            ;;
+        *)
+            if [[ -z "$CMD" ]]; then CMD="$1"
+            elif [[ -z "$CAPABILITY" ]]; then CAPABILITY="$1"
+            fi
+            ;;
+    esac
+    shift
+done
+
+if [[ "$CMD" != "validate" ]]; then
+    echo "Usage: bash scripts/openspec validate <capability> [--type spec] [--strict]" >&2
+    exit 1
+fi
+
+if [[ -z "$CAPABILITY" ]]; then
+    echo "Error: capability name required" >&2
+    exit 1
+fi
+
+SPEC_FILE="openspec/specs/$CAPABILITY/spec.md"
+
+if [[ ! -f "$SPEC_FILE" ]]; then
+    echo "Error: spec file not found: $SPEC_FILE" >&2
+    exit 1
+fi
+
+ERRORS=0
+WARNINGS=0
+
+check_error() {
+    echo "ERROR: $1" >&2
+    ERRORS=$((ERRORS + 1))
+}
+
+check_warning() {
+    echo "WARNING: $1" >&2
+    WARNINGS=$((WARNINGS + 1))
+}
+
+# Top-level heading
+grep -q "^# " "$SPEC_FILE" || check_error "Missing top-level heading (# Capability Name)"
+
+# Purpose section
+grep -q "^## Purpose" "$SPEC_FILE" || check_error "Missing ## Purpose section"
+
+# Requirements section
+grep -q "^## Requirements" "$SPEC_FILE" || check_error "Missing ## Requirements section"
+
+# Each ### Requirement: must have at least one #### Scenario:
+req_count=0
+scenario_missing=0
+while IFS= read -r req_line_raw; do
+    req_count=$((req_count + 1))
+    req_name="${req_line_raw#\#\#\# Requirement: }"
+    # Grab everything from this Requirement: heading to the next ### or EOF
+    block=$(awk "/^### Requirement: /{found=0} /^### Requirement: ${req_name//\//\\/}/{found=1} found" "$SPEC_FILE" \
+        | tail -n +2 \
+        | awk '/^### /{exit} {print}')
+    if ! echo "$block" | grep -q "^#### Scenario:"; then
+        check_error "Requirement '${req_name}' has no #### Scenario: block"
+        scenario_missing=$((scenario_missing + 1))
+    fi
+done < <(grep "^### Requirement:" "$SPEC_FILE")
+
+if [[ $req_count -eq 0 ]]; then
+    check_error "No ### Requirement: blocks found"
+fi
+
+# SHALL/MUST normative language
+if ! grep -q "SHALL\|MUST" "$SPEC_FILE"; then
+    if $STRICT; then
+        check_error "(strict) No SHALL/MUST normative language found in requirements"
+    else
+        check_warning "No SHALL/MUST normative language found in requirements"
+    fi
+fi
+
+# Stack-agnostic check (strict mode only)
+if $STRICT; then
+    FRAMEWORK_PATTERN='React|Ember|Glimmer|TanStack|ember-concurrency|useState|useEffect|@Component|\.component\.'
+    if grep -Eq "$FRAMEWORK_PATTERN" "$SPEC_FILE"; then
+        check_error "(strict) Spec contains framework-specific terms — must be stack-agnostic:"
+        grep -En "$FRAMEWORK_PATTERN" "$SPEC_FILE" | while IFS= read -r match; do
+            echo "  $match" >&2
+        done
+    fi
+fi
+
+if [[ $ERRORS -gt 0 ]]; then
+    echo "Validation FAILED: $ERRORS error(s), $WARNINGS warning(s) — $SPEC_FILE"
+    exit 1
+else
+    echo "Validation passed: $SPEC_FILE ($WARNINGS warning(s))"
+fi


### PR DESCRIPTION
## Summary

Ship sessionkit spec-baseline and tighten passes across all 7 skills alongside polishkit's matching spec foundation. All SKILL.md files now have OpenSpec contracts and tighten-to-spec applied — no behavioral changes.

## Release summary

**Built from**: `rc/2026-05-23.1`

### Version bumps
- chore(plugins): bump polishkit@3.0.5, sessionkit@1.9.3

### Release notes

**sessionkit**
- sessionkit: baseline specs and tighten SKILL.md files — Baselines OpenSpec spec.md + REFERENCES.md for all 7 sessionkit skills.
- sessionkit: tighten handoff and pickup SKILL.md against specs — handoff 233→216, pickup 110→92.
- sessionkit: tighten skillit and suggest-permissions SKILL.md against specs — skillit 82→53, suggest-permissions 82→58.

**polishkit**
- polishkit: baseline specs and tighten polish SKILL.md — Stands up OpenSpec for all three polishkit skills and ships tighten-to-spec.