### PR TITLE
speckit: baseline specs and tighten SKILL.md files

### DIFF
--- a/openspec/specs/speckit-catalog/REFERENCES.md
+++ b/openspec/specs/speckit-catalog/REFERENCES.md
@@ -1,0 +1,173 @@
+# speckit-catalog — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `sop/`.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Finding Extraction
+
+**Sources**
+- `plugins/speckit/skills/catalog/SKILL.md:32-43` — Step 1 defines parsing into discrete findings with title, category, severity, body fields.
+- `plugins/speckit/skills/catalog/SKILL.md:12-18` — Input section defines the three source precedence order: explicit arguments, conversation context, file path, then ask.
+
+**Notes**
+- Category values are enumerated at line 36 (bug/enhancement/refactor/documentation/hygiene).
+- Severity maps to `priority` in the filing step; line 36 gives the three levels.
+
+### Scenario: Explicit input parsed into findings
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:13` — first precedence: explicit input in `$ARGUMENTS`.
+**Interpolated; no direct test.**
+
+### Scenario: Conversation context used when arguments empty
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:15` — second precedence: earlier conversation containing structured findings.
+**Interpolated; no direct test.**
+
+### Scenario: File path resolved to findings
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:16-17` — third precedence: if `$ARGUMENTS` is a path, read and extract.
+**Interpolated; no direct test.**
+
+### Scenario: No findings available
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:18` — "If no findings are available, ask the user what to catalog."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Phase Consolidation
+
+**Sources**
+- `plugins/speckit/skills/catalog/SKILL.md:44-55` — Step 1.5 defines the default consolidation rule: same phase + shared scope + no inter-dependency → merge into one issue with checklist body.
+- `plugins/speckit/skills/catalog/SKILL.md:55` — `--split` disables consolidation entirely.
+- `plugins/speckit/skills/catalog/SKILL.md:48-50` — "Shared scope" definition.
+- `plugins/speckit/skills/catalog/SKILL.md:50-52` — "No inter-dependency" definition and counter-example.
+
+### Scenario: Same-phase same-scope findings consolidated
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:46-54` — consolidation rule with resulting issue shape.
+**Interpolated; no direct test.**
+
+### Scenario: Split flag bypasses consolidation
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:55` — `--split` disables and files one issue per row.
+**Interpolated; no direct test.**
+
+### Scenario: Findings with inter-dependencies stay separate
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:50-52` — rows with explicit ordering dependencies stay split.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Consolidation Summary
+
+**Sources**
+- `plugins/speckit/skills/catalog/SKILL.md:57-74` — Step 1.6 defines the pre-file consolidation summary and its exact format.
+- `plugins/speckit/skills/catalog/SKILL.md:73-74` — Summary prints even under `--auto`.
+
+### Scenario: Summary printed before catalog table
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:57-66` — one line per phase format with rows → issues and reason.
+**Interpolated; no direct test.**
+
+### Scenario: Split mode summary
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:68-71` — `--split` produces a single summary line.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Label Provisioning
+
+**Sources**
+- `plugins/speckit/skills/catalog/SKILL.md:77-105` — Step 2 covers label detection and creation, including the epic label provisioning block.
+- `plugins/speckit/skills/catalog/SKILL.md:88-103` — Epic label provisioning: create if missing, warn and confirm if already present.
+
+### Scenario: Missing category or priority labels created
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:82-85` — create missing category and priority labels.
+**Interpolated; no direct test.**
+
+### Scenario: Epic label created when slug supplied and missing
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:90-96` — `gh label create` with color `5319E7` when label is missing.
+**Interpolated; no direct test.**
+
+### Scenario: Existing epic label requires confirmation before reuse
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:97-103` — warning emitted and explicit approval required before reuse.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Catalog Approval Gate
+
+**Sources**
+- `plugins/speckit/skills/catalog/SKILL.md:107-156` — Step 3 specifies table shape, epic header, and the same-turn `AskUserQuestion` contract.
+- `plugins/speckit/skills/catalog/SKILL.md:129` — `--auto` skips the approval step.
+- `plugins/speckit/skills/catalog/SKILL.md:131-156` — Wrong/right shape examples documenting the same-turn requirement.
+
+### Scenario: Catalog table and approval call in same turn
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:131-154` — "The catalog table and the `AskUserQuestion` approval call must be emitted in the same assistant turn."
+**Interpolated; no direct test.**
+
+### Scenario: Auto flag bypasses approval
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:129` — "If `--auto` was passed in `$ARGUMENTS`, skip the approval step."
+**Interpolated; no direct test.**
+
+### Scenario: Epic label column shown in catalog table
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:117-127` — table includes epic label on every row when epic slug is active.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Sequential Issue Creation
+
+**Sources**
+- `plugins/speckit/skills/catalog/SKILL.md:168-180` — Step 4: create sequentially in priority order, never parallelize, capture URL immediately.
+- `plugins/speckit/skills/catalog/SKILL.md:169-172` — Epic label applied to every issue in batch.
+
+### Scenario: Issues created sequentially in priority order
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:176-179` — "Create issues sequentially (one at a time) in priority order (high first)."
+**Interpolated; no direct test.**
+
+### Scenario: Epic label applied to every issue in batch
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:169-172` — `--label "epic:<slug>"` on every `gh issue create` when slug is active.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Title–Number Verification
+
+**Sources**
+- `plugins/speckit/skills/catalog/SKILL.md:182-196` — Step 4.5: fetch each issue title via `gh issue view` and assert match.
+- `plugins/speckit/skills/catalog/SKILL.md:193-196` — Mismatch halts and reports before passing numbers downstream.
+
+### Scenario: Created issue titles verified
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:182-191` — verification loop with `gh issue view --json title`.
+**Interpolated; no direct test.**
+
+### Scenario: Mismatch halts reporting
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:193-196` — "halt and report — do not pass unverified numbers to downstream steps."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Handoff Block Emission
+
+**Sources**
+- `plugins/speckit/skills/catalog/SKILL.md:198-234` — Step 5 report section and Handoff Contract define `spec-handoff` fenced block shape, schema, placement rule, and conditional emission.
+- `plugins/speckit/skills/catalog/SKILL.md:208` — "emit the handoff block immediately after the results table, then stop."
+- `plugins/speckit/skills/catalog/SKILL.md:234` — "nothing follows the closing fence."
+
+### Scenario: Handoff block emitted after epic-mode issue table
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:212-222` — fenced `spec-handoff` block with `filed`, `epic_slug`, `next_phase` fields.
+**Interpolated; no direct test.**
+
+### Scenario: Handoff block omitted without epic flag
+**Source:** `plugins/speckit/skills/catalog/SKILL.md:238-240` — "When `--epic <slug>` is NOT passed, this block is omitted entirely."
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. **All scenarios interpolated from absence of tests** — speckit/catalog has no automated test suite. Every scenario is derived from reading the SKILL.md prose and verified by structural analysis of the skill's process steps. No test file exists to cross-verify any behavioral claim.
+
+2. **`--auto` and consolidation summary interaction** — Line 73-74 explicitly states the summary prints even under `--auto`. This is a non-obvious design choice (auto bypasses approval but not the summary) worth flagging for reviewers.
+
+3. **Epic label confirmation fires at most once** — Line 103 states "This prompt fires at most once per catalog invocation." This deduplication behavior is documented in the skill but has no test coverage.
+
+4. **Downstream number safety** — The title–number verification step (step 4.5) exists specifically because parallel `gh issue create` calls scramble URL↔title mapping. This is the stated rationale for sequential creation at line 177.

--- a/openspec/specs/speckit-catalog/spec.md
+++ b/openspec/specs/speckit-catalog/spec.md
@@ -1,0 +1,115 @@
+# speckit-catalog
+
+## Purpose
+
+Convert code review findings or assessment results into prioritized, labeled GitHub issues. Accepts findings from explicit input, conversation context, or a file path.
+
+## Requirements
+
+### Requirement: Finding Extraction
+The skill SHALL parse the source input into discrete findings, each with a title (under 70 characters), category (bug/enhancement/refactor/documentation/hygiene), severity (high/medium/low), and body.
+
+#### Scenario: Explicit input parsed into findings
+- **WHEN** `$ARGUMENTS` contains a pasted list or structured findings text
+- **THEN** the skill extracts one finding object per discrete finding with title, category, severity, and body
+
+#### Scenario: Conversation context used when arguments empty
+- **WHEN** `$ARGUMENTS` is empty and earlier conversation contains structured findings from a code review or assessment
+- **THEN** the skill uses those findings as the source
+
+#### Scenario: File path resolved to findings
+- **WHEN** `$ARGUMENTS` is a file path
+- **THEN** the skill reads the file and extracts findings from its contents
+
+#### Scenario: No findings available
+- **WHEN** no findings can be derived from arguments, context, or file
+- **THEN** the skill asks the user what to catalog before proceeding
+
+### Requirement: Phase Consolidation
+By default, the skill SHALL consolidate mechanically-related findings in the same phase into a single issue. A finding qualifies for consolidation only when it shares scope with phase-mates AND has no inter-dependencies with them. The `--split` flag disables consolidation and files one issue per finding.
+
+#### Scenario: Same-phase same-scope findings consolidated
+- **WHEN** multiple findings share a phase label and describe instances of the same mechanical work with no inter-dependencies
+- **THEN** they are merged into a single issue whose body lists each original finding as a checklist item
+
+#### Scenario: Split flag bypasses consolidation
+- **WHEN** `--split` is present in `$ARGUMENTS`
+- **THEN** every finding becomes its own issue regardless of phase or scope
+
+#### Scenario: Findings with inter-dependencies stay separate
+- **WHEN** one finding in a phase lists another finding in the same phase as a prerequisite or dependency
+- **THEN** those two findings are not consolidated
+
+### Requirement: Consolidation Summary
+The skill SHALL print a one-line-per-phase consolidation summary before the catalog table, even when `--auto` is active or no consolidation occurred.
+
+#### Scenario: Summary printed before catalog table
+- **WHEN** the catalog table is about to be presented
+- **THEN** a consolidation summary line per phase is emitted first, showing rows → issues and the consolidation reason
+
+#### Scenario: Split mode summary
+- **WHEN** `--split` is active
+- **THEN** the summary is a single line stating that one issue per row will be filed
+
+### Requirement: Label Provisioning
+The skill SHALL ensure all labels required for the current batch exist in the repo before filing. Labels are created only when they will be used by the current findings.
+
+#### Scenario: Missing category or priority labels created
+- **WHEN** a finding requires a category or priority label that does not exist in the repo
+- **THEN** the skill creates the missing label before filing
+
+#### Scenario: Epic label created when slug supplied and missing
+- **WHEN** `--epic <slug>` is present and the `epic:<slug>` label does not exist
+- **THEN** the skill creates the label with color `#5319E7` and a description referencing the epic title or slug
+
+#### Scenario: Existing epic label requires confirmation before reuse
+- **WHEN** `--epic <slug>` is present and the `epic:<slug>` label already exists
+- **THEN** the skill warns the user and asks for explicit approval before reusing the label for the batch
+
+### Requirement: Catalog Approval Gate
+The skill SHALL present the catalog table and an `AskUserQuestion` approval call in the same assistant turn before creating any issues. The `--auto` flag skips the approval gate.
+
+#### Scenario: Catalog table and approval call in same turn
+- **WHEN** the catalog is ready to present and `--auto` is not active
+- **THEN** the catalog table and an `AskUserQuestion` call appear in the same assistant turn with no turn-ending prose between them
+
+#### Scenario: Auto flag bypasses approval
+- **WHEN** `--auto` is present in `$ARGUMENTS`
+- **THEN** the skill proceeds directly to issue creation without presenting the catalog for approval
+
+#### Scenario: Epic label column shown in catalog table
+- **WHEN** `--epic <slug>` is active
+- **THEN** every row in the catalog table shows the `epic:<slug>` label in the Labels column
+
+### Requirement: Sequential Issue Creation
+The skill SHALL create issues one at a time in priority order (high first). Parallel creation is forbidden.
+
+#### Scenario: Issues created sequentially in priority order
+- **WHEN** the user approves the catalog
+- **THEN** issues are created one at a time from highest to lowest priority, and each URL is captured immediately after creation
+
+#### Scenario: Epic label applied to every issue in batch
+- **WHEN** `--epic <slug>` is active
+- **THEN** every `gh issue create` call includes `--label "epic:<slug>"` alongside category and priority labels
+
+### Requirement: Title–Number Verification
+After creating all issues, the skill SHALL verify that each created issue's title matches the intended title before reporting or passing numbers downstream.
+
+#### Scenario: Created issue titles verified
+- **WHEN** all issues in the batch have been created
+- **THEN** the skill fetches each issue's title via `gh issue view` and asserts it matches the catalog table row
+
+#### Scenario: Mismatch halts reporting
+- **WHEN** any retrieved title does not match the intended title
+- **THEN** the skill halts and reports the mismatch without passing unverified issue numbers downstream
+
+### Requirement: Handoff Block Emission
+When invoked with `--epic <slug>`, the skill SHALL emit a fenced `spec-handoff` JSON block as the final output after the issue table, with no trailing prose.
+
+#### Scenario: Handoff block emitted after epic-mode issue table
+- **WHEN** `--epic <slug>` is present and all issues have been created and verified
+- **THEN** a fenced block with info string `spec-handoff` containing `filed`, `epic_slug`, and `next_phase` fields is the last element of the output
+
+#### Scenario: Handoff block omitted without epic flag
+- **WHEN** `--epic <slug>` is not present
+- **THEN** no `spec-handoff` block appears in the output

--- a/openspec/specs/speckit-interview/REFERENCES.md
+++ b/openspec/specs/speckit-interview/REFERENCES.md
@@ -1,0 +1,128 @@
+# speckit-interview — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `sop/`.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Input Handling
+
+**Sources**
+- `plugins/speckit/skills/interview/SKILL.md:22-23` — `$ARGUMENTS` is the freeform description; if empty, ask before starting.
+- `plugins/speckit/skills/interview/SKILL.md:28-30` — explicit empty-argument handler: ask "What would you like to think through?"
+
+### Scenario: Description provided via arguments
+**Source:** `plugins/speckit/skills/interview/SKILL.md:22` — "`$ARGUMENTS` — a freeform description of a feature, bug, or change to think through."
+**Interpolated; no direct test.**
+
+### Scenario: Empty arguments prompts for topic
+**Source:** `plugins/speckit/skills/interview/SKILL.md:28-30` — asks "What would you like to think through?" when arguments empty.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Codebase Grounding
+
+**Sources**
+- `plugins/speckit/skills/interview/SKILL.md:32-34` — "If `$ARGUMENTS` references files or areas of the codebase, grep or glob for relevant files so questions are grounded in the actual code. Run this in the background while forming the first question batch."
+
+### Scenario: Relevant files fetched in background
+**Source:** `plugins/speckit/skills/interview/SKILL.md:32-34` — background grep/glob without blocking first questions.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Multi-Round Interview
+
+**Sources**
+- `plugins/speckit/skills/interview/SKILL.md:36-44` — Step 2 defines the five probing dimensions (scope, behaviour, constraints, decisions, acceptance criteria) and the continuation rule.
+- `plugins/speckit/skills/interview/SKILL.md:134` — "Ask 1–4 questions per round."
+- `plugins/speckit/skills/interview/SKILL.md:43-44` — "Challenge inconsistencies, assumptions, and contradictions directly."
+
+### Scenario: Questions sent 1–4 per round
+**Source:** `plugins/speckit/skills/interview/SKILL.md:134` — constraint: "Ask 1–4 questions per round — never one-at-a-time, never a wall of questions."
+**Interpolated; no direct test.**
+
+### Scenario: Interview continues until unambiguous
+**Source:** `plugins/speckit/skills/interview/SKILL.md:44` — "Continue rounds until the plan is complete and unambiguous."
+**Interpolated; no direct test.**
+
+### Scenario: Inconsistencies challenged directly
+**Source:** `plugins/speckit/skills/interview/SKILL.md:43` — "Challenge inconsistencies, assumptions, and contradictions directly."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Structured Plan Production
+
+**Sources**
+- `plugins/speckit/skills/interview/SKILL.md:46-74` — Step 3 specifies all five required sections and the Tasks table schema.
+- `plugins/speckit/skills/interview/SKILL.md:71-74` — Documentation task auto-appended unless pure refactor.
+- `plugins/speckit/skills/interview/SKILL.md:139` — "Output sections must match `/spec` exactly: Goal, Background, Requirements, Out of Scope, Tasks."
+
+### Scenario: Plan contains all five required sections
+**Source:** `plugins/speckit/skills/interview/SKILL.md:50-66` — Goal, Background, Requirements, Out of Scope, Tasks sections defined with their content shapes.
+**Interpolated; no direct test.**
+
+### Scenario: Documentation task appended unless pure refactor
+**Source:** `plugins/speckit/skills/interview/SKILL.md:71-74` — auto-appended "Update documentation" row unless pure refactor or internal-only change.
+**Interpolated; no direct test.**
+
+### Scenario: Tasks table includes Depends On column
+**Source:** `plugins/speckit/skills/interview/SKILL.md:64-70` — Tasks table schema with `Depends On` column; `—` when no dependency.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Silent Task Consolidation
+
+**Sources**
+- `plugins/speckit/skills/interview/SKILL.md:76-115` — Step 3a defines the four merge signals, merge rules, and a worked example.
+- `plugins/speckit/skills/interview/SKILL.md:78` — "The user sees only the consolidated result."
+- `plugins/speckit/skills/interview/SKILL.md:89-95` — Merge rules: priority (higher wins), category (higher-impact wins), description (sub-bullets), dependencies (remapped).
+
+### Scenario: Same-file same-change tasks merged
+**Source:** `plugins/speckit/skills/interview/SKILL.md:81-82` — Signal 1: same file + same logical change.
+**Interpolated; no direct test.**
+
+### Scenario: Strict-ordering no-standalone-value tasks merged
+**Source:** `plugins/speckit/skills/interview/SKILL.md:83-84` — Signal 2: strict ordering with no independent acceptance criteria.
+**Interpolated; no direct test.**
+
+### Scenario: Soft cap re-examination when task count exceeds four
+**Source:** `plugins/speckit/skills/interview/SKILL.md:85-88` — Signal 3: soft cap triggers a second pass; does not force count below 4 if remaining tasks are independent.
+**Interpolated; no direct test.**
+
+### Scenario: Priority and category resolved deterministically on merge
+**Source:** `plugins/speckit/skills/interview/SKILL.md:89-95` — merge rule table: priority takes higher, category takes higher-impact.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Handoff Behaviour
+
+**Sources**
+- `plugins/speckit/skills/interview/SKILL.md:118-130` — Step 4 defines sub-skill vs. standalone handoff behavior.
+- `plugins/speckit/skills/interview/SKILL.md:123-125` — "Do NOT emit any trailing sentence, next-steps paragraph, `/catalog` suggestion, or hand-off prose" when invoked as sub-skill.
+- `plugins/speckit/skills/interview/SKILL.md:127-130` — Standalone mode states plan is ready for `/speckit:catalog`.
+
+### Scenario: Sub-skill invocation produces plan only
+**Source:** `plugins/speckit/skills/interview/SKILL.md:122-125` — response ends at Tasks table with no trailing prose.
+**Interpolated; no direct test.**
+
+### Scenario: Standalone invocation states catalog handoff
+**Source:** `plugins/speckit/skills/interview/SKILL.md:127-130` — states plan is ready to feed into `/speckit:catalog`.
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. **All scenarios interpolated from absence of tests** — speckit/interview has no automated test suite. All behavioral claims are derived from reading the SKILL.md prose.
+
+2. **Sub-skill notice at top of file** — Line 14 contains a sub-skill notice warning that `/spec` should invoke `speckit:spec`, not this skill directly. This is a routing guard, not a behavioral requirement, and is not captured in the spec.
+
+3. **Soft cap is not a hard limit** — Signal 3 (line 85-88) explicitly states the soft cap "is a prompt to re-examine, not a hard limit" and stops when no further defensible merges remain. The spec captures this nuance in the scenario text.
+
+4. **Docs-only tail merge (Signal 4)** — `plugins/speckit/skills/interview/SKILL.md:85-88` describes Signal 4 (fold docs task into impl when conditions are met). This was not elevated to a standalone requirement because it is a secondary refinement of the consolidation pass, not a separate behavioral surface.

--- a/openspec/specs/speckit-interview/spec.md
+++ b/openspec/specs/speckit-interview/spec.md
@@ -1,0 +1,85 @@
+# speckit-interview
+
+## Purpose
+
+Conduct a deep, structured interview to think through a feature, bug, or change. Produces a structured plan ready to feed into `/spec` or `/catalog`.
+
+## Requirements
+
+### Requirement: Input Handling
+The skill SHALL accept a freeform description via `$ARGUMENTS`. When `$ARGUMENTS` is empty, the skill SHALL ask the user what they want to think through before proceeding.
+
+#### Scenario: Description provided via arguments
+- **WHEN** `$ARGUMENTS` contains a freeform description
+- **THEN** the skill uses it as the starting context for the interview
+
+#### Scenario: Empty arguments prompts for topic
+- **WHEN** `$ARGUMENTS` is empty
+- **THEN** the skill asks the user what they want to work through before forming interview questions
+
+### Requirement: Codebase Grounding
+When `$ARGUMENTS` references files or areas of the codebase, the skill SHALL search for relevant files to ground interview questions in actual code. This search runs in the background while forming the first question batch.
+
+#### Scenario: Relevant files fetched in background
+- **WHEN** `$ARGUMENTS` references codebase areas or files
+- **THEN** the skill greps or globs for relevant files without waiting for results before asking the first questions
+
+### Requirement: Multi-Round Interview
+The skill SHALL use `AskUserQuestion` to probe scope, behaviour, constraints, decisions, and acceptance criteria. Each round SHALL contain 1–4 questions. The skill SHALL challenge inconsistencies, assumptions, and contradictions and continue rounds until the plan is unambiguous.
+
+#### Scenario: Questions sent 1–4 per round
+- **WHEN** the skill is gathering information
+- **THEN** each `AskUserQuestion` call contains between 1 and 4 questions, never a single question alone and never more than 4
+
+#### Scenario: Interview continues until unambiguous
+- **WHEN** a round's answers leave ambiguities unresolved
+- **THEN** the skill asks a follow-up round rather than producing the plan
+
+#### Scenario: Inconsistencies challenged directly
+- **WHEN** the user's answers contain a contradiction or unsupported assumption
+- **THEN** the skill calls it out directly before moving to the next dimension
+
+### Requirement: Structured Plan Production
+The skill SHALL synthesise the interview into a plan with exactly these sections in order: Goal, Background, Requirements, Out of Scope, Tasks. The Tasks section SHALL use a table with columns: #, Title, Category, Priority, Depends On, Description.
+
+#### Scenario: Plan contains all five required sections
+- **WHEN** the interview is complete
+- **THEN** the produced plan contains Goal, Background, Requirements, Out of Scope, and Tasks sections in that order
+
+#### Scenario: Documentation task appended unless pure refactor
+- **WHEN** the plan is not a pure refactor or internal-only change
+- **THEN** an "Update documentation" task is appended as the final row in the Tasks table
+
+#### Scenario: Tasks table includes Depends On column
+- **WHEN** the Tasks table is rendered
+- **THEN** every row includes a Depends On value (`—` when none)
+
+### Requirement: Silent Task Consolidation
+Before presenting the Tasks table, the skill SHALL run a silent consolidation pass that merges over-decomposed tasks. The user sees only the consolidated result.
+
+#### Scenario: Same-file same-change tasks merged
+- **WHEN** two tasks touch only the same single file and address related changes to the same function or section
+- **THEN** they are merged into one task with both originals preserved as sub-bullets
+
+#### Scenario: Strict-ordering no-standalone-value tasks merged
+- **WHEN** one task cannot ship without another and provides no independent acceptance criteria
+- **THEN** the two tasks are merged
+
+#### Scenario: Soft cap re-examination when task count exceeds four
+- **WHEN** after the main consolidation pass the task count is still greater than 4
+- **THEN** a second pass re-examines under looser merge signals until no further defensible merges remain
+
+#### Scenario: Priority and category resolved deterministically on merge
+- **WHEN** two tasks are merged
+- **THEN** the merged task takes the higher priority and higher-impact category, and remaps dependencies accordingly
+
+### Requirement: Handoff Behaviour
+When invoked as a sub-skill, the skill SHALL output only the structured plan with no trailing prose. When invoked standalone, the skill SHALL state that the plan is ready to feed into `/speckit:catalog`.
+
+#### Scenario: Sub-skill invocation produces plan only
+- **WHEN** the skill is invoked as a sub-skill by an orchestrator
+- **THEN** the response ends at the Tasks table with no trailing sentence, next-steps paragraph, or hand-off prose
+
+#### Scenario: Standalone invocation states catalog handoff
+- **WHEN** the skill is invoked directly via `/interview`
+- **THEN** the response ends by stating the plan is ready to feed into `/speckit:catalog`

--- a/openspec/specs/speckit-issue/REFERENCES.md
+++ b/openspec/specs/speckit-issue/REFERENCES.md
@@ -1,0 +1,100 @@
+# speckit-issue — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `sop/`.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Input Handling
+
+**Sources**
+- `plugins/speckit/skills/issue/SKILL.md:20-21` — "`$ARGUMENTS` — a freeform description of the issue. If empty, ask the user what the issue is about before proceeding."
+
+### Scenario: Description provided via arguments
+**Source:** `plugins/speckit/skills/issue/SKILL.md:20` — freeform description accepted via `$ARGUMENTS`.
+**Interpolated; no direct test.**
+
+### Scenario: Empty arguments prompts for description
+**Source:** `plugins/speckit/skills/issue/SKILL.md:21` — "If empty, ask the user what the issue is about before proceeding."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Issue Drafting
+
+**Sources**
+- `plugins/speckit/skills/issue/SKILL.md:30-44` — Step 2 defines derivation of title (under 70 chars), type, priority (default medium), and body structure.
+- `plugins/speckit/skills/issue/SKILL.md:38` — body sections: Problem, Why this matters, Suggested fix.
+
+### Scenario: Title derived under 70 characters
+**Source:** `plugins/speckit/skills/issue/SKILL.md:33` — "Title: short, specific, under 70 characters."
+**Interpolated; no direct test.**
+
+### Scenario: Priority inferred from description
+**Source:** `plugins/speckit/skills/issue/SKILL.md:35` — "Priority: high | medium | low (infer from the description; default to medium)."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Duplicate Check
+
+**Sources**
+- `plugins/speckit/skills/issue/SKILL.md:46-50` — Step 3: `gh issue list` for similar titles; flag and ask whether to proceed.
+
+### Scenario: Similar existing issue flagged
+**Source:** `plugins/speckit/skills/issue/SKILL.md:49-50` — "If a similar issue exists, flag it and ask whether to proceed with a new one."
+**Interpolated; no direct test.**
+
+### Scenario: No similar issues proceeds without prompting
+**Source:** `plugins/speckit/skills/issue/SKILL.md:46-50` — implied: check runs, no match found, no interruption.
+**Interpolated from absence.**
+
+---
+
+## Requirement: Preview Approval Gate
+
+**Sources**
+- `plugins/speckit/skills/issue/SKILL.md:52-86` — Step 4: show draft and call `AskUserQuestion` in the same turn; wrong/right shape examples.
+- `plugins/speckit/skills/issue/SKILL.md:62` — "Never end the turn after the preview without the tool call."
+- `plugins/speckit/skills/issue/SKILL.md:86` — Pre-end self-check.
+
+### Scenario: Preview and approval call in same turn
+**Source:** `plugins/speckit/skills/issue/SKILL.md:62-83` — "In a single assistant turn, emit (a) the preview above and (b) an `AskUserQuestion` call."
+**Interpolated; no direct test.**
+
+### Scenario: Adjustment request loops back
+**Source:** `plugins/speckit/skills/issue/SKILL.md:88-89` — "If the user selects an adjust or cancel option, loop back (update the draft or abort) before re-asking."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Label Provisioning
+
+**Sources**
+- `plugins/speckit/skills/issue/SKILL.md:91-93` — Step 5: check `gh label list` and create missing labels before filing.
+
+### Scenario: Missing labels created before filing
+**Source:** `plugins/speckit/skills/issue/SKILL.md:91-93` — "Check `gh label list` and create any missing labels (type + priority) before filing."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Hash Token Safety
+
+**Sources**
+- `plugins/speckit/skills/issue/SKILL.md:108-111` — constraint: never write `#<number>` tokens unless intentional cross-references; strip or rewrite tokens from `$ARGUMENTS`.
+
+### Scenario: Hash tokens from arguments rewritten
+**Source:** `plugins/speckit/skills/issue/SKILL.md:108-111` — explicit constraint: "Strip or rewrite any such token inherited from `$ARGUMENTS` before filing."
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. **All scenarios interpolated from absence of tests** — speckit/issue has no automated test suite. All behavioral claims are derived from reading the SKILL.md prose.
+
+2. **Suggested fix omission** — Line 38 notes "omit [Suggested fix] if unknown." This edge case was not elevated to a separate scenario because it is a drafting hint, not a behavioral requirement with distinct outcomes.
+
+3. **Duplicate check scope** — Step 3 checks only open issues (`--state open`). Closed issues with similar titles are not flagged. This is a deliberate scope limit in the skill (line 47 specifies `--state open`).

--- a/openspec/specs/speckit-issue/spec.md
+++ b/openspec/specs/speckit-issue/spec.md
@@ -1,0 +1,65 @@
+# speckit-issue
+
+## Purpose
+
+Quickly draft and file a single GitHub issue from a freeform description. Checks for duplicates and previews the draft before creating.
+
+## Requirements
+
+### Requirement: Input Handling
+The skill SHALL accept a freeform issue description via `$ARGUMENTS`. When `$ARGUMENTS` is empty, the skill SHALL ask the user what the issue is about before proceeding.
+
+#### Scenario: Description provided via arguments
+- **WHEN** `$ARGUMENTS` contains a freeform description
+- **THEN** the skill derives the issue title, type, priority, and body from it
+
+#### Scenario: Empty arguments prompts for description
+- **WHEN** `$ARGUMENTS` is empty
+- **THEN** the skill asks the user what the issue is about before drafting anything
+
+### Requirement: Issue Drafting
+The skill SHALL derive a title (under 70 characters), type (bug/enhancement/refactor/documentation/hygiene), priority (high/medium/low, defaulting to medium), and a body with Problem, Why this matters, and Suggested fix sections.
+
+#### Scenario: Title derived under 70 characters
+- **WHEN** a description is available
+- **THEN** the drafted title is specific and under 70 characters
+
+#### Scenario: Priority inferred from description
+- **WHEN** the description contains severity signals
+- **THEN** the priority is inferred accordingly; when signals are absent, priority defaults to medium
+
+### Requirement: Duplicate Check
+Before presenting the draft, the skill SHALL check for existing open issues with similar titles and flag any matches.
+
+#### Scenario: Similar existing issue flagged
+- **WHEN** an open issue with a similar title exists
+- **THEN** the skill flags it and asks the user whether to proceed with a new issue
+
+#### Scenario: No similar issues proceeds without prompting
+- **WHEN** no open issues with similar titles exist
+- **THEN** the skill proceeds to the preview step without interruption
+
+### Requirement: Preview Approval Gate
+The skill SHALL present the draft preview and an `AskUserQuestion` approval call in the same assistant turn. Ending the turn after the preview without calling `AskUserQuestion` is a defect.
+
+#### Scenario: Preview and approval call in same turn
+- **WHEN** the draft is ready to present
+- **THEN** the title, labels, and body preview are followed immediately by an `AskUserQuestion` call in the same turn
+
+#### Scenario: Adjustment request loops back
+- **WHEN** the user selects an adjust option
+- **THEN** the skill updates the draft and re-presents the preview with a new `AskUserQuestion` call
+
+### Requirement: Label Provisioning
+The skill SHALL check that all labels required for the issue exist and create any that are missing before filing.
+
+#### Scenario: Missing labels created before filing
+- **WHEN** the required type or priority label does not exist in the repo
+- **THEN** the skill creates the missing label to match the repo's existing label style
+
+### Requirement: Hash Token Safety
+The skill SHALL NOT write `#<number>` tokens in the issue body unless they are intentional cross-references to that exact issue. Tokens inherited from `$ARGUMENTS` SHALL be stripped or rewritten before filing.
+
+#### Scenario: Hash tokens from arguments rewritten
+- **WHEN** `$ARGUMENTS` contains a `#N` token that is not an intentional issue cross-reference
+- **THEN** the skill rewrites it as "task N" or equivalent prose before including it in the body

--- a/openspec/specs/speckit-spec/REFERENCES.md
+++ b/openspec/specs/speckit-spec/REFERENCES.md
@@ -1,0 +1,181 @@
+# speckit-spec — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `sop/`.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Codebase Context Exploration
+
+**Sources**
+- `plugins/speckit/skills/spec/SKILL.md:25-29` — Step 1: grep/glob for files relevant to `$ARGUMENTS`; run in background while forming first question batch; collect before writing plan in step 3.
+
+### Scenario: Relevant files fetched before plan is written
+**Source:** `plugins/speckit/skills/spec/SKILL.md:25-29` — "Run this in the background while forming the first question batch; do not wait for it. Collect results before writing the plan in step 3."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Simple vs. Full Path Classification
+
+**Sources**
+- `plugins/speckit/skills/spec/SKILL.md:62-130` — Step 2a: heuristic definition, three cases (clearly simple, clearly full, ambiguous), simple-path short-circuit steps.
+- `plugins/speckit/skills/spec/SKILL.md:68-75` — Simple-path heuristic: single cohesive change AND single file/co-located files.
+- `plugins/speckit/skills/spec/SKILL.md:78-84` — Classification handling: narrate inline when confident, `AskUserQuestion` only when ambiguous.
+- `plugins/speckit/skills/spec/SKILL.md:108-125` — Simple-path execution: inline interview, single-issue plan, catalog without `--epic`.
+
+### Scenario: Clearly simple path narrated and short-circuited
+**Source:** `plugins/speckit/skills/spec/SKILL.md:86-92` — "Narrate the classification inline in one sentence … and proceed directly to the inline lightweight interview."
+**Interpolated; no direct test.**
+
+### Scenario: Clearly full path narrated and falls through to interview
+**Source:** `plugins/speckit/skills/spec/SKILL.md:93-99` — "Narrate the classification inline … and fall through to step 2."
+**Interpolated; no direct test.**
+
+### Scenario: Ambiguous path asks user once
+**Source:** `plugins/speckit/skills/spec/SKILL.md:100-107` — "call `AskUserQuestion` once with options `Simple path — one issue`, `Full interview — epic path`, `Cancel`."
+**Interpolated; no direct test.**
+
+### Scenario: Simple path files one issue without epic
+**Source:** `plugins/speckit/skills/spec/SKILL.md:108-125` — "hand the single task to `/catalog` with no `--epic` flag … Skip step 2.5, step 5 (no epic tracking issue), and the sub-issue / blocked-by wiring."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Epic Slug Derivation
+
+**Sources**
+- `plugins/speckit/skills/spec/SKILL.md:132-150` — Step 2.5: slug derivation rules (lowercase, kebab-case, strip fillers, cap 30 chars), editable during plan approval.
+
+### Scenario: Slug derived from epic title
+**Source:** `plugins/speckit/skills/spec/SKILL.md:137-143` — derivation rules with example.
+**Interpolated; no direct test.**
+
+### Scenario: Slug omitted for single-issue plans
+**Source:** `plugins/speckit/skills/spec/SKILL.md:133-134` — "Only run this step if the plan will produce an epic — i.e. there are 2 or more tasks."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Plan Approval Gate
+
+**Sources**
+- `plugins/speckit/skills/spec/SKILL.md:152-274` — Step 3: plan sections, turn shape requirements, wrong/right shape examples, option sets for simple and full paths.
+- `plugins/speckit/skills/spec/SKILL.md:185-193` — "Required turn shape: the turn that presents the plan MUST contain, in this exact order, (a) the plan markdown and (b) exactly one `AskUserQuestion` tool call."
+- `plugins/speckit/skills/spec/SKILL.md:277-291` — TaskCreate block on full-path approval.
+
+### Scenario: Full-path plan and approval call in same turn
+**Source:** `plugins/speckit/skills/spec/SKILL.md:247-261` — right shape example with four options.
+**Interpolated; no direct test.**
+
+### Scenario: Simple-path plan and approval call in same turn
+**Source:** `plugins/speckit/skills/spec/SKILL.md:263-268` — right shape for simple path with four options.
+**Interpolated; no direct test.**
+
+### Scenario: Task tracking created on full-path approval
+**Source:** `plugins/speckit/skills/spec/SKILL.md:277-291` — `TaskCreate` called immediately after approval with five tasks: file-children, create-epic-tracking-issue, wire-sub-issues, wire-blocked-by-edges, final-report.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Child Issue Filing
+
+**Sources**
+- `plugins/speckit/skills/spec/SKILL.md:293-317` — Step 4 and Continuation Gate: invoke `/catalog` with `--epic <slug>`, advance immediately after it returns.
+- `plugins/speckit/skills/spec/SKILL.md:304-316` — Continuation Gate explicitly prohibits pausing after `/catalog` returns.
+
+### Scenario: Catalog invoked with epic flag
+**Source:** `plugins/speckit/skills/spec/SKILL.md:296-299` — "Pass the full task list from the plan to `/catalog` in a single call, prefixing the arguments with `--epic <slug>`."
+**Interpolated; no direct test.**
+
+### Scenario: Orchestrator advances after catalog returns
+**Source:** `plugins/speckit/skills/spec/SKILL.md:304-307` — "After `/catalog` returns, do not pause and do not wait for user input. Proceed immediately to step 5."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Epic Tracking Issue Creation
+
+**Sources**
+- `plugins/speckit/skills/spec/SKILL.md:319-386` — Step 5: epic creation, label provisioning, sub-issue wiring, blocked-by wiring.
+- `plugins/speckit/skills/spec/SKILL.md:343-370` — Epic label provisioning: check, create if missing, confirm if existing.
+- `plugins/speckit/skills/spec/SKILL.md:372-384` — Sub-issue wiring via GitHub API using numeric `id`.
+
+### Scenario: Epic issue created after all children
+**Source:** `plugins/speckit/skills/spec/SKILL.md:326-342` — epic body shape, title format `epic: <description>`, three required labels.
+**Interpolated; no direct test.**
+
+### Scenario: Epic label provisioned before creation
+**Source:** `plugins/speckit/skills/spec/SKILL.md:347-355` — `gh label create` with color `5319e7` when label is missing.
+**Interpolated; no direct test.**
+
+### Scenario: Existing epic label requires confirmation
+**Source:** `plugins/speckit/skills/spec/SKILL.md:356-361` — `AskUserQuestion` with options Reuse/Pick different slug/Cancel.
+**Interpolated; no direct test.**
+
+### Scenario: Children attached as sub-issues
+**Source:** `plugins/speckit/skills/spec/SKILL.md:372-379` — `gh api repos/{owner}/{repo}/issues/{epic_number}/sub_issues` POST with numeric `id` (not issue number).
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Blocked-By Edge Wiring
+
+**Sources**
+- `plugins/speckit/skills/spec/SKILL.md:380-386` — Step 5 blocked-by wiring: GitHub blocked-by API call for each task with a Depends On value.
+
+### Scenario: Blocked-by edges wired for dependent tasks
+**Source:** `plugins/speckit/skills/spec/SKILL.md:380-385` — `gh api repos/{owner}/{repo}/issues/{blocked_number}/dependencies/blocked_by` POST with `-F issue_id`.
+**Interpolated; no direct test.**
+
+### Scenario: No-dependency plan skips wiring
+**Source:** `plugins/speckit/skills/spec/SKILL.md:386` — "Close with `TaskUpdate(wire-blocked-by-edges, status: 'completed')` once every edge is set (or immediately, if the plan declares no `Depends On` edges)."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Team-Readiness Assessment
+
+**Sources**
+- `plugins/speckit/skills/spec/SKILL.md:388-474` — Step 6: four suitability signals, three-signal threshold, phase label provisioning, phase assignment, dispatch comment shape.
+- `plugins/speckit/skills/spec/SKILL.md:398-409` — Four suitability signals enumerated.
+- `plugins/speckit/skills/spec/SKILL.md:411-415` — Skip line when fewer than three signals hold.
+
+### Scenario: Team-suitable spec gets phase labels and dispatch comment
+**Source:** `plugins/speckit/skills/spec/SKILL.md:417-473` — provision phase labels, assign issues to phases, post dispatch summary comment on epic.
+**Interpolated; no direct test.**
+
+### Scenario: Non-team-suitable spec prints skip line
+**Source:** `plugins/speckit/skills/spec/SKILL.md:411-415` — "print a single line and stop" when fewer than three signals hold.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Pre-End Self-Check
+
+**Sources**
+- `plugins/speckit/skills/spec/SKILL.md:500-507` — Pre-end self-check section: `TaskList` as turn-end gate, worked failure-mode example.
+- `plugins/speckit/skills/spec/SKILL.md:303-316` — Continuation Gate (companion rule for the `/catalog` boundary specifically).
+
+### Scenario: Pending tasks prevent turn end
+**Source:** `plugins/speckit/skills/spec/SKILL.md:500-505` — "If any spec task is `pending` or `in_progress`, do not end the turn — execute the next task."
+**Interpolated; no direct test.**
+
+### Scenario: All tasks completed allows turn end
+**Source:** `plugins/speckit/skills/spec/SKILL.md:500` — implied: turn-end is legitimate only when all tasks are completed or the user has explicitly halted.
+**Interpolated from absence.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. **All scenarios interpolated from absence of tests** — speckit/spec has no automated test suite. All behavioral claims are derived from reading the SKILL.md prose.
+
+2. **Two-gate continuation model** — The skill has two overlapping continuation guards: the Continuation Gate (lines 303-316, specific to the `/catalog` boundary) and the Pre-end Self-Check (lines 500-507, the orchestrator-wide gate). Both are intentionally separate; the skill comment at line 503 explains why.
+
+3. **Simple path skips five steps** — The simple path short-circuit (step 2a) skips slug derivation (step 2.5), epic creation (step 5), sub-issue wiring, blocked-by wiring, and team assessment (step 6). These skips are all documented in lines 108-125 but only implied elsewhere.
+
+4. **Team dispatch comment is a comment, not an issue** — Line 455 specifies `gh issue comment` (not `gh issue create`). This is a non-obvious detail that distinguishes the dispatch summary from the child issues filed in step 4.
+
+5. **Sub-issue API uses numeric id, not issue number** — Line 377 notes "Use the numeric `id` (not the issue number) — fetch it from `gh issue view {number} --json id`." This is a GitHub API quirk and the most common source of failure in this step.

--- a/openspec/specs/speckit-spec/spec.md
+++ b/openspec/specs/speckit-spec/spec.md
@@ -1,0 +1,122 @@
+# speckit-spec
+
+## Purpose
+
+Orchestrate the full discuss → interview → plan → file workflow for a bug, fix, or feature. Interviews the user, builds a structured plan, and files it as a GitHub epic with linked child issues.
+
+## Requirements
+
+### Requirement: Codebase Context Exploration
+Before the first interview question, the skill SHALL search for files relevant to `$ARGUMENTS` to ground the interview in actual code. This search runs in the background without blocking the first question batch.
+
+#### Scenario: Relevant files fetched before plan is written
+- **WHEN** `$ARGUMENTS` references a codebase area
+- **THEN** grep or glob results are collected before the plan is written in step 3
+
+### Requirement: Simple vs. Full Path Classification
+The skill SHALL classify the request as simple (single cohesive change, single file or tightly co-located files) or full (multiple conceptual changes or files spanning unrelated modules). Classification is narrated inline when confident; `AskUserQuestion` fires only when the heuristic is ambiguous.
+
+#### Scenario: Clearly simple path narrated and short-circuited
+- **WHEN** both heuristic tests pass unambiguously
+- **THEN** the skill narrates the classification inline and runs the simple path without calling `AskUserQuestion` for routing
+
+#### Scenario: Clearly full path narrated and falls through to interview
+- **WHEN** at least one heuristic test fails unambiguously
+- **THEN** the skill narrates the classification inline and invokes `speckit:interview`
+
+#### Scenario: Ambiguous path asks user once
+- **WHEN** the heuristic is uncertain
+- **THEN** the skill calls `AskUserQuestion` once with options Simple path, Full interview, and Cancel
+
+#### Scenario: Simple path files one issue without epic
+- **WHEN** the simple path is selected or approved
+- **THEN** the skill files one standalone issue via `/catalog` with no `--epic` flag, skips epic creation, and jumps to the report step
+
+### Requirement: Epic Slug Derivation
+For plans with 2 or more tasks, the skill SHALL derive a short kebab-case slug from the epic title, capped at 30 characters after the `epic:` prefix. The user reviews and may edit the slug during plan approval.
+
+#### Scenario: Slug derived from epic title
+- **WHEN** the plan will produce an epic
+- **THEN** the slug is lowercase kebab-case with filler words stripped and at most 30 characters after the `epic:` prefix
+
+#### Scenario: Slug omitted for single-issue plans
+- **WHEN** the plan produces only one task
+- **THEN** no `## Epic label` section appears in the plan
+
+### Requirement: Plan Approval Gate
+The skill SHALL present the plan and an `AskUserQuestion` approval call in the same assistant turn. Ending the turn after the plan without the tool call is a defect.
+
+#### Scenario: Full-path plan and approval call in same turn
+- **WHEN** the full-path plan is ready
+- **THEN** the plan markdown and an `AskUserQuestion` call appear in the same turn with options: Approve and file issues, Condense to single issue, Adjust plan, Cancel
+
+#### Scenario: Simple-path plan and approval call in same turn
+- **WHEN** the simple-path plan is ready
+- **THEN** the plan markdown and an `AskUserQuestion` call appear in the same turn with options: Approve and file, Run full interview instead, Adjust, Cancel
+
+#### Scenario: Task tracking created on full-path approval
+- **WHEN** the user approves a full-path plan
+- **THEN** the skill creates tasks for file-children, create-epic-tracking-issue, wire-sub-issues, wire-blocked-by-edges, and final-report before invoking `/catalog`
+
+### Requirement: Child Issue Filing
+The skill SHALL pass the full task list to `/catalog` with `--epic <slug>` and advance to epic creation immediately after `/catalog` returns, without waiting for user input.
+
+#### Scenario: Catalog invoked with epic flag
+- **WHEN** a full-path plan is approved
+- **THEN** `/catalog` is invoked with `--epic <slug>` and the complete task list
+
+#### Scenario: Orchestrator advances after catalog returns
+- **WHEN** `/catalog` returns the issue table
+- **THEN** the skill proceeds to epic tracking issue creation without pausing
+
+### Requirement: Epic Tracking Issue Creation
+After all child issues are filed, the skill SHALL create one parent epic issue with title `epic: <description>`, labels `epic`, `epic:<slug>`, and `priority:<highest-child-priority>`. Child issues are linked as GitHub sub-issues, not via checklist.
+
+#### Scenario: Epic issue created after all children
+- **WHEN** all child issues have been filed
+- **THEN** the skill creates the epic tracking issue with the three required labels
+
+#### Scenario: Epic label provisioned before creation
+- **WHEN** the `epic:<slug>` label does not exist
+- **THEN** the skill creates it with color `#5319e7` before invoking `gh issue create`
+
+#### Scenario: Existing epic label requires confirmation
+- **WHEN** the `epic:<slug>` label already exists
+- **THEN** the skill asks the user via `AskUserQuestion` before reusing it
+
+#### Scenario: Children attached as sub-issues
+- **WHEN** the epic tracking issue is created
+- **THEN** each child is added via the GitHub sub-issues API using the child's numeric `id`
+
+### Requirement: Blocked-By Edge Wiring
+For each task with a `Depends On` value in the plan, the skill SHALL set the corresponding GitHub blocked-by relationship using the sub-issues API.
+
+#### Scenario: Blocked-by edges wired for dependent tasks
+- **WHEN** a task's `Depends On` column references another task
+- **THEN** the skill calls the GitHub blocked-by API to wire the relationship between the two issue IDs
+
+#### Scenario: No-dependency plan skips wiring
+- **WHEN** no tasks have `Depends On` values
+- **THEN** the wire-blocked-by-edges step completes immediately with no API calls
+
+### Requirement: Team-Readiness Assessment
+For full-path epics, the skill SHALL assess whether the work is suited for parallel agent-team execution using four signals. When at least three signals hold, the skill re-decomposes issues by phase and posts a dispatch summary as a comment on the epic.
+
+#### Scenario: Team-suitable spec gets phase labels and dispatch comment
+- **WHEN** at least three of the four suitability signals hold
+- **THEN** the skill provisions phase labels, assigns each child to a phase, and posts a team dispatch summary comment on the epic issue
+
+#### Scenario: Non-team-suitable spec prints skip line
+- **WHEN** fewer than three suitability signals hold
+- **THEN** the skill prints a single-line skip message with the reason and proceeds to the report step
+
+### Requirement: Pre-End Self-Check
+Before ending any turn while the skill is the active orchestrator, the skill SHALL check the task list. If any task is pending or in-progress, the skill SHALL execute the next task rather than ending the turn.
+
+#### Scenario: Pending tasks prevent turn end
+- **WHEN** the skill considers ending a turn and a task is pending or in-progress
+- **THEN** the skill executes the next task instead of ending the turn
+
+#### Scenario: All tasks completed allows turn end
+- **WHEN** all tracked tasks are completed
+- **THEN** the skill ends the turn after the report step

--- a/plugins/speckit/skills/catalog/SKILL.md
+++ b/plugins/speckit/skills/catalog/SKILL.md
@@ -22,7 +22,7 @@ If no findings are available, ask the user what to catalog.
 Before extracting findings, scan `$ARGUMENTS` for these optional leading tokens and strip them from the findings text:
 
 - `--auto` — skip the approval step in step 3 (see below).
-- `--epic <slug>` — associate the catalogued issues with an epic identified by `<slug>`. The slug drives the epic-label logic in step 2 (ensure `epic:<slug>` exists) and step 4 (apply `epic:<slug>` to every issue in the batch). When invoked from `/speckit:spec`, the approved epic slug is passed through this same public mechanism — there is no private side channel. An optional epic title may accompany the slug (e.g. passed through from `/spec`); it is used as the label description when creating the label.
+- `--epic <slug>` — associate the catalogued issues with an epic. Ensures `epic:<slug>` label exists (step 2) and applies it to every issue in the batch (step 4). An optional epic title may accompany the slug; it is used as the label description when creating the label.
 - `--split` — disable the consolidation heuristic (see step 1.5 below) and file one issue per row of the source blueprint table. Use this when the rows of a phase really are independent units of work that need separate issues, branches, or owners. Without `--split`, mechanically-related rows in the same phase fold into a single issue per phase (the default).
 
 If `--epic <slug>` is **not** present, behaviour is unchanged from the no-epic flow: no epic label is applied, no warning is emitted, and the rest of the process runs exactly as documented below.
@@ -130,29 +130,6 @@ If `--auto` was passed in `$ARGUMENTS`, skip the approval step and proceed direc
 
 Otherwise, **in a single assistant turn**, emit (a) the catalog table above and (b) an `AskUserQuestion` call. Never end the turn after presenting the table without the tool call — a prose-only prompt like "let me know if you'd like changes" is a defect.
 
-**Wrong shape** (never do this):
-
-```
-| # | Title | Category | Priority | Labels |
-...
-Let me know if you'd like any adjustments.
-← turn ends here; silent wait
-```
-
-**Right shape** (always do this):
-
-```
-| # | Title | Category | Priority | Labels |
-...
-← immediately followed by AskUserQuestion in the same turn:
-AskUserQuestion("File these issues?", [
-  "Approve and file",
-  "Adjust priorities / titles",
-  "Remove some findings",
-  "Cancel"
-])
-```
-
 **Pre-end self-check**: Before ending the turn in step 3, verify that the last action is an `AskUserQuestion` call. If the table was shown but no tool call was made, emit the call immediately.
 
 The user may ask to:
@@ -233,22 +210,6 @@ When `/catalog` is invoked with `--epic <slug>`, it appends a final fenced block
 
 The block is the final element of the catalog's output, AFTER the issue table. Nothing follows the closing ` ``` ` fence.
 
-### Conditional emission
-
-When `--epic <slug>` is NOT passed, this block is omitted entirely. The handoff contract applies only to orchestrator-invoked catalog runs.
-
-### Consumer contract
-
-Orchestrators (e.g. `/speckit:spec`) parse the JSON inside this block to populate their task list and confirm filed children. The contract is stable across speckit minor versions.
-
 ## Constraints
 
-- Never create issues without showing the user the catalog first (unless `--auto` was passed)
-- The catalog table and the `AskUserQuestion` approval call must be emitted in the **same assistant turn** — showing the table and ending the turn without calling `AskUserQuestion` is a defect
-- Never create duplicate issues — check `gh issue list` for similar titles before creating
-- Keep issue bodies concise — problem + impact + fix, nothing more
-- Match the label style already in the repo (don't impose a new scheme)
-- Never parallelize `gh issue create` in a batch; URL↔title mapping breaks
-- Never treat a blueprint row count as the issue count without running step 1.5; the consolidation pass is on by default and only disables under `--split`
-- Always print the step 1.6 consolidation summary before the catalog table, even under `--auto`, so the consolidation decision is visible in the run record
 - Never write `#<number>` tokens in issue bodies unless you intend a real cross-reference to that exact issue — GitHub auto-links them, so a token like `#3` in a body about "task 3" will link to unrelated issue 3 in the repo. When referring to sibling tasks from a plan, use "task 3" (no hash) or omit the reference entirely — task-to-task dependencies are wired by the caller (e.g. `/spec`) via the native GitHub blocked-by API, not via issue-body text.

--- a/plugins/speckit/skills/interview/SKILL.md
+++ b/plugins/speckit/skills/interview/SKILL.md
@@ -11,8 +11,6 @@ argument-hint: [description]
 allowed-tools: AskUserQuestion, Read, Glob, Grep, Write, Edit
 ---
 
-> **Sub-skill notice:** This skill is designed to be invoked by `speckit:spec` (step 2) or standalone via `/interview`. If the user typed `/spec`, do not run this skill directly — invoke `speckit:spec` instead so the full orchestration flow runs (interview → plan approval → catalog → epic).
-
 # Interview
 
 Conduct a deep, structured interview to think through a feature, bug, or change. Challenges inconsistencies, surfaces assumptions, and continues until the thinking is unambiguous. Produces a plan in the same format that `/spec` emits, so the output can be piped directly into `/spec` or `/catalog`.
@@ -94,25 +92,6 @@ Only merge when a signal clearly applies. Tasks that are legitimately independen
 - **Dependencies** — remap: if task C depended on B, and A+B merged into A', then C now depends on A'.
 - **Numbering** — renumber the resulting table sequentially after all merges are applied.
 
-**Worked example**
-
-*Before consolidation* — two tasks flagged by signal 2 (strict ordering, no standalone value):
-
-| # | Title | Category | Priority | Depends On | Description |
-|---|-------|----------|----------|------------|-------------|
-| 1 | Add `autoRetry` config option | enhancement | medium | — | Add `autoRetry: boolean` to `config.ts` and wire defaults in `loadConfig()` |
-| 2 | Wire `autoRetry` into request handler | enhancement | medium | 1 | Read `autoRetry` from config in `requestHandler.ts` and retry on transient errors |
-| 3 | Add retry integration tests | test | low | 2 | Cover retry behaviour in `requestHandler.test.ts` |
-
-Task 2 has no standalone value — it cannot ship without task 1 and its only purpose is to consume what task 1 adds. Signal 2 fires.
-
-*After consolidation* — tasks 1 and 2 merge into a single task; task 3 remaps its dependency:
-
-| # | Title | Category | Priority | Depends On | Description |
-|---|-------|----------|----------|------------|-------------|
-| 1 | Add and wire `autoRetry` config option | enhancement | medium | — | - Add `autoRetry: boolean` to `config.ts` and wire defaults in `loadConfig()` - Read `autoRetry` from config in `requestHandler.ts` and retry on transient errors |
-| 2 | Add retry integration tests | test | low | 1 | Cover retry behaviour in `requestHandler.test.ts` |
-
 Present the plan inline.
 
 ### 4. Hand off
@@ -131,10 +110,4 @@ off cleanly.
 
 ## Constraints
 
-- Ask 1–4 questions per round — never one-at-a-time, never a wall of questions
-- Do not produce a plan until ambiguities are resolved
-- Never file GitHub issues from this skill — always hand off to `/speckit:catalog` (or return to the orchestrating skill if invoked as a sub-skill)
 - Never write the plan to disk unless the user explicitly asks
-- Keep the plan concise — it's a decision record, not an essay
-- Output sections must match `/spec` exactly: Goal, Background, Requirements, Out of Scope, Tasks
-- Tasks table must include the `Depends On` column — use `—` when a task has no dependencies

--- a/plugins/speckit/skills/issue/SKILL.md
+++ b/plugins/speckit/skills/issue/SKILL.md
@@ -61,28 +61,6 @@ Labels:   <type>, priority:<level>
 
 **In a single assistant turn**, emit (a) the preview above and (b) an `AskUserQuestion` call. Never end the turn after the preview without the tool call.
 
-**Wrong shape** (never do this):
-
-```
-Title: Harden approval gates
-Labels: enhancement, priority:medium
----
-## Problem ...
-Let me know if you'd like changes.
-← turn ends; silent wait
-```
-
-**Right shape** (always do this):
-
-```
-Title: Harden approval gates
-Labels: enhancement, priority:medium
----
-## Problem ...
-← immediately followed by AskUserQuestion in the same turn:
-AskUserQuestion("File this issue?", ["File as shown", "Adjust title / labels / body", "Cancel"])
-```
-
 **Pre-end self-check**: Before ending the turn in step 4, verify that the last action is an `AskUserQuestion` call. If the preview was shown but no tool call was made, emit the call immediately.
 
 If the user selects an adjust or cancel option, loop back (update the draft or abort) before re-asking.
@@ -103,9 +81,4 @@ Output the created issue URL.
 
 ## Constraints
 
-- The draft preview and the `AskUserQuestion` approval call must be emitted in the **same assistant turn** — showing the preview and ending the turn without calling `AskUserQuestion` is a defect, even if a prose invitation is included.
-- Never create the issue without showing the preview first
-- Never skip the duplicate check
-- Keep body concise — problem + impact + fix only
-- Match the label style already in the repo
 - Never write `#<number>` tokens in the issue body unless you intend a real cross-reference to that exact issue — GitHub auto-links them, so a stray `#3` will silently link to unrelated issue 3 in the repo. Strip or rewrite any such token inherited from `$ARGUMENTS` before filing (use "task 3" or "issue 3" without the hash).

--- a/plugins/speckit/skills/spec/SKILL.md
+++ b/plugins/speckit/skills/spec/SKILL.md
@@ -217,77 +217,11 @@ full-path epic. `AskUserQuestion` supports max 4 options total (including
   - On `Adjust plan`: revise the plan (priorities, tasks, or the epic label),
     then re-show with the same options.
 
-**Wrong shape — silent wait** (never do this):
-
-```
-Here is the plan:
-## Goal
-Harden approval gates in speckit skills.
-...
-Let me know if you'd like changes.
-← turn ends here; silent wait
-```
-
-**Wrong shape — `/catalog` hand-off prose** (never do this):
-
-```
-Here is the plan:
-## Goal
-Harden approval gates in speckit skills.
-...
-Plan ready to feed into `/speckit:catalog` to file as a single prioritised, labelled GitHub issue.
-← turn ends here
-```
-
-This is a defect — the `/catalog` hand-off prose was inherited from the
-interview sub-skill's standalone-mode wording and must not be propagated. The
-orchestrator owns the handoff and the only legitimate way to end this turn is
-with an `AskUserQuestion` call.
-
-**Right shape — full-path plan** (always do this):
-
-```
-Here is the plan:
-## Goal
-Harden approval gates in speckit skills.
-...
-← immediately followed by AskUserQuestion in the same turn:
-AskUserQuestion("Approve this plan and file the issues?", [
-  "Approve and file issues",
-  "Condense to single issue",
-  "Adjust plan",
-  "Cancel"
-])
-```
-
-**Right shape — simple-path plan**:
-
-```
-AskUserQuestion("Approve this plan and file the issue?", [
-  "Approve and file",
-  "Run full interview instead",
-  "Adjust",
-  "Cancel"
-])
-```
-
 Do not proceed to step 4 until the user has answered via `AskUserQuestion`. If the user selects an adjust, re-scope, or cancel option, loop back (revise the plan, fall through to the other path, or abort) before re-asking.
 
 The slug the user approves in this step is the single source of truth for the epic label and must be used verbatim in step 4 (catalog handoff for children) and step 5 (epic tracking issue).
 
-**On approval (full path only)**: immediately after the user approves the plan, and before invoking `/catalog`, call `TaskCreate` to register the five remaining post-approval phases as a single batch of todos. The orchestrator will use this list as the mechanical contract for what remains to do; subsequent steps open with `TaskUpdate` to `in_progress` and close with `TaskUpdate` to `completed`, and the **Pre-end self-check** below uses this list as its turn-end gate.
-
-```
-TaskCreate([
-  { subject: "file-children",                description: "Step 4 — hand the task list to /catalog with --epic <slug>",          activeForm: "Filing child issues via /catalog" },
-  { subject: "create-epic-tracking-issue",   description: "Step 5 — create the parent epic tracking issue with epic:<slug> label", activeForm: "Creating the epic tracking issue" },
-  { subject: "wire-sub-issues",              description: "Step 5 — attach each child as a GitHub sub-issue of the epic",          activeForm: "Wiring sub-issue relationships" },
-  { subject: "wire-blocked-by-edges",        description: "Step 5 — set GitHub blocked-by edges for each task with Depends On",    activeForm: "Wiring blocked-by relationships" },
-  { subject: "final-report",                 description: "Step 7 — print the summary table (and step 6 if team-suitable)",         activeForm: "Reporting filed issues" }
-])
-```
-
-Skip this `TaskCreate` block on the simple path — single-issue plans short-circuit through `/catalog` and step 7 only, and do not need phase tracking.
+**On approval (full path only)**: immediately after the user approves the plan, and before invoking `/catalog`, call `TaskCreate` to register the five remaining post-approval phases as todos: file-children, create-epic-tracking-issue, wire-sub-issues, wire-blocked-by-edges, final-report. Subsequent steps open with `TaskUpdate` to `in_progress` and close with `TaskUpdate` to `completed`. Skip this on the simple path — single-issue plans do not need phase tracking.
 
 ### 4. File child issues
 
@@ -503,15 +437,8 @@ Close this step with `TaskUpdate(final-report, status: "completed")` once the ta
 
 `TaskList` is the orchestrator's first action whenever it considers ending a turn while `/speckit:spec` is active. Treat it as the mechanical gate on top of all the prose-level continuation rules elsewhere in this skill (in particular the **Continuation Gate (after /catalog returns)** above, which is the empirically-observed stall point). The two rules are intentionally separate: this section is the orchestrator-wide turn-end gate, while the Continuation Gate is a sub-skill-boundary rule for `/catalog` specifically.
 
-**Worked failure-mode example.** 9 children were filed via `/catalog`, the agent ended the turn, and the user had to ask "are you waiting on me for something?" to trigger creation of the epic tracking issue and the dependency wiring. With this section's `TaskList` gate, the orchestrator would have seen `create-epic-tracking-issue` as pending and continued.
-
 ## Constraints
 
-- A turn that presents the plan and ends without an `AskUserQuestion` call is a defect — whether the ending prose is silent waiting, a `/catalog` hand-off suggestion, or any other text.
-- The plan and the `AskUserQuestion` approval call must be emitted in the **same assistant turn** — presenting the plan and ending the turn without calling `AskUserQuestion` is a defect, even if a prose invitation is included.
-- Never create issues without showing the plan and getting approval first
 - Never write plan files to disk — the plan lives in the conversation only
-- Only create an epic if there are 2 or more child issues — skip step 5 entirely for single-issue plans
-- Epic issue must be created last, after all child issue numbers are known
 - If `$ARGUMENTS` is empty, ask what to spec before doing anything else
 - Never invoke `speckit:interview` directly in response to a user typing `/spec` or triggering this skill. `speckit:interview` is a sub-skill called from within step 2 of this skill — it is never a substitute for `speckit:spec`. If you find yourself about to invoke `speckit:interview` as a top-level response to `/spec`, stop and invoke `speckit:spec` instead.


### PR DESCRIPTION
## Summary

Applies the spec-baseline → tighten-to-spec loop to all 4 speckit skills.

## Changes

- Baselines OpenSpec `spec.md` + `REFERENCES.md` for speckit-catalog, speckit-interview, speckit-issue, and speckit-spec. All 4 specs validate clean under `scripts/openspec validate --strict`.
- Tightens all 4 `SKILL.md` files against their specs: 1022 → 856 lines (−166). Removes constraints restatements, wrong/right shape examples, sub-skill routing notice, worked consolidation example, and TaskCreate string scaffolding. Behavioral coverage unchanged.

## Test plan

- [ ] `bash scripts/openspec validate speckit-catalog --type spec --strict` passes
- [ ] `bash scripts/openspec validate speckit-interview --type spec --strict` passes
- [ ] `bash scripts/openspec validate speckit-issue --type spec --strict` passes
- [ ] `bash scripts/openspec validate speckit-spec --type spec --strict` passes