### PR TITLE
feat(flowkit): baseline specs + tighten 14 SKILL.md files

### DIFF
--- a/openspec/specs/flowkit/REFERENCES.md
+++ b/openspec/specs/flowkit/REFERENCES.md
@@ -1,0 +1,572 @@
+# flowkit — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `plugins/flowkit/` unless otherwise noted.
+Line numbers verified on 2026-05-23.
+
+---
+
+## Requirement: Base Branch Resolution
+
+**Sources**
+- `../_shared/base-resolution.md:5-12` — the four-step canonical algorithm.
+- `skills/open-pr/SKILL.md:49-85` — bash implementation of the chain including the self-targeting guard.
+
+### Scenario: Explicit --base flag wins
+**Source:** `skills/open-pr/SKILL.md:51-54` — grep for `--base[= ]` token in `$ARGUMENTS`; assignment of `BASE`.
+**Interpolated; no direct test.**
+
+### Scenario: Config key consulted after explicit arg
+**Source:** `skills/open-pr/SKILL.md:57-59` — `BASE=$(git config claude.flowkit.prBase 2>/dev/null)`.
+**Interpolated; no direct test.**
+
+### Scenario: develop preferred when on origin
+**Source:** `skills/open-pr/SKILL.md:62-66` — `git ls-remote --heads origin develop | grep -q 'refs/heads/develop'` then `BASE="develop"`.
+**Interpolated; no direct test.**
+
+### Scenario: Repo default fallback with warning
+**Source:** `skills/open-pr/SKILL.md:69-73` — `gh repo view ... defaultBranchRef` resolution plus the `warning: no base branch configured...` stderr emission.
+**Interpolated; no direct test.**
+
+### Scenario: Self-targeting guard rejects pin pointing at current branch
+**Source:** `skills/open-pr/SKILL.md:76-84` — `if [ "$BASE" = "$HEAD_BRANCH" ]; then ... exit 1; fi` with multi-line operator guidance.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Default Branch Prompt
+
+**Sources**
+- `skills/default-branch-prompt/SKILL.md:1-101` — full sub-skill including marker check, gh probe, three-option prompt, double-confirm path.
+- `skills/open-pr/SKILL.md:23-31` — call-site explaining the no-op cases and that open-pr is fire-and-forget over the result.
+
+### Scenario: Marker skips the prompt
+**Source:** `skills/default-branch-prompt/SKILL.md:13-18` — `if [ "$(git config --get claude.flowkit.defaultBranchPrompted ...)" = "true" ]; then exit 0; fi`.
+**Interpolated; no direct test.**
+
+### Scenario: Non-main default skips the prompt
+**Source:** `skills/default-branch-prompt/SKILL.md:22-42` — `gh repo view --json defaultBranchRef` then `if [ "$DEFAULT_BRANCH" != "main" ]; then exit 0; fi`. Comment on line 28 covers `gh` failure paths.
+**Interpolated; no direct test.**
+
+### Scenario: Switch requires double confirmation
+**Source:** `skills/default-branch-prompt/SKILL.md:60-69` — second AskUserQuestion wording and options.
+**Interpolated; no direct test.**
+
+### Scenario: Successful switch sets the marker
+**Source:** `skills/default-branch-prompt/SKILL.md:71-77` — `gh repo edit --default-branch develop` followed by setting the marker on success.
+**Interpolated; no direct test.**
+
+### Scenario: Cancelled switch keeps marker unset
+**Source:** `skills/default-branch-prompt/SKILL.md:79` — "On `Cancel`: marker stays unset; the three-option prompt resurfaces next time."
+**Interpolated; no direct test.**
+
+### Scenario: Keep or skip sets the marker without mutation
+**Source:** `skills/default-branch-prompt/SKILL.md:81-95` — both `Keep main as default` and `Don't ask again` branches set `git config claude.flowkit.defaultBranchPrompted true` and do not mutate the repo.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Branch Creation
+
+**Sources**
+- `skills/create-branch/SKILL.md:1-65` — full skill: fetch, name derivation, validation, checkout from `origin/develop`.
+
+### Scenario: Inferred name from description
+**Source:** `skills/create-branch/SKILL.md:32-36` — type-prefix selection, kebab-case conversion, 50-char cap with examples.
+**Interpolated; no direct test.**
+
+### Scenario: Explicit branch name used as-is
+**Source:** `skills/create-branch/SKILL.md:31` — "If it looks like a branch name (kebab-case, already has a prefix), use it directly."
+**Interpolated; no direct test.**
+
+### Scenario: Reserved names rejected
+**Source:** `skills/create-branch/SKILL.md:42-47` — list of rejected names and the stop-and-ask directive.
+**Interpolated; no direct test.**
+
+### Scenario: Branch always cut from origin
+**Source:** `skills/create-branch/SKILL.md:51-53` — `git checkout -b <name> origin/develop`. Also constraint at line 63: "Always branch from `origin/develop`, never from a local `develop`".
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Conventional Commit Format
+
+**Sources**
+- `skills/commit/SKILL.md:1-116` — full commit skill including type enum, subject-length rule, body guidance, HEREDOC requirement.
+
+### Scenario: Subject under 72 characters
+**Source:** `skills/commit/SKILL.md:39-41` — "Keep the subject line (first line) under 72 characters."
+**Interpolated; no direct test.**
+
+### Scenario: Logical groupings split into multiple commits
+**Source:** `skills/commit/SKILL.md:62-64` — "Group files by concern — each group should represent a single logical change ... If multiple concerns are present, plan one commit per concern."
+**Interpolated; no direct test.**
+
+### Scenario: Nothing to commit reported cleanly
+**Source:** `skills/commit/SKILL.md:115` — "If `git status` is clean, report 'Nothing to commit' and stop".
+**Interpolated; no direct test.**
+
+### Scenario: HEREDOC syntax used for multi-line messages
+**Source:** `skills/commit/SKILL.md:86-95` — full HEREDOC commit template. Also constraint at line 112.
+**Interpolated; no direct test.**
+
+### Scenario: Amend never used
+**Source:** `skills/commit/SKILL.md:114` — "Never amend an existing commit — always create new ones".
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: PR Body Standard
+
+**Sources**
+- `../_shared/pr-body.md` — canonical body shape (Summary / Changes / Test plan) plus issue-reference footer grammar.
+- `skills/open-pr/SKILL.md:112-127` — body assembly with the canonical three sections.
+- `skills/open-pr/SKILL.md:144-160` — lint that rejects broken multi-ref footers.
+- `skills/open-pr/SKILL.md:100-110` — issue-ref token discovery from commits with case-insensitive match and verbatim emission.
+
+### Scenario: Three sections in order
+**Source:** `skills/open-pr/SKILL.md:115-119` — explicit list of `## Summary`, `## Changes`, `## Test plan`, then footer.
+**Interpolated; no direct test.**
+
+### Scenario: Closing-keyword tokens one per line
+**Source:** `../_shared/pr-body.md` (Issue-reference footer section) — "Always emit one token per line (`Closes #A` / `Closes #B`)."
+**Interpolated; no direct test.**
+
+### Scenario: Broken multi-ref footer rejected
+**Source:** `skills/open-pr/SKILL.md:148-158` — grep for space-separated multi-ref form; `exit 1` with rewrite guidance. "Fail loudly rather than auto-rewriting".
+**Interpolated; no direct test.**
+
+### Scenario: Verbatim forwarding of author-committed keywords
+**Source:** `skills/open-pr/SKILL.md:100-110` — "case-insensitively ... but emit each match verbatim (preserving the author's original casing)". Also override rule at line 127.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Open PR
+
+**Sources**
+- `skills/open-pr/SKILL.md:1-185` — full skill.
+
+### Scenario: Protected branch blocked
+**Source:** `skills/open-pr/SKILL.md:33-41` — "If the current branch is `develop`, `main`, or `master`, stop immediately". Also constraint at line 182.
+**Interpolated; no direct test.**
+
+### Scenario: Default-branch prompt fires before any other preflight
+**Source:** `skills/open-pr/SKILL.md:23-31` — "Before any other preflight, invoke the default-branch-prompt sub-skill."
+**Interpolated; no direct test.**
+
+### Scenario: Branch pushed with -u, not force-pushed
+**Source:** `skills/open-pr/SKILL.md:87-91` — `git push -u origin HEAD`. Also constraint at line 184.
+**Interpolated; no direct test.**
+
+### Scenario: Closing-keyword on non-default-branch base warned
+**Source:** `skills/open-pr/SKILL.md:129-140` — step 7 grep + `gh repo view defaultBranchRef` comparison; `note: 'Closes #N' won't fire ...` to stderr. "This is informational only — do not abort or rewrite the body."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: PR Lifecycle Orchestrator
+
+**Sources**
+- `skills/pr/SKILL.md:1-54` — full chain orchestrator.
+
+### Scenario: Branch creation skipped on feature branch
+**Source:** `skills/pr/SKILL.md:22-32` — branch-detection `git rev-parse --abbrev-ref HEAD`, then "If the current branch is already a non-protected branch ... skip step 2".
+**Interpolated; no direct test.**
+
+### Scenario: Commit skipped on clean workspace
+**Source:** `skills/pr/SKILL.md:34-38` — "If the workspace is already clean (nothing to commit), skip this step."
+**Interpolated; no direct test.**
+
+### Scenario: Failure aborts the chain
+**Source:** `skills/pr/SKILL.md:52` — "If any step fails, stop and report the error — do not continue to the next step".
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: PR Merge
+
+**Sources**
+- `skills/merge-pr/SKILL.md:1-63` — skill prose.
+- `skills/merge-pr/SKILL.md:46-56` — Script contract describing worktree cleanup, stacked-PR retargeting, `with-clean-workspace` wrapper.
+
+### Scenario: Rebase-merge only
+**Source:** `skills/merge-pr/SKILL.md:46-48` — "with-clean-workspace–wrapped `gh pr merge --rebase --delete-branch`". Also constraint at line 61: "Always rebase-merge (never squash or merge commit)".
+**Interpolated; no direct test.**
+
+### Scenario: Stacked children retargeted before merge
+**Source:** `skills/merge-pr/SKILL.md:14` — "Open PRs that use this PR's head as their base are retargeted first so GitHub does not auto-close them when the head branch is deleted." Script contract line 46-48 confirms.
+**Interpolated; no direct test.**
+
+### Scenario: Main worktree holding head auto-checks out base
+**Source:** `skills/merge-pr/SKILL.md:48` — "When the branch is held by the main worktree (the canonical state after `push-or-pr`) the script instead runs `git checkout <base>` in the main worktree".
+**Interpolated; no direct test.**
+
+### Scenario: Caller-owned worktree refuses removal
+**Source:** `skills/merge-pr/SKILL.md:48` — "unless the caller's cwd is inside that worktree, in which case the script refuses with operator guidance to exit the worktree first".
+**Interpolated; no direct test.**
+
+### Scenario: Implicit post-merge pull wrapped against dirty workspace
+**Source:** `skills/merge-pr/SKILL.md:46-48` — "`with-clean-workspace`–wrapped `gh pr merge`". Underlying mechanism in `skills/with-clean-workspace/SKILL.md`.
+**Interpolated; no direct test.**
+
+### Scenario: Issues never closed by merge-pr
+**Source:** `README.md:226-228` — "Issue Lifecycle: `/merge-pr` never closes issues — that's intentional. Issues are closed by `/release` when work actually ships to `main`."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Restack Descendants
+
+**Sources**
+- `skills/restack/SKILL.md:1-66` — full skill including script contract and result schema.
+
+### Scenario: Auto-resolve parent from current branch
+**Source:** `skills/restack/SKILL.md:21-22` — "Empty — auto-resolve the PR for the current branch (`gh pr list --head $BRANCH`); equivalent to passing the resolved PR as `--pr`".
+**Interpolated; no direct test.**
+
+### Scenario: Subtree walked breadth-first
+**Source:** `skills/restack/SKILL.md:55` — "`scripts/restack.sh` implements ... BFS descendant discovery". Sibling-continuation behavior implied by `skipped` array shape at line 63.
+**Interpolated; no direct test.**
+
+### Scenario: Rebase conflict on one branch does not stop siblings
+**Source:** `skills/restack/SKILL.md:62-63` — `failed` array with `reason: "rebase-conflict"` plus `skipped` array with `reason: "ancestor-failed"` indicates sibling continuation.
+**Interpolated; no direct test.**
+
+### Scenario: Force-push uses lease
+**Source:** `skills/restack/SKILL.md:55` — "a `git rebase` + `git push --force-with-lease` loop".
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Shared-Branch Publishing
+
+**Sources**
+- `skills/push-or-pr/SKILL.md:1-68` — full sub-skill including args, output JSON schema, constraints.
+
+### Scenario: No-op on clean upstream
+**Source:** `skills/push-or-pr/SKILL.md:38-39` — "If there are no pending commits (`noop`), PR args are unused." Also output table at line 44-50: `push_result: "noop"`.
+**Interpolated; no direct test.**
+
+### Scenario: Pending commits trigger feature-branch detour
+**Source:** `skills/push-or-pr/SKILL.md:7-10` — "saves your commits on a dated feature branch, resets your local copy of that branch to match `origin/<branch>`, pushes the feature branch, and opens a PR". Also `--prefix` description at line 33: "appends `-YYYY-MM-DD` and a numeric suffix on collision".
+**Interpolated; no direct test.**
+
+### Scenario: Original branch reset to upstream
+**Source:** `skills/push-or-pr/SKILL.md:64-65` — "Never force-push. The script resets the local copy of the branch you were on to its upstream before creating the feature branch."
+**Interpolated; no direct test.**
+
+### Scenario: Missing required PR args rejected
+**Source:** `skills/push-or-pr/SKILL.md:38` — "If there are pending commits and any of `--prefix` / `--title` / `--body` is missing, the script exits non-zero with exit code 2."
+Verified by `assert_invalid_args` cases in `skills/push-or-pr/scripts/test.sh`.
+
+### Scenario: Tags never pushed
+**Source:** `skills/push-or-pr/SKILL.md:66` — "The script does not push tags. Tag creation belongs to the caller".
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Develop Sync
+
+**Sources**
+- `skills/sync/SKILL.md:1-50` — full skill.
+
+### Scenario: develop checked out and pulled first
+**Source:** `skills/sync/SKILL.md:22-29` — "Check out develop and pull the latest from origin (never leave develop stale before the prune/cleanup steps below)".
+**Interpolated; no direct test.**
+
+### Scenario: Stale remote refs pruned
+**Source:** `skills/sync/SKILL.md:31-35` — `git fetch --prune`.
+**Interpolated; no direct test.**
+
+### Scenario: Merged local branches deleted
+**Source:** `skills/sync/SKILL.md:37-43` — `git branch --merged develop | grep -vE '^\*|develop|main' | xargs -r git branch -d` — excludes `develop`, `main`, and the current branch.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Workspace Stash Guard
+
+**Sources**
+- `skills/with-clean-workspace/SKILL.md:1-34` — full sub-skill including the Contract section.
+
+### Scenario: Missing -- separator returns usage error
+**Source:** `skills/with-clean-workspace/SKILL.md:29` — "Interface: `-- <command ...>`; missing `--` or command exits `2` with stderr usage text."
+Verified by `assert_invalid_args` cases in `skills/with-clean-workspace/scripts/test.sh:41-60`.
+
+### Scenario: Tracked + untracked changes stashed
+**Source:** `skills/with-clean-workspace/SKILL.md:30` — "stashes tracked + untracked changes (`git stash push -u -m 'flowkit-auto-stash'`)".
+Verified by `test_dirty_success_pops_stash` in `skills/with-clean-workspace/scripts/test.sh`.
+
+### Scenario: Stash restored on success
+**Source:** `skills/with-clean-workspace/SKILL.md:31` — "Success path: restores stash (`git stash pop`)".
+Verified by `test_dirty_success_pops_stash` in `skills/with-clean-workspace/scripts/test.sh`.
+
+### Scenario: Stash kept on pop conflict
+**Source:** `skills/with-clean-workspace/SKILL.md:32` — "Pop conflict path: warns to stderr and leaves stash on stack."
+Verified by `test_pop_conflict_preserves_stash` in `skills/with-clean-workspace/scripts/test.sh`.
+
+### Scenario: Wrapped command exit code preserved on failure
+**Source:** `skills/with-clean-workspace/SKILL.md:33` — "Failure path: keeps stash, warns to stderr, exits with wrapped command's non-zero exit code."
+Verified by `test_dirty_failure_preserves_stash` in `skills/with-clean-workspace/scripts/test.sh`.
+
+---
+
+## Requirement: Epic Branch Creation
+
+**Sources**
+- `skills/cut-epic/SKILL.md:1-146` — full skill: slug resolution, validation, idempotent branch create, push, pin.
+
+### Scenario: Slug inferred from issue title
+**Source:** `skills/cut-epic/SKILL.md:35-41` — `gh issue view "$ISSUE" --json title --jq .title` then kebab-case conversion with `cut -c1-40`.
+**Interpolated; no direct test.**
+
+### Scenario: Explicit slug used verbatim
+**Source:** `skills/cut-epic/SKILL.md:42` — "If `$ARGUMENTS` contains both a number and a kebab-case word, use them as `<issue>` and `<slug>` regardless of order."
+**Interpolated; no direct test.**
+
+### Scenario: Branch name capped at 60 characters
+**Source:** `skills/cut-epic/SKILL.md:62` — "The full branch name must be 60 characters or fewer. If the slug pushes it over, truncate the slug, not the issue number."
+**Interpolated; no direct test.**
+
+### Scenario: Reserved names rejected
+**Source:** `skills/cut-epic/SKILL.md:58-60` — rejection list including `main`, `master`, `develop`, and non-`feature/` prefix.
+**Interpolated; no direct test.**
+
+### Scenario: Branch reused if it exists
+**Source:** `skills/cut-epic/SKILL.md:72-82` — three-way `if/elif/else` chain handling local-exists, remote-exists, and create-from-develop cases. Constraint at line 144: "Idempotent: re-running with the same arguments must not error".
+**Interpolated; no direct test.**
+
+### Scenario: Pin written to claude.flowkit.prBase
+**Source:** `skills/cut-epic/SKILL.md:96-98` — `git config claude.flowkit.prBase "$BRANCH"`.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Epic Promotion
+
+**Sources**
+- `skills/ship-epic/SKILL.md:1-82` — full skill including script delegation, output schema, constraints, composition table.
+
+### Scenario: Empty pin and missing --epic stops the skill
+**Source:** `skills/ship-epic/SKILL.md:21-26` — "Empty — resolved from `git config --get claude.flowkit.prBase`. If unset or equal to `develop`, the skill stops" with the "No epic in flight" message.
+**Interpolated; no direct test.**
+
+### Scenario: Override --epic must start with feature/
+**Source:** `skills/ship-epic/SKILL.md:20-22` — `--epic <branch>` "Must start with `feature/` and must not equal `develop`, `main`, or `master`".
+Argument validation verified by `assert_invalid_args` cases in `skills/ship-epic/scripts/test.sh`.
+
+### Scenario: Rebase-merge to develop
+**Source:** `skills/ship-epic/SKILL.md:69-70` — "Always rebase-merge to `develop`, never squash-merge, never merge-commit. This preserves per-feature first-parent linearity."
+**Interpolated; no direct test.**
+
+### Scenario: Closing tokens aggregated from squashes and child PRs
+**Source:** `skills/ship-epic/SKILL.md:64` — "Closing-keyword lines aggregated from child squash commits, merged child PR bodies (in case `gh pr merge --squash` dropped the token from the commit message), and the epic issue ref. De-duped case-insensitively."
+**Interpolated; no direct test.**
+
+### Scenario: prBase unset and epic branch deleted on success
+**Source:** `skills/ship-epic/SKILL.md:43-47` — "`claude.flowkit.prBase` cleared. Local develop fast-forwarded." Plus output table `pr_base_unset` at line 65 and "delete the epic branch" at line 41.
+**Interpolated; no direct test.**
+
+### Scenario: Develop fast-forward skipped on different worktree
+**Source:** `skills/ship-epic/SKILL.md:51-53` — "If `result.develop_advanced` is `false`, note: Local develop was not fast-forwarded (operator is on a different worktree). Run `/sync` to pull develop."
+**Interpolated; no direct test.**
+
+### Scenario: Conflict leaves state intact for retry
+**Source:** `skills/ship-epic/SKILL.md:73` — "On rebase-merge conflict: exits 1 with a recovery hint; `claude.flowkit.prBase` and the epic branch are left intact so the operator can rebase and re-invoke."
+**Interpolated; no direct test.**
+
+### Scenario: Stacked-PR merge commits stop promotion
+**Source:** `skills/ship-epic/SKILL.md:71-72` — "If the epic has no commits ahead of `develop`, or contains raw `worktree-agent-*` merge commits (meaning `swarmkit:merge-stack` was not run), the skill stops with a recovery hint."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Release Candidate Cut
+
+**Sources**
+- `skills/cut/SKILL.md:1-82` — full skill including the N-from-tags computation, refspec collision discussion, brace-the-variable rule.
+
+### Scenario: N derived from existing tags, not branches
+**Source:** `skills/cut/SKILL.md:37-43` — `LAST_N=$(git tag --list "rc/$TODAY.*" | grep -oE '\.[0-9]+$' | tr -d '.' | sort -n | tail -1)`. Comment: "tags persist after branch deletion; using max rather than count handles gaps".
+**Interpolated; no direct test.**
+
+### Scenario: Always cut from origin/develop
+**Source:** `skills/cut/SKILL.md:46-48` — `git checkout -b "$RC_BRANCH" origin/develop`. Constraint at line 79: "Always cut from `origin/develop`, never from a local branch".
+**Interpolated; no direct test.**
+
+### Scenario: Tag pushed immediately
+**Source:** `skills/cut/SKILL.md:48-54` — branch push, tag, tag push; comment line 54: "The tag is pushed immediately so future cuts count it correctly even after the branch is deleted."
+**Interpolated; no direct test.**
+
+### Scenario: Qualified refspec required by tag/branch ambiguity
+**Source:** `skills/cut/SKILL.md:56-70` — full discussion of `src refspec matches more than one`, the `git push --force-with-lease origin "refs/heads/${RC_BRANCH}:refs/heads/${RC_BRANCH}"` fix, and the zsh `:r` modifier gotcha requiring `${VAR}` bracing.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Release to Main
+
+**Sources**
+- `skills/release/SKILL.md:1-465` — full skill: rebase, ref aggregation, divergence check, PR body assembly, merge, tag, close loop, cleanup.
+
+### Scenario: No RC branch aborts cleanly
+**Source:** `skills/release/SKILL.md:36-39` — `if [ -z "$SOURCE" ]; then echo "release: no rc/* branch ... Run /cut first." >&2; exit 1; fi`. Constraint at line 465.
+**Interpolated; no direct test.**
+
+### Scenario: Unconditional rebase onto main
+**Source:** `skills/release/SKILL.md:42-52` — full discussion of why this is unconditional (committer-date rewrites from `gh pr merge --rebase`) plus the rebase + force-push.
+**Interpolated; no direct test.**
+
+### Scenario: Ancestry assertion after rebase
+**Source:** `skills/release/SKILL.md:56-62` — `if ! git merge-base --is-ancestor origin/main "origin/$SOURCE"; then ... exit 1`. "if it fires, something unexpected happened during the rebase".
+**Interpolated; no direct test.**
+
+### Scenario: Pre-merge divergence check before opening PR
+**Source:** `skills/release/SKILL.md:316-338` — full `git rev-list --left-right --cherry-pick --count` block with remediation message and the "skill does not auto-rebase on the operator's behalf" explanation.
+**Interpolated; no direct test.**
+
+### Scenario: Issue refs aggregated since last tag
+**Source:** `skills/release/SKILL.md:64-81` — `LAST_TAG` discovery, `TAG_DATE` via python3 ISO conversion, `gh pr list --base develop --state merged --json body,mergedAt` filtered by tag date, grep for closing-keyword footers.
+**Interpolated; no direct test.**
+
+### Scenario: Already-closed issues dropped from refs
+**Source:** `skills/release/SKILL.md:83-97` — full filter loop with `gh issue view ... --jq '.state'` check and the "Skipped already-closed issue" stderr message.
+**Interpolated; no direct test.**
+
+### Scenario: Legacy checklist epics auto-closed when children resolved
+**Source:** `skills/release/SKILL.md:100-119` — legacy path: `gh issue list --label "epic"` filtered for `- [ ] #N` bodies, then `OPEN_CHILDREN=$(... grep -oE '- \[ \] #[0-9]+')` and conditional `Closes #$EPIC_N` append.
+**Interpolated; no direct test.**
+
+### Scenario: Native sub-issue epics auto-closed when all children resolved
+**Source:** `skills/release/SKILL.md:121-165` — sub-issue path: `gh api "repos/$REPO/issues/$EPIC_N/sub_issues"` with `ALL_RESOLVED` check covering both already-closed and in-refs children.
+**Interpolated; no direct test.**
+
+### Scenario: Sub-issues fetch failure surfaces non-fatally
+**Source:** `skills/release/SKILL.md:135-140` — `if [ $? -ne 0 ]; then echo "$EPIC_N" >> "$SKIPPED_EPICS_FILE" ... continue; fi`. Report covers it at line 458.
+**Interpolated; no direct test.**
+
+### Scenario: Release notes grouped by scope
+**Source:** `skills/release/SKILL.md:183-198` — `.flowkit/scopes.txt` preferred when present, else auto-detect; full bash logic for both paths.
+**Interpolated; no direct test.**
+
+### Scenario: Auto-scope normalization
+**Source:** `skills/release/SKILL.md:192-197` — `sed -E 's/^[a-z]+\(([^):/]+).*/\1/'` strips `:sub-scope` portion from `type(scope:sub-scope):` tokens; `sort -u` dedupes.
+**Interpolated; no direct test.**
+
+### Scenario: Rebase-merge with delete-branch
+**Source:** `skills/release/SKILL.md:344-348` — `gh pr merge "$PR_URL" --rebase --delete-branch`. Constraint at line 464: "Always pass `--rebase --delete-branch` ... Never use `--merge` or `--squash`".
+**Interpolated; no direct test.**
+
+### Scenario: Merge wrapped against dirty workspace
+**Source:** `skills/release/SKILL.md:342-348` — full discussion of why and the `with-clean-workspace` invocation.
+**Interpolated; no direct test.**
+
+### Scenario: Calver tag with collision counter
+**Source:** `skills/release/SKILL.md:356-373` — `TAG="v$(date +%Y.%-m.%-d)"` then while-loop incrementing `.N` suffix until free.
+**Interpolated; no direct test.**
+
+### Scenario: Per-plugin tags pushed at release
+**Source:** `skills/release/SKILL.md:376-397` — full block fetching `*--v*` tags, comparing against origin, pushing missing ones, and the idempotency note.
+**Interpolated; no direct test.**
+
+### Scenario: Explicit issue close loop runs regardless of default branch
+**Source:** `skills/release/SKILL.md:399-426` — full explanation of why the loop is needed (auto-close only fires on default branch), the idempotent `gh issue close --reason completed`, and the `$EXPLICITLY_CLOSED` reporting variable.
+**Interpolated; no direct test.**
+
+### Scenario: RC branch cleanup is the safety net, not the primary cleanup
+**Source:** `skills/release/SKILL.md:428-448` — "The primary RC remote-branch cleanup happens in step 6 via `gh pr merge --delete-branch` ... This step is a safety net for RC branches that were ever created but never PR'd".
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Ship Closer
+
+**Sources**
+- `skills/ship/SKILL.md:1-89` — full skill: preflight, cut invocation, release invocation, final report.
+
+### Scenario: Open swarm PRs abort ship
+**Source:** `skills/ship/SKILL.md:24-42` — full preflight bash: query open PRs against `$BASE`, jq-filter for `worktree-agent-` prefix, exit non-zero with the directive message.
+**Interpolated; no direct test.**
+
+### Scenario: Resolved base equals prBase pin
+**Source:** `skills/ship/SKILL.md:27` — `BASE=$(git config --get claude.flowkit.prBase 2>/dev/null || echo "develop")`. Discussion at line 47: "If `claude.flowkit.prBase` is set to a `feature/*` branch, that branch is the resolved base".
+**Interpolated; no direct test.**
+
+### Scenario: jq-filtered head match
+**Source:** `skills/ship/SKILL.md:43-44` — "`gh pr list --head` is exact-match only — it does not support glob patterns ... Filtering the full open-PR set through `jq`'s `startswith` matches the intended prefix semantics."
+**Interpolated; no direct test.**
+
+### Scenario: Cut failure aborts before release
+**Source:** `skills/ship/SKILL.md:59-60` — "If cut fails (e.g., empty diff against main), stop and report." Also constraint at line 89: "Stop on any sub-skill failure".
+**Interpolated; no direct test.**
+
+### Scenario: No internal verify gate
+**Source:** `skills/ship/SKILL.md:88` — "No internal verify gate. Ship assumes the operator has already verified the integrated state against the project's tests between merge-stack and ship-epic (or between ship-epic and ship). Ship just packages what is already on develop".
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: PR-Base Scope Set/Unset
+
+**Sources**
+- `skills/pr-base-scope/SKILL.md:1-43` — full sub-skill.
+
+### Scenario: Set writes the scoped key
+**Source:** `skills/pr-base-scope/SKILL.md:14-18` — `git config claude.flowkit.prBase <branch>`.
+**Interpolated; no direct test.**
+
+### Scenario: Unset clears the scoped key
+**Source:** `skills/pr-base-scope/SKILL.md:28-32` — `git config --unset claude.flowkit.prBase`.
+**Interpolated; no direct test.**
+
+### Scenario: Legacy key never written
+**Source:** `skills/pr-base-scope/SKILL.md:42` — "Never write to the legacy `claude.prBase` key. All set/unset operations target `claude.flowkit.prBase` only".
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Pipeline Status
+
+**Sources**
+- `skills/pipeline-status/SKILL.md:1-128` — full skill: fetch, collect, format, suggest, constraints.
+
+### Scenario: Read-only behavior
+**Source:** `skills/pipeline-status/SKILL.md:124` — constraint: "Read-only — never mutate any branch, tag, PR, or label".
+**Interpolated; no direct test.**
+
+### Scenario: Fetch precedes any read
+**Source:** `skills/pipeline-status/SKILL.md:25-29` — step 1 `git fetch origin`. Constraint at line 125: "Always run `git fetch origin` first so data is current".
+**Interpolated; no direct test.**
+
+### Scenario: All four stages always printed
+**Source:** `skills/pipeline-status/SKILL.md:53` — "Always print every stage, even if empty — the empty state is itself information. Use 'none' for empty sections." Constraint at line 126.
+**Interpolated; no direct test.**
+
+### Scenario: Next step priority order
+**Source:** `skills/pipeline-status/SKILL.md:109-118` — priority table mapping conditions to suggestions in first-match-wins order.
+**Interpolated; no direct test.**
+
+### Scenario: Draft PRs never trigger a review suggestion
+**Source:** `skills/pipeline-status/SKILL.md:120` — "Draft PRs never block the suggestion — they're flagged in the display but skipped in the 'needs review' rule."
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+1. **Test coverage is uneven across skills.** `with-clean-workspace/scripts/test.sh` covers all four documented behaviors (invalid usage, dirty-success pop, dirty-failure preserve, pop-conflict preserve) via throwaway git repos. `push-or-pr`, `ship-epic`, `merge-pr`, and `restack` ship argument-validation smoke tests only (`assert_invalid_args`) — their happy paths require live remotes and `gh` auth and are not exercised by the suites. The remaining 14 skills have no automated tests; all their scenarios are interpolated from prose.
+
+2. **Release-cycle ref aggregation relies on PR-body grep, not just commit-message grep.** Step 4 of release scans `gh pr list --json body` rather than `git log` because squash-merges can drop closing-keyword tokens from the commit message footer (line 64-81 of release/SKILL.md). Tests of this behavior would need to exercise the squash/non-squash distinction.
+
+3. **The bubble-free invariant is the load-bearing design constraint.** Multiple skills enforce slices of it (`/merge-pr` rebase-merges to develop, `/ship-epic` rebase-merges epic to develop, `/release` rebase-merges RC to main; all use `--delete-branch`). If any one drifts to squash or merge-commit, `main`'s first-parent line stops being linear and per-feature commits collapse or sprout merge bubbles.
+
+4. **`claude.flowkit.prBase` has three writers and one reader.** Writers: `cut-epic` (set to feature branch), `pr-base-scope` Set (set arbitrary), `swarmkit:swarm` loop mode preflight (set to base) — all via direct `git config` rather than going through `pr-base-scope`. Unsetters: `ship-epic` (on success), `pr-base-scope` Unset, `swarmkit:swarm` teardown (non-epic mode). Reader: `open-pr`'s base-resolution chain. This is the single piece of cross-skill shared state in flowkit.
+
+5. **The default-branch nudge is silent in steady state.** Once `claude.flowkit.defaultBranchPrompted` is `true`, the sub-skill always exits in step 1 without printing anything. The skill is intentionally designed to be loud once and silent forever after.
+
+6. **Reusing `cut-epic` with the same arguments is the supported resume path.** Idempotency is built in: if the branch exists locally or on origin, it is checked out and the pin is refreshed (lines 72-82, 144). Operators who get interrupted mid-epic can re-run `cut-epic` and continue.
+
+7. **`gh pr list --head` is exact-match only.** This is a GitHub CLI behavior, not a flowkit choice — but ship/SKILL.md (line 43) documents it because the prior code used `--head 'worktree-agent-*'` and silently returned empty. Anywhere else in flowkit (and downstream skills) that needs prefix matching against PR head branches must do it via `gh pr list --json headRefName` + `jq startswith`.
+
+8. **release-step-3's rebase target is the short-lived RC, never main.** This is called out at line 46 of release/SKILL.md to defuse the obvious worry about force-pushing during a release. The RC branch is deleted minutes later by `gh pr merge --delete-branch` in step 6, so even the worst-case race is bounded.

--- a/openspec/specs/flowkit/spec.md
+++ b/openspec/specs/flowkit/spec.md
@@ -1,0 +1,472 @@
+# flowkit
+
+## Purpose
+
+Manage the full git lifecycle from branch creation to production release on a `develop` → `main` workflow. Handle branch creation, conventional-format commits, PR creation/merge/restack, long-lived epic branches, release-candidate cut and release, and release-pipeline visibility — composing into a bubble-free release shape where `main`'s first-parent line is linear and per-feature commits stay visible.
+
+## Requirements
+
+### Requirement: Base Branch Resolution
+Every skill that opens a PR SHALL resolve the base branch via a deterministic four-step chain: explicit `--base` arg → `claude.flowkit.prBase` config key → `develop` if present on origin → repo default branch with a stderr warning. The resolved base SHALL be non-empty and SHALL NOT equal the current HEAD.
+
+#### Scenario: Explicit --base flag wins
+- **WHEN** `$ARGUMENTS` contains a `--base <branch>` token
+- **THEN** that branch is used and later resolution steps are skipped
+
+#### Scenario: Config key consulted after explicit arg
+- **WHEN** no `--base` arg is provided and `claude.flowkit.prBase` is set
+- **THEN** the config value is used
+
+#### Scenario: develop preferred when on origin
+- **WHEN** no `--base` arg and no config key, and `origin/develop` exists
+- **THEN** `develop` is used
+
+#### Scenario: Repo default fallback with warning
+- **WHEN** no `--base` arg, no config key, and `develop` is not on origin
+- **THEN** the GitHub default branch is used and a one-line stderr warning is emitted
+
+#### Scenario: Self-targeting guard rejects pin pointing at current branch
+- **WHEN** the resolved base equals the current HEAD branch
+- **THEN** the skill exits non-zero with operator guidance to override with `--base` or unset the pin
+
+### Requirement: Default Branch Prompt
+The first time `/open-pr` runs in a repository whose GitHub default branch is exactly `main`, the system SHALL present a one-time prompt offering to switch the default to `develop`. The choice SHALL be persisted via `claude.flowkit.defaultBranchPrompted` so the prompt never reappears once decided.
+
+#### Scenario: Marker skips the prompt
+- **WHEN** `claude.flowkit.defaultBranchPrompted` is `true`
+- **THEN** the sub-skill exits silently and `/open-pr` proceeds
+
+#### Scenario: Non-main default skips the prompt
+- **WHEN** the GitHub default branch is anything other than `main` (including unreadable / missing `gh` auth)
+- **THEN** the sub-skill exits silently
+
+#### Scenario: Switch requires double confirmation
+- **WHEN** the user selects `Switch to develop`
+- **THEN** a second confirmation prompt is required before `gh repo edit --default-branch develop` runs
+
+#### Scenario: Successful switch sets the marker
+- **WHEN** the switch confirmation succeeds and the `gh repo edit` call returns success
+- **THEN** `claude.flowkit.defaultBranchPrompted` is set to `true`
+
+#### Scenario: Cancelled switch keeps marker unset
+- **WHEN** the user cancels at the second confirmation
+- **THEN** the marker stays unset and the three-option prompt resurfaces on next invocation
+
+#### Scenario: Keep or skip sets the marker without mutation
+- **WHEN** the user selects `Keep main as default` or `Don't ask again`
+- **THEN** the marker is set to `true` and no repository default-branch change is made
+
+### Requirement: Branch Creation
+The system SHALL create new branches off `origin/develop`, infer kebab-case names with appropriate `feat/`, `fix/`, `chore/`, or `docs/` prefixes from a description, and refuse to create the reserved names `main`, `master`, or `develop`.
+
+#### Scenario: Inferred name from description
+- **WHEN** `$ARGUMENTS` is a plain English description (e.g. "add user auth")
+- **THEN** the branch name is generated as a kebab-case slug with a type-prefix (e.g. `feat/add-user-auth`) and capped at 50 characters
+
+#### Scenario: Explicit branch name used as-is
+- **WHEN** `$ARGUMENTS` is already a branch name with a recognized prefix
+- **THEN** it is used directly without re-inference
+
+#### Scenario: Reserved names rejected
+- **WHEN** the inferred or provided name is `main`, `master`, or `develop`
+- **THEN** the skill stops and prompts the user for a different name
+
+#### Scenario: Branch always cut from origin
+- **WHEN** the branch is created
+- **THEN** it is created from `origin/develop`, never from a local stale `develop`
+
+### Requirement: Conventional Commit Format
+All commits authored by the system SHALL follow the format `type(scope): description` with a subject line under 72 characters and one of the recognized type tokens: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`, `style`.
+
+#### Scenario: Subject under 72 characters
+- **WHEN** a commit message is written
+- **THEN** the subject line is 72 characters or fewer
+
+#### Scenario: Logical groupings split into multiple commits
+- **WHEN** the workspace diff contains multiple unrelated concerns
+- **THEN** the changes are split into one commit per logical concern, each with its own conventional-format message
+
+#### Scenario: Nothing to commit reported cleanly
+- **WHEN** `git status` is clean
+- **THEN** the skill reports "Nothing to commit" and stops
+
+#### Scenario: HEREDOC syntax used for multi-line messages
+- **WHEN** a commit message has a body
+- **THEN** it is composed via HEREDOC so newlines are preserved
+
+#### Scenario: Amend never used
+- **WHEN** new commits are created
+- **THEN** they are new commits, never an amend of a previous commit
+
+### Requirement: PR Body Standard
+Every PR opened by the system SHALL emit a body with three sections in order — `## Summary` (1–3 sentence narrative), `## Changes` (bulleted concrete edits), `## Test plan` (`- [ ]` checklist) — followed by an issue-reference footer with one closing-keyword token per line.
+
+#### Scenario: Three sections in order
+- **WHEN** a PR body is assembled
+- **THEN** it contains `## Summary`, `## Changes`, and `## Test plan` headings in that order
+
+#### Scenario: Closing-keyword tokens one per line
+- **WHEN** the footer references multiple issues
+- **THEN** each `Closes #N` / `Refs #N` token appears on its own line
+
+#### Scenario: Broken multi-ref footer rejected
+- **WHEN** the assembled body contains a space-separated multi-ref form (e.g. `Closes #1 #2 #3`)
+- **THEN** the skill exits non-zero with guidance to rewrite one token per line — it does not auto-rewrite
+
+#### Scenario: Verbatim forwarding of author-committed keywords
+- **WHEN** issue-ref tokens are extracted from commit messages on the branch
+- **THEN** they are emitted in the footer verbatim, preserving the author's original casing and keyword choice (`Fixes`/`Resolves`/`Closes`)
+
+### Requirement: Open PR
+The system SHALL push the current branch to origin with `-u`, refuse to open a PR from a protected branch (`develop`, `main`, `master`), resolve `$BASE` via the canonical chain, assemble the canonical body, and call `gh pr create --base "$BASE"` with the body. Force-push SHALL NOT be used.
+
+#### Scenario: Protected branch blocked
+- **WHEN** the current branch is `develop`, `main`, or `master`
+- **THEN** the skill stops with an error directing the operator to check out a feature branch
+
+#### Scenario: Default-branch prompt fires before any other preflight
+- **WHEN** `/open-pr` runs
+- **THEN** the default-branch-prompt sub-skill is invoked before checking the current branch
+
+#### Scenario: Branch pushed with -u, not force-pushed
+- **WHEN** the current branch is pushed
+- **THEN** the command used is `git push -u origin HEAD` without `--force` or `--force-with-lease`
+
+#### Scenario: Closing-keyword on non-default-branch base warned
+- **WHEN** the assembled body contains a closing keyword and `$BASE` is not the GitHub default branch
+- **THEN** a one-line stderr note is emitted pointing the user at `/release` (which will explicitly close the issues), but the PR is still opened
+
+### Requirement: PR Lifecycle Orchestrator
+The `/pr` skill SHALL chain `create-branch` (if on a protected branch) → `commit` (if there are uncommitted changes) → `open-pr` in sequence, stopping on the first sub-skill failure.
+
+#### Scenario: Branch creation skipped on feature branch
+- **WHEN** the current branch is not `develop`, `main`, or `master`
+- **THEN** `/pr` skips `create-branch` and proceeds directly to `commit`
+
+#### Scenario: Commit skipped on clean workspace
+- **WHEN** the workspace has no changes
+- **THEN** `/pr` skips `commit` and proceeds directly to `open-pr`
+
+#### Scenario: Failure aborts the chain
+- **WHEN** any sub-skill fails
+- **THEN** the chain stops at that step and reports the error; no subsequent step runs
+
+### Requirement: PR Merge
+The merge-pr skill SHALL rebase-merge the open PR for the current branch (never squash, never merge-commit), delete the remote branch via `--delete-branch`, retarget any open PRs that base on this PR's head before deleting, and free the local branch when a worktree holds it — auto-checking out the base branch if the main worktree holds the head.
+
+#### Scenario: Rebase-merge only
+- **WHEN** the merge runs
+- **THEN** the call uses `gh pr merge --rebase --delete-branch`; never `--squash` or `--merge`
+
+#### Scenario: Stacked children retargeted before merge
+- **WHEN** other open PRs base on this PR's head branch
+- **THEN** they are retargeted before the merge runs so GitHub does not auto-close them when the head branch is deleted
+
+#### Scenario: Main worktree holding head auto-checks out base
+- **WHEN** the head branch is checked out in the main worktree (the canonical post-`push-or-pr` state)
+- **THEN** the main worktree is checked out to the base branch so the head branch can be released without manual intervention
+
+#### Scenario: Caller-owned worktree refuses removal
+- **WHEN** the head branch is held by a linked worktree containing the caller's cwd
+- **THEN** the script refuses with operator guidance to exit the worktree first
+
+#### Scenario: Implicit post-merge pull wrapped against dirty workspace
+- **WHEN** the workspace has uncommitted changes at merge time
+- **THEN** the merge is wrapped via `with-clean-workspace` so the implicit post-merge pull does not fail with `cannot pull with rebase`
+
+#### Scenario: Issues never closed by merge-pr
+- **WHEN** `/merge-pr` lands the PR into `develop`
+- **THEN** referenced issues remain open and are closed later by `/release` when work reaches `main`
+
+### Requirement: Restack Descendants
+The restack skill SHALL discover open descendant PRs of a parent PR breadth-first, rebase each onto its parent's updated head, and force-push with `--force-with-lease`. Siblings SHALL continue independently if any one branch hits a rebase conflict, with conflicted branches reported and their subtrees skipped.
+
+#### Scenario: Auto-resolve parent from current branch
+- **WHEN** `/restack` is invoked without arguments
+- **THEN** the parent PR is resolved from the current branch via `gh pr list --head $BRANCH`
+
+#### Scenario: Subtree walked breadth-first
+- **WHEN** a parent has multiple direct descendants
+- **THEN** all direct descendants are rebased before any of their own descendants
+
+#### Scenario: Rebase conflict on one branch does not stop siblings
+- **WHEN** one branch fails to rebase
+- **THEN** sibling branches continue; the conflicted branch's own subtree is marked skipped with reason `ancestor-failed`
+
+#### Scenario: Force-push uses lease
+- **WHEN** a rebased branch is pushed
+- **THEN** the command uses `git push --force-with-lease`; never plain `--force`
+
+### Requirement: Shared-Branch Publishing
+The push-or-pr skill SHALL never push directly to a shared branch (`develop`/`main` or any other checked-out branch). When pending commits exist, it SHALL save them on an auto-created dated feature branch, reset the original local branch to its upstream, push the feature branch, and open a PR against `$BASE` (default `develop`).
+
+#### Scenario: No-op on clean upstream
+- **WHEN** the current branch has no commits ahead of upstream
+- **THEN** the script emits `push_result: "noop"` and does nothing
+
+#### Scenario: Pending commits trigger feature-branch detour
+- **WHEN** there are pending commits
+- **THEN** they are placed on an auto-created branch named `<prefix>-YYYY-MM-DD[<-N>]` and a PR is opened from that branch against `$BASE`
+
+#### Scenario: Original branch reset to upstream
+- **WHEN** the detour completes
+- **THEN** the local copy of the original branch is reset to its upstream so it no longer holds the unpublished commits
+
+#### Scenario: Missing required PR args rejected
+- **WHEN** there are pending commits and any of `--prefix` / `--title` / `--body` is missing
+- **THEN** the script exits with code 2 and stderr describing the missing argument
+
+#### Scenario: Tags never pushed
+- **WHEN** the script runs
+- **THEN** no tag push is performed; tag creation belongs to the caller
+
+### Requirement: Develop Sync
+The sync skill SHALL check out `develop`, pull the latest from origin, prune stale remote-tracking refs, and delete every local branch already merged into `develop` (excluding `develop`, `main`, and the current branch).
+
+#### Scenario: develop checked out and pulled first
+- **WHEN** sync runs
+- **THEN** the first action is `git checkout develop && git pull origin develop`
+
+#### Scenario: Stale remote refs pruned
+- **WHEN** sync runs
+- **THEN** `git fetch --prune` is invoked to drop stale remote-tracking refs
+
+#### Scenario: Merged local branches deleted
+- **WHEN** local branches are fully merged into `develop`
+- **THEN** they are deleted, excluding `develop`, `main`, and the current branch
+
+### Requirement: Workspace Stash Guard
+The with-clean-workspace script SHALL stash tracked and untracked changes before running the wrapped command, restore the stash on success via `git stash pop`, and on stash-pop conflict leave the stash on the stack with a stderr warning while preserving the wrapped command's exit code.
+
+#### Scenario: Missing -- separator returns usage error
+- **WHEN** the script is invoked without the `--` separator
+- **THEN** it exits with code 2 and prints usage text to stderr
+
+#### Scenario: Tracked + untracked changes stashed
+- **WHEN** the workspace is dirty (including untracked files)
+- **THEN** they are stashed with the message `flowkit-auto-stash` before the wrapped command runs
+
+#### Scenario: Stash restored on success
+- **WHEN** the wrapped command exits zero
+- **THEN** the stash is popped, restoring the workspace
+
+#### Scenario: Stash kept on pop conflict
+- **WHEN** `git stash pop` encounters a conflict after the wrapped command
+- **THEN** the stash is left on the stack and a stderr warning is emitted
+
+#### Scenario: Wrapped command exit code preserved on failure
+- **WHEN** the wrapped command exits non-zero
+- **THEN** the script exits with the same non-zero code and the stash remains on the stack
+
+### Requirement: Epic Branch Creation
+The cut-epic skill SHALL create a long-lived `feature/<slug>-<issue>` branch from `origin/develop`, push it to origin, and pin `claude.flowkit.prBase` to it so every subsequent PR in the repo targets the epic branch. The skill SHALL be idempotent — re-running with an existing branch reuses it and refreshes the pin.
+
+#### Scenario: Slug inferred from issue title
+- **WHEN** `$ARGUMENTS` is a single issue number
+- **THEN** the slug is derived from the issue title via `gh issue view`, lower-cased, kebab-cased, and capped at 40 characters
+
+#### Scenario: Explicit slug used verbatim
+- **WHEN** `$ARGUMENTS` contains both an issue number and a kebab-case word in either order
+- **THEN** they are used as `<issue>` and `<slug>` directly without re-inference
+
+#### Scenario: Branch name capped at 60 characters
+- **WHEN** the assembled branch name exceeds 60 characters
+- **THEN** the slug is truncated; the issue number is preserved
+
+#### Scenario: Reserved names rejected
+- **WHEN** the resolved branch would be `main`, `master`, `develop`, or any non-`feature/`-prefixed name
+- **THEN** the skill refuses to create it
+
+#### Scenario: Branch reused if it exists
+- **WHEN** the resolved branch exists locally or on origin
+- **THEN** it is checked out (or fetched-and-checked-out) instead of recreated; the pin is refreshed
+
+#### Scenario: Pin written to claude.flowkit.prBase
+- **WHEN** the branch is created or reused
+- **THEN** `git config claude.flowkit.prBase <branch>` is set to the epic branch name
+
+### Requirement: Epic Promotion
+The ship-epic skill SHALL rebase-merge the epic to `develop` (never squash, never merge-commit), aggregate `Closes #N` tokens from child squash commits and merged child PR bodies plus the epic issue ref, unset `claude.flowkit.prBase`, delete the epic branch, and fast-forward local `develop` when feasible.
+
+#### Scenario: Empty pin and missing --epic stops the skill
+- **WHEN** `claude.flowkit.prBase` is unset (or equals `develop`) and no `--epic` flag is passed
+- **THEN** the skill stops with a "no epic in flight" message
+
+#### Scenario: Override --epic must start with feature/
+- **WHEN** `--epic <branch>` is passed
+- **THEN** the branch must start with `feature/` and must not equal `develop`, `main`, or `master`
+
+#### Scenario: Rebase-merge to develop
+- **WHEN** the epic merges
+- **THEN** the strategy is rebase-merge so child squash commits replay onto `develop` linearly with no merge bubble
+
+#### Scenario: Closing tokens aggregated from squashes and child PRs
+- **WHEN** building the epic PR body
+- **THEN** `Closes #N` lines are aggregated from child squash commit messages, merged child PR bodies (covering the case where `gh pr merge --squash` dropped the token), and the epic issue ref; de-duplicated case-insensitively
+
+#### Scenario: prBase unset and epic branch deleted on success
+- **WHEN** the rebase-merge succeeds
+- **THEN** `claude.flowkit.prBase` is cleared and the epic branch is deleted on origin
+
+#### Scenario: Develop fast-forward skipped on different worktree
+- **WHEN** the operator is on a worktree other than the main one
+- **THEN** local `develop` is not touched and the result indicates `develop_advanced: false` with guidance to run `/sync`
+
+#### Scenario: Conflict leaves state intact for retry
+- **WHEN** the rebase-merge fails with a conflict
+- **THEN** `claude.flowkit.prBase` and the epic branch are left intact so the operator can rebase locally and re-invoke
+
+#### Scenario: Stacked-PR merge commits stop promotion
+- **WHEN** the epic carries raw `worktree-agent-*` merge commits (meaning `swarmkit:merge-stack` was not run)
+- **THEN** the skill stops with a recovery hint directing the operator to run merge-stack first
+
+### Requirement: Release Candidate Cut
+The cut skill SHALL create a release-candidate branch named `rc/YYYY-MM-DD.N` (with N as the next available counter computed from existing tags) from `origin/develop`, push it with the fully qualified refspec form, create a same-named tag, and push the tag.
+
+#### Scenario: N derived from existing tags, not branches
+- **WHEN** prior RC branches for today have been deleted but their tags remain
+- **THEN** N is computed as the max existing tag suffix + 1, not the count of existing branches
+
+#### Scenario: Always cut from origin/develop
+- **WHEN** the RC branch is created
+- **THEN** it is created from `origin/develop`, never from a local branch
+
+#### Scenario: Tag pushed immediately
+- **WHEN** the RC branch is pushed
+- **THEN** the matching `rc/YYYY-MM-DD.N` tag is pushed immediately so future cuts see it for the N calculation
+
+#### Scenario: Qualified refspec required by tag/branch ambiguity
+- **WHEN** any subsequent push targets the RC name after the tag exists
+- **THEN** the fully qualified refspec form `refs/heads/<name>:refs/heads/<name>` is used to avoid the `src refspec matches more than one` error
+
+### Requirement: Release to Main
+The release skill SHALL pick the newest `rc/*` branch from origin, rebase it onto `origin/main` and force-push, aggregate closing-keyword refs from PRs merged into `develop` since the last release tag, drop refs to already-closed issues, detect resolved epics via legacy checklist or native sub-issues, open a `release: YYYY-MM-DD` PR into `main`, rebase-merge with `--delete-branch`, sync `main`, create a `vYYYY.M.D[.N]` tag, push per-plugin tags, and explicitly close every aggregated issue idempotently.
+
+#### Scenario: No RC branch aborts cleanly
+- **WHEN** no `rc/*` branch exists on origin
+- **THEN** the skill exits non-zero with guidance to run `/cut` first
+
+#### Scenario: Unconditional rebase onto main
+- **WHEN** the source RC is identified
+- **THEN** it is rebased onto `origin/main` unconditionally before the PR is opened, then force-pushed with the qualified refspec form
+
+#### Scenario: Ancestry assertion after rebase
+- **WHEN** the rebase completes
+- **THEN** the skill verifies `origin/main` is an ancestor of the rebased `origin/$SOURCE` and aborts if not
+
+#### Scenario: Pre-merge divergence check before opening PR
+- **WHEN** `origin/main` has commits with no patch-id equivalent on `origin/$SOURCE`
+- **THEN** the skill aborts with remediation guidance (manual rebase + force-push), exiting non-zero
+
+#### Scenario: Issue refs aggregated since last tag
+- **WHEN** building the release PR body
+- **THEN** `Closes/Fixes/Resolves #N` references are collected from PRs merged into `develop` since the last `v*` tag's date
+
+#### Scenario: Already-closed issues dropped from refs
+- **WHEN** an aggregated ref points at an issue already in the CLOSED state
+- **THEN** that ref is dropped before the epic-detection block runs
+
+#### Scenario: Legacy checklist epics auto-closed when children resolved
+- **WHEN** an open epic's body contains `- [ ] #N` lines and every referenced child appears in this release's refs
+- **THEN** `Closes #<epic>` is appended to the release PR body
+
+#### Scenario: Native sub-issue epics auto-closed when all children resolved
+- **WHEN** an open epic's children attached via the native sub-issue API are all either already closed or appear in this release's refs
+- **THEN** `Closes #<epic>` is appended to the release PR body
+
+#### Scenario: Sub-issues fetch failure surfaces non-fatally
+- **WHEN** `gh api .../sub_issues` fails for an epic
+- **THEN** the epic is added to a "skipped" list reported in the final summary; the release proceeds
+
+#### Scenario: Release notes grouped by scope
+- **WHEN** the release notes are built
+- **THEN** bullets are grouped by conventional-commit scope, with scopes either read from `.flowkit/scopes.txt` (one per line, `#` comments ignored) or auto-detected from the commit range
+
+#### Scenario: Auto-scope normalization
+- **WHEN** scopes are auto-detected
+- **THEN** sub-scopes like `flowkit:open-pr` are normalized to `flowkit` and the set is de-duplicated
+
+#### Scenario: Rebase-merge with delete-branch
+- **WHEN** the release PR merges
+- **THEN** the strategy is `gh pr merge --rebase --delete-branch`; never `--squash` or `--merge`
+
+#### Scenario: Merge wrapped against dirty workspace
+- **WHEN** the workspace has uncommitted changes
+- **THEN** the merge call is wrapped via `with-clean-workspace` so the implicit post-merge pull does not fail
+
+#### Scenario: Calver tag with collision counter
+- **WHEN** the tag `vYYYY.M.D` already exists on origin
+- **THEN** an incrementing suffix is appended (`vYYYY.M.D.1`, `.2`, ...) until a free tag name is found
+
+#### Scenario: Per-plugin tags pushed at release
+- **WHEN** `*--v*` tags exist locally but not on origin
+- **THEN** they are pushed alongside the calver tag
+
+#### Scenario: Explicit issue close loop runs regardless of default branch
+- **WHEN** every aggregated issue ref is processed
+- **THEN** an idempotent `gh issue close --reason completed` loop runs against each open issue so the lifecycle completes under either `main`-default or `develop`-default repos
+
+#### Scenario: RC branch cleanup is the safety net, not the primary cleanup
+- **WHEN** `gh pr merge --delete-branch` has already removed the RC branch
+- **THEN** the safety-net step finds nothing to delete and reports the no-op
+
+### Requirement: Ship Closer
+The ship skill SHALL run `cut` then `release` as a sequenced chain. Before any step runs, it SHALL abort if any open PRs with `worktree-agent-*` head branches target the resolved base. Any sub-skill failure SHALL stop the chain without proceeding.
+
+#### Scenario: Open swarm PRs abort ship
+- **WHEN** open PRs with `worktree-agent-*` head branches target the resolved base
+- **THEN** ship exits non-zero with their numbers listed and a directive to run `/swarmkit:merge-stack`
+
+#### Scenario: Resolved base equals prBase pin
+- **WHEN** `claude.flowkit.prBase` is set
+- **THEN** the preflight queries open PRs against the pinned base (not `develop`)
+
+#### Scenario: jq-filtered head match
+- **WHEN** the preflight checks for `worktree-agent-*` heads
+- **THEN** matching is done by filtering the full open-PR JSON through `jq`'s `startswith`, not via `gh pr list --head` glob (which is exact-match only)
+
+#### Scenario: Cut failure aborts before release
+- **WHEN** `/cut` fails
+- **THEN** ship stops and does not invoke `/release`
+
+#### Scenario: No internal verify gate
+- **WHEN** ship runs
+- **THEN** it assumes the operator has already verified the integrated state between `/swarmkit:merge-stack` and `/ship-epic` (or between `/ship-epic` and ship); ship does not run any project-specific test/lint command of its own
+
+### Requirement: PR-Base Scope Set/Unset
+The pr-base-scope sub-skill SHALL write only to `claude.flowkit.prBase` (never to the legacy unscoped `claude.prBase`), and supports two operations: set the key to a branch name and unset the key entirely.
+
+#### Scenario: Set writes the scoped key
+- **WHEN** the Set operation runs with a branch name
+- **THEN** `git config claude.flowkit.prBase <branch>` is invoked
+
+#### Scenario: Unset clears the scoped key
+- **WHEN** the Unset operation runs
+- **THEN** `git config --unset claude.flowkit.prBase` is invoked
+
+#### Scenario: Legacy key never written
+- **WHEN** any set/unset operation runs
+- **THEN** `claude.prBase` is never read or written
+
+### Requirement: Pipeline Status
+The pipeline-status skill SHALL be read-only, fetch the latest remote state first, and print all four pipeline stages in left-to-right order — in-flight (open PRs → develop), awaiting cut (commits on develop ahead of main), awaiting release (RC branches), and released (most recent `v*` tag) — even when stages are empty, followed by an actionable "Next step" line.
+
+#### Scenario: Read-only behavior
+- **WHEN** the skill runs
+- **THEN** no branch, tag, PR, or label is mutated
+
+#### Scenario: Fetch precedes any read
+- **WHEN** the skill starts
+- **THEN** `git fetch origin` runs before any read of remote state
+
+#### Scenario: All four stages always printed
+- **WHEN** any stage is empty
+- **THEN** the stage is still printed with "none" rather than omitted
+
+#### Scenario: Next step priority order
+- **WHEN** multiple states could trigger a suggestion
+- **THEN** the highest-priority match wins: blockers/conflicts on a PR → resolve those; approved+clean PR → merge it; non-draft unreviewed PRs → review them; RC exists → run `/release`; commits on develop but no RC → run `/cut`; otherwise → "Nothing to ship"
+
+#### Scenario: Draft PRs never trigger a review suggestion
+- **WHEN** the only unreviewed PRs are drafts
+- **THEN** the "review open PRs" suggestion does not fire

--- a/plugins/flowkit/skills/commit/SKILL.md
+++ b/plugins/flowkit/skills/commit/SKILL.md
@@ -59,6 +59,8 @@ git diff --cached
 git diff
 ```
 
+If `git status` is clean, report "Nothing to commit" and stop. Never amend a previous commit — always create new ones.
+
 ### 2. Identify logical groupings
 
 Examine the changed files and their diffs. Group files by concern — each group should represent a single logical change (e.g. a new feature, a bug fix, a dependency bump). If all changes belong to one concern, there is one commit. If multiple concerns are present, plan one commit per concern.
@@ -105,11 +107,3 @@ git log --oneline -5
 ```
 
 Report what was committed.
-
-## Constraints
-
-- Never group unrelated changes into a single commit
-- Never skip the HEREDOC syntax — it preserves newlines correctly
-- Never add co-author lines or mention Claude in commit messages
-- Never amend an existing commit — always create new ones
-- If `git status` is clean, report "Nothing to commit" and stop

--- a/plugins/flowkit/skills/create-branch/SKILL.md
+++ b/plugins/flowkit/skills/create-branch/SKILL.md
@@ -57,8 +57,3 @@ git checkout -b <name> origin/develop
 Report the branch name that was created, e.g.:
 
 > Branch `feat/add-user-auth` created from `origin/develop`.
-
-## Constraints
-
-- Always branch from `origin/develop`, never from a local `develop` (which may be behind)
-- If unable to infer a branch name and `$ARGUMENTS` is empty, ask the user what the branch is for

--- a/plugins/flowkit/skills/cut-epic/SKILL.md
+++ b/plugins/flowkit/skills/cut-epic/SKILL.md
@@ -107,39 +107,10 @@ Print a confirmation including the branch name, the upstream, and the scoped con
 > `claude.flowkit.prBase` is now scoped to this branch.
 > Sub-PRs opened in this repo will target `feature/onboarding-v2-1264` until you tear down the scope.
 
-## Composition
-
-| Caller | Behavior |
-|--------|----------|
-| `flowkit:open-pr` | Reads `claude.flowkit.prBase` and targets the epic branch automatically. |
-| `flowkit:pr` | Same — branches off `origin/develop` for sub-work, but PRs target the epic branch. |
-| `swarmkit:swarm` | Loop-mode agents inherit the scoped base; each spawned PR targets the epic branch. Combine with `swarmkit:merge-stack` to fan child PRs into the epic branch. |
-| `flowkit:ship` | Will override `claude.flowkit.prBase` to `develop` for its own flow, then unset. **Do not run `/ship` while an epic is in flight** unless you intend to ship the epic itself. |
-
 ## Teardown
 
-When the epic is ready to ship, run `flowkit:ship-epic`. It opens the epic-to-`develop` PR, rebase-merges (so children's squashes replay onto develop linearly), unsets `claude.flowkit.prBase`, deletes the epic branch, and fast-forwards local develop. See [`ship-epic/SKILL.md`](../ship-epic/SKILL.md) for full details.
-
-To close out by hand (manual fallback):
-
-1. Open a final PR from the epic branch into `develop`:
-   ```bash
-   gh pr create --base develop --head feature/<slug>-<issue>
-   ```
-2. Rebase-merge via the GitHub UI or CLI (`gh pr merge --rebase --delete-branch`).
-3. Clear the scope so future PRs default back to `develop`:
-   ```bash
-   git config --unset claude.flowkit.prBase
-   ```
-4. (Optional) Delete the local epic branch:
-   ```bash
-   git branch -D feature/<slug>-<issue>
-   ```
+When the epic is ready to ship, run `flowkit:ship-epic` — it opens the epic-to-`develop` PR, rebase-merges, unsets `claude.flowkit.prBase`, deletes the epic branch, and fast-forwards local develop.
 
 ## Constraints
 
-- Always branch from `origin/develop`, never from a local `develop` (which may be behind).
-- Never write a non-`feature/` prefix — this skill is purposely narrow.
-- Never modify `claude.prBase` (the legacy unscoped key, no longer read by any plugin) — only `claude.flowkit.prBase`. See `pr-base-scope` for the rationale.
-- Idempotent: re-running with the same arguments must not error if the branch already exists.
-- This skill does not open a PR. It only sets up the branch and scope. Use `flowkit:pr` / `flowkit:open-pr` for sub-work.
+- This skill does not open a PR — only sets up the branch and scope. Use `flowkit:pr` / `flowkit:open-pr` for sub-work.

--- a/plugins/flowkit/skills/cut/SKILL.md
+++ b/plugins/flowkit/skills/cut/SKILL.md
@@ -53,21 +53,9 @@ git push origin "refs/tags/${RC_BRANCH}"
 
 The tag (`rc/YYYY-MM-DD.N`) intentionally shares the branch name. The tag is pushed immediately so future cuts count it correctly even after the branch is deleted.
 
-**Refspec collision (read before pushing an RC branch anywhere else).** Once both the RC branch and the same-named tag exist locally, every subsequent `git push origin <name>` against that name is ambiguous and fails with:
+**Refspec collision.** Once branch and same-named tag both exist, every `git push origin <name>` against that name fails with `error: src refspec ... matches more than one`. Both pushes above use the fully qualified form (`refs/heads/${RC_BRANCH}:refs/heads/${RC_BRANCH}`) to avoid this. Any later push of the RC branch — most notably the force-push in `flowkit:release` step 3 — must do the same.
 
-```
-error: src refspec rc/YYYY-MM-DD.N matches more than one
-```
-
-This affects any later RC-branch push — most notably the force-push performed by `flowkit:release` step 3 after rebasing the RC onto `origin/main`. The fix is to use the fully qualified refspec form whenever pushing the RC branch in the presence of the matching tag:
-
-```bash
-git push --force-with-lease origin "refs/heads/${RC_BRANCH}:refs/heads/${RC_BRANCH}"
-```
-
-Both pushes above (the initial `-u` push of the branch and the tag push) already use the disambiguated form for consistency, even though only one of the two names exists at the moment of the first push. Renaming the tag to a separate namespace (e.g. `rc-tag/...`) would also resolve this but is out of scope here — the documentation route is preferred because it keeps the tag/branch pairing intact and the cost is one extra refspec qualifier at each push site.
-
-**Always brace the variable** (`${RC_BRANCH}`, not `$RC_BRANCH`) inside the refspec strings. When the snippet runs under zsh (or any shell with the `:r` parameter modifier), the unbraced form `$RC_BRANCH:refs/heads/...` is parsed as "value of `$RC_BRANCH` with trailing extension stripped, followed by the literal `efs/heads/...`" — the `:r` modifier consumes the `r` from `refs/heads/` and drops the `.N` suffix from the branch name. The resulting refspec looks like `refs/heads/rc/YYYY-MM-DDefs/heads/rc/YYYY-MM-DD.N` and fails with `src refspec ... does not match any`. Bracing the variable terminates the parameter name before the `:`, so the modifier path is never taken. Bash 5.x does not implement `:r` and ignores the problem; zsh does and silently mangles the string.
+**Always brace the variable** (`${RC_BRANCH}`, not `$RC_BRANCH`) inside refspec strings. Under zsh the unbraced form triggers the `:r` parameter modifier and silently mangles the refspec; bash 5.x doesn't have `:r` so the bug is invisible until the snippet runs under zsh.
 
 ### 4. Report
 
@@ -76,6 +64,4 @@ Output:
 
 ## Constraints
 
-- Always cut from `origin/develop`, never from a local branch
-- RC branch naming must follow `rc/YYYY-MM-DD.N` exactly (N starts at 1)
 - Never push to any branch other than the new RC branch in this skill

--- a/plugins/flowkit/skills/default-branch-prompt/SKILL.md
+++ b/plugins/flowkit/skills/default-branch-prompt/SKILL.md
@@ -94,8 +94,6 @@ git config claude.flowkit.defaultBranchPrompted true
 
 Report: "OK, won't ask again. Re-run by clearing the marker: `git config --unset claude.flowkit.defaultBranchPrompted`."
 
-## Constraints
+## Reset
 
-- Never run `gh repo edit` without the second confirmation; never set the marker without a user choice.
-- Marker key is `claude.flowkit.defaultBranchPrompted` (repo-local `git config`). Never use `claude.prBase`.
-- To reset: `git config --unset claude.flowkit.defaultBranchPrompted`.
+To re-surface the prompt: `git config --unset claude.flowkit.defaultBranchPrompted`.

--- a/plugins/flowkit/skills/merge-pr/SKILL.md
+++ b/plugins/flowkit/skills/merge-pr/SKILL.md
@@ -54,9 +54,3 @@ Rebase-merge the open PR for the current branch and delete the remote branch. Op
 | `local_delete_failed` | boolean | Remote merge succeeded but local branch deletion failed |
 
 Errors: non-zero exit, message on stderr only, stdout empty. See [`plugins/_shared/script-authoring.md`](../../../_shared/script-authoring.md).
-
-## Constraints
-
-- Never merge into `main` directly — this skill targets the default merge base only
-- Always rebase-merge (never squash or merge commit)
-- Always delete the remote branch on merge (`--delete-branch`)

--- a/plugins/flowkit/skills/open-pr/SKILL.md
+++ b/plugins/flowkit/skills/open-pr/SKILL.md
@@ -22,13 +22,7 @@ Push the current branch to origin and open a GitHub pull request against the bas
 
 ### 0. First-run default-branch nudge
 
-Before any other preflight, invoke the [`default-branch-prompt`](../default-branch-prompt/SKILL.md) sub-skill. It is a no-op in every case except the narrow first-run-on-`main`-default scenario:
-
-- If `git config --get claude.flowkit.defaultBranchPrompted` is `true`, the sub-skill exits silently.
-- If `gh repo view --json defaultBranchRef -q '.defaultBranchRef.name'` fails, returns empty, or returns anything other than `main`, the sub-skill exits silently.
-- Only when the GitHub default branch is exactly `main` does the sub-skill surface an `AskUserQuestion` offering `Switch to develop` / `Keep main as default` / `Don't ask again`. Each definitive answer (`Switch` success, `Keep main as default`, `Don't ask again`) sets `claude.flowkit.defaultBranchPrompted=true`; `Cancel` at the second confirmation leaves the marker unset so the prompt resurfaces next time. `Switch` additionally runs `gh repo edit --default-branch develop` after a second confirmation.
-
-This nudge is fire-and-forget — open-pr does not branch on its outcome. After the sub-skill returns, continue with step 1 regardless of which path the user took (or whether the prompt fired at all).
+Before any other preflight, invoke the [`default-branch-prompt`](../default-branch-prompt/SKILL.md) sub-skill. It is fire-and-forget — open-pr does not branch on its outcome. Continue with step 1 regardless of which path the user took (or whether the prompt fired at all).
 
 ### 1. Check current branch
 
@@ -177,8 +171,4 @@ Output the PR URL returned by `gh pr create`.
 
 ## Constraints
 
-- Always resolve `--base` before calling `gh pr create` per [`plugins/_shared/base-resolution.md`](../../../_shared/base-resolution.md). `$BASE` is always non-empty; `--base "$BASE"` is always passed.
-- Never target `main` directly unless `claude.flowkit.prBase` is explicitly set to `main`
-- Never open a PR from a protected branch (`develop`, `main`, `master`)
 - If `gh` is not installed or not authenticated, report the error and stop — do not attempt workarounds
-- Do not force-push; use a plain `git push -u origin HEAD`

--- a/plugins/flowkit/skills/pipeline-status/SKILL.md
+++ b/plugins/flowkit/skills/pipeline-status/SKILL.md
@@ -90,20 +90,6 @@ Next step: merge #471 (approved), then /cut
 ───────────────────────────────────────────────────
 ```
 
-**Example (everything clear):**
-
-```
-── Pipeline Status ────────────────────────────────
-Released: v2026.4.19.12
-
-[In flight] Open PRs → develop: none
-[Awaiting cut] Develop → main: none
-[Awaiting release] RC branches: none
-
-Next step: nothing to ship — develop is in sync with main.
-───────────────────────────────────────────────────
-```
-
 ### 4. Suggest next action
 
 Priority — first matching rule wins:
@@ -118,10 +104,3 @@ Priority — first matching rule wins:
 | Nothing pending anywhere | "Nothing to ship. Develop is in sync with main." |
 
 Draft PRs never block the suggestion — they're flagged in the display but skipped in the "needs review" rule.
-
-## Constraints
-
-- Read-only — never mutate any branch, tag, PR, or label
-- Always run `git fetch origin` first so data is current
-- Always print all four pipeline stages, even empty ones, so the user sees the whole shape
-- Never omit the "Next step" line — always conclude with actionable guidance

--- a/plugins/flowkit/skills/pr-base-scope/SKILL.md
+++ b/plugins/flowkit/skills/pr-base-scope/SKILL.md
@@ -39,4 +39,3 @@ Resolution order is the canonical chain at [`plugins/_shared/base-resolution.md`
 
 - This key is local to the repo — it is never committed or pushed
 - Always unset after a scoped flow completes to avoid stale targeting in future sessions
-- Never write to the legacy `claude.prBase` key. All set/unset operations target `claude.flowkit.prBase` only

--- a/plugins/flowkit/skills/pr/SKILL.md
+++ b/plugins/flowkit/skills/pr/SKILL.md
@@ -45,9 +45,4 @@ Follow `/open-pr` with `$ARGUMENTS` to push the branch and open a GitHub pull re
 
 Output the PR URL.
 
-## Constraints
-
-- Never skip the branch check — always detect whether you're already on a feature branch before creating a new one
-- Each step delegates fully to its sub-skill; do not re-implement their logic inline
-- If any step fails, stop and report the error — do not continue to the next step
-- If the workspace is clean and no commits are needed, note this and proceed directly to `/open-pr`
+If any step fails, stop and report the error — do not continue to the next step.

--- a/plugins/flowkit/skills/push-or-pr/SKILL.md
+++ b/plugins/flowkit/skills/push-or-pr/SKILL.md
@@ -60,8 +60,6 @@ Branch on `push_result`:
 
 After `pr`, the working tree is left on `new_branch`. Callers that need to return to the original branch must explicitly `git checkout <branch> && git pull origin <branch>` after the PR merges.
 
-## Constraints
+## Implementation note
 
-- Never force-push. The script resets the local copy of the branch you were on to its upstream before creating the feature branch.
-- The script does not push tags. Tag creation belongs to the caller and must run after the PR is merged so tags point at the post-merge commit.
-- The script checks out `new_branch` before resetting the original branch — `git branch -f` refuses to update the currently-checked-out branch, so the order matters.
+The script checks out `new_branch` before resetting the original branch — `git branch -f` refuses to update the currently-checked-out branch, so the order matters.

--- a/plugins/flowkit/skills/release/SKILL.md
+++ b/plugins/flowkit/skills/release/SKILL.md
@@ -41,9 +41,7 @@ fi
 
 ### 3. Rebase RC onto `origin/main`
 
-`gh pr merge --rebase` requires the RC to include every commit on `main` by SHA ancestry, not just by content. After each rebase-merge release, `main`'s tip and `develop`'s tip contain content-equivalent commits with **structurally different SHAs**: `flowkit:merge-pr` rebase-merges into `develop`, while `gh pr merge --rebase` rewrites committer dates on every commit it lands on `main` — even when the RC is already a linear descendant. New committer date → new commit SHA → `main`'s rebased SHAs are not in `develop`'s ancestry. The next RC, cut from `develop`, therefore fails an `is-ancestor` check against `origin/main` on every release after the first, with no hotfixes needed to trigger it.
-
-The fix is to rebase the RC onto `origin/main` unconditionally before opening the release PR. In the trivial case (no hotfixes, standard flow) the rebase is a no-op and the force-push is a fast-forward. The force-push target is the short-lived RC branch (deleted minutes later by `gh pr merge --delete-branch` in step 6), never `main`; `--force-with-lease` blocks the concurrent-writer race. A qualified refspec is required because `cut` creates both a branch and a same-named tag (e.g. `rc/2026-05-09.1`), making the unqualified form ambiguous:
+Rebase the RC onto `origin/main` unconditionally before opening the release PR. `gh pr merge --rebase` rewrites committer dates on every commit it lands on `main`, so `main`'s rebased SHAs are not in `develop`'s ancestry after the first release — every subsequent RC, cut from `develop`, fails an `is-ancestor` check against `origin/main` without this step. In the trivial case the rebase is a no-op and the force-push is a fast-forward. The force-push target is the short-lived RC branch (deleted minutes later by `gh pr merge --delete-branch` in step 6), never `main`. A qualified refspec is required because `cut` creates a same-named tag, making the unqualified form ambiguous:
 
 ```bash
 git checkout "$SOURCE"
@@ -51,7 +49,7 @@ git rebase origin/main
 git push --force-with-lease origin "refs/heads/$SOURCE:refs/heads/$SOURCE"
 ```
 
-After the rebase, assert that the invariant now holds. This is a paranoid post-rebase sanity check — if it fires, something unexpected happened during the rebase (e.g. an interactive conflict left a detached HEAD) and it is safer to abort than to open a PR that will fail at merge time:
+After the rebase, assert that the invariant now holds — if it fires, something unexpected happened during the rebase and aborting is safer than opening a PR that will fail at merge time:
 
 ```bash
 if ! git merge-base --is-ancestor origin/main "origin/$SOURCE"; then
@@ -232,25 +230,6 @@ if [ -n "$LAST_TAG" ] && [ -n "$TAG_DATE" ]; then
 fi
 RELEASE_NOTES=$(cat "$RELEASE_NOTES_FILE"); rm -f "$RELEASE_NOTES_FILE"
 
-# Smoke-test: verify the synthesis produced output before proceeding.
-# Run this one-liner against the real repo to confirm jq parses the regex
-# and at least one PR is matched:
-#
-#   TAG_DATE=$(git log -1 --format=%aI $(git for-each-ref --sort=-creatordate \
-#     --format='%(refname:short)' 'refs/tags/v[0-9]*' | head -1) \
-#     | python3 -c "import sys; from datetime import datetime, timezone; \
-#       print(datetime.fromisoformat(sys.stdin.read().strip()) \
-#             .astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ'))") \
-#   && gh pr list --base develop --state merged --limit 200 --json title,body,mergedAt \
-#   | jq --arg td "$TAG_DATE" -r \
-#       '.[] | select((.mergedAt | fromdateiso8601) > ($td | fromdateiso8601))
-#              | [.title, (.body // "" | gsub("\r";"")
-#                 | capture("(?i)## Summary\n+(?<s>[^\n]+)").s // "")] | @tsv' \
-#   | head -5
-#
-# A non-empty result (exit 0) confirms the pipeline is healthy.
-# An empty result or non-zero exit means the tag range or jq regex needs investigation.
-
 # --- narrative summary ---
 # Synthesize a 1–3 sentence narrative from the collected merged-PR summaries
 # and version bumps. State what this release contains overall — e.g.
@@ -313,7 +292,7 @@ Capture the PR number from the URL output.
 
 ### 5.5. Pre-merge divergence check
 
-Before attempting the merge, detect commits on `origin/main` that have no patch-id equivalent on `origin/$SOURCE`. This typically fires after a prior release rebase-merged into `main` and the back-merge never landed on `develop` (and therefore never reached the RC) — leaving `main` with commits whose rebase-equivalent forms exist nowhere on the RC by either SHA or patch-id. Even with the unconditional rebase in step 3, a stale RC force-pushed elsewhere or an aborted prior rebase can produce the same shape. `gh pr merge --rebase` fails mid-flight when this divergence exists, leaving the release in a half-shipped state. Surface it as an explicit precondition instead:
+Detect commits on `origin/main` with no patch-id equivalent on `origin/$SOURCE`. `gh pr merge --rebase` fails mid-flight on this divergence and leaves the release half-shipped; surface it as an explicit precondition instead. The check fires after a prior release rebase-merged into `main` and the back-merge never landed on `develop`, or after a stale RC was force-pushed elsewhere.
 
 ```bash
 DUP_PATCHES=$(git rev-list --left-right --cherry-pick --count \
@@ -333,9 +312,7 @@ if [ "$DUP_PATCHES" -gt 0 ]; then
 fi
 ```
 
-The check uses `git rev-list --left-right --cherry-pick --count` against the symmetric difference `origin/main...origin/$SOURCE`. The left-side count (after `--cherry-pick` filters out patch-id-equivalent commits) is the set of commits on `main` whose changes are not represented on the RC by any commit, identical SHA or otherwise. Any non-zero value means the merge will not be clean.
-
-The snippet aborts with the remediation message printed above and exits non-zero — the operator runs the three `git checkout` / `rebase` / `push` commands manually and then re-invokes `/release`. The skill does not auto-rebase on the operator's behalf, because a force-push to a release candidate that has already been advertised to other consumers deserves an explicit human decision rather than a wrapped prompt.
+The skill does not auto-rebase — a force-push to an already-advertised RC deserves an explicit human decision. The operator runs the three remediation commands manually and re-invokes `/release`.
 
 ### 6. Merge the PR
 
@@ -461,5 +438,3 @@ Output:
 
 - Never push directly to `main` — always merge via PR
 - Always create the git tag after the merge, never before
-- Always pass `--rebase --delete-branch` to `gh pr merge` for the release PR. Never use `--merge` or `--squash` — those reintroduce merge bubbles or collapse per-feature history, both of which the bubble-free invariant forbids.
-- If no RC branch exists, abort with a clear error message.

--- a/plugins/flowkit/skills/ship-epic/SKILL.md
+++ b/plugins/flowkit/skills/ship-epic/SKILL.md
@@ -67,10 +67,7 @@ If the script exits non-zero (empty stdout), surface stderr and stop. Do not ret
 
 ## Constraints
 
-- Always rebase-merge to `develop`, never squash-merge, never merge-commit. This preserves per-feature first-parent linearity.
-- Always promotes to `develop` only. ship-epic is opinionated about the target branch.
-- Preflight guardrails are advisory — no `--force-promote` bypass flag. If the epic has no commits ahead of `develop`, or contains raw `worktree-agent-*` merge commits (meaning `swarmkit:merge-stack` was not run), the skill stops with a recovery hint. Use the manual fallback in `flowkit:cut-epic` Teardown for rare edge cases.
-- On rebase-merge conflict: exits 1 with a recovery hint; `claude.flowkit.prBase` and the epic branch are left intact so the operator can rebase and re-invoke.
+- Preflight guardrails are advisory — no `--force-promote` bypass flag.
 - Concurrent invocations (second call while first `gh pr merge --rebase` is in flight) fail at PR-create or merge; both paths exit 1 with stderr and no state corruption.
 
 ## Composition

--- a/plugins/flowkit/skills/ship/SKILL.md
+++ b/plugins/flowkit/skills/ship/SKILL.md
@@ -82,8 +82,5 @@ Report:
 
 ## Constraints
 
-- Never commit directly to `develop` or `main`
-- No branch/commit/PR creation outside what `cut` and `release` produce — those belong to `/pr` and `/swarm`
 - The preflight is non-negotiable: do not bypass or weaken it. Open swarm PRs must be merged via `/swarmkit:merge-stack` (and the epic promoted via `/flowkit:ship-epic` when applicable) before ship runs
-- No internal verify gate. Ship assumes the operator has already verified the integrated state against the project's tests between merge-stack and ship-epic (or between ship-epic and ship). Ship just packages what is already on `develop`
-- Stop on any sub-skill failure. State is recoverable across partial failures: re-running `/ship` after the operator resolves the failure picks up where the chain left off
+- State is recoverable across partial failures: re-running `/ship` after the operator resolves the failure picks up where the chain left off


### PR DESCRIPTION
## Summary
- Baseline OpenSpec spec for flowkit: 19 requirements, 78 scenarios across all 18 skills. REFERENCES.md cites every requirement back to source file:line, including the four shell test suites where coverage exists.
- Tighten 14 SKILL.md files against the spec: 1839 → 1707 lines (−132, 7%). Drops spec-restating constraints, release smoke-test block, cut-epic Composition + manual-fallback, pipeline-status redundant example, and verbose rationale prose in release/cut.

## Changes
- `openspec/specs/flowkit/spec.md` — new behavioral spec.
- `openspec/specs/flowkit/REFERENCES.md` — new citation file with 8 cross-cutting interpretive notes; test attributions for with-clean-workspace, push-or-pr, ship-epic, merge-pr, restack.
- 14 SKILL.md files tightened (release, cut-epic, pipeline-status, cut, open-pr, commit, pr, merge-pr, create-branch, ship, ship-epic, default-branch-prompt, push-or-pr, pr-base-scope).

## Test plan
- [x] \`bash scripts/openspec validate flowkit --type spec --strict\` passes.
- [x] Citation audit ran via Explore agent — 28 citations checked; revised REFERENCES.md after auditor caught over-flagged test coverage on with-clean-workspace.
- [x] Coverage check after tightening — restored 3 directives inline (Nothing to commit, Never amend, Failure aborts the chain) after the constraint drop left them uncovered. All 78 spec scenarios map.

Stacked on #976 (swarmkit) → #975 (speckit) → develop. Merge bottom-up.