### PR TITLE
feat(swarmkit): baseline specs + tighten 5 SKILL.md files

### DIFF
--- a/openspec/specs/swarmkit/REFERENCES.md
+++ b/openspec/specs/swarmkit/REFERENCES.md
@@ -1,0 +1,418 @@
+# swarmkit — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `plugins/swarmkit/` unless otherwise noted.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Issue Fetching and Filtering
+
+**Sources**
+- `skills/gh-fetch-issues/SKILL.md:16-21` — defines the canonical fetch command and the two filter rules: exclude `on-hold` and `status:in-progress` labeled issues.
+
+**Notes**
+- Both filters apply in every caller context (next-issue, swarm one-shot, loop mode). The `gh issue list --search '-label:"status:in-progress"'` flag handles the in-progress exclusion at the API level; the `on-hold` exclusion is a post-fetch filter rule in the same sub-skill.
+
+### Scenario: On-hold issues excluded
+**Source:** `skills/gh-fetch-issues/SKILL.md:17-18` — "Filter out any issue with the `on-hold` label".
+Verified by behavior in `skills/swarm/SKILL.md:374-379` (loop mode picks batch using gh-fetch-issues).
+**Interpolated; no direct test.**
+
+### Scenario: In-progress issues excluded
+**Source:** `skills/gh-fetch-issues/SKILL.md:14-15` — `--search '-label:"status:in-progress"'` in the `gh issue list` command; also `skills/gh-fetch-issues/SKILL.md:20-21` — prose rule.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Issue Ranking
+
+**Sources**
+- `skills/issue-rank/SKILL.md:1-34` — full ranking table and assessment criteria.
+
+### Scenario: Priority labels respected
+**Source:** `skills/issue-rank/SKILL.md:8-15` — ranking table: `priority:high` → highest, `priority:medium` → high, `priority:low` → low, no label → medium (read body to judge).
+**Interpolated; no direct test.**
+
+### Scenario: Specificity and impact favor architectural unblocking
+**Source:** `skills/issue-rank/SKILL.md:21-24` — assessment criteria: specificity (exact files, line numbers), architectural impact (unblocks other work), and the note on line 30: "A well-specced `priority:medium` issue often beats a vague `priority:high` one for autonomous agent work".
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: One-Shot Mode
+
+**Sources**
+- `skills/swarm/SKILL.md:99-349` — full one-shot mode section (steps 1–7).
+- `skills/swarm/SKILL.md:100-138` — gather script invocation, work_items parsing, skip announcements, unwired-epic handling.
+
+### Scenario: Closed and on-hold issues skipped from requested set
+**Source:** `skills/swarm/SKILL.md:122-131` — "Parse the JSON. Use `work_items` as the list to act on" and "Skip announcement — for each entry in `skipped`, the script has already applied the existing rules (`on-hold` label, `closed` state)."
+**Interpolated; no direct test.**
+
+### Scenario: Epic expansion
+**Source:** `skills/swarm/SKILL.md:121-131` — `epics_expanded` field in gather script output, skip announcement template: "#N is an epic. Swarming: #101, #102. Skipped (closed/on-hold): #103."
+**Interpolated; no direct test.**
+
+### Scenario: Unwired epic skipped with guidance
+**Source:** `skills/swarm/SKILL.md:133-137` — "for each number in `epics_unwired`, announce with the existing template" citing the `#N is labeled epic but has no sub-issues wired` message.
+**Interpolated; no direct test.**
+
+### Scenario: Empty work set stops dispatch
+**Source:** `skills/swarm/SKILL.md:132` — "If `work_items` is empty because every requested issue ... was skipped, announce and stop."
+**Interpolated; no direct test.**
+
+### Scenario: Plan presented before dispatch
+**Source:** `skills/swarm/SKILL.md:158-173` — "Show the user a table before launching" with columns Agent, Issue(s), Branch, Files affected, Model, Notes; also "Present the plan and proceed immediately with the proposed groupings."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Dependency Graph and Topological Dispatch
+
+**Sources**
+- `skills/swarm/SKILL.md:140-156` — dependency analysis: use `deps` array from gather script (native `blockedBy` preferred, body-text fallback), build DAG, topological sort.
+- `skills/swarm/SKILL.md:197-218` — spawn strategy: independent in parallel, dependent sequential in topological order, branching from upstream tip.
+- `METHODOLOGY.md:41-65` — narrative on stacked branch strategy and why mid-swarm merge is forbidden.
+
+### Scenario: Independent issues spawn in parallel
+**Source:** `skills/swarm/SKILL.md:198-202` — "Independent issues (no dependencies within this batch): Spawn all in parallel … `run_in_background: true`".
+**Interpolated; no direct test.**
+
+### Scenario: Dependent agent branches from upstream tip
+**Source:** `skills/swarm/SKILL.md:206-211` — "The dependent agent branches from its dependency's branch tip … `git fetch origin worktree-agent-<dependency-issue>; git checkout -b worktree-agent-<this-issue> origin/worktree-agent-<dependency-issue>`".
+Also `METHODOLOGY.md:43-56`.
+**Interpolated; no direct test.**
+
+### Scenario: Dependent agent PR targets upstream branch
+**Source:** `skills/swarm/SKILL.md:212-215` — "The dependent agent's PR targets the dependency's branch … `gh pr create --base worktree-agent-<dependency-issue>`".
+**Interpolated; no direct test.**
+
+### Scenario: Mid-swarm merge forbidden
+**Source:** `skills/swarm/SKILL.md:218-219` — "Why no mid-swarm merge is needed … Never merge a dependency's PR early to 'unblock' a downstream agent." Also `skills/swarm/SKILL.md:456-458` — constraint: "Never merge a PR mid-swarm".
+Also `METHODOLOGY.md:62-66`.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Worktree Isolation
+
+**Sources**
+- `skills/swarm/SKILL.md:222-224` — all agents use `isolation: "worktree"`, `mode: "bypassPermissions"`, `run_in_background: true`.
+- `skills/swarm/SKILL.md:228-231` — agent CONTEXT instruction: "use relative paths only for all file operations".
+- `skills/swarm/SKILL.md:244-248` — safety check: `[[ "$PWD" != *"worktrees"* ]] && echo "ERROR…" && exit 1`.
+- `skills/swarm/SKILL.md:249-261` — ancestry check: `git merge-base --is-ancestor origin/<base> HEAD` with abort on failure.
+- `METHODOLOGY.md:31-38` — narrative on worktree isolation and why relative paths are required.
+
+### Scenario: Worktree safety check aborts on wrong directory
+**Source:** `skills/swarm/SKILL.md:244-248` — `[[ "$PWD" != *"worktrees"* ]] && echo "ERROR: Not running in an isolated worktree. Aborting to prevent branch collision." && exit 1`.
+**Interpolated; no direct test.**
+
+### Scenario: Ancestry check aborts on stale base
+**Source:** `skills/swarm/SKILL.md:249-261` — `if ! git merge-base --is-ancestor origin/<base> HEAD; then echo "ERROR: HEAD is not a descendant of origin/<base>. Worktree may be rooted on a stale base." >&2 … exit 1; fi`. Comment at line 251 identifies the motivating bug: post-rebase-merge worktree-base drift (#923).
+**Interpolated; no direct test.**
+
+### Scenario: Relative paths enforced
+**Source:** `skills/swarm/SKILL.md:228-231` — "Instruct agents that their CWD is the repo root — use relative paths only for all file operations … Do NOT include the absolute repo path."
+Also constraint `skills/swarm/SKILL.md:455-457`: "Never pass absolute repo paths to spawned agents".
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: PR Creation Standards
+
+**Sources**
+- `skills/swarm/SKILL.md:264-300` — agent workflow steps 3–5: commit format, push, PR creation with body template.
+- `skills/swarm/SKILL.md:300` — "This is the ONLY acceptable termination condition for this workflow."
+- `skills/conventional-commit-message/SKILL.md:1-35` — conventional commit format, type enum, subject length.
+
+### Scenario: Branch naming convention
+**Source:** `skills/swarm/SKILL.md:224` — "Branch naming: `worktree-agent-<issue>` (required for `clean-worktrees`)".
+Also `README.md:162-164` — "Every agent branch follows this exact pattern … It is not configurable."
+**Interpolated; no direct test.**
+
+### Scenario: PR body standard sections
+**Source:** `skills/swarm/SKILL.md:275-300` — PR body template showing `## Summary`, `## Test plan`, and `Closes #<issue>` footer.
+**Interpolated; no direct test.**
+
+### Scenario: Conventional commit format
+**Source:** `skills/swarm/SKILL.md:263-265` — "Stage and commit using conventional-commit-message format … `git add <files> && git commit -m '<type>(<scope>): <description>'"`. Sub-skill `skills/conventional-commit-message/SKILL.md:1-35`.
+**Interpolated; no direct test.**
+
+### Scenario: PR termination only after PR URL reported
+**Source:** `skills/swarm/SKILL.md:300` — "Report the PR URL. This is the ONLY acceptable termination condition for this workflow. Do not stop before the PR exists and its URL has been reported."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Issue Labeling
+
+**Sources**
+- `skills/swarm/SKILL.md:183-193` — before spawning each agent: create label if missing, then `gh issue edit <issue> --add-label "status:in-progress"`.
+- `README.md:178-184` — "When an agent is spawned for an issue, swarmkit applies `status:in-progress` to it."
+
+### Scenario: Label created if absent
+**Source:** `skills/swarm/SKILL.md:185-188` — `gh label list | grep -q "status:in-progress" || gh label create "status:in-progress" --description "Actively being worked on" --color "E4E669"`.
+**Interpolated; no direct test.**
+
+### Scenario: Label applied before dispatch
+**Source:** `skills/swarm/SKILL.md:183-190` — full block: label existence check, creation if absent, then `gh issue edit <issue> --add-label "status:in-progress"` immediately before spawn.
+**Interpolated; no direct test.**
+
+### Scenario: Issue never closed by swarm
+**Source:** `skills/swarm/SKILL.md:448-449` — constraint: "Never close issues — issues are closed by the release process when the release merges to main".
+Also `README.md:182-184`.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Feature-Branch Mode
+
+**Sources**
+- `skills/swarm/SKILL.md:22-58` — epic mode resolution: EPIC_MODE logic, slug derivation table, empty-board edge case, cross-pin guard, cut-epic invocation.
+- `skills/swarm/SKILL.md:73-93` — preflight with `--scope-pr-base` when EPIC_MODE=on.
+- `skills/swarm/SKILL.md:399-416` — teardown: `--keep-pr-base` in epic mode, announcement of remaining pin.
+- `METHODOLOGY.md:92-168` — full feature-branch mode narrative including trigger rule, slug derivation, loop-mode reuse, ship-epic handoff, escape hatches, cross-pin guard, squadkit symmetry.
+
+### Scenario: Multi-issue one-shot cuts epic branch
+**Source:** `skills/swarm/SKILL.md:23-24` — "When the run will spawn ≥2 agents … swarm cuts a `feature/<slug>-<N>` branch via `flowkit:cut-epic`". EPIC_MODE logic at lines 33-38: one-shot AND issue_count==1 → off; otherwise → on.
+Also `METHODOLOGY.md:94-100`.
+**Interpolated; no direct test.**
+
+### Scenario: Loop mode cuts epic at first non-empty cycle
+**Source:** `skills/swarm/SKILL.md:47-48` — "defer the cut-epic invocation until the first cycle that selects ≥1 issue." Also `METHODOLOGY.md:123-127`.
+**Interpolated; no direct test.**
+
+### Scenario: Single-issue one-shot stays flat
+**Source:** `skills/swarm/SKILL.md:34-35` — `elif arg-mode == one-shot AND issue_count == 1: EPIC_MODE=off`.
+Also `METHODOLOGY.md:101-102`.
+**Interpolated; no direct test.**
+
+### Scenario: --no-epic suppresses the cut
+**Source:** `skills/swarm/SKILL.md:33-34` — `elif --no-epic is set: EPIC_MODE=off`.
+Also `METHODOLOGY.md:154-155`.
+**Interpolated; no direct test.**
+
+### Scenario: --base suppresses the cut
+**Source:** `skills/swarm/SKILL.md:32-33` — `if --base is set: EPIC_MODE=off`.
+Also `METHODOLOGY.md:156-157`.
+**Interpolated; no direct test.**
+
+### Scenario: Empty board in loop mode skips cut
+**Source:** `skills/swarm/SKILL.md:47-48` — "If the board is clear at loop entry, announce 'Board is clear' and exit without cutting any branch."
+Also `METHODOLOGY.md:124-127`.
+**Interpolated; no direct test.**
+
+### Scenario: Cross-pin guard prevents silent overwrite
+**Source:** `skills/swarm/SKILL.md:50-52` — cross-pin defensive guard: read `claude.flowkit.prBase`; if set AND starts with `feature/` AND differs from branch about to be cut, exit with error message.
+Also `METHODOLOGY.md:159-164`.
+**Interpolated; no direct test.**
+
+### Scenario: cut-epic is idempotent on resume
+**Source:** `skills/swarm/SKILL.md:53-54` — "cut-epic is idempotent — if the branch already exists locally or on origin it is reused and the pin is refreshed."
+Also `METHODOLOGY.md:106-108`.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Loop Mode
+
+**Sources**
+- `skills/swarm/SKILL.md:354-443` — full loop mode section: setup, loop cycle, checkpoint, teardown, smart failure rules.
+- `METHODOLOGY.md:79-90` — loop mode and failure handling narrative.
+
+### Scenario: Batch selection avoids file conflicts
+**Source:** `skills/swarm/SKILL.md:373-378` — batch selection criteria: "No two issues touch the same files; No unresolved dependencies within the batch."
+Also `METHODOLOGY.md:82-84`.
+**Interpolated; no direct test.**
+
+### Scenario: Checkpoint printed after each cycle
+**Source:** `skills/swarm/SKILL.md:384-396` — checkpoint block format with PRs opened, failed, blocked, remaining; and "Proceed immediately to the next cycle after printing the checkpoint summary."
+**Interpolated; no direct test.**
+
+### Scenario: Failed issue blocks dependents in subsequent cycles
+**Source:** `skills/swarm/SKILL.md:433-438` — "Check all remaining issues in current and future cycles for file overlap or explicit references to the failed issue; Mark those as blocked; continue with all unblocked issues."
+Also `METHODOLOGY.md:83-87`.
+**Interpolated; no direct test.**
+
+### Scenario: Agent crash with no PR is unrecoverable
+**Source:** `skills/swarm/SKILL.md:439-440` — "Unrecoverable failures (exit loop immediately): Agent produced no PR (crash, timeout, no push)".
+Also `METHODOLOGY.md:85-87`.
+**Interpolated; no direct test.**
+
+### Scenario: Base branch deletion is unrecoverable
+**Source:** `skills/swarm/SKILL.md:441-442` — "`$BASE` branch deleted or corrupted externally".
+**Interpolated; no direct test.**
+
+### Scenario: prBase config cleaned up on teardown
+**Source:** `skills/swarm/SKILL.md:399-416` — teardown: `teardown.sh --base "$BASE"` in non-epic mode; "Leaving it set will cause subsequent PR creation (even in unrelated workflows) to target the wrong base."
+Also `METHODOLOGY.md:88-90`.
+**Interpolated; no direct test.**
+
+### Scenario: prBase kept on teardown in epic mode
+**Source:** `skills/swarm/SKILL.md:401-414` — `teardown.sh --keep-pr-base` in epic mode; `config_kept_for_epic: true` JSON field triggers announcement: "Epic branch `<EPIC_BRANCH>` is left in place with `claude.flowkit.prBase` pinned. Run `/ship-epic` to promote it…"
+Also `METHODOLOGY.md:129-148`.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Bottom-Up Stack Merge
+
+**Sources**
+- `skills/merge-stack/SKILL.md:1-222` — full merge-stack skill.
+- `METHODOLOGY.md:68-77` — bottom-up merge with up-front retargeting narrative.
+
+### Scenario: Only worktree-agent-* PRs are included
+**Source:** `skills/merge-stack/SKILL.md:22-29` — `gh pr list … --jq '.[] | select(.headRefName | startswith("worktree-agent-"))'`.
+**Interpolated; no direct test.**
+
+### Scenario: Non-root PRs retargeted before first merge
+**Source:** `skills/merge-stack/SKILL.md:49-57` — step 3: "retarget every non-root PR to `$BASE` before merging anything." `gh pr edit <N> --base $BASE`.
+Also `METHODOLOGY.md:68-73`.
+**Interpolated; no direct test.**
+
+### Scenario: Independent PRs merge in any order
+**Source:** `skills/merge-stack/SKILL.md:41-45` — "Independent PRs: PRs whose `baseRefName` is already `$BASE` and that no other PR sits on top of — these have no stack relationship and can merge in any order."
+Also constraint `skills/merge-stack/SKILL.md:219`: "Independent PRs (targeting `$BASE` with nothing stacked on them) may merge in any order".
+**Interpolated; no direct test.**
+
+### Scenario: Downstream PRs rebased after predecessor merges
+**Source:** `skills/merge-stack/SKILL.md:7-15` — introductory explanation of the rebase step and why it is necessary. Step 5e at lines `skills/merge-stack/SKILL.md:155-169` — uses `flowkit:restack` script to rebase each downstream branch onto `origin/$BASE`; `git rebase` patch-id matching drops predecessor commits.
+**Interpolated; no direct test.**
+
+### Scenario: Malformed closing-keyword footer warned before merge
+**Source:** `skills/merge-stack/SKILL.md:119-130` — step 5b: grep body for space-separated form; emit warning to stderr; merge proceeds without blocking.
+**Interpolated; no direct test.**
+
+### Scenario: Conflict stops chain and blocks dependents
+**Source:** `skills/merge-stack/SKILL.md:143-151` — step 5d: "Stop the chain at this PR; Report the conflict; Mark all PRs above it in the same chain as blocked; Continue with any independent PRs or unrelated chains."
+**Interpolated; no direct test.**
+
+### Scenario: No PR found stops cleanly
+**Source:** `skills/merge-stack/SKILL.md:27-29` — "If no open swarm PRs are found, report 'No open swarm PRs found' and stop."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Swarm-Plus Review/Fix Pass
+
+**Sources**
+- `skills/swarm-plus/SKILL.md:1-209` — full swarm-plus skill.
+- `agents/swarm-reviewer.md:1-87` — reviewer agent definition, output format, verdict delivery contract.
+- `METHODOLOGY.md:207-219` — swarm-plus narrative.
+
+### Scenario: Reviewer dispatched as swarm agent completes
+**Source:** `skills/swarm-plus/SKILL.md:73-78` — "Do NOT block on every swarm agent before spawning reviewers. As each swarm agent's task notification arrives: Verify the PR exists … Spawn a reviewer for that PR … Continue handling other notifications in parallel."
+**Interpolated; no direct test.**
+
+### Scenario: Skip-on-clean rule
+**Source:** `skills/swarm-plus/SKILL.md:103-106` — table row: "Verdict `Approve` AND no blockers AND no concerns AND no `[recommended]` coverage gaps → No fix-round worker."
+Also `METHODOLOGY.md:211-212`.
+**Interpolated; no direct test.**
+
+### Scenario: Blocker or concern triggers fresh worker
+**Source:** `skills/swarm-plus/SKILL.md:107-112` — table rows: blockers, concerns, `[recommended]` gaps each trigger a fresh worker. Lines 121-122: "spawn a fresh `general-purpose` agent … The original builder is never re-engaged."
+Also `METHODOLOGY.md:212-213`.
+**Interpolated; no direct test.**
+
+### Scenario: Worker branches from existing PR head
+**Source:** `skills/swarm-plus/SKILL.md:134-136` — "Branch from the existing PR branch, NOT from `develop`: `git fetch origin <head_branch>; git checkout -B <head_branch> origin/<head_branch>`".
+**Interpolated; no direct test.**
+
+### Scenario: Nits and optional gaps never trigger a worker
+**Source:** `skills/swarm-plus/SKILL.md:103-106` — table: nits and `[optional]` gaps produce no fix-round worker. Also `METHODOLOGY.md:213-214`.
+**Interpolated; no direct test.**
+
+### Scenario: --review-only suppresses fix-round workers
+**Source:** `skills/swarm-plus/SKILL.md:109-110` — "`--review-only` flag set → Never spawn a fix-round worker, regardless of reviewer verdict."
+**Interpolated; no direct test.**
+
+### Scenario: Worker must not push a failing build
+**Source:** `skills/swarm-plus/SKILL.md:136-138` — "Run `<verify_command>` … Resolve any failures before proceeding — never push a red build."
+Also constraint at `skills/swarm-plus/SKILL.md:194-195`.
+**Interpolated; no direct test.**
+
+### Scenario: Single pass per PR
+**Source:** `skills/swarm-plus/SKILL.md:174-176` — constraint: "Single pass — no reviewer-after-fix re-review. The user can manually trigger another review with `/review <pr>` if desired."
+Also `METHODOLOGY.md:215-217`.
+**Interpolated; no direct test.**
+
+### Scenario: Reviewer output never posted as PR comment
+**Source:** `agents/swarm-reviewer.md:71-72` — critical constraint: "Return the review inline. Never post it as a `gh pr comment`."
+Also `skills/swarm-plus/SKILL.md:181`: "Reviewer output stays inline, never posted as a PR comment by the reviewer itself."
+**Interpolated; no direct test.**
+
+### Scenario: Swarm agent failure skips review
+**Source:** `skills/swarm-plus/SKILL.md:187-189` — failure mode table: "Swarm agent fails to produce a PR → Skip review/fix round for that issue; report in final summary."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Local Worktree Cleanup
+
+**Sources**
+- `skills/clean-worktrees/SKILL.md:1-113` — full clean-worktrees skill.
+
+### Scenario: Stuck worktrees block cleanup
+**Source:** `skills/clean-worktrees/SKILL.md:47-56` — "Parse the `stuck` array. If it is non-empty, stop immediately and report … Do not proceed to removal if `stuck` is non-empty."
+**Interpolated; no direct test.**
+
+### Scenario: Nothing to clean reported cleanly
+**Source:** `skills/clean-worktrees/SKILL.md:60-65` — "If both `worktrees_to_remove` and `branches_to_delete` are empty arrays, report: Nothing to clean — no agent worktrees or orphaned branches found."
+**Interpolated; no direct test.**
+
+### Scenario: Caller branch restored after cleanup
+**Source:** `skills/clean-worktrees/SKILL.md:98-113` — report section includes "Caller branch: restored to `<caller_branch>` / skipped (branch was removed)". Lines 108-110: warning if `caller_branch_restored` is `false`.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Remote Branch Cleanup
+
+**Sources**
+- `skills/clean-remote-worktrees/SKILL.md:1-153` — full clean-remote-worktrees skill.
+
+### Scenario: Merged branches deleted
+**Source:** `skills/clean-remote-worktrees/SKILL.md:43-44` — classify script output: `"state": "MERGED"` entries land in the `merged` array; step 5 deletes exactly the `merged` array.
+**Interpolated; no direct test.**
+
+### Scenario: Open PR branches skipped
+**Source:** `skills/clean-remote-worktrees/SKILL.md:144-146` — constraint: "Never delete a branch that is the head of an OPEN PR."
+**Interpolated; no direct test.**
+
+### Scenario: Closed-non-merged branches preserved
+**Source:** `skills/clean-remote-worktrees/SKILL.md:147-148` — constraint: "Never delete a branch whose most-recent PR is CLOSED (non-merged) — the branch contains rejected work that persists nowhere else."
+**Interpolated; no direct test.**
+
+### Scenario: No-PR branches surfaced for manual inspection
+**Source:** `skills/clean-remote-worktrees/SKILL.md:149-150` — constraint: "Never delete a branch with no associated PR — surface it for manual inspection."
+Also output template at `skills/clean-remote-worktrees/SKILL.md:131-140`: "No PR (inspect manually):" section.
+**Interpolated; no direct test.**
+
+### Scenario: Interactive mode confirms before deletion
+**Source:** `skills/clean-remote-worktrees/SKILL.md:99-104` — step 4: "In interactive mode (no `--yes`), ask before proceeding: 'Proceed with deleting <count> remote branch(es)?' … If the user declines, stop without deleting anything."
+**Interpolated; no direct test.**
+
+### Scenario: --yes enables non-interactive deletion
+**Source:** `skills/clean-remote-worktrees/SKILL.md:105-106` — "With `--yes`, skip the prompt and proceed immediately."
+**Interpolated; no direct test.**
+
+### Scenario: Idempotent on clean repo
+**Source:** `skills/clean-remote-worktrees/SKILL.md:59-62` — step 2: "If `candidates` is an empty array, report: No remote `worktree-agent-*` branches found." Also constraint `skills/clean-remote-worktrees/SKILL.md:152`: "Idempotent: running twice on a clean repo is a no-op."
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. **All scenarios are interpolated from code/prose; no automated tests exist.** The `skills/*/scripts/test.sh` files exist for swarm, clean-worktrees, and clean-remote-worktrees but are shell-level unit tests for script helpers, not behavioral tests for the skill scenarios themselves.
+
+2. **Feature-branch mode uses different thresholds for one-shot vs. loop mode.** One-shot requires ≥2 issue numbers to trigger the epic cut; loop mode cuts at the first cycle that selects ≥1 issue. This asymmetry is documented in `METHODOLOGY.md:94-101` ("any board with ≥1 issue → epic cut at first non-empty cycle") and the spec's Feature-Branch Mode requirement. It is intentional design, not an edge case.
+
+3. **`claude.flowkit.prBase` pin scope is the local git config, not a shell variable.** The pin persists across agent invocations and tool calls within the session. Teardown must unset it or the scope bleeds into unrelated PR commands — cited in `METHODOLOGY.md:88-90` and teardown prose in `skills/swarm/SKILL.md:368`.
+
+4. **Reviewer verdict delivery uses `SendMessage`, not just the idle notification.** `skills/swarm-plus/SKILL.md:93-96` and `agents/swarm-reviewer.md:78-86` both state that the structured verdict must be sent via `SendMessage` before the reviewer terminates; the idle notification alone does not carry the verdict. This timing contract has no test coverage and is critical to the skip-on-clean logic.
+
+5. **Builder agents are treated as non-addressable post-PR.** `skills/swarm-plus/SKILL.md:16-22` documents that `SendMessage` to a former builder consistently fails under the current runtime. The `STANDBY_READY` sentinel and STANDBY clause in builder prompts are forward-compatibility stubs only. Any future runtime change that makes builders addressable would change this behavior.
+
+6. **worktree-agent-* branch naming is load-bearing.** Both `clean-worktrees` (local) and `clean-remote-worktrees` (remote) and `merge-stack` all key on this prefix. The convention is documented as "not configurable" in `README.md:162-166`.

--- a/openspec/specs/swarmkit/spec.md
+++ b/openspec/specs/swarmkit/spec.md
@@ -1,0 +1,306 @@
+# swarmkit
+
+## Purpose
+
+Resolve GitHub issues with parallel, isolated-worktree agents. Each agent creates a branch, implements the issue, opens a pull request, and stops — leaving all PRs open for human review and merge. Supports one-shot runs against specific issues, loop mode to continuously clear the board, layered review/fix passes via swarm-plus, and bottom-up stack merging via merge-stack.
+
+## Requirements
+
+### Requirement: Issue Fetching and Filtering
+The system SHALL fetch open GitHub issues and exclude any issue labeled `on-hold` or `status:in-progress` from all ranking and dispatch operations.
+
+#### Scenario: On-hold issues excluded
+- **WHEN** an issue carries the `on-hold` label
+- **THEN** it is not surfaced, ranked, or selected for agent dispatch
+
+#### Scenario: In-progress issues excluded
+- **WHEN** an issue carries the `status:in-progress` label
+- **THEN** it is not surfaced, ranked, or selected for agent dispatch in subsequent cycles
+
+### Requirement: Issue Ranking
+The system SHALL rank open issues by priority label, implementation specificity, architectural impact, and testability before presenting candidates or selecting a batch.
+
+#### Scenario: Priority labels respected
+- **WHEN** issues carry `priority:high`, `priority:medium`, or `priority:low` labels
+- **THEN** they are ranked in that order, with unlabeled issues evaluated from body content
+
+#### Scenario: Specificity and impact favor architectural unblocking
+- **WHEN** an issue's body calls out exact files, interfaces, or line numbers
+- **THEN** it ranks above a same-priority issue with a vague description
+
+### Requirement: One-Shot Mode
+The system SHALL accept explicit issue numbers, gather their details in a single batch, analyze inter-issue dependencies, present a swarm plan before dispatching, and spawn one agent per issue (or grouped set) in parallel.
+
+#### Scenario: Closed and on-hold issues skipped from requested set
+- **WHEN** a requested issue is closed or labeled `on-hold`
+- **THEN** it is excluded from `work_items` with the skip reason reported before dispatch
+
+#### Scenario: Epic expansion
+- **WHEN** a requested issue number is an epic with sub-issues wired via the native sub-issue API
+- **THEN** the epic is expanded to its children; closed or on-hold children are excluded and reported
+
+#### Scenario: Unwired epic skipped with guidance
+- **WHEN** a requested issue is labeled `epic` but has no sub-issues attached via the native API
+- **THEN** it is skipped with a message directing the operator to wire children before swarming
+
+#### Scenario: Empty work set stops dispatch
+- **WHEN** every requested issue (or every child of a requested epic) is filtered out
+- **THEN** swarm announces the empty set and stops without spawning any agent
+
+#### Scenario: Plan presented before dispatch
+- **WHEN** work items are ready
+- **THEN** a table showing agent assignments, branches, files affected, model, and merge order is presented before any agent spawns
+
+### Requirement: Dependency Graph and Topological Dispatch
+The system SHALL parse inter-issue dependencies from the native `blockedBy` API field (falling back to `Depends on #N` / `Blocked by #N` body text), build a directed acyclic graph, and dispatch agents in topological order.
+
+#### Scenario: Independent issues spawn in parallel
+- **WHEN** a set of issues has no dependency edges among them
+- **THEN** all their agents spawn concurrently
+
+#### Scenario: Dependent agent branches from upstream tip
+- **WHEN** issue B depends on issue A within the same batch
+- **THEN** the agent for B fetches and branches from `origin/worktree-agent-<A>` so A's output is already present in B's working tree without waiting for A's PR to merge
+
+#### Scenario: Dependent agent PR targets upstream branch
+- **WHEN** issue B depends on issue A
+- **THEN** B's PR targets `worktree-agent-<A>` as its base, forming a stack
+
+#### Scenario: Mid-swarm merge forbidden
+- **WHEN** a downstream agent needs files from an upstream agent
+- **THEN** the upstream PR is never merged early; the stacked-branch strategy provides the upstream output directly
+
+### Requirement: Worktree Isolation
+Every agent SHALL run in a dedicated git worktree under `.claude/worktrees/agent-<issue>`, use relative paths for all file operations, and abort if not inside a path containing `worktrees`.
+
+#### Scenario: Worktree safety check aborts on wrong directory
+- **WHEN** an agent's working directory does not contain the substring `worktrees`
+- **THEN** the agent emits an error and exits without making changes
+
+#### Scenario: Ancestry check aborts on stale base
+- **WHEN** the agent's HEAD is not a descendant of `origin/<base>`
+- **THEN** the agent emits an error with remediation instructions and exits
+
+#### Scenario: Relative paths enforced
+- **WHEN** agent prompts reference files in the repository
+- **THEN** paths are relative to the worktree CWD; no absolute repo root paths appear in agent prompts
+
+### Requirement: PR Creation Standards
+Each agent SHALL create a branch named `worktree-agent-<issue>`, commit in conventional-commit format (no Claude mentions, no co-author lines), push the branch, and open a PR whose body includes a `Closes #<issue>` reference, a `## Summary` section, and a `## Test plan` section.
+
+#### Scenario: Branch naming convention
+- **WHEN** an agent is dispatched for issue N
+- **THEN** its branch is named `worktree-agent-<N>`
+
+#### Scenario: PR body standard sections
+- **WHEN** a PR is opened
+- **THEN** the body contains `## Summary`, `## Test plan`, and a `Closes #N` footer
+
+#### Scenario: Conventional commit format
+- **WHEN** an agent commits
+- **THEN** the commit message follows `type(scope): description` with a subject line under 72 characters
+
+#### Scenario: PR termination only after PR URL reported
+- **WHEN** an agent reaches the end of its workflow
+- **THEN** it does not stop until the PR exists and its URL has been reported
+
+### Requirement: Issue Labeling
+The system SHALL apply the `status:in-progress` label to each issue before its agent spawns, creating the label if it does not yet exist.
+
+#### Scenario: Label created if absent
+- **WHEN** the `status:in-progress` label does not exist in the repository
+- **THEN** it is created before the first issue is labeled
+
+#### Scenario: Label applied before dispatch
+- **WHEN** an issue is selected for agent dispatch
+- **THEN** `status:in-progress` is applied to the issue before the agent spawns
+
+#### Scenario: Issue never closed by swarm
+- **WHEN** an agent's PR is opened with `Closes #N`
+- **THEN** the issue remains open until the PR merges; swarm never closes issues directly
+
+### Requirement: Feature-Branch Mode
+The system SHALL automatically cut a `feature/<slug>-<N>` branch via `flowkit:cut-epic` and pin `claude.flowkit.prBase` to it whenever a run will spawn two or more agents, routing all spawned PRs to the epic branch.
+
+#### Scenario: Multi-issue one-shot cuts epic branch
+- **WHEN** two or more issue numbers are passed
+- **THEN** a feature branch is cut before any agent spawns; all PRs target that branch
+
+#### Scenario: Loop mode cuts epic at first non-empty cycle
+- **WHEN** loop mode starts with a non-empty board
+- **THEN** the epic branch is cut at the start of the first cycle that selects at least one issue
+
+#### Scenario: Single-issue one-shot stays flat
+- **WHEN** exactly one issue number is passed
+- **THEN** no epic branch is cut; the PR targets `$BASE` directly
+
+#### Scenario: --no-epic suppresses the cut
+- **WHEN** `--no-epic` flag is set
+- **THEN** no epic branch is cut regardless of agent count; PRs target `$BASE` directly
+
+#### Scenario: --base suppresses the cut
+- **WHEN** `--base <branch>` is set
+- **THEN** no epic branch is cut; all PRs target `<branch>` directly
+
+#### Scenario: Empty board in loop mode skips cut
+- **WHEN** loop mode finds no open issues at entry
+- **THEN** the skill announces "Board is clear" and exits without cutting any branch
+
+#### Scenario: Cross-pin guard prevents silent overwrite
+- **WHEN** `claude.flowkit.prBase` is already set to a different `feature/` branch
+- **THEN** swarm exits with an error message naming the existing pin and offering `--no-epic` or `--epic <existing-slug>` as escapes
+
+#### Scenario: cut-epic is idempotent on resume
+- **WHEN** the epic branch already exists on origin (e.g. resuming a loop run)
+- **THEN** `cut-epic` reuses the existing branch and refreshes the pin
+
+### Requirement: Loop Mode
+The system SHALL continuously cycle through fetch → rank → batch → swarm until the board is clear, printing a checkpoint summary after each cycle and never pausing between cycles.
+
+#### Scenario: Batch selection avoids file conflicts
+- **WHEN** two open issues touch the same files
+- **THEN** they are not selected in the same batch cycle
+
+#### Scenario: Checkpoint printed after each cycle
+- **WHEN** a swarm cycle completes
+- **THEN** a checkpoint shows PRs opened, failed issues, blocked issues, and remaining count
+
+#### Scenario: Failed issue blocks dependents in subsequent cycles
+- **WHEN** an issue fails (agent crash, no PR produced)
+- **THEN** all issues with file overlap or explicit references to the failed issue are marked blocked and skipped in current and future cycles
+
+#### Scenario: Agent crash with no PR is unrecoverable
+- **WHEN** an agent crashes without producing a PR
+- **THEN** the loop halts immediately and reports the unrecoverable failure
+
+#### Scenario: Base branch deletion is unrecoverable
+- **WHEN** `$BASE` is deleted or corrupted externally during a loop run
+- **THEN** the loop halts immediately
+
+#### Scenario: prBase config cleaned up on teardown
+- **WHEN** the loop completes or is torn down in non-epic mode
+- **THEN** `claude.flowkit.prBase` is unset so subsequent PR-creation commands are not affected
+
+#### Scenario: prBase kept on teardown in epic mode
+- **WHEN** the loop completes in epic mode
+- **THEN** `claude.flowkit.prBase` remains pinned to the epic branch and the operator is directed to run `/ship-epic`
+
+### Requirement: Bottom-Up Stack Merge
+The merge-stack skill SHALL retarget every non-root PR in a multi-PR chain to `$BASE` before merging anything, then merge each chain from root to leaf using a uniform squash-and-delete-branch strategy, rebasing each downstream PR onto `$BASE` after its predecessor merges.
+
+#### Scenario: Only worktree-agent-* PRs are included
+- **WHEN** merge-stack scans for open PRs
+- **THEN** only PRs whose head branch starts with `worktree-agent-` are included
+
+#### Scenario: Non-root PRs retargeted before first merge
+- **WHEN** a multi-PR chain is present
+- **THEN** every non-root PR's base is changed to `$BASE` before any merge runs, preventing GitHub's auto-close cascade
+
+#### Scenario: Independent PRs merge in any order
+- **WHEN** a PR's base is already `$BASE` and no other PR is stacked on it
+- **THEN** it may merge in any order relative to other independent PRs
+
+#### Scenario: Downstream PRs rebased after predecessor merges
+- **WHEN** a non-leaf PR in a chain has been squash-merged into `$BASE`
+- **THEN** every still-open downstream PR in that chain is rebased onto `$BASE` locally and force-pushed before the next merge, dropping the already-applied predecessor commits via patch-id matching
+
+#### Scenario: Malformed closing-keyword footer warned before merge
+- **WHEN** a PR body contains a space-separated multi-ref footer (e.g. `Closes #A #B`)
+- **THEN** a warning is emitted before merge and the merge proceeds without blocking
+
+#### Scenario: Conflict stops chain and blocks dependents
+- **WHEN** a merge or rebase fails with a content conflict
+- **THEN** the chain stops at that PR, all PRs above it in the chain are marked blocked, unrelated chains and independent PRs continue, and the user is directed to resolve and re-run
+
+#### Scenario: No PR found stops cleanly
+- **WHEN** no open PRs with `worktree-agent-` head branches exist
+- **THEN** merge-stack reports "No open swarm PRs found" and stops
+
+### Requirement: Swarm-Plus Review/Fix Pass
+The swarm-plus skill SHALL dispatch one reviewer agent per PR as each swarm agent completes, apply a skip-on-clean rule to decide whether to spawn a fix-round worker, and produce a final summary of all verdict and worker outcomes.
+
+#### Scenario: Reviewer dispatched as swarm agent completes
+- **WHEN** a swarm agent reports its PR
+- **THEN** the reviewer is dispatched immediately in the background without waiting for other swarm agents
+
+#### Scenario: Skip-on-clean rule
+- **WHEN** the reviewer verdict is `Approve` with no blockers, no concerns, and no `[recommended]` coverage gaps
+- **THEN** no fix-round worker is spawned; the PR stands as-is
+
+#### Scenario: Blocker or concern triggers fresh worker
+- **WHEN** the reviewer surfaces any blocker, concern, or `[recommended]` coverage gap
+- **THEN** a brand-new worker agent is spawned; the original builder agent is never re-engaged
+
+#### Scenario: Worker branches from existing PR head
+- **WHEN** a fix-round worker is spawned
+- **THEN** it fetches and branches from the existing PR's head branch, not from `develop`
+
+#### Scenario: Nits and optional gaps never trigger a worker
+- **WHEN** the reviewer's only findings are nits or `[optional]` coverage gaps
+- **THEN** no fix-round worker is spawned
+
+#### Scenario: --review-only suppresses fix-round workers
+- **WHEN** `--review-only` flag is set
+- **THEN** reviewers run but no fix-round workers are ever dispatched
+
+#### Scenario: Worker must not push a failing build
+- **WHEN** a fix-round worker has applied changes
+- **THEN** it runs the project's verify command and resolves any failures before pushing
+
+#### Scenario: Single pass per PR
+- **WHEN** a fix-round worker has completed and pushed
+- **THEN** no second reviewer pass is triggered; users may invoke `/review <pr>` manually for a second opinion
+
+#### Scenario: Reviewer output never posted as PR comment
+- **WHEN** the reviewer produces findings
+- **THEN** the findings are returned inline to the orchestrator only; no `gh pr comment` is posted by the reviewer
+
+#### Scenario: Swarm agent failure skips review
+- **WHEN** a swarm agent fails to produce a PR
+- **THEN** no reviewer or worker is dispatched for that issue; the failure is noted in the final summary
+
+### Requirement: Local Worktree Cleanup
+The clean-worktrees skill SHALL remove all agent worktrees under `.claude/worktrees/` and delete all local branches with the `worktree-agent-*` prefix, halting if any worktree branch is still actively checked out.
+
+#### Scenario: Stuck worktrees block cleanup
+- **WHEN** a `worktree-agent-*` branch is still checked out by an active worktree
+- **THEN** cleanup halts immediately and reports the stuck branches with manual remediation instructions
+
+#### Scenario: Nothing to clean reported cleanly
+- **WHEN** no agent worktrees or orphaned branches exist
+- **THEN** the skill reports "Nothing to clean" and stops without error
+
+#### Scenario: Caller branch restored after cleanup
+- **WHEN** the caller's branch is among those removed
+- **THEN** the result reports whether the caller branch was restored
+
+### Requirement: Remote Branch Cleanup
+The clean-remote-worktrees skill SHALL sweep orphaned remote `worktree-agent-*` branches, deleting only those whose most-recent PR is merged, and skipping open, closed-non-merged, and no-PR branches.
+
+#### Scenario: Merged branches deleted
+- **WHEN** a remote `worktree-agent-*` branch's most-recent PR is merged
+- **THEN** it is selected for deletion
+
+#### Scenario: Open PR branches skipped
+- **WHEN** a remote `worktree-agent-*` branch's most-recent PR is still open
+- **THEN** it is not deleted
+
+#### Scenario: Closed-non-merged branches preserved
+- **WHEN** a remote `worktree-agent-*` branch's most-recent PR was closed without merging
+- **THEN** it is preserved (contains rejected work that exists nowhere else)
+
+#### Scenario: No-PR branches surfaced for manual inspection
+- **WHEN** a remote `worktree-agent-*` branch has no associated PR
+- **THEN** it is reported for manual inspection and not deleted automatically
+
+#### Scenario: Interactive mode confirms before deletion
+- **WHEN** invoked without `--yes`
+- **THEN** the plan is presented and user confirmation is required before any deletion
+
+#### Scenario: --yes enables non-interactive deletion
+- **WHEN** invoked with `--yes`
+- **THEN** branches are deleted without prompting
+
+#### Scenario: Idempotent on clean repo
+- **WHEN** invoked when no remote `worktree-agent-*` branches exist
+- **THEN** the skill reports nothing to delete and stops without error

--- a/plugins/swarmkit/skills/clean-remote-worktrees/SKILL.md
+++ b/plugins/swarmkit/skills/clean-remote-worktrees/SKILL.md
@@ -18,13 +18,7 @@ Parse `$ARGUMENTS`:
 
 ## Setup
 
-**Resolve the skill base directory first.** Capture the runtime-resolved absolute path from the harness header (`Base directory for this skill: <absolute path>`):
-
-```bash
-export SKILL_DIR="<absolute path from the 'Base directory for this skill:' header line>"
-```
-
-Use `"$SKILL_DIR/scripts/..."` for every script invocation. Do **not** hardcode `plugins/swarmkit/...`.
+Capture the harness-emitted `Base directory for this skill:` path as `SKILL_DIR`; use `"$SKILL_DIR/scripts/..."` for every script invocation.
 
 ## Process
 
@@ -141,12 +135,3 @@ Skipped:  <count> branch(es)
 
 Errors: <list any errors; omit section if empty>
 ```
-
-## Constraints
-
-- Never delete a branch that is the head of an OPEN PR
-- Never delete a branch whose most-recent PR is CLOSED (non-merged) — the branch contains rejected work that persists nowhere else
-- Never delete a branch with no associated PR — surface it for manual inspection
-- Always use refspec syntax (`git push origin :branch1 :branch2 ...`) for batch deletion; never loop `git push --delete` per branch (handled inside delete.sh)
-- Never touch local state — worktrees and local branches are `swarmkit:clean-worktrees`'s concern
-- Idempotent: running twice on a clean repo is a no-op

--- a/plugins/swarmkit/skills/clean-worktrees/SKILL.md
+++ b/plugins/swarmkit/skills/clean-worktrees/SKILL.md
@@ -11,13 +11,7 @@ For remote branch cleanup, see `swarmkit:clean-remote-worktrees`.
 
 ## Setup
 
-**Resolve the skill base directory first.** Capture the runtime-resolved absolute path from the harness header (`Base directory for this skill: <absolute path>`):
-
-```bash
-export SKILL_DIR="<absolute path from the 'Base directory for this skill:' header line>"
-```
-
-Use `"$SKILL_DIR/scripts/..."` for every script invocation. Do **not** hardcode `plugins/swarmkit/...`.
+Capture the harness-emitted `Base directory for this skill:` path as `SKILL_DIR`; use `"$SKILL_DIR/scripts/..."` for every script invocation.
 
 ## Process
 
@@ -63,11 +57,7 @@ If both `worktrees_to_remove` and `branches_to_delete` are empty arrays, report:
 
 And stop.
 
-### Step 4 — Proceed
-
-No confirmation prompt needed for this automated cleanup step.
-
-### Step 5 — Perform removal
+### Step 4 — Perform removal
 
 Run the remove script with the gathered state:
 
@@ -93,7 +83,7 @@ On success the script exits 0 and emits a single JSON object on stdout:
 
 If the script exits non-zero, surface stderr and stop. (The script refuses with operator guidance if the caller's cwd is inside any of the worktrees listed for removal — exit the worktree first.)
 
-### Step 6 — Report
+### Step 5 — Report
 
 Parse the JSON and produce a clean summary:
 

--- a/plugins/swarmkit/skills/merge-stack/SKILL.md
+++ b/plugins/swarmkit/skills/merge-stack/SKILL.md
@@ -9,8 +9,6 @@ Merges all open swarm PRs bottom-up — root PRs first, then their former childr
 
 Between merges, each still-open downstream branch is locally rebased onto the freshly-updated `$BASE` and force-pushed. Git's patch-id matching drops the predecessor commits (which are already on `$BASE` in squashed form under a different SHA), leaving only the downstream PR's own new commits. Without this rebase, the next PR would flip to `CONFLICTING` the moment its predecessor merges, because the old predecessor commits in its history collide with the new squash commit on `$BASE`.
 
-This matches the merge direction used by Graphite, git-spice, Sapling, and Phabricator: reviewers see and land the same diff, CI runs once per PR instead of re-running on every rebase, and conflicts surface at the leaf instead of cascading down into the root.
-
 ## When to use
 
 Run after `/swarm` finishes. All swarm agents have pushed branches and opened PRs; none have merged yet. You've reviewed the PRs and are ready to merge them.
@@ -188,6 +186,7 @@ Where `$BASE` is the base branch of the root PRs (typically `develop`).
 
 ### 7. Report
 
+
 Append a follow-up suggestion that points the user at `swarmkit:clean-worktrees`. If any `worktree-agent-*` worktrees still exist, recommend running it; otherwise note that the worktrees are already gone:
 
 ```bash
@@ -209,13 +208,3 @@ fi
 Next: /swarmkit:clean-worktrees   (remove worktrees + prune orphan local branches)
 ──────────────────────────────────────────────────────
 ```
-
-## Constraints
-
-- Always merge bottom-up (root PRs first, leaves last)
-- Always retarget every non-root PR in a multi-PR chain to `$BASE` before merging anything in that chain
-- After each non-leaf merge in a chain, always rebase every still-open downstream branch onto `$BASE` locally and force-push before merging the next one — `gh pr update-branch` cannot resolve the squash-history collision
-- Use `gh pr merge <N> --squash --delete-branch` for every PR — no per-role strategy matrix
-- Never merge into `main` directly — only into `$BASE` (e.g., `develop`)
-- Never skip a conflicted chain's dependents — block and report them
-- Independent PRs (targeting `$BASE` with nothing stacked on them) may merge in any order

--- a/plugins/swarmkit/skills/swarm-plus/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-plus/SKILL.md
@@ -144,8 +144,6 @@ The fix-round worker prompt MUST:
 - Forbid: branching off `develop`, force-pushing, rewriting prior commits, closing the issue manually.
 - Termination: report the new commit SHAs and confirm `gh pr view <pr_number> --json commits` includes them.
 
-> **Best-effort SendMessage optimization (currently inert).** If a future runtime version preserves builders past their final notification, an orchestrator could optimistically `SendMessage` the findings to `swarm-builder-<issue>` and skip the spawn. This is documented for forward reference only — under today's runtime the SendMessage call always fails ("No agent named X is currently addressable"), so the orchestrator MUST go straight to spawning a fresh worker. Do not waste a turn attempting SendMessage on builders.
-
 ### 5. Wait for all fix-round workers
 
 Continue until every spawned fix-round worker reports completion. Verify the PR's HEAD has advanced:
@@ -171,19 +169,6 @@ All PRs ready for human merge.
 
 Suggest next step: `/merge-pr` for one PR or `/merge-stack` for two or more.
 
-## Constraints
-
-- **Single pass** — no reviewer-after-fix re-review. The user can manually trigger another review with `/review <pr>` if desired.
-- **Builders are not addressable post-PR** — under today's runtime the harness terminates builders after their final notification. Never attempt SendMessage on a builder; always spawn a fresh worker for the fix round.
-- **Fix-round worker never re-branches off develop** — it branches off the existing PR head (`worktree-agent-<issue>`) so its commits stack onto the PR.
-- **`/swarmkit:swarm` default behavior is untouched** — swarm-plus constructs its own Agent calls following swarm's spawn pattern, with `name:` and the (forward-compat) STANDBY clause added. Plain `/swarmkit:swarm` invocations still terminate at step 6 of the swarm prompt.
-- **`--worker-model` controls the fix-round worker** — every non-clean reviewer verdict spawns a fresh worker, so this knob applies on the canonical fix-round path.
-- **Reviewer output stays inline, never posted as a PR comment** by the reviewer itself. The fix-round worker is the only sub-agent that may comment on the PR (and only with a brief "addressed feedback" summary).
-- **Never merge** any PR — final state is open PRs awaiting human merge.
-- **Never close issues** — `Closes #N` in PR bodies handles it on merge.
-- **Defer rather than guess** — if the reviewer's findings are ambiguous (e.g. "consider X"), the worker should explicitly defer in a PR comment rather than implement guesses.
-- All swarm constraints from `/swarmkit:swarm` apply transitively: worktree isolation, conventional commits, no Claude/co-author mentions, no absolute repo paths in agent prompts, never commit directly to develop or main.
-
 ## Failure modes
 
 | Symptom | Handling |
@@ -192,17 +177,3 @@ Suggest next step: `/merge-pr` for one PR or `/merge-stack` for two or more.
 | Reviewer crashes or returns no output | Note the missing review in the final summary; leave PR open without a fix pass |
 | Fix-round worker push rejected (branch advanced underneath) | Worker re-fetches and rebases (`git fetch origin <head>; git rebase origin/<head>`); if conflicts arise, abort and report to user |
 | Fix-round worker introduces new test failures | Worker MUST resolve before push — never push a red build |
-
-## Known issue: TeamDelete leaves zombie subprocesses
-
-`TeamDelete` returns success but does not signal or kill the long-running agent processes whose `--team-name` flag matches. This is a harness-level limitation and will be addressed upstream (see #924). Until the harness fix lands, operators should sweep lingering agent subprocesses manually after `TeamDelete`:
-
-```bash
-ps aux \
-  | grep -- "--team-name <team-name>" \
-  | grep -v grep \
-  | awk '{print $2}' \
-  | xargs -r kill
-```
-
-Replace `<team-name>` with the team name passed to `TeamDelete`. Run this sweep immediately after `TeamDelete` returns — the zombie processes consume no dispatch but do hold open file descriptors and tmux panes.

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -21,8 +21,6 @@ Parse `$ARGUMENTS` to determine the mode:
 - `--no-epic` → suppress feature-branch mode for this run; PRs target `$BASE` directly
 - `--epic <slug>` → explicit slug for the auto-cut epic branch (verbatim; `flowkit:cut-epic` enforces the `feature/` prefix)
 
-**Default behavior — feature-branch mode.** When the run will spawn ≥2 agents (any of: 2+ issue numbers, label filter, or loop mode), swarm cuts a `feature/<slug>-<N>` branch via `flowkit:cut-epic`, pins `claude.flowkit.prBase` to it, and routes every spawned PR to that branch. Single-issue one-shot runs are flat-to-`$BASE` (unchanged). Pass `--no-epic` to suppress the cut for a multi-issue run, or `--base <branch>` to override targeting entirely (which also suppresses the cut).
-
 ---
 
 ## Epic Mode Resolution
@@ -61,13 +59,7 @@ Skip the cut. `EPIC_BRANCH` is unset; PRs target `$BASE` directly. Behavior is i
 
 ## Setup
 
-**Resolve the skill base directory first.** This skill ships with extracted scripts under `scripts/`. When swarmkit is installed via the plugin marketplace, those scripts live in the plugin cache directory — they are **not** at `plugins/swarmkit/skills/swarm/scripts/` relative to the consumer repo's CWD. Before invoking any script, capture the runtime-resolved absolute path that the harness emits in this skill's header (the line `Base directory for this skill: <absolute path>`) into a shell variable:
-
-```bash
-export SKILL_DIR="<absolute path from the 'Base directory for this skill:' header line>"
-```
-
-Use `"$SKILL_DIR/scripts/..."` for every script invocation below. Do **not** hardcode `plugins/swarmkit/...` — that path only resolves in repos that vendor swarmkit directly.
+Capture the harness-emitted `Base directory for this skill:` path as `SKILL_DIR`; use `"$SKILL_DIR/scripts/..."` for every script invocation below.
 
 Run the preflight script once. It handles fetch, base-branch verification (creating it from `main` and pushing if missing), and `gh` auth check in a single call:
 
@@ -233,26 +225,18 @@ Each agent prompt MUST include:
 Each agent prompt MUST include these **workflow steps** (in order):
 
 ```
-1. Create and check out branch from the appropriate base. Use `origin/<base>` as the starting point so this works inside an isolated worktree — a plain `git checkout develop` would fail if `develop` is already checked out in the main repo.
-   # For independent issues (no deps in this batch):
-   git fetch origin develop
-   git checkout -B worktree-agent-<issue> origin/develop
+1. Create and check out branch from the appropriate base. Use `origin/<base>` as the starting point so this works inside an isolated worktree — a plain `git checkout develop` would fail if `develop` is already checked out in the main repo. `<base>` is `develop` for independent issues and `worktree-agent-<dependency-issue>` for dependent ones.
 
-   # For dependent issues (has a dependency in this batch):
-   git fetch origin worktree-agent-<dependency-issue>
-   git checkout -B worktree-agent-<issue> origin/worktree-agent-<dependency-issue>
+   git fetch origin <base>
+   git checkout -B worktree-agent-<issue> origin/<base>
 
    # Safety check — abort if not in an isolated worktree
    [[ "$PWD" != *"worktrees"* ]] && echo "ERROR: Not running in an isolated worktree. Aborting to prevent branch collision." && exit 1
 
-   # Ancestry sanity — abort if HEAD doesn't descend from the requested base.
-   # Defends against the post-rebase-merge worktree-base drift bug (#923): after a
-   # rebase-merge release, origin/main and origin/develop share identical trees but
-   # diverge in SHA history. EnterWorktree may silently root the worktree on main's
-   # SHA chain even though the checkout targeted develop, producing a 50+-file diff
-   # for an 11-file change. Fail fast here instead.
-   #
-   # Use the same <base> as the checkout above — one variant, not both:
+   # Ancestry sanity — abort if HEAD doesn't descend from origin/<base>. Defends
+   # against the post-rebase-merge worktree-base drift bug (#923): EnterWorktree
+   # may silently root the worktree on a stale SHA chain even when the checkout
+   # targeted the right branch.
    if ! git merge-base --is-ancestor origin/<base> HEAD; then
      echo "ERROR: HEAD is not a descendant of origin/<base>. Worktree may be rooted on a stale base." >&2
      echo "       Run: git fetch origin <base> && git reset --hard origin/<base>" >&2
@@ -265,27 +249,12 @@ Each agent prompt MUST include these **workflow steps** (in order):
    git add <files> && git commit -m "<type>(<scope>): <description>"
 4. Push the branch:
    git push -u origin worktree-agent-<issue>
-5. Create PR targeting the appropriate base. The body MUST be a richer summary, not just `Closes #<issue>` — synthesize the `## Summary` bullets from the issue's acceptance criteria and your diff, and describe the `## Test plan` in terms of those acceptance criteria. Fill in the angle-bracket placeholders; do not copy them literally.
+5. Create PR targeting the appropriate base — `develop` for independent issues, `worktree-agent-<dependency-issue>` for dependent ones. The body MUST be a richer summary, not just `Closes #<issue>` — synthesize the `## Summary` bullets from the issue's acceptance criteria and your diff, and describe the `## Test plan` in terms of those acceptance criteria. Fill in the angle-bracket placeholders; do not copy them literally.
 
    <!-- include: plugins/_shared/pr-body.md -->
    <!-- Summary-content rules derive from the canonical doc; `## Changes` is intentionally omitted for single-issue swarm PRs — Summary is sufficient when the scope is one issue. -->
 
-   # For independent issues:
-   gh pr create --base develop --head worktree-agent-<issue> \
-     --title "<type>(<scope>): <description>" \
-     --body "$(cat <<'EOF'
-   ## Summary
-   <1–3 bullets synthesizing what was changed, derived from the issue acceptance criteria and the diff>
-
-   ## Test plan
-   <how to verify the changes satisfy the acceptance criteria>
-
-   Closes #<issue>
-   EOF
-   )"
-
-   # For dependent issues:
-   gh pr create --base worktree-agent-<dependency-issue> --head worktree-agent-<issue> \
+   gh pr create --base <base> --head worktree-agent-<issue> \
      --title "<type>(<scope>): <description>" \
      --body "$(cat <<'EOF'
    ## Summary
@@ -439,20 +408,3 @@ When an issue fails at any point:
 **Unrecoverable failures** (exit loop immediately):
 - Agent produced no PR (crash, timeout, no push)
 - `$BASE` branch deleted or corrupted externally
-
----
-
-## Constraints
-
-- Never merge into `main` — all PRs ultimately merge into `$BASE`; stacked (dependent) PRs may target an intermediate dependency branch and cascade into `$BASE` via `swarmkit:merge-stack`
-- Never pause between loop cycles — proceed immediately after printing the checkpoint summary
-- Never skip a failed issue's dependents — always analyze and block them
-- Every agent must work in an isolated worktree
-- Every PR must reference the issue it closes (`Closes #N`)
-- Commit messages must follow `conventional-commit-message` sub-skill format
-- Never mention Claude or add co-author lines in commit messages
-- Agents spawn with `mode: "bypassPermissions"` so they can push and create PRs without prompting
-- Never commit directly to develop or main — always work on the `worktree-agent-<issue>` branch
-- **Never close issues** — issues are closed by the release process when the release merges to main
-- **Never pass absolute repo paths to spawned agents** — always instruct them to use relative paths from their CWD to ensure edits land in the isolated worktree, not the main directory
-- **Never merge a PR mid-swarm**, even when a downstream agent needs files produced by an upstream agent. Dependent agents branch from `origin/worktree-agent-<dependency>` and already have access to the upstream output. Merging to unblock a downstream agent bypasses the user's review gate and is never acceptable.


### PR DESCRIPTION
## Summary
- Baseline OpenSpec spec for swarmkit: 12 requirements, 65 scenarios across all 9 skills + the swarm-reviewer agent. REFERENCES.md cites every requirement back to source file:line.
- Tighten 5 SKILL.md files against the spec: 1388 → 1275 lines (−113). Drops constraints sections that restate spec, collapses 3× SKILL_DIR boilerplate, merges duplicate PR-body bash blocks, drops swarm-plus dead-code notes and TeamDelete operator block.

## Changes
- `openspec/specs/swarmkit/spec.md` — new behavioral spec.
- `openspec/specs/swarmkit/REFERENCES.md` — new citation file with 6 cross-cutting interpretive notes.
- `plugins/swarmkit/skills/swarm/SKILL.md` — 458 → 410 (−48).
- `plugins/swarmkit/skills/swarm-plus/SKILL.md` — 208 → 179 (−29).
- `plugins/swarmkit/skills/merge-stack/SKILL.md` — 221 → 210 (−11).
- `plugins/swarmkit/skills/clean-worktrees/SKILL.md` — 113 → 103 (−10).
- `plugins/swarmkit/skills/clean-remote-worktrees/SKILL.md` — 152 → 137 (−15).

## Test plan
- [x] \`bash scripts/openspec validate swarmkit --type spec --strict\` passes.
- [x] Citation audit ran via Explore agent against REFERENCES.md — "OK to trust" verdict (15 citations spot-checked, 0 real issues).
- [x] Coverage check — all 65 spec scenarios still map to directives in the tightened implementation.

Stacked on #975. Merge speckit first, then this.