### PR TITLE
feat(opsx-bridge): implement apply-via-squad dispatch skill

### DIFF
--- a/plugins/opsx-bridge/skills/apply-via-squad/SKILL.md
+++ b/plugins/opsx-bridge/skills/apply-via-squad/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: apply-via-squad
+description: Dispatch an OpenSpec change to a squadkit crew. Reads openspec/changes/<name>/, derives a squad profile from the proposal's ## Capabilities (one builder per unique capability, capped at 4, default 1 when none), and invokes /squadkit:spawn-team with the proposal + design as briefs on an epic branch. Reconciles tasks.md after the crew's PRs land.
+triggers:
+  - "/opsx-bridge:apply-via-squad"
+  - "apply via squad"
+  - "apply change via squad"
+  - "dispatch change to squad"
+  - "spawn a squad for change"
+allowed-tools: Bash, Read, Edit, Skill
+---
+
+# Apply via Squad
+
+Bridge a single OpenSpec change to a coordinated squadkit crew. The skill reads `openspec/changes/<name>/`, derives a crew profile from the proposal's `## Capabilities` (the universal unit of work — see D3), and hands the proposal + design off to `/squadkit:spawn-team` as the architect's mission brief. After the crew's PRs land, it reconciles completed sections back into `tasks.md` so `/opsx:archive` works.
+
+The bridge is **additive** — it calls `spawn-team` as a black box through its public flag surface and never modifies squadkit, opsx, or the change proposal.
+
+## Input
+
+`$ARGUMENTS` — the change name (positional) plus optional flags.
+
+| Argument | Default | Effect |
+|----------|---------|--------|
+| `<change-name>` | required | Directory under `openspec/changes/`. Resolved by `read-change`. |
+| `--profile <name>` | derived | Named crew profile to pass through to spawn-team. When present, **skips** capability-based builder derivation (D3). |
+| `--base <branch>` | resolved | Override the base branch the epic is cut from. See base resolution below. |
+| `--no-epic` | epic on | Suppress the `--epic` flag; the crew commits directly against the resolved base branch instead of a feature epic branch (D5). |
+
+`--profile` and the derived builder count are mutually exclusive — when `--profile` is given the bridge does not compute `--builders`.
+
+## Process
+
+### 1. Preflight — read and validate the change
+
+Invoke the internal `read-change` sub-skill for the named change. Consume its documented JSON output contract (`capabilities`, `applyReady`, `applyRequires`); do not re-parse the change directory here.
+
+```
+Skill({skill: "opsx-bridge:read-change", args: "<change-name>"})
+```
+
+**Change not found.** `read-change` exits non-zero with a stderr message when `openspec/changes/<name>/` does not exist. On that failure, refuse to dispatch and list available changes so the operator can correct the name:
+
+```bash
+openspec list --json | jq -r '.[].name'
+```
+
+Report: `apply-via-squad: no change "<name>". Available: <list>.`
+
+**Apply-readiness.** Validate the change is apply-ready before dispatching. The CLI is the source of truth:
+
+```bash
+STATUS=$(openspec status --change "<name>" --json)
+```
+
+Every artifact named in `applyRequires` must have `status: "done"`. Equivalently, `read-change`'s `applyReady` field is `true`. If any required artifact is not `done`:
+
+- Refuse to dispatch.
+- Report which `applyRequires` artifacts are incomplete (name + current status).
+- Suggest completing them: `Run /opsx:propose <name> to finish the outstanding artifacts, then re-run apply-via-squad.`
+
+This mirrors the spec's "Apply-readiness unsatisfied" scenario — the bridge proceeds only when readiness is satisfied.
+
+### 2. Resolve the base branch
+
+Never hardcode `develop` or `main`. Resolve `$BASE` in order, stopping at the first non-empty result (D5):
+
+1. `--base <branch>` flag (per-invocation override).
+2. `git config claude.flowkit.prBase` (operator session pin).
+3. `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` (GitHub default).
+
+```bash
+BASE="${BASE_FLAG:-$(git config claude.flowkit.prBase 2>/dev/null)}"
+[ -n "$BASE" ] || BASE=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+```
+
+`spawn-team` cuts the epic branch from its own configured base; the bridge surfaces `$BASE` to the operator so the resolved target is explicit, and passes `--base` through when overriding.
+
+### 3. Derive the crew profile from capabilities
+
+Skip this step when `--profile <name>` was passed — pass that profile through to spawn-team verbatim and let it size the crew (D3, "Explicit profile override").
+
+Otherwise derive the builder count from `read-change`'s `capabilities` array:
+
+- `N = number of unique capabilities` (New + Modified, already de-duplicated by read-change).
+- Builder count = `min(N, 4)` — one builder per capability, capped at 4.
+- When `N == 0` (no-specs change — proposal.md + tasks.md only, per D8), default to **1** builder. The bridge does **not** refuse; OpenSpec only requires `tasks` for apply-readiness and the bridge respects that contract.
+
+```bash
+N=$(jq 'length' <<<"$CAPABILITIES")
+if [ "$N" -eq 0 ]; then BUILDERS=1; elif [ "$N" -gt 4 ]; then BUILDERS=4; else BUILDERS="$N"; fi
+```
+
+The default crew shape is `1 architect + N builders + 1 reviewer + 1 tester`, expressed by passing `--builders <BUILDERS>` against spawn-team's default profile. The architect coordinates; the bridge does not invent a new profile format.
+
+### 4. Compose the briefs
+
+Pass the proposal as a brief always; add the design brief only when `design.md` exists and is non-empty (spec scenarios "Proposal and design both present" / "Proposal only"):
+
+```bash
+BRIEFS=(--brief "@openspec/changes/<name>/proposal.md")
+DESIGN="openspec/changes/<name>/design.md"
+[ -s "$DESIGN" ] && BRIEFS+=(--brief "@$DESIGN")
+```
+
+`spawn-team` reads each `@path` and embeds the concatenated content into the architect's spawn prompt under `## Mission brief`. Only the architect receives the brief; other roles get scoped tasks from the lead.
+
+### 5. Compose the epic flag
+
+Include `--epic <change-name>` by default so the crew works on `feature/<change-name>-<parent-issue>` cut from the resolved base (D5, "Default epic mode"). Suppress it when the operator passed `--no-epic` — the squad then commits directly against the resolved base (spec scenario "Operator disables epic"):
+
+```bash
+EPIC=(--epic "<change-name>")
+[ -n "$NO_EPIC" ] && EPIC=()
+```
+
+### 6. Dispatch to spawn-team
+
+Compose the full invocation from the pieces above and dispatch via the Skill tool. The bridge is a non-interactive caller, so it MUST pass an explicit `--mode` (spawn-team prompts only for `--mode inherit`); default to `--mode none` so the operator's harness defaults apply unless they say otherwise.
+
+With derived builders (no `--profile`):
+
+```
+Skill({skill: "squadkit:spawn-team",
+       args: "--builders <BUILDERS> <EPIC> <BRIEFS> --mode none"})
+```
+
+With an explicit profile override:
+
+```
+Skill({skill: "squadkit:spawn-team",
+       args: "--profile <name> <EPIC> <BRIEFS> --mode none"})
+```
+
+Show the operator the constructed argument string before dispatching. Example (this very change — one capability `opsx-bridge`, proposal + design both present):
+
+```
+/squadkit:spawn-team --builders 1 --epic opsx-bridge \
+  --brief @openspec/changes/opsx-bridge/proposal.md \
+  --brief @openspec/changes/opsx-bridge/design.md \
+  --mode none
+```
+
+spawn-team owns the rest: epic-branch cut (via `flowkit:cut-epic`), worktree provisioning, member spawn, and the dispatch loop. The bridge does not micromanage the crew.
+
+### 7. Post-completion reconciliation
+
+After the crew's PRs land, reconcile `tasks.md`. Detect completion by matching merged PRs for issues labeled `opsx-change:<name>`:
+
+```bash
+gh pr list --search "label:opsx-change:<name> is:merged" --state merged \
+  --json number,title,body
+```
+
+For each `tasks.md` section whose corresponding work has landed (a matching merged PR), mark every `- [ ]` item in that section `- [x]` via `Edit`. Then:
+
+- **All sections complete** — every section has a matching merged PR: mark all tasks `[x]` and suggest `/opsx:archive <name>`. Confirm via `openspec status --change <name> --json` (`isComplete: true`).
+- **Partial completion** — only some sections have merged PRs: mark **only** the completed sections' tasks `[x]`, leave incomplete sections untouched, and report which sections remain.
+
+**Never mutate `tasks.md` for failed or incomplete sections** (D7). The operator decides whether to re-run for the unfinished work.
+
+### 8. Failure surfacing — no retry
+
+If a squad member fails its verify gate or stops responding, surface the member name and its current task, and **do not** mutate `tasks.md` for that section (D7). The bridge **never auto-retries** — a failure is a signal for human attention. The operator inspects the crew, fixes the blocker, and re-invokes if they choose.
+
+## Notes
+
+- **Stack-agnostic.** The bridge sizes the crew from OpenSpec capabilities, never from `plugin.json`, directory structure, or any release unit. A capability may map to a plugin, a package, a service, or a logical grouping the spec author chose.
+- **read-change is the parser.** This skill consumes read-change's payload; it does not re-implement capability parsing or apply-readiness derivation. Apply-readiness is *reported* by read-change and *enforced* here.
+- **spawn-team is a black box.** apply-via-squad composes valid spawn-team flags (`--profile`, `--builders`, `--epic`, `--brief @path`, `--mode`) and dispatches. It never inspects or modifies squadkit internals.
+
+## Composition
+
+| Calls | Why |
+|-------|-----|
+| `opsx-bridge:read-change` | Parse the change into capabilities + apply-readiness (preflight). |
+| `squadkit:spawn-team` | Materialize the crew with the derived/overridden profile, briefs, and epic. |

--- a/plugins/opsx-bridge/skills/apply-via-squad/SKILL.md
+++ b/plugins/opsx-bridge/skills/apply-via-squad/SKILL.md
@@ -47,16 +47,18 @@ openspec list --json | jq -r '.[].name'
 
 Report: `apply-via-squad: no change "<name>". Available: <list>.`
 
-**Apply-readiness.** Validate the change is apply-ready before dispatching. The CLI is the source of truth:
+**Apply-readiness.** The readiness GATE consumes `read-change`'s `applyReady` boolean (= `openspec status`'s `.isComplete`). Dispatch only when `applyReady` is `true`.
+
+`read-change` flattens `applyRequires` to a `string[]` of artifact names — it carries no per-artifact status. So when the gate is closed and the bridge needs to report *which* required artifacts are still incomplete, it sources that status detail by re-querying the CLI directly (the source of truth):
 
 ```bash
 STATUS=$(openspec status --change "<name>" --json)
 ```
 
-Every artifact named in `applyRequires` must have `status: "done"`. Equivalently, `read-change`'s `applyReady` field is `true`. If any required artifact is not `done`:
+If `applyReady` is `false`:
 
 - Refuse to dispatch.
-- Report which `applyRequires` artifacts are incomplete (name + current status).
+- Re-query `openspec status` to report which `applyRequires` artifacts are incomplete (name + current status from the CLI, not from `read-change`).
 - Suggest completing them: `Run /opsx:propose <name> to finish the outstanding artifacts, then re-run apply-via-squad.`
 
 This mirrors the spec's "Apply-readiness unsatisfied" scenario — the bridge proceeds only when readiness is satisfied.
@@ -113,6 +115,8 @@ Include `--epic <change-name>` by default so the crew works on `feature/<change-
 EPIC=(--epic "<change-name>")
 [ -n "$NO_EPIC" ] && EPIC=()
 ```
+
+**Known limitation — `--no-epic` cannot fully suppress spawn-team's epic prompt.** squadkit exposes no `--no-epic` flag. When `--epic` is omitted, spawn-team's documented behavior is to *prompt* for epic confirmation (an `AskUserQuestion`) rather than silently skip the epic. `--mode none` sets the member permission mode only — it does NOT suppress that confirmation prompt. So under `--no-epic` the operator will still see spawn-team's epic-confirmation prompt; the intended contract is that they answer it "use base branch" to keep the crew on the resolved base. A future squadkit `--no-epic` flag would let the bridge pass through and close this loop; until then this is a known, documented interaction the bridge cannot eliminate from its side.
 
 ### 6. Dispatch to spawn-team
 

--- a/plugins/opsx-bridge/skills/read-change/SKILL.md
+++ b/plugins/opsx-bridge/skills/read-change/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: read-change
+description: Parse an OpenSpec change directory into a structured payload (capabilities, tasks-by-section, dependency edges, apply-readiness). Internal sub-skill used by opsx-bridge:apply-via-squad and apply-via-swarm. Not user-facing.
+---
+
+# read-change
+
+Tier 4 sub-skill (internal component, not user-facing). It parses `openspec/changes/<name>/` into the single structured representation both dispatch paths consume. `apply-via-squad` reads the capabilities to size the crew; `apply-via-swarm` reads the tasks-by-section map and the merged dependency edges to file and order issues.
+
+There is **no top-level command** for this skill. It is invoked only by its sibling bridge skills (or directly during development), never advertised to operators. The frontmatter declares `name` + `description` only — no `triggers`, so the harness registers no `/opsx-bridge:read-change` command.
+
+## Input
+
+A single change name (the directory under `openspec/changes/`). No flags.
+
+## Output
+
+A bare JSON payload on stdout with these fields:
+
+| Field | Type | Source |
+|-------|------|--------|
+| `changeName` | string | the input name |
+| `schemaName` | string | `openspec status --json` → `.schemaName` |
+| `capabilities` | string[] | unique New + Modified capability names from `proposal.md` (§2.2) |
+| `tasksBySection` | object | section-id → array of task strings (§2.3) |
+| `inlineEdges` | {from,to}[] | inline `<!-- depends: -->` markers (§2.4) |
+| `blockEdges` | {from,to}[] | `## Dependencies` block lines (§2.5) |
+| `applyReady` | boolean | `openspec status --json` → `.isComplete` |
+| `applyRequires` | string[] | `openspec status --json` → `.applyRequires` |
+
+Section IDs are stable slugs of the `##` heading text. Edges are directional `blocked-by`: `{from: dependent-section, to: blocking-section}` means *from* is blocked by *to*.
+
+On any cycle in the merged edge set, the skill emits nothing to stdout, writes the cycle to stderr, and exits non-zero (§2.6).
+
+## Process
+
+### 1. Resolve the change and validate it exists
+
+```bash
+NAME="$1"
+CHANGE_DIR="openspec/changes/$NAME"
+[ -d "$CHANGE_DIR" ] || { echo "read-change: no change directory openspec/changes/$NAME (run: openspec list --json)" >&2; exit 1; }
+```
+
+### 2. Read status (schema, apply-readiness)
+
+The OpenSpec CLI is the source of truth for schema and apply-readiness — never re-derive these from the filesystem.
+
+```bash
+STATUS=$(openspec status --change "$NAME" --json) || { echo "read-change: openspec status failed for $NAME" >&2; exit 1; }
+SCHEMA=$(jq -r '.schemaName' <<<"$STATUS")
+APPLY_READY=$(jq -r '.isComplete' <<<"$STATUS")
+APPLY_REQUIRES=$(jq -c '.applyRequires' <<<"$STATUS")
+```
+
+`openspec instructions apply --change <name> --json` is also available — it returns `contextFiles` (absolute paths to proposal/design/specs/tasks) and a parsed `tasks` array. Prefer it when you want the CLI's own task parse rather than re-reading `tasks.md`; the section grouping below still has to be done by this skill since the CLI returns a flat task list.
+
+### 3. Parse capabilities from proposal.md (§2.2)
+
+Extract the backtick-wrapped kebab-case identifiers from the bullet lists under `### New Capabilities` and `### Modified Capabilities` inside the `## Capabilities` section. Capability names look like `` `opsx-bridge` `` at the start of each bullet. De-duplicate (a name appearing under both New and Modified counts once). Skip the literal word `None`.
+
+```bash
+PROPOSAL="$CHANGE_DIR/proposal.md"
+CAPS='[]'
+if [ -f "$PROPOSAL" ]; then
+  CAPS=$(awk '
+    /^## Capabilities/ {incap=1; next}
+    /^## / && incap {incap=0}
+    incap && /^- `/ {
+      line=$0
+      sub(/^- `/, "", line); sub(/`.*/, "", line)
+      if (line != "" && line != "None") print line
+    }
+  ' "$PROPOSAL" | awk '!seen[$0]++' | jq -R . | jq -s -c .)
+fi
+```
+
+`### New Capabilities` and `### Modified Capabilities` are both `### ` (level-3) headings inside the `## Capabilities` (level-2) section, so the level-2 guard above keeps scanning across them and stops at the next `## `.
+
+### 4. Parse tasks grouped by section (§2.3)
+
+Group every `- [ ]` / `- [x]` item under its nearest preceding `##` heading. Compute the section-id by slugifying the heading text. **Exclude** a `## Dependencies` section — it carries edges, not tasks.
+
+Slug rule: lowercase, replace each run of non-alphanumeric characters with a single hyphen, trim leading/trailing hyphens.
+
+```bash
+slug() { tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//'; }
+```
+
+When parsing a `##` heading, strip any trailing inline `<!-- ... -->` comment before slugifying (the heading "`## Foo <!-- depends: bar -->`" has section-id `foo`, not `foo-depends-bar`).
+
+```bash
+TASKS=$(TASKS_BY_SECTION_via_awk "$CHANGE_DIR/tasks.md")
+```
+
+Implement the grouping in `awk`: on each `## ` line, strip `<!-- ... -->`, slug the remainder, set the current section (skipping `dependencies`); on each `- [` line, append the item text (without the `- [ ] ` / `- [x] ` prefix) to the current section's list. Emit a JSON object of `section-id → [task, ...]`, preserving heading order. If `tasks.md` has no `##` headings at all, the whole file is one implicit section (matching the swarm path's "no section headings → single grouping" contract) — key it on the change name slug.
+
+### 5. Parse inline depends markers (§2.4)
+
+For each `## ` heading, scan its text for `<!-- depends: <section-id> -->`. Each marker yields an edge `{from: <this heading's section-id>, to: <referenced section-id>}`. A heading may carry more than one marker. The referenced id is used verbatim (it is already a section-id slug by convention) — but pass it through the same slug rule defensively.
+
+### 6. Parse the Dependencies block (§2.5)
+
+Read the `## Dependencies` section. Each non-empty line matches `<Name B> blocked by <Name A>` (case-insensitive on the connector). Map both human names back to section-ids by slugifying them, then emit `{from: slug(B), to: slug(A)}`. Also accept the inverse phrasing `<Name A> blocks <Name B>`, which yields the same `{from: slug(B), to: slug(A)}`.
+
+**Resolve each operand to a real section-id**, do not blindly slug it. Block operands are written for humans (`Section 3 (apply-via-squad)`, `Section B`) and rarely slug to the exact heading slug — `Section 3 (apply-via-squad)` slugs to `section-3-apply-via-squad`, which is not the heading slug `3-apply-via-squad-skill`. Resolution rule, applied to each operand against the set of section-ids built in step 4:
+
+1. Exact match of `slug(operand)` against a known section-id.
+2. Else, if the operand contains a leading section number (`Section 3`, `3.`), match the section-id that starts with that number (`3-...`).
+3. Else, if `slug(operand)` is a substring of exactly one section-id (or vice-versa), match that one.
+4. Else, leave the operand unresolved and report it on stderr as a dangling dependency reference (do not silently drop it; an edge to a non-existent section is an authoring error worth surfacing).
+
+This keeps the block tolerant of human phrasing while still emitting edges keyed on the same section-ids the rest of the payload uses. (Author convention: write Dependencies-block names so step 1 or step 2 resolves them — e.g. keep the leading `Section N`.)
+
+### 7. Merge edges and detect cycles (§2.6)
+
+Union `inlineEdges` and `blockEdges`, deduplicating identical `{from,to}` pairs. Build the directed graph (edge `from → to`) and run a DFS/topological check. If a back-edge is found, the change has a dependency cycle:
+
+```bash
+# pseudo: nodes = sections; edges = from -> to (from is blocked by to)
+# if Kahn's algorithm cannot drain all nodes, a cycle remains.
+if HAS_CYCLE; then
+  echo "read-change: dependency cycle detected: $CYCLE_PATH (e.g. a -> b -> a). Fix the depends markers or ## Dependencies block in $CHANGE_DIR/tasks.md." >&2
+  exit 1
+fi
+```
+
+Name the offending nodes in the stderr message so the operator can find the bad marker. Refuse — do not emit a payload.
+
+### 8. Emit the payload
+
+Assemble with `jq -n` using `--arg` / `--argjson` so the output is always valid JSON. Never echo a hand-built JSON string.
+
+```bash
+jq -n \
+  --arg name "$NAME" \
+  --arg schema "$SCHEMA" \
+  --argjson caps "$CAPS" \
+  --argjson tasks "$TASKS" \
+  --argjson inline "$INLINE_EDGES" \
+  --argjson block "$BLOCK_EDGES" \
+  --argjson ready "$APPLY_READY" \
+  --argjson requires "$APPLY_REQUIRES" \
+  '{
+    changeName: $name,
+    schemaName: $schema,
+    capabilities: $caps,
+    tasksBySection: $tasks,
+    inlineEdges: $inline,
+    blockEdges: $block,
+    applyReady: $ready,
+    applyRequires: $requires
+  }'
+```
+
+## Worked example: this change itself
+
+Run against `openspec/changes/opsx-bridge/` the skill produces:
+
+- `capabilities`: `["opsx-bridge"]` (one New capability; Modified is `None`).
+- `tasksBySection`: seven sections. The headings are numbered (`## 1. Plugin Scaffolding`, ...) so the slugs preserve the number prefix: `1-plugin-scaffolding`, `2-internal-sub-skill-read-change`, `3-apply-via-squad-skill`, `4-apply-via-swarm-skill`, `5-openspec-capability-files`, `6-documentation-and-integration`, `7-validation`. The `## Dependencies` section is excluded.
+- `inlineEdges`: `[]` (this tasks.md uses no inline markers).
+- `blockEdges`: the edges from the `## Dependencies` block. The block phrases them as `Section 3 (apply-via-squad) blocked by Section 2 (read-change)`; the step-6 leading-number resolution maps each operand onto its heading section-id, yielding e.g. `{from: "3-apply-via-squad-skill", to: "2-internal-sub-skill-read-change"}`, plus the four-edge fan-in for sections 5–7.
+- `applyReady`: `true`, `applyRequires`: `["tasks"]`.
+
+No cycle, so the payload is emitted.
+
+## Notes for callers
+
+- **Apply-readiness is reported, not enforced here.** This sub-skill surfaces `applyReady` / `applyRequires`; the calling bridge skill decides whether to refuse dispatch (per the spec's apply-readiness requirement).
+- **Cycle detection is enforced here.** A cyclic dependency graph is structurally unusable for topological dispatch, so `read-change` refuses up front rather than handing a broken graph to `swarm-plus`.
+- **Edges are returned split (inline vs block), not pre-merged.** Callers that only need the union should merge-and-dedupe; the split is preserved so a caller can report provenance if it wants. Cycle detection above runs on the union regardless.


### PR DESCRIPTION
## Summary

- Adds the user-facing `/opsx-bridge:apply-via-squad <change>` skill that bridges an OpenSpec change to a squadkit crew.
- Derives builder count from the proposal's `## Capabilities` (one per unique capability, capped at 4, default 1 when none — D3/D8); `--profile` overrides and skips derivation.
- Passes `proposal.md` (always) + `design.md` (when present, non-empty) as `--brief @path` to `/squadkit:spawn-team`, defaults to `--epic <change>` (suppressed by `--no-epic`), and resolves the base branch via `--base` → `claude.flowkit.prBase` → GitHub default (D4/D5).
- Reconciles `tasks.md` after the crew's PRs land — marks completed sections `[x]`, suggests `/opsx:archive` when all complete, never mutates failed/incomplete sections, never auto-retries (D6/D7).

## Changes

- `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md` — new user-facing skill (registers `/opsx-bridge:apply-via-squad`).

## Test plan

- Preflight on the `opsx-bridge` change: `read-change` yields one capability (`opsx-bridge`) → 1 builder; proposal + design both present → two `--brief` args; default `--epic opsx-bridge`.
- Missing-change name: `read-change` exits non-zero → bridge refuses and lists available changes via `openspec list --json`.
- Apply-readiness unsatisfied (an `applyRequires` artifact not `done`) → bridge refuses, names the incomplete artifact, suggests `/opsx:propose <name>`.
- `--profile <name>` → capability derivation skipped, profile passed through.
- `--no-epic` → `--epic` flag omitted from the spawn-team invocation.

Stacked on #990 (`worktree-agent-990`, the `read-change` sub-skill). When #990 merges, GitHub auto-retargets this PR to the default branch.

Closes #991