### PR TITLE
docs(opsx-bridge): surface bridge plugin in repo docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@ The full operator-controlled release flow is four explicit steps, with a verify 
 
 For a release with no swarm in flight (no epic, no open `worktree-agent-*` PRs), `/flowkit:ship` runs unconditionally — it is just `cut → release`.
 
+When work originates as an OpenSpec change, `opsx-bridge` can dispatch its implementation into the squad or swarm flow that produces the epic and `worktree-agent-*` PRs this sequence later integrates and ships (see the Plugins section below).
+
 ## Plugins
 
 `squadkit` is the interactive multi-role collaboration plugin (sibling to swarmkit's parallel-issue resolution). It introduces the `roles → squads → crews` vocabulary and ships `spawn-team`, `init`, and a `SessionStart` hook that re-asserts role context on resume.
@@ -47,6 +49,8 @@ For a release with no swarm in flight (no epic, no open `worktree-agent-*` PRs),
 **Base-branch convention.** Execution crews always work on a `feature/<slug>-<issue>` branch cut from `develop`, owned by `spawn-team`. They never commit directly to `develop`. Discovery crews stay on `develop` since they don't produce code. The supporting flow primitive lives in flowkit:
 
 - `flowkit:cut-epic` — cut the long-lived feature branch standalone (the primitive that `spawn-team --epic` invokes).
+
+`opsx-bridge` connects OpenSpec changes to those same dispatchers. It is purely additive — it leaves opsx, squadkit, and swarmkit untouched, calling them through their existing skill surface. Given a proposed `openspec/changes/<name>/`, `opsx-bridge:apply-via-squad <change>` derives a squad profile from the proposal's `## Capabilities` and dispatches via `/squadkit:spawn-team`, while `opsx-bridge:apply-via-swarm <change>` maps each `tasks.md` section to a GitHub issue and dispatches via `/swarmkit:swarm-plus`. These are the multi-agent alternative to stock single-agent `/opsx:apply`. See [`plugins/opsx-bridge/README.md`](./plugins/opsx-bridge/README.md).
 
 ## Skill Authoring Conventions
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Claude Code plugins for plan, execute, and ship — each keeping you at the hand
 | **[polishkit](./plugins/polishkit/)** | `/plugin install polishkit@smallorbit-plugins` | Appraise code quality, sweep dead code and cruft, and apply cross-cutting fixes |
 | **[flowkit](./plugins/flowkit/)** | `/plugin install flowkit@smallorbit-plugins` | Manage the full git lifecycle from branch to release |
 | **[sessionkit](./plugins/sessionkit/)** | `/plugin install sessionkit@smallorbit-plugins` | Session continuity, context handoffs, planning, and meta-learning. Map work-in-flight into an approved task chain with `/roadmap` and drive it to completion with `/drive`. |
+| **[opsx-bridge](./plugins/opsx-bridge/)** | `/plugin install opsx-bridge@smallorbit-plugins` | Dispatch an OpenSpec change's implementation to a coordinated squad (`/apply-via-squad`) or a parallel swarm (`/apply-via-swarm`) — the multi-agent alternative to stock single-agent `/opsx:apply`. See the plugin's [which-dispatcher-to-pick table](./plugins/opsx-bridge/README.md#which-dispatcher-to-pick). |
 
 ### Utilities & Productivity
 
@@ -156,6 +157,17 @@ The development-lifecycle plugins form a complete loop from idea to release:
 Each plugin's README describes how it pairs with the others.
 
 See each plugin's README for detailed usage.
+
+## Spec-driven workflow with opsx-bridge
+
+If you author work as [OpenSpec](https://github.com/Fission-AI/OpenSpec) changes rather than GitHub epics, **opsx-bridge** connects that workflow to the same multi-agent dispatchers. Once a change is proposed with `/opsx:propose` and ready to implement, the bridge drives it through a coordinated crew or a parallel swarm instead of the stock single-agent `/opsx:apply` loop:
+
+```
+/opsx-bridge:apply-via-squad <change>     # squadkit:spawn-team — one architect coordinating cross-capability work
+/opsx-bridge:apply-via-swarm <change>     # swarmkit:swarm-plus — parallel agents, one per tasks.md section
+```
+
+The bridge is purely additive — it leaves opsx, squadkit, and swarmkit untouched, calling them through their existing skill surface. For the full "which dispatcher to pick" decision table, see the [opsx-bridge README](./plugins/opsx-bridge/README.md#which-dispatcher-to-pick).
 
 ## Conventions
 

--- a/openspec/README.md
+++ b/openspec/README.md
@@ -30,3 +30,12 @@ requirement back to specific file:line evidence.
 **Proposing changes** — once a capability is baselined, use `/opsx:propose` to draft
 changes against the existing spec rather than modifying it directly. Proposed changes
 go through a review and apply workflow before the spec is updated.
+
+**Implementing changes** — stock `/opsx:apply` walks a change's `tasks.md` linearly in
+one conversation. For changes that span multiple capabilities or have parallelizable
+work, the **opsx-bridge** plugin offers a multi-agent alternative: once a change is
+proposed and ready, `/opsx-bridge:apply-via-squad <change>` dispatches it to a
+coordinated crew (one architect over cross-capability work) and
+`/opsx-bridge:apply-via-swarm <change>` dispatches it to a parallel swarm (one agent
+per `tasks.md` section). See [`plugins/opsx-bridge/README.md`](../plugins/opsx-bridge/README.md)
+for the dispatcher decision table.

--- a/plugins/opsx-bridge/openspec/specs/opsx-bridge/REFERENCES.md
+++ b/plugins/opsx-bridge/openspec/specs/opsx-bridge/REFERENCES.md
@@ -1,0 +1,263 @@
+# opsx-bridge — Source References
+
+Companion to [spec.md](./spec.md). Not part of the OpenSpec spec.
+Paths relative to `<repo-root>/`.
+Line numbers verified on 2026-05-27.
+
+> **Citation-stability note.** `read-change/SKILL.md` and `apply-via-swarm/SKILL.md`
+> citations use exact line numbers (stable on this branch). `apply-via-squad/SKILL.md`
+> line numbers are **as-of-this-branch** — a fix-round PR (#997) added documentation
+> lines to that file after this branch was cut, so a post-merge re-derivation may shift
+> them by a few lines. Each `apply-via-squad` citation is therefore also anchored to a
+> process-step heading and a short quoted snippet so small drift does not invalidate it.
+
+Both bridge skills (`apply-via-squad` and `apply-via-swarm`) implement the cross-cutting
+requirements — change discovery, apply-readiness, base resolution, reconciliation, and
+failure surfacing — verbatim so they stay consistent; those requirements cite both files.
+
+---
+
+## Requirement: Change discovery by name
+
+**Sources**
+- `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:42-48` — step 1 "Change not found." block: `read-change` exits non-zero when `openspec/changes/<name>/` does not exist; the bridge lists `openspec list --json | jq -r '.[].name'` and reports `apply-via-squad: no change "<name>". Available: <list>.`
+- `plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md:44-50` — step 1 "Change not found." block: same contract for the swarm path.
+- `plugins/opsx-bridge/skills/read-change/SKILL.md:39-43` — `CHANGE_DIR="openspec/changes/$NAME"; [ -d "$CHANGE_DIR" ] || { ... exit 1; }` — the directory-existence resolution itself.
+
+### Scenario: Change name matches existing directory
+**Source:** `plugins/opsx-bridge/skills/read-change/SKILL.md:40-42` — `CHANGE_DIR` resolved from the name; existing directory passes the `[ -d ... ]` guard and the skill proceeds (consumed as preflight by both dispatch skills, e.g. `apply-via-squad/SKILL.md:34-39` step 1 "Preflight — read and validate the change").
+**Interpolated; no direct test.**
+
+### Scenario: Change name does not match
+**Source:** `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:42-48` — "Change not found." block lists available changes via `openspec list --json`. Mirror in `apply-via-swarm/SKILL.md:44-50`.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Apply-readiness validation
+
+**Sources**
+- `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:50-62` — step 1 "Apply-readiness." block: `STATUS=$(openspec status --change "<name>" --json)`, "Every artifact named in `applyRequires` must have `status: "done"`", refuse + suggest `/opsx:propose <name>` otherwise.
+- `plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md:54-66` — step 1 "Apply-readiness." block: identical contract for the swarm path.
+- `plugins/opsx-bridge/skills/read-change/SKILL.md:50-53` — `STATUS=$(openspec status --change "$NAME" --json)`, `APPLY_READY=$(jq -r '.isComplete' ...)`, `APPLY_REQUIRES=$(jq -c '.applyRequires' ...)` — the readiness fields the bridge enforces.
+
+### Scenario: Apply-readiness satisfied
+**Source:** `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:62` — "the bridge proceeds only when readiness is satisfied." Mirror in `apply-via-swarm/SKILL.md:66`.
+**Interpolated; no direct test.**
+
+### Scenario: Apply-readiness unsatisfied
+**Source:** `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:56-60` — "If any required artifact is not `done`: Refuse to dispatch. Report which `applyRequires` artifacts are incomplete ... Suggest ... `/opsx:propose <name>`". Mirror in `apply-via-swarm/SKILL.md:60-64`.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Base branch resolution
+
+**Sources**
+- `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:64-75` — step 2 "Resolve the base branch": "Never hardcode `develop` or `main`", precedence `--base` → `git config claude.flowkit.prBase` → `gh repo view --json defaultBranchRef -q .defaultBranchRef.name`, with the `BASE="${BASE_FLAG:-$(git config claude.flowkit.prBase ...)}"` snippet.
+- `plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md:68-79` — step 2 "Resolve the base branch": "Identical to `apply-via-squad` step 2 — shared logic", same precedence + snippet.
+
+### Scenario: Explicit --base flag
+**Source:** `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:68` — precedence item 1 "`--base <branch>` flag (per-invocation override)." Mirror in `apply-via-swarm/SKILL.md:72`.
+**Interpolated; no direct test.**
+
+### Scenario: Session-pinned base
+**Source:** `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:69` — precedence item 2 "`git config claude.flowkit.prBase` (operator session pin)." Mirror in `apply-via-swarm/SKILL.md:73`.
+**Interpolated; no direct test.**
+
+### Scenario: GitHub default fallback
+**Source:** `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:70` — precedence item 3 "`gh repo view --json defaultBranchRef -q .defaultBranchRef.name` (GitHub default)." Mirror in `apply-via-swarm/SKILL.md:74`.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Squad path builder derivation from capabilities
+
+**Sources**
+- `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:79-94` — step 3 "Derive the crew profile from capabilities": `N = number of unique capabilities`, `Builder count = min(N, 4)`, `N == 0 → 1 builder`, skip when `--profile` given. Snippet at `:90-92` (`if [ "$N" -eq 0 ]; then BUILDERS=1; elif [ "$N" -gt 4 ]; then BUILDERS=4; else BUILDERS="$N"; fi`).
+
+### Scenario: Multiple capabilities
+**Source:** `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:86` — "Builder count = `min(N, 4)` — one builder per capability, capped at 4." (`N <= 4` branch yields `BUILDERS="$N"` at `:91`).
+**Interpolated; no direct test.**
+
+### Scenario: Capability count exceeds cap
+**Source:** `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:91` — `elif [ "$N" -gt 4 ]; then BUILDERS=4` caps the count at 4.
+**Interpolated; no direct test.**
+
+### Scenario: No capabilities (no-specs change)
+**Source:** `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:87` — "When `N == 0` ... default to **1** builder. The bridge does **not** refuse". Snippet `if [ "$N" -eq 0 ]; then BUILDERS=1` at `:91`.
+**Interpolated; no direct test.**
+
+### Scenario: Explicit profile override
+**Source:** `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:81` — "Skip this step when `--profile <name>` was passed — pass that profile through to spawn-team verbatim". Also the `--profile` input row at `:26`.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Squad path brief passing
+
+**Sources**
+- `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:96-106` — step 4 "Compose the briefs": `BRIEFS=(--brief "@openspec/changes/<name>/proposal.md")`, `[ -s "$DESIGN" ] && BRIEFS+=(--brief "@$DESIGN")`.
+
+### Scenario: Proposal and design both present
+**Source:** `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:100-103` — both briefs appended when `design.md` exists and is non-empty (`[ -s "$DESIGN" ]`).
+**Interpolated; no direct test.**
+
+### Scenario: Proposal only
+**Source:** `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:98` — "add the design brief only when `design.md` exists and is non-empty" (the `-s` guard at `:103` is false → proposal-only).
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Squad path epic branch handling
+
+**Sources**
+- `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:108-115` — step 5 "Compose the epic flag": `EPIC=(--epic "<change-name>")` by default, `[ -n "$NO_EPIC" ] && EPIC=()`.
+
+### Scenario: Default epic mode
+**Source:** `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:110` — "Include `--epic <change-name>` by default so the crew works on `feature/<change-name>-<parent-issue>` cut from the resolved base". Snippet `EPIC=(--epic "<change-name>")` at `:113`.
+**Interpolated; no direct test.**
+
+### Scenario: Operator disables epic
+**Source:** `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:114` — `[ -n "$NO_EPIC" ] && EPIC=()` suppresses the flag; "the squad then commits directly against the resolved base" at `:110`. Input row `--no-epic` at `:28`.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Swarm path section grouping
+
+**Sources**
+- `plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md:91-98` — step 4 "Group tasks into section-issues": one section maps to one GitHub issue; N sections → N issue groupings; no `##` headings → single grouping keyed on the change-name slug.
+- `plugins/opsx-bridge/skills/read-change/SKILL.md:80-96` — step 4 "Parse tasks grouped by section": group every `- [ ]`/`- [x]` under nearest `##`, exclude `## Dependencies`, single implicit section when no headings exist.
+
+### Scenario: Multiple sections
+**Source:** `plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md:95` — "**N sections** → N issue groupings, one per section". `## Dependencies` exclusion at `read-change/SKILL.md:82`.
+**Interpolated; no direct test.**
+
+### Scenario: No section headings
+**Source:** `plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md:96` — "**No `##` headings** → `read-change` returns a single section ... that becomes one issue grouping containing all tasks". Backing parse at `read-change/SKILL.md:96` ("If `tasks.md` has no `##` headings at all, the whole file is one implicit section").
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Swarm path issue matching and filing
+
+**Sources**
+- `plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md:100-137` — step 5 "Match or file one issue per section": match via `gh issue list --label "opsx-change:<name>"` grepping each body for `<!-- opsx-section: <section-id> -->`; file via `gh issue create --label "opsx-change:<name>"` with the marker + task checklist.
+
+### Scenario: Matching issue exists
+**Source:** `plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md:104-111` — "the section is matched when its body contains `<!-- opsx-section: <section-id> -->`. Reuse the matched issue number — do **not** file a duplicate."
+**Interpolated; no direct test.**
+
+### Scenario: No matching issue
+**Source:** `plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md:113-135` — "When no open issue matches a section, create a new one"; body starts with the marker, inlines tasks as `- [ ]`, applies the `opsx-change:<name>` label at creation via `gh issue create`.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Swarm path dependency wiring from dual sources
+
+**Sources**
+- `plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md:139-151` — step 6 "Wire blocked-by edges": "Use the **union of `inlineEdges` and `blockEdges`** ... deduplicated", wired via GitHub's native issue-dependencies API.
+- `plugins/opsx-bridge/skills/read-change/SKILL.md:98-128` — steps 5–7: parse inline `<!-- depends: -->` markers, parse the `## Dependencies` block, union edges and detect cycles.
+
+### Scenario: Inline depends marker
+**Source:** `plugins/opsx-bridge/skills/read-change/SKILL.md:98-100` — step 5 "Parse inline depends markers": each `<!-- depends: <section-id> -->` yields `{from: <this section-id>, to: <referenced section-id>}`.
+**Interpolated; no direct test.**
+
+### Scenario: Explicit Dependencies block
+**Source:** `plugins/opsx-bridge/skills/read-change/SKILL.md:102-104` — step 6 "Parse the Dependencies block": each `<Name B> blocked by <Name A>` line emits `{from: slug(B), to: slug(A)}`.
+**Interpolated; no direct test.**
+
+### Scenario: Inline and block both present
+**Source:** `plugins/opsx-bridge/skills/read-change/SKILL.md:115-117` — step 7 "Merge edges and detect cycles": "Union `inlineEdges` and `blockEdges`, deduplicating identical `{from,to}` pairs." Consumed at `apply-via-swarm/SKILL.md:141` ("union ... deduplicated").
+**Interpolated; no direct test.**
+
+### Scenario: Cycle detected
+**Source:** `plugins/opsx-bridge/skills/read-change/SKILL.md:117-128` — step 7: on a back-edge "Refuse — do not emit a payload" (exit non-zero, cycle on stderr). Surfaced by the swarm path at `apply-via-swarm/SKILL.md:52` ("Surface its stderr message verbatim and refuse to dispatch").
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Swarm path topological dispatch
+
+**Sources**
+- `plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md:153-176` — step 7 "Compute topological order" + step 8 "Linearize the order, then dispatch to swarm-plus": topo-sort the union edge set, linearize, dispatch via `Skill({skill: "swarmkit:swarm-plus", args: "<n1> <n2> ... --base <BASE>"})`.
+
+### Scenario: Issues in dependency order
+**Source:** `plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md:163-168` — "Compose the ordered issue numbers as a space-separated list and dispatch via the Skill tool" passing the issue numbers in topological order.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Post-completion tasks.md reconciliation
+
+**Sources**
+- `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:146-160` — step 7 "Post-completion reconciliation": match merged PRs via `gh pr list --search "label:opsx-change:<name> is:merged"`, mark completed sections `[x]`, all-complete vs partial-completion branches.
+- `plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md:178-192` — step 9 "Post-completion reconciliation": "Identical shape to `apply-via-squad` step 7", same all-complete vs partial branches.
+
+### Scenario: All sections complete
+**Source:** `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:157` — "**All sections complete** ... mark all tasks `[x]` and suggest `/opsx:archive <name>`." Mirror at `apply-via-swarm/SKILL.md:189`.
+**Interpolated; no direct test.**
+
+### Scenario: Partial completion
+**Source:** `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:158` — "**Partial completion** ... mark **only** the completed sections' tasks `[x]`, leave incomplete sections untouched, and report which sections remain." Mirror at `apply-via-swarm/SKILL.md:190`.
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: Failure surfacing without retry
+
+**Sources**
+- `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:162-164` — step 8 "Failure surfacing — no retry": squad-member failure surfaces member name + current task, never mutates `tasks.md` for that section, "never auto-retries".
+- `plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md:194-196` — step 10 "Failure surfacing — no retry": closed/stalled PR surfaces the issue number, never mutates `tasks.md`, re-invocation only re-dispatches sections without a matching merged PR.
+
+### Scenario: Squad member fails verify
+**Source:** `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md:164` — "If a squad member fails its verify gate or stops responding, surface the member name and its current task, and **do not** mutate `tasks.md` for that section ... never auto-retries".
+**Interpolated; no direct test.**
+
+### Scenario: Swarm worker fails
+**Source:** `plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md:196` — "If a per-issue worker's PR is closed without merge or stalls, surface the issue number and **do not** mutate `tasks.md` ... only sections without a matching merged PR get re-dispatched."
+**Interpolated; no direct test.**
+
+---
+
+## Requirement: read-change internal sub-skill
+
+**Sources**
+- `plugins/opsx-bridge/skills/read-change/SKILL.md:1-10` — frontmatter (`name` + `description` only, "Not user-facing.") and the Tier-4 internal-component intro: "the single structured representation both dispatch paths consume."
+- `plugins/opsx-bridge/skills/read-change/SKILL.md:130-154` — step 8 "Emit the payload": `jq -n` assembling `changeName`, `schemaName`, `capabilities`, `tasksBySection`, `inlineEdges`, `blockEdges`, `applyReady`, `applyRequires`.
+
+### Scenario: Parsed change structure
+**Source:** `plugins/opsx-bridge/skills/read-change/SKILL.md:144-153` — the emitted object `{ changeName, schemaName, capabilities, tasksBySection, inlineEdges, blockEdges, applyReady, applyRequires }` (matches the Output table at `:20-29`).
+**Interpolated; no direct test.**
+
+### Scenario: Internal-only visibility
+**Source:** `plugins/opsx-bridge/skills/read-change/SKILL.md:10` — "There is **no top-level command** for this skill ... The frontmatter declares `name` + `description` only — no `triggers`, so the harness registers no `/opsx-bridge:read-change` command."
+**Interpolated; no direct test.**
+
+---
+
+## Cross-cutting interpretive notes
+
+Every scenario in this spec is **interpolated** from skill-document prose and bash
+snippets — these are instruction-style SKILL.md files, not executable code with a test
+suite, so no scenario is backed by a direct automated test. The numbered items below are
+the human reviewer's checklist:
+
+1. **Change discovery** — directory existence is enforced inside `read-change`
+   (`read-change/SKILL.md:40-42`); both dispatch skills consume that failure and list
+   available changes. No standalone test of the "available changes" listing path.
+2. **Apply-readiness** — `read-change` *reports* `applyReady`/`applyRequires`
+   (`read-change/SKILL.md:50-53`); enforcement (refuse + suggest `/opsx:propose`) lives
+   in both dispatch skills' step 1. The reporting/enforcing split is by-design.
+3. **Base resolution** — the three-step precedence is duplicated verbatim across both
+   dispatch skills (squad step 2 / swarm step 2) by intent; verify they stay in sync.
+4. **Squad capability derivation** — `min(N,4)` with `N==0 → 1` is the only place builder
+   count is computed; `--profile` short-circuits it.
+5. **Swarm dependency union + cycle detection** — parsing/union/cycle-check live in
+   `read-change` (steps 5–7); the swarm path consumes the resolved edges and surfaces the
+   cycle refusal. Verify the swarm path does not re-derive edges.
+6. **Reconciliation & failure surfacing** — both are shared verbatim across the two
+   dispatch skills; the "never mutate tasks.md for failed/incomplete sections" invariant
+   (D7) is the load-bearing claim to re-check after any edit.

--- a/plugins/opsx-bridge/openspec/specs/opsx-bridge/spec.md
+++ b/plugins/opsx-bridge/openspec/specs/opsx-bridge/spec.md
@@ -1,0 +1,209 @@
+# opsx-bridge
+
+## Purpose
+
+Bridge a single apply-ready OpenSpec change to one of two execution surfaces — a coordinated squadkit crew or a swarmkit swarm — without modifying squadkit, swarmkit, opsx, or the change proposal. The bridge resolves a change by name, validates apply-readiness, resolves the target base branch through a documented precedence chain, dispatches through each dispatcher's public flag surface, and reconciles `tasks.md` against merged PRs afterward. An internal `read-change` sub-skill parses the change directory into the single structured representation both dispatch paths consume.
+
+## Requirements
+
+### Requirement: Change discovery by name
+
+The bridge SHALL resolve a change directory by name from `openspec/changes/<name>/`.
+
+#### Scenario: Change name matches existing directory
+
+- **WHEN** the operator invokes `/opsx-bridge:apply-via-squad <name>` or `/opsx-bridge:apply-via-swarm <name>` and `openspec/changes/<name>/` exists
+- **THEN** the bridge proceeds with that change as the dispatch target
+
+#### Scenario: Change name does not match
+
+- **WHEN** the operator invokes a bridge skill with a name that does not match any `openspec/changes/<name>/` directory
+- **THEN** the bridge SHALL refuse to dispatch and report the missing change with a list of available changes (via `openspec list --json`)
+
+### Requirement: Apply-readiness validation
+
+The bridge SHALL validate that a change is apply-ready before invoking any dispatcher.
+
+#### Scenario: Apply-readiness satisfied
+
+- **WHEN** `openspec status --change <name> --json` reports all `applyRequires` artifacts have `status: "done"`
+- **THEN** the bridge proceeds to dispatch
+
+#### Scenario: Apply-readiness unsatisfied
+
+- **WHEN** one or more `applyRequires` artifacts have status other than `"done"`
+- **THEN** the bridge SHALL refuse to dispatch and report which artifacts are incomplete, suggesting `/opsx:propose <name>` to complete them
+
+### Requirement: Base branch resolution
+
+The bridge SHALL resolve the target base branch via a documented precedence chain and never hardcode a specific branch name.
+
+#### Scenario: Explicit --base flag
+
+- **WHEN** the operator passes `--base <branch>` on the bridge invocation
+- **THEN** the bridge uses `<branch>` as the base
+
+#### Scenario: Session-pinned base
+
+- **WHEN** no `--base` flag is provided and `git config claude.flowkit.prBase` returns a value
+- **THEN** the bridge uses the pinned value as the base
+
+#### Scenario: GitHub default fallback
+
+- **WHEN** no `--base` flag is provided and no session pin is set
+- **THEN** the bridge resolves the base via `gh repo view --json defaultBranchRef -q .defaultBranchRef.name`
+
+### Requirement: Squad path builder derivation from capabilities
+
+The `apply-via-squad` skill SHALL derive default builder count from the proposal's `## Capabilities` section, treating capabilities as the universal unit of work.
+
+#### Scenario: Multiple capabilities
+
+- **WHEN** the proposal lists N unique capabilities (New + Modified combined) and N <= 4
+- **THEN** the derived profile includes N builders
+
+#### Scenario: Capability count exceeds cap
+
+- **WHEN** the proposal lists more than 4 unique capabilities
+- **THEN** the derived profile caps the builder count at 4
+
+#### Scenario: No capabilities (no-specs change)
+
+- **WHEN** the proposal lists zero capabilities (e.g. refactor change with proposal.md + tasks.md only)
+- **THEN** the derived profile defaults to 1 builder, and the bridge proceeds without refusing
+
+#### Scenario: Explicit profile override
+
+- **WHEN** the operator passes `--profile <name>`
+- **THEN** the bridge skips capability-based derivation and passes `--profile <name>` through to `/squadkit:spawn-team`
+
+### Requirement: Squad path brief passing
+
+The `apply-via-squad` skill SHALL pass proposal and design documents as briefs to `/squadkit:spawn-team`.
+
+#### Scenario: Proposal and design both present
+
+- **WHEN** both `proposal.md` and `design.md` exist in the change directory
+- **THEN** the bridge invokes spawn-team with `--brief @<proposal.md> --brief @<design.md>`
+
+#### Scenario: Proposal only
+
+- **WHEN** only `proposal.md` exists (design.md absent or empty)
+- **THEN** the bridge invokes spawn-team with `--brief @<proposal.md>` only
+
+### Requirement: Squad path epic branch handling
+
+The `apply-via-squad` skill SHALL invoke `/squadkit:spawn-team` with an epic flag by default.
+
+#### Scenario: Default epic mode
+
+- **WHEN** the bridge invokes spawn-team without `--no-epic`
+- **THEN** the invocation includes `--epic <change-name>` so the crew works on `feature/<change-name>-<parent-issue>` cut from the resolved base
+
+#### Scenario: Operator disables epic
+
+- **WHEN** the operator passes `--no-epic` to the bridge
+- **THEN** the bridge invokes spawn-team without the `--epic` flag and the squad commits directly against the resolved base branch
+
+### Requirement: Swarm path section grouping
+
+The `apply-via-swarm` skill SHALL group `tasks.md` items by their parent `##` heading and map each section to one GitHub issue.
+
+#### Scenario: Multiple sections
+
+- **WHEN** `tasks.md` contains N `##` sections (excluding any `## Dependencies` block)
+- **THEN** the bridge produces N issue groupings, one per section
+
+#### Scenario: No section headings
+
+- **WHEN** `tasks.md` contains no `##` headings
+- **THEN** the bridge produces a single issue grouping containing all tasks
+
+### Requirement: Swarm path issue matching and filing
+
+The `apply-via-swarm` skill SHALL reuse existing GitHub issues that match a section, or file new ones when no match exists.
+
+#### Scenario: Matching issue exists
+
+- **WHEN** an open issue carries the label `opsx-change:<name>` and its body contains the marker `<!-- opsx-section: <section-id> -->`
+- **THEN** the bridge reuses that issue rather than filing a new one
+
+#### Scenario: No matching issue
+
+- **WHEN** no open issue matches the label + marker for a section
+- **THEN** the bridge files a new GitHub issue with the section's tasks inlined as a checklist, applies the `opsx-change:<name>` label, and includes the `<!-- opsx-section: <section-id> -->` marker in the body
+
+### Requirement: Swarm path dependency wiring from dual sources
+
+The `apply-via-swarm` skill SHALL compute blocked-by edges between section-issues from two sources, merged as a union.
+
+#### Scenario: Inline depends marker
+
+- **WHEN** a section header includes `<!-- depends: <other-section-id> -->`
+- **THEN** the bridge wires a blocked-by edge from this section's issue to the referenced section's issue
+
+#### Scenario: Explicit Dependencies block
+
+- **WHEN** `tasks.md` includes a `## Dependencies` block with lines like `Section B blocked by Section A`
+- **THEN** the bridge wires the corresponding blocked-by edges
+
+#### Scenario: Inline and block both present
+
+- **WHEN** both sources specify edges for the same change
+- **THEN** the bridge merges them as a union, deduplicating identical edges
+
+#### Scenario: Cycle detected
+
+- **WHEN** the computed edge set contains a cycle
+- **THEN** the bridge SHALL refuse to dispatch and report the cycle
+
+### Requirement: Swarm path topological dispatch
+
+The `apply-via-swarm` skill SHALL invoke `/swarmkit:swarm-plus` with section-issues in topological dependency order.
+
+#### Scenario: Issues in dependency order
+
+- **WHEN** the bridge has resolved or filed all section-issues and computed a valid topological order
+- **THEN** the invocation of `/swarmkit:swarm-plus` passes the issue numbers in that order
+
+### Requirement: Post-completion tasks.md reconciliation
+
+The bridge SHALL reconcile `tasks.md` checkbox state with merged PRs after dispatcher completion.
+
+#### Scenario: All sections complete
+
+- **WHEN** every section-issue has a corresponding merged PR (label-matched)
+- **THEN** the bridge marks every task in `tasks.md` as `[x]` and suggests `/opsx:archive <name>`
+
+#### Scenario: Partial completion
+
+- **WHEN** some section-issues have merged PRs and others do not
+- **THEN** the bridge marks only the completed sections' tasks as `[x]`, leaves incomplete sections unmodified, and reports which sections remain
+
+### Requirement: Failure surfacing without retry
+
+The bridge SHALL surface dispatcher failures without auto-retrying.
+
+#### Scenario: Squad member fails verify
+
+- **WHEN** a squad member fails its verify gate or does not respond to coordination messages
+- **THEN** the bridge reports the member name and current task, and SHALL NOT mutate `tasks.md` for the failed section
+
+#### Scenario: Swarm worker fails
+
+- **WHEN** a swarm worker's PR is closed without merge or stalls
+- **THEN** the bridge reports the issue number, and SHALL NOT mutate `tasks.md` for that section. The operator may re-invoke `apply-via-swarm`, and the bridge will only dispatch agents for issues without matching merged PRs.
+
+### Requirement: read-change internal sub-skill
+
+The `opsx-bridge` plugin SHALL include an internal sub-skill `read-change` that parses `openspec/changes/<name>/` into a structured representation consumed by `apply-via-squad` and `apply-via-swarm`.
+
+#### Scenario: Parsed change structure
+
+- **WHEN** `read-change` is invoked with a change name
+- **THEN** it returns a structured payload containing: change name, schema name, proposal capabilities (list of strings), tasks-by-section (map of section-id → task list), inline dependency markers (list of {from, to}), explicit Dependencies block edges (list of {from, to}), and apply-readiness status
+
+#### Scenario: Internal-only visibility
+
+- **WHEN** an operator types `/opsx-bridge:read-change <name>` directly
+- **THEN** the skill is not advertised as a user-facing slash command (it lives under `skills/read-change/SKILL.md` without a corresponding top-level command file)

--- a/plugins/opsx-bridge/skills/apply-via-squad/SKILL.md
+++ b/plugins/opsx-bridge/skills/apply-via-squad/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: apply-via-squad
+description: Dispatch an OpenSpec change to a squadkit crew. Reads openspec/changes/<name>/, derives a squad profile from the proposal's ## Capabilities (one builder per unique capability, capped at 4, default 1 when none), and invokes /squadkit:spawn-team with the proposal + design as briefs on an epic branch. Reconciles tasks.md after the crew's PRs land.
+triggers:
+  - "/opsx-bridge:apply-via-squad"
+  - "apply via squad"
+  - "apply change via squad"
+  - "dispatch change to squad"
+  - "spawn a squad for change"
+allowed-tools: Bash, Read, Edit, Skill
+---
+
+# Apply via Squad
+
+Bridge a single OpenSpec change to a coordinated squadkit crew. The skill reads `openspec/changes/<name>/`, derives a crew profile from the proposal's `## Capabilities` (the universal unit of work — see D3), and hands the proposal + design off to `/squadkit:spawn-team` as the architect's mission brief. After the crew's PRs land, it reconciles completed sections back into `tasks.md` so `/opsx:archive` works.
+
+The bridge is **additive** — it calls `spawn-team` as a black box through its public flag surface and never modifies squadkit, opsx, or the change proposal.
+
+## Input
+
+`$ARGUMENTS` — the change name (positional) plus optional flags.
+
+| Argument | Default | Effect |
+|----------|---------|--------|
+| `<change-name>` | required | Directory under `openspec/changes/`. Resolved by `read-change`. |
+| `--profile <name>` | derived | Named crew profile to pass through to spawn-team. When present, **skips** capability-based builder derivation (D3). |
+| `--base <branch>` | resolved | Override the base branch the epic is cut from. See base resolution below. |
+| `--no-epic` | epic on | Suppress the `--epic` flag; the crew commits directly against the resolved base branch instead of a feature epic branch (D5). |
+
+`--profile` and the derived builder count are mutually exclusive — when `--profile` is given the bridge does not compute `--builders`.
+
+## Process
+
+### 1. Preflight — read and validate the change
+
+Invoke the internal `read-change` sub-skill for the named change. Consume its documented JSON output contract (`capabilities`, `applyReady`, `applyRequires`); do not re-parse the change directory here.
+
+```
+Skill({skill: "opsx-bridge:read-change", args: "<change-name>"})
+```
+
+**Change not found.** `read-change` exits non-zero with a stderr message when `openspec/changes/<name>/` does not exist. On that failure, refuse to dispatch and list available changes so the operator can correct the name:
+
+```bash
+openspec list --json | jq -r '.[].name'
+```
+
+Report: `apply-via-squad: no change "<name>". Available: <list>.`
+
+**Apply-readiness.** Validate the change is apply-ready before dispatching. The CLI is the source of truth:
+
+```bash
+STATUS=$(openspec status --change "<name>" --json)
+```
+
+Every artifact named in `applyRequires` must have `status: "done"`. Equivalently, `read-change`'s `applyReady` field is `true`. If any required artifact is not `done`:
+
+- Refuse to dispatch.
+- Report which `applyRequires` artifacts are incomplete (name + current status).
+- Suggest completing them: `Run /opsx:propose <name> to finish the outstanding artifacts, then re-run apply-via-squad.`
+
+This mirrors the spec's "Apply-readiness unsatisfied" scenario — the bridge proceeds only when readiness is satisfied.
+
+### 2. Resolve the base branch
+
+Never hardcode `develop` or `main`. Resolve `$BASE` in order, stopping at the first non-empty result (D5):
+
+1. `--base <branch>` flag (per-invocation override).
+2. `git config claude.flowkit.prBase` (operator session pin).
+3. `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` (GitHub default).
+
+```bash
+BASE="${BASE_FLAG:-$(git config claude.flowkit.prBase 2>/dev/null)}"
+[ -n "$BASE" ] || BASE=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+```
+
+`spawn-team` cuts the epic branch from its own configured base; the bridge surfaces `$BASE` to the operator so the resolved target is explicit, and passes `--base` through when overriding.
+
+### 3. Derive the crew profile from capabilities
+
+Skip this step when `--profile <name>` was passed — pass that profile through to spawn-team verbatim and let it size the crew (D3, "Explicit profile override").
+
+Otherwise derive the builder count from `read-change`'s `capabilities` array:
+
+- `N = number of unique capabilities` (New + Modified, already de-duplicated by read-change).
+- Builder count = `min(N, 4)` — one builder per capability, capped at 4.
+- When `N == 0` (no-specs change — proposal.md + tasks.md only, per D8), default to **1** builder. The bridge does **not** refuse; OpenSpec only requires `tasks` for apply-readiness and the bridge respects that contract.
+
+```bash
+N=$(jq 'length' <<<"$CAPABILITIES")
+if [ "$N" -eq 0 ]; then BUILDERS=1; elif [ "$N" -gt 4 ]; then BUILDERS=4; else BUILDERS="$N"; fi
+```
+
+The default crew shape is `1 architect + N builders + 1 reviewer + 1 tester`, expressed by passing `--builders <BUILDERS>` against spawn-team's default profile. The architect coordinates; the bridge does not invent a new profile format.
+
+### 4. Compose the briefs
+
+Pass the proposal as a brief always; add the design brief only when `design.md` exists and is non-empty (spec scenarios "Proposal and design both present" / "Proposal only"):
+
+```bash
+BRIEFS=(--brief "@openspec/changes/<name>/proposal.md")
+DESIGN="openspec/changes/<name>/design.md"
+[ -s "$DESIGN" ] && BRIEFS+=(--brief "@$DESIGN")
+```
+
+`spawn-team` reads each `@path` and embeds the concatenated content into the architect's spawn prompt under `## Mission brief`. Only the architect receives the brief; other roles get scoped tasks from the lead.
+
+### 5. Compose the epic flag
+
+Include `--epic <change-name>` by default so the crew works on `feature/<change-name>-<parent-issue>` cut from the resolved base (D5, "Default epic mode"). Suppress it when the operator passed `--no-epic` — the squad then commits directly against the resolved base (spec scenario "Operator disables epic"):
+
+```bash
+EPIC=(--epic "<change-name>")
+[ -n "$NO_EPIC" ] && EPIC=()
+```
+
+### 6. Dispatch to spawn-team
+
+Compose the full invocation from the pieces above and dispatch via the Skill tool. The bridge is a non-interactive caller, so it MUST pass an explicit `--mode` (spawn-team prompts only for `--mode inherit`); default to `--mode none` so the operator's harness defaults apply unless they say otherwise.
+
+With derived builders (no `--profile`):
+
+```
+Skill({skill: "squadkit:spawn-team",
+       args: "--builders <BUILDERS> <EPIC> <BRIEFS> --mode none"})
+```
+
+With an explicit profile override:
+
+```
+Skill({skill: "squadkit:spawn-team",
+       args: "--profile <name> <EPIC> <BRIEFS> --mode none"})
+```
+
+Show the operator the constructed argument string before dispatching. Example (this very change — one capability `opsx-bridge`, proposal + design both present):
+
+```
+/squadkit:spawn-team --builders 1 --epic opsx-bridge \
+  --brief @openspec/changes/opsx-bridge/proposal.md \
+  --brief @openspec/changes/opsx-bridge/design.md \
+  --mode none
+```
+
+spawn-team owns the rest: epic-branch cut (via `flowkit:cut-epic`), worktree provisioning, member spawn, and the dispatch loop. The bridge does not micromanage the crew.
+
+### 7. Post-completion reconciliation
+
+After the crew's PRs land, reconcile `tasks.md`. Detect completion by matching merged PRs for issues labeled `opsx-change:<name>`:
+
+```bash
+gh pr list --search "label:opsx-change:<name> is:merged" --state merged \
+  --json number,title,body
+```
+
+For each `tasks.md` section whose corresponding work has landed (a matching merged PR), mark every `- [ ]` item in that section `- [x]` via `Edit`. Then:
+
+- **All sections complete** — every section has a matching merged PR: mark all tasks `[x]` and suggest `/opsx:archive <name>`. Confirm via `openspec status --change <name> --json` (`isComplete: true`).
+- **Partial completion** — only some sections have merged PRs: mark **only** the completed sections' tasks `[x]`, leave incomplete sections untouched, and report which sections remain.
+
+**Never mutate `tasks.md` for failed or incomplete sections** (D7). The operator decides whether to re-run for the unfinished work.
+
+### 8. Failure surfacing — no retry
+
+If a squad member fails its verify gate or stops responding, surface the member name and its current task, and **do not** mutate `tasks.md` for that section (D7). The bridge **never auto-retries** — a failure is a signal for human attention. The operator inspects the crew, fixes the blocker, and re-invokes if they choose.
+
+## Notes
+
+- **Stack-agnostic.** The bridge sizes the crew from OpenSpec capabilities, never from `plugin.json`, directory structure, or any release unit. A capability may map to a plugin, a package, a service, or a logical grouping the spec author chose.
+- **read-change is the parser.** This skill consumes read-change's payload; it does not re-implement capability parsing or apply-readiness derivation. Apply-readiness is *reported* by read-change and *enforced* here.
+- **spawn-team is a black box.** apply-via-squad composes valid spawn-team flags (`--profile`, `--builders`, `--epic`, `--brief @path`, `--mode`) and dispatches. It never inspects or modifies squadkit internals.
+
+## Composition
+
+| Calls | Why |
+|-------|-----|
+| `opsx-bridge:read-change` | Parse the change into capabilities + apply-readiness (preflight). |
+| `squadkit:spawn-team` | Materialize the crew with the derived/overridden profile, briefs, and epic. |

--- a/plugins/opsx-bridge/skills/apply-via-squad/SKILL.md
+++ b/plugins/opsx-bridge/skills/apply-via-squad/SKILL.md
@@ -47,16 +47,18 @@ openspec list --json | jq -r '.[].name'
 
 Report: `apply-via-squad: no change "<name>". Available: <list>.`
 
-**Apply-readiness.** Validate the change is apply-ready before dispatching. The CLI is the source of truth:
+**Apply-readiness.** The readiness GATE consumes `read-change`'s `applyReady` boolean (= `openspec status`'s `.isComplete`). Dispatch only when `applyReady` is `true`.
+
+`read-change` flattens `applyRequires` to a `string[]` of artifact names — it carries no per-artifact status. So when the gate is closed and the bridge needs to report *which* required artifacts are still incomplete, it sources that status detail by re-querying the CLI directly (the source of truth):
 
 ```bash
 STATUS=$(openspec status --change "<name>" --json)
 ```
 
-Every artifact named in `applyRequires` must have `status: "done"`. Equivalently, `read-change`'s `applyReady` field is `true`. If any required artifact is not `done`:
+If `applyReady` is `false`:
 
 - Refuse to dispatch.
-- Report which `applyRequires` artifacts are incomplete (name + current status).
+- Re-query `openspec status` to report which `applyRequires` artifacts are incomplete (name + current status from the CLI, not from `read-change`).
 - Suggest completing them: `Run /opsx:propose <name> to finish the outstanding artifacts, then re-run apply-via-squad.`
 
 This mirrors the spec's "Apply-readiness unsatisfied" scenario — the bridge proceeds only when readiness is satisfied.
@@ -113,6 +115,8 @@ Include `--epic <change-name>` by default so the crew works on `feature/<change-
 EPIC=(--epic "<change-name>")
 [ -n "$NO_EPIC" ] && EPIC=()
 ```
+
+**Known limitation — `--no-epic` cannot fully suppress spawn-team's epic prompt.** squadkit exposes no `--no-epic` flag. When `--epic` is omitted, spawn-team's documented behavior is to *prompt* for epic confirmation (an `AskUserQuestion`) rather than silently skip the epic. `--mode none` sets the member permission mode only — it does NOT suppress that confirmation prompt. So under `--no-epic` the operator will still see spawn-team's epic-confirmation prompt; the intended contract is that they answer it "use base branch" to keep the crew on the resolved base. A future squadkit `--no-epic` flag would let the bridge pass through and close this loop; until then this is a known, documented interaction the bridge cannot eliminate from its side.
 
 ### 6. Dispatch to spawn-team
 

--- a/plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md
+++ b/plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md
@@ -1,0 +1,209 @@
+---
+name: apply-via-swarm
+description: Dispatch an OpenSpec change to a swarmkit swarm. Reads openspec/changes/<name>/, groups tasks.md by ## section, files or reuses one GitHub issue per section (labelled opsx-change:<name> with an <!-- opsx-section: --> marker), wires blocked-by edges from the change's merged dependency set, and invokes /swarmkit:swarm-plus with the issue numbers in topological order. Reconciles tasks.md after the per-issue PRs land.
+triggers:
+  - "/opsx-bridge:apply-via-swarm"
+  - "apply via swarm"
+  - "apply change via swarm"
+  - "dispatch change to swarm"
+  - "swarm a change"
+allowed-tools: Bash, Read, Edit, Skill
+---
+
+# Apply via Swarm
+
+Bridge a single OpenSpec change to a `/swarmkit:swarm-plus` run. The skill reads `openspec/changes/<name>/`, groups `tasks.md` into one GitHub issue per `##` section (the granularity swarm dispatches on — see D2), wires blocked-by edges between those issues from the change's merged dependency set, and hands the ordered issue numbers to `/swarmkit:swarm-plus`. After the per-issue PRs land, it reconciles completed sections back into `tasks.md` so `/opsx:archive` works.
+
+The bridge is **additive** — it calls `swarm-plus` as a black box through its public flag surface and never modifies swarmkit, opsx, or the change proposal. It is the sibling of `apply-via-squad`; the two share base-branch resolution, apply-readiness preflight, and post-completion reconciliation verbatim so they stay consistent.
+
+## Input
+
+`$ARGUMENTS` — the change name (positional) plus optional flags.
+
+| Argument | Default | Effect |
+|----------|---------|--------|
+| `<change-name>` | required | Directory under `openspec/changes/`. Resolved by `read-change`. |
+| `--base <branch>` | resolved | Override the base branch the section-issue PRs target. See base resolution below. |
+
+Swarm-plus knobs (`--model`, `--worker-model`, `--reviewer-model`, `--review-only`) are not re-declared here; pass-through is out of scope for the bridge — the operator runs `/swarmkit:swarm-plus` directly if they want those.
+
+## Process
+
+### 1. Preflight — read and validate the change
+
+Invoke the internal `read-change` sub-skill for the named change. Consume its documented JSON output contract; do not re-parse the change directory here. The fields this skill uses:
+
+- `tasksBySection` — section-id → task list. Drives section grouping (step 4).
+- `inlineEdges` + `blockEdges` — the two dependency sources. **Union and dedupe them** to get the edge set this skill wires (step 6). read-change has already resolved each `## Dependencies` operand to a real section-id and run a cycle check on the union — consume its resolved `{from, to}` pairs; do **not** re-derive section-ids or re-slug the operands yourself.
+- `applyReady` / `applyRequires` — apply-readiness (this step).
+
+```
+Skill({skill: "opsx-bridge:read-change", args: "<change-name>"})
+```
+
+**Change not found.** `read-change` exits non-zero with a stderr message when `openspec/changes/<name>/` does not exist. On that failure, refuse to dispatch and list available changes so the operator can correct the name:
+
+```bash
+openspec list --json | jq -r '.[].name'
+```
+
+Report: `apply-via-swarm: no change "<name>". Available: <list>.`
+
+**Cycle in the dependency graph.** `read-change` refuses (non-zero, nothing on stdout) when the merged edge set has a cycle. Surface its stderr message verbatim and refuse to dispatch — a cyclic graph has no topological order (spec scenario "Cycle detected"). Do not attempt to break the cycle.
+
+**Apply-readiness.** Validate the change is apply-ready before dispatching. The CLI is the source of truth:
+
+```bash
+STATUS=$(openspec status --change "<name>" --json)
+```
+
+Every artifact named in `applyRequires` must have `status: "done"`. Equivalently, `read-change`'s `applyReady` field is `true`. If any required artifact is not `done`:
+
+- Refuse to dispatch.
+- Report which `applyRequires` artifacts are incomplete (name + current status).
+- Suggest completing them: `Run /opsx:propose <name> to finish the outstanding artifacts, then re-run apply-via-swarm.`
+
+This mirrors the spec's "Apply-readiness unsatisfied" scenario — the bridge proceeds only when readiness is satisfied.
+
+### 2. Resolve the base branch
+
+Identical to `apply-via-squad` step 2 — shared logic, do not diverge. Never hardcode `develop` or `main`. Resolve `$BASE` in order, stopping at the first non-empty result (D5):
+
+1. `--base <branch>` flag (per-invocation override).
+2. `git config claude.flowkit.prBase` (operator session pin).
+3. `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` (GitHub default).
+
+```bash
+BASE="${BASE_FLAG:-$(git config claude.flowkit.prBase 2>/dev/null)}"
+[ -n "$BASE" ] || BASE=$(gh repo view --json defaultBranchRef -q .defaultBranchRef.name)
+```
+
+The resolved `$BASE` is passed through to `swarm-plus` via `--base <BASE>` (step 8). Each independent section-issue PR targets `$BASE`; dependent ones stack onto their predecessor's branch and retarget to `$BASE` on merge (swarm's own model).
+
+### 3. Resolve the repo owner/name
+
+GitHub's dependency API and issue filing need the `{owner}/{repo}` slug. Resolve it once:
+
+```bash
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner)
+```
+
+### 4. Group tasks into section-issues
+
+Consume `read-change`'s `tasksBySection` map — one section maps to one GitHub issue (D2). The map is keyed by section-id and preserves heading order.
+
+- **N sections** → N issue groupings, one per section (spec "Multiple sections").
+- **No `##` headings** → `read-change` returns a single section keyed on the change-name slug; that becomes one issue grouping containing all tasks (spec "No section headings", D8 no-specs note).
+
+Each grouping carries: the section-id (for the marker), the section heading text (for the issue title), and the task list (for the body checklist).
+
+### 5. Match or file one issue per section
+
+For each section, find an existing issue or file a new one. Build the section-id → issue-number map as you go (needed for dependency wiring and topological dispatch).
+
+**Match.** List issues carrying the change label and grep each body for the section marker (spec "Matching issue exists"):
+
+```bash
+gh issue list --label "opsx-change:<name>" --state open --json number,body \
+  | jq -r '.[] | "\(.number)\t\(.body)"'
+```
+
+For each candidate, the section is matched when its body contains `<!-- opsx-section: <section-id> -->`. Reuse the matched issue number — do **not** file a duplicate.
+
+**File.** When no open issue matches a section, create a new one (spec "No matching issue", D2 step 3). The body MUST:
+
+- Start with the marker `<!-- opsx-section: <section-id> -->` on its own line.
+- Inline the section's tasks as a `- [ ]` checklist (the work the per-issue agent resolves).
+- Carry a footer pointing the agent at the change directory so it reads `proposal.md` + `design.md` for orientation (D4 swarm-path briefing).
+
+Apply the `opsx-change:<name>` label at creation:
+
+```bash
+gh issue create \
+  --title "[<change-name> §<section>] <heading text>" \
+  --label "opsx-change:<name>" \
+  --body "$(cat <<'EOF'
+<!-- opsx-section: <section-id> -->
+
+<section task checklist as - [ ] items>
+
+## Context
+
+Part of OpenSpec change `<change-name>`. Read `openspec/changes/<change-name>/proposal.md` and `design.md` for the full design before implementing.
+EOF
+)"
+```
+
+> **Live example.** Issue #992 (the one resolved by this very section of the opsx-bridge change) is exactly this shape: label `opsx-change:opsx-bridge`, a leading `<!-- opsx-section: apply-via-swarm -->` marker, tasks inlined as a checklist, and a context footer pointing at the change directory. Preserve this shape when filing.
+
+### 6. Wire blocked-by edges
+
+Use the **union of `inlineEdges` and `blockEdges`** from `read-change`, deduplicated (spec "Inline and block both present"). Each edge is `{from: dependent-section, to: blocking-section}` keyed on section-ids — read-change already resolved the `## Dependencies` operands to real section-ids and cycle-checked the union, so wire them as-is.
+
+Map both endpoints through the section-id → issue-number map (step 5), then resolve each issue number to its GitHub node id and wire the blocked-by edge via GitHub's native issue-dependencies API. Use `-F` for the integer id field so it is sent as a number, not a string:
+
+```bash
+# blocked = issue number of edge.from (the dependent); blocking = issue number of edge.to
+blocking_id=$(gh api "repos/$REPO/issues/$blocking" -q .id)
+gh api "repos/$REPO/issues/$blocked/dependencies/blocked_by" -X POST -F issue_id="$blocking_id"
+```
+
+This is the same `blockedBy` connection swarm reads in its dependency-graph step — wiring it here means swarm-plus picks the edges up natively without re-parsing issue bodies. An edge whose endpoint has no filed issue (e.g. an unresolved dangling reference read-change reported on stderr) is skipped with a warning — do not invent an issue for it.
+
+### 7. Compute topological order
+
+Build the DAG from the same union edge set (edge `from → to` means *from* is blocked by *to*) over the section-issue nodes and topologically sort it so every blocking issue precedes the issues it blocks. read-change has already guaranteed the graph is acyclic, so a valid order always exists (spec "Issues in dependency order").
+
+### 8. Linearize the order, then dispatch to swarm-plus
+
+> **Design note — diamond graphs must be linearized.** swarm's stacked-PR model is **single-parent**: each dependent agent branches from exactly *one* parent's branch tip (`git checkout -b worktree-agent-<this> origin/worktree-agent-<dependency>`) and its PR targets that one parent. But an OpenSpec change's dependency graph can be a **diamond** — a section depending on two others (a fan-in). swarm cannot express two parents for one branch. So when the graph is not a simple chain, the bridge MUST **linearize** the topological order into a single stack before handing issue numbers to swarm-plus: emit the issues in topological order as one linear sequence, so each downstream issue stacks on the single issue immediately before it. This is correctness-preserving when the fan-in sections touch disjoint files (the common case — sections map to distinct capabilities/areas) because a linear stack still has every upstream section's commits present in each downstream worktree; it only over-constrains ordering, never under-constrains it.
+>
+> This was discovered dogfooding this very plugin: the opsx-bridge change graph had #993 (section 5, the capability files) depending on **both** #991 (apply-via-squad) and #992 (apply-via-swarm) — a diamond fan-in. Linearizing the topo order into `#990 → #991 → #992 → #993` lets swarm chain each as a single-parent stack while still respecting every blocked-by edge.
+
+Compose the ordered issue numbers as a space-separated list and dispatch via the Skill tool, passing the resolved base through:
+
+```
+Skill({skill: "swarmkit:swarm-plus",
+       args: "<n1> <n2> <n3> ... --base <BASE>"})
+```
+
+Show the operator the constructed argument string before dispatching. Example (this very change — five section-issues after linearization, targeting the resolved base):
+
+```
+/swarmkit:swarm-plus 990 991 992 993 994 --base develop
+```
+
+swarm-plus owns the rest: per-issue worktree provisioning, the stacked-PR chain, the automatic review/fix pass per PR, and leaving the PRs open for human merge. The bridge does not micromanage the workers.
+
+### 9. Post-completion reconciliation
+
+Identical shape to `apply-via-squad` step 7 — shared logic. After the per-issue PRs land, reconcile `tasks.md`. Detect completion by matching merged PRs for issues labeled `opsx-change:<name>`:
+
+```bash
+gh pr list --search "label:opsx-change:<name> is:merged" --state merged \
+  --json number,title,body
+```
+
+For each `tasks.md` section whose corresponding section-issue has a matching merged PR, mark every `- [ ]` item in that section `- [x]` via `Edit`. Then:
+
+- **All sections complete** — every section-issue has a matching merged PR: mark all tasks `[x]` and suggest `/opsx:archive <name>`. Confirm via `openspec status --change <name> --json` (`isComplete: true`).
+- **Partial completion** — only some section-issues have merged PRs: mark **only** the completed sections' tasks `[x]`, leave incomplete sections untouched, and report which sections remain.
+
+**Never mutate `tasks.md` for failed or incomplete sections** (D7). The operator decides whether to re-run for the unfinished work.
+
+### 10. Failure surfacing — no retry
+
+If a per-issue worker's PR is closed without merge or stalls, surface the issue number and **do not** mutate `tasks.md` for that section (D7, spec "Swarm worker fails"). The bridge **never auto-retries**. Because step 5 reuses any existing matching issue and reconciliation keys on merged PRs, the operator can simply re-invoke `apply-via-swarm <name>`: matched issues with merged PRs are already reconciled, and only sections without a matching merged PR get re-dispatched.
+
+## Notes
+
+- **read-change is the parser.** This skill consumes read-change's `tasksBySection` and the union of its `inlineEdges` + `blockEdges`; it does not re-implement section parsing, operand resolution, or cycle detection. Apply-readiness is *reported* by read-change and *enforced* here.
+- **swarm-plus is a black box.** apply-via-swarm files/matches issues, wires native blocked-by edges, linearizes the order, and dispatches issue numbers + `--base`. It never inspects or modifies swarmkit internals.
+- **Issues are the contract, tasks.md is authoritative.** `tasks.md` decides *which* sections exist; the section-issue body is (re)generated from it. Issue reuse is keyed on the `<!-- opsx-section: -->` marker so re-invocations are idempotent against the GH board.
+
+## Composition
+
+| Calls | Why |
+|-------|-----|
+| `opsx-bridge:read-change` | Parse the change into tasks-by-section + merged dependency edges + apply-readiness (preflight). |
+| `swarmkit:swarm-plus` | Dispatch the ordered section-issues as a reviewed stacked-PR chain. |

--- a/plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md
+++ b/plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: apply-via-swarm
-description: Dispatch an OpenSpec change to a swarmkit swarm. Reads openspec/changes/<name>/, groups tasks.md by ## section, files or reuses one GitHub issue per section (labelled opsx-change:<name> with an <!-- opsx-section: --> marker), wires blocked-by edges from the change's merged dependency set, and invokes /swarmkit:swarm-plus with the issue numbers in topological order. Reconciles tasks.md after the per-issue PRs land.
+description: Dispatch an OpenSpec change to a swarmkit swarm. Reads openspec/changes/<name>/, groups tasks.md by ## section, files or reuses one GitHub issue per section (labelled opsx-change:<name> with an <!-- opsx-section: --> marker), topologically orders the change's merged dependency set and wires a linearized blocked-by chain (each issue blocked_by only its immediate predecessor) so swarm's single-parent stack model holds, then invokes /swarmkit:swarm-plus with the issue numbers in that order. Reconciles tasks.md after the per-issue PRs land.
 triggers:
   - "/opsx-bridge:apply-via-swarm"
   - "apply via swarm"
@@ -12,7 +12,7 @@ allowed-tools: Bash, Read, Edit, Skill
 
 # Apply via Swarm
 
-Bridge a single OpenSpec change to a `/swarmkit:swarm-plus` run. The skill reads `openspec/changes/<name>/`, groups `tasks.md` into one GitHub issue per `##` section (the granularity swarm dispatches on — see D2), wires blocked-by edges between those issues from the change's merged dependency set, and hands the ordered issue numbers to `/swarmkit:swarm-plus`. After the per-issue PRs land, it reconciles completed sections back into `tasks.md` so `/opsx:archive` works.
+Bridge a single OpenSpec change to a `/swarmkit:swarm-plus` run. The skill reads `openspec/changes/<name>/`, groups `tasks.md` into one GitHub issue per `##` section (the granularity swarm dispatches on — see D2), topologically orders the change's merged dependency set, wires a **linearized** blocked-by chain between those issues (each issue blocked_by only its immediate predecessor), and hands the ordered issue numbers to `/swarmkit:swarm-plus`. After the per-issue PRs land, it reconciles completed sections back into `tasks.md` so `/opsx:archive` works.
 
 The bridge is **additive** — it calls `swarm-plus` as a black box through its public flag surface and never modifies swarmkit, opsx, or the change proposal. It is the sibling of `apply-via-squad`; the two share base-branch resolution, apply-readiness preflight, and post-completion reconciliation verbatim so they stay consistent.
 
@@ -34,7 +34,7 @@ Swarm-plus knobs (`--model`, `--worker-model`, `--reviewer-model`, `--review-onl
 Invoke the internal `read-change` sub-skill for the named change. Consume its documented JSON output contract; do not re-parse the change directory here. The fields this skill uses:
 
 - `tasksBySection` — section-id → task list. Drives section grouping (step 4).
-- `inlineEdges` + `blockEdges` — the two dependency sources. **Union and dedupe them** to get the edge set this skill wires (step 6). read-change has already resolved each `## Dependencies` operand to a real section-id and run a cycle check on the union — consume its resolved `{from, to}` pairs; do **not** re-derive section-ids or re-slug the operands yourself.
+- `inlineEdges` + `blockEdges` — the two dependency sources. **Union and dedupe them** to get the true dependency edge set this skill topologically orders, then linearizes into the native blocked-by chain it wires (steps 6–7). read-change has already resolved each `## Dependencies` operand to a real section-id and run a cycle check on the union — consume its resolved `{from, to}` pairs; do **not** re-derive section-ids or re-slug the operands yourself.
 - `applyReady` / `applyRequires` — apply-readiness (this step).
 
 ```
@@ -104,9 +104,11 @@ For each section, find an existing issue or file a new one. Build the section-id
 **Match.** List issues carrying the change label and grep each body for the section marker (spec "Matching issue exists"):
 
 ```bash
-gh issue list --label "opsx-change:<name>" --state open --json number,body \
+gh issue list --label "opsx-change:<name>" --state open --limit 200 --json number,body \
   | jq -r '.[] | "\(.number)\t\(.body)"'
 ```
+
+`--limit 200` overrides `gh issue list`'s 30-result default cap — without it a matching section-issue past the 30th would be missed and a duplicate filed, breaking idempotent reuse on a busy board or a change with many sections.
 
 For each candidate, the section is matched when its body contains `<!-- opsx-section: <section-id> -->`. Reuse the matched issue number — do **not** file a duplicate.
 
@@ -136,51 +138,53 @@ EOF
 
 > **Live example.** Issue #992 (the one resolved by this very section of the opsx-bridge change) is exactly this shape: label `opsx-change:opsx-bridge`, a leading `<!-- opsx-section: apply-via-swarm -->` marker, tasks inlined as a checklist, and a context footer pointing at the change directory. Preserve this shape when filing.
 
-### 6. Wire blocked-by edges
+### 6. Topologically order the sections, then derive the linearized edge chain
 
-Use the **union of `inlineEdges` and `blockEdges`** from `read-change`, deduplicated (spec "Inline and block both present"). Each edge is `{from: dependent-section, to: blocking-section}` keyed on section-ids — read-change already resolved the `## Dependencies` operands to real section-ids and cycle-checked the union, so wire them as-is.
+> **Design note — linearize the native edges, not just the arg order.** swarm's stacked-PR model is **single-parent**: each dependent agent branches from exactly *one* parent's branch tip (`git checkout -b worktree-agent-<this> origin/worktree-agent-<dependency>`) and its PR targets that one parent. swarm builds this stack from the **native `blockedBy` edges it reads off the issues** (`plugins/swarmkit/skills/swarm/SKILL.md:134`), not from the order issue numbers arrive in. It has no multi-parent/diamond handling — its dependent chain spawns from exactly one parent. So an OpenSpec change's true dependency graph, which can be a **diamond** (a section depending on two others — a fan-in), cannot be wired natively as-is: swarm would read two `blockedBy` edges on the fan-in node and hit the undocumented diamond case. Reordering the arg list alone does **not** fix this, because swarm ignores arg order when computing the DAG.
+>
+> The fix is to linearize **the edges that get wired**, not just the dispatch order. Take the union edge set, topologically sort the section-issues, and derive a **linear chain** where each issue is blocked_by *only its immediate predecessor* in that order. Wire **those** chain edges as the native `blockedBy` connection (step 7). swarm then reads exactly one parent per node and produces a clean single-parent stack. This is correctness-preserving when sections touch disjoint files (the common case — sections map to distinct capabilities/areas): in a linear stack each branch transitively contains all its true ancestors' work (a node branched off its predecessor inherits everything below it), so every original dependency is satisfied through the chain. It only over-constrains ordering, never under-constrains it.
+>
+> This was discovered dogfooding this very plugin: the opsx-bridge change graph had #993 (section 5, the capability files) depending on **both** #991 (apply-via-squad) and #992 (apply-via-swarm) — a diamond fan-in. Wiring that union natively would give swarm two parents for #993. Linearizing to the chain `#990 → #991 → #992 → #993 → #994 → #995` and wiring each node blocked_by only its predecessor (#991←#990, #992←#991, #993←#992, …) lets swarm chain each as a single-parent stack while still respecting every original blocked-by edge transitively.
 
-Map both endpoints through the section-id → issue-number map (step 5), then resolve each issue number to its GitHub node id and wire the blocked-by edge via GitHub's native issue-dependencies API. Use `-F` for the integer id field so it is sent as a number, not a string:
+Build the DAG from the union of `inlineEdges` and `blockEdges` (deduplicated — spec "Inline and block both present"; each edge `{from: dependent, to: blocking}` keyed on section-ids, already resolved and cycle-checked by read-change). Topologically sort it over the section-issue nodes so every blocking section precedes the sections it blocks; read-change has guaranteed acyclicity, so a valid order always exists (spec "Issues in dependency order").
+
+Then derive the **linearized edge chain**: walk the topo order and emit one edge per adjacent pair — issue *k* blocked_by issue *k−1*. For order `[990, 991, 992, 993, 994, 995]` this is exactly `{991←990, 992←991, 993←992, 994←993, 995←994}`. These chain edges — **not** the raw union — are what gets wired natively in step 7 and dispatched in step 8.
+
+### 7. Wire the linearized blocked-by chain natively
+
+Wire each edge of the chain from step 6 as a native GitHub issue dependency. Map both endpoints through the section-id → issue-number map from step 5: for a chain edge `<this> blocked_by <predecessor>`, `$blocked` is `<this>`'s issue number and `$blocking` is `<predecessor>`'s. Resolve the blocking issue's GitHub node id and POST the blocked-by edge. Use `-F` for the integer id field so it is sent as a number, not a string:
 
 ```bash
-# blocked = issue number of edge.from (the dependent); blocking = issue number of edge.to
+# blocked = issue number of this node; blocking = issue number of its immediate topo predecessor
 blocking_id=$(gh api "repos/$REPO/issues/$blocking" -q .id)
 gh api "repos/$REPO/issues/$blocked/dependencies/blocked_by" -X POST -F issue_id="$blocking_id"
 ```
 
-This is the same `blockedBy` connection swarm reads in its dependency-graph step — wiring it here means swarm-plus picks the edges up natively without re-parsing issue bodies. An edge whose endpoint has no filed issue (e.g. an unresolved dangling reference read-change reported on stderr) is skipped with a warning — do not invent an issue for it.
+This is the same `blockedBy` connection swarm reads in its dependency-graph step — wiring the *linearized chain* here means swarm-plus picks up a single parent per node natively, without re-parsing issue bodies and without ever seeing the diamond. A chain edge whose endpoint has no filed issue (e.g. an unresolved dangling reference read-change reported on stderr) is skipped with a warning — do not invent an issue for it.
 
-### 7. Compute topological order
+### 8. Dispatch to swarm-plus
 
-Build the DAG from the same union edge set (edge `from → to` means *from* is blocked by *to*) over the section-issue nodes and topologically sort it so every blocking issue precedes the issues it blocks. read-change has already guaranteed the graph is acyclic, so a valid order always exists (spec "Issues in dependency order").
-
-### 8. Linearize the order, then dispatch to swarm-plus
-
-> **Design note — diamond graphs must be linearized.** swarm's stacked-PR model is **single-parent**: each dependent agent branches from exactly *one* parent's branch tip (`git checkout -b worktree-agent-<this> origin/worktree-agent-<dependency>`) and its PR targets that one parent. But an OpenSpec change's dependency graph can be a **diamond** — a section depending on two others (a fan-in). swarm cannot express two parents for one branch. So when the graph is not a simple chain, the bridge MUST **linearize** the topological order into a single stack before handing issue numbers to swarm-plus: emit the issues in topological order as one linear sequence, so each downstream issue stacks on the single issue immediately before it. This is correctness-preserving when the fan-in sections touch disjoint files (the common case — sections map to distinct capabilities/areas) because a linear stack still has every upstream section's commits present in each downstream worktree; it only over-constrains ordering, never under-constrains it.
->
-> This was discovered dogfooding this very plugin: the opsx-bridge change graph had #993 (section 5, the capability files) depending on **both** #991 (apply-via-squad) and #992 (apply-via-swarm) — a diamond fan-in. Linearizing the topo order into `#990 → #991 → #992 → #993` lets swarm chain each as a single-parent stack while still respecting every blocked-by edge.
-
-Compose the ordered issue numbers as a space-separated list and dispatch via the Skill tool, passing the resolved base through:
+Compose the issue numbers in the same linear topo order as a space-separated list and dispatch via the Skill tool, passing the resolved base through:
 
 ```
 Skill({skill: "swarmkit:swarm-plus",
        args: "<n1> <n2> <n3> ... --base <BASE>"})
 ```
 
-Show the operator the constructed argument string before dispatching. Example (this very change — five section-issues after linearization, targeting the resolved base):
+Show the operator the constructed argument string before dispatching. Example (this very change — the six-issue linearized chain `#990 → #991 → #992 → #993 → #994 → #995`, targeting the resolved base):
 
 ```
-/swarmkit:swarm-plus 990 991 992 993 994 --base develop
+/swarmkit:swarm-plus 990 991 992 993 994 995 --base develop
 ```
 
-swarm-plus owns the rest: per-issue worktree provisioning, the stacked-PR chain, the automatic review/fix pass per PR, and leaving the PRs open for human merge. The bridge does not micromanage the workers.
+swarm-plus owns the rest: per-issue worktree provisioning, the stacked-PR chain (driven by the native chain edges from step 7), the automatic review/fix pass per PR, and leaving the PRs open for human merge. The bridge does not micromanage the workers.
 
 ### 9. Post-completion reconciliation
 
 Identical shape to `apply-via-squad` step 7 — shared logic. After the per-issue PRs land, reconcile `tasks.md`. Detect completion by matching merged PRs for issues labeled `opsx-change:<name>`:
 
 ```bash
-gh pr list --search "label:opsx-change:<name> is:merged" --state merged \
+gh pr list --search "label:opsx-change:<name> is:merged" --state merged --limit 200 \
   --json number,title,body
 ```
 
@@ -198,7 +202,8 @@ If a per-issue worker's PR is closed without merge or stalls, surface the issue 
 ## Notes
 
 - **read-change is the parser.** This skill consumes read-change's `tasksBySection` and the union of its `inlineEdges` + `blockEdges`; it does not re-implement section parsing, operand resolution, or cycle detection. Apply-readiness is *reported* by read-change and *enforced* here.
-- **swarm-plus is a black box.** apply-via-swarm files/matches issues, wires native blocked-by edges, linearizes the order, and dispatches issue numbers + `--base`. It never inspects or modifies swarmkit internals.
+- **swarm-plus is a black box.** apply-via-swarm files/matches issues, topologically orders the union edge set and wires a *linearized* native blocked-by chain (single parent per node), then dispatches the issue numbers in that order + `--base`. It never inspects or modifies swarmkit internals.
+- **Linearize the native edges, not the arg order.** swarm builds its stack from the native `blockedBy` edges on the issues, not from the order issue numbers arrive in. The bridge therefore wires the *chain* edges (each node blocked_by only its topo predecessor) rather than the raw union, so swarm's single-parent model never encounters a diamond.
 - **Issues are the contract, tasks.md is authoritative.** `tasks.md` decides *which* sections exist; the section-issue body is (re)generated from it. Issue reuse is keyed on the `<!-- opsx-section: -->` marker so re-invocations are idempotent against the GH board.
 
 ## Composition

--- a/plugins/opsx-bridge/skills/read-change/SKILL.md
+++ b/plugins/opsx-bridge/skills/read-change/SKILL.md
@@ -1,0 +1,172 @@
+---
+name: read-change
+description: Parse an OpenSpec change directory into a structured payload (capabilities, tasks-by-section, dependency edges, apply-readiness). Internal sub-skill used by opsx-bridge:apply-via-squad and apply-via-swarm. Not user-facing.
+---
+
+# read-change
+
+Tier 4 sub-skill (internal component, not user-facing). It parses `openspec/changes/<name>/` into the single structured representation both dispatch paths consume. `apply-via-squad` reads the capabilities to size the crew; `apply-via-swarm` reads the tasks-by-section map and the merged dependency edges to file and order issues.
+
+There is **no top-level command** for this skill. It is invoked only by its sibling bridge skills (or directly during development), never advertised to operators. The frontmatter declares `name` + `description` only — no `triggers`, so the harness registers no `/opsx-bridge:read-change` command.
+
+## Input
+
+A single change name (the directory under `openspec/changes/`). No flags.
+
+## Output
+
+A bare JSON payload on stdout with these fields:
+
+| Field | Type | Source |
+|-------|------|--------|
+| `changeName` | string | the input name |
+| `schemaName` | string | `openspec status --json` → `.schemaName` |
+| `capabilities` | string[] | unique New + Modified capability names from `proposal.md` (§2.2) |
+| `tasksBySection` | object | section-id → array of task strings (§2.3) |
+| `inlineEdges` | {from,to}[] | inline `<!-- depends: -->` markers (§2.4) |
+| `blockEdges` | {from,to}[] | `## Dependencies` block lines (§2.5) |
+| `applyReady` | boolean | `openspec status --json` → `.isComplete` |
+| `applyRequires` | string[] | `openspec status --json` → `.applyRequires` |
+
+Section IDs are stable slugs of the `##` heading text. Edges are directional `blocked-by`: `{from: dependent-section, to: blocking-section}` means *from* is blocked by *to*.
+
+On any cycle in the merged edge set, the skill emits nothing to stdout, writes the cycle to stderr, and exits non-zero (§2.6).
+
+## Process
+
+### 1. Resolve the change and validate it exists
+
+```bash
+NAME="$1"
+CHANGE_DIR="openspec/changes/$NAME"
+[ -d "$CHANGE_DIR" ] || { echo "read-change: no change directory openspec/changes/$NAME (run: openspec list --json)" >&2; exit 1; }
+```
+
+### 2. Read status (schema, apply-readiness)
+
+The OpenSpec CLI is the source of truth for schema and apply-readiness — never re-derive these from the filesystem.
+
+```bash
+STATUS=$(openspec status --change "$NAME" --json) || { echo "read-change: openspec status failed for $NAME" >&2; exit 1; }
+SCHEMA=$(jq -r '.schemaName' <<<"$STATUS")
+APPLY_READY=$(jq -r '.isComplete' <<<"$STATUS")
+APPLY_REQUIRES=$(jq -c '.applyRequires' <<<"$STATUS")
+```
+
+`openspec instructions apply --change <name> --json` is also available — it returns `contextFiles` (absolute paths to proposal/design/specs/tasks) and a parsed `tasks` array. Prefer it when you want the CLI's own task parse rather than re-reading `tasks.md`; the section grouping below still has to be done by this skill since the CLI returns a flat task list.
+
+### 3. Parse capabilities from proposal.md (§2.2)
+
+Extract the backtick-wrapped kebab-case identifiers from the bullet lists under `### New Capabilities` and `### Modified Capabilities` inside the `## Capabilities` section. Capability names look like `` `opsx-bridge` `` at the start of each bullet. De-duplicate (a name appearing under both New and Modified counts once). Skip the literal word `None`.
+
+```bash
+PROPOSAL="$CHANGE_DIR/proposal.md"
+CAPS='[]'
+if [ -f "$PROPOSAL" ]; then
+  CAPS=$(awk '
+    /^## Capabilities/ {incap=1; next}
+    /^## / && incap {incap=0}
+    incap && /^- `/ {
+      line=$0
+      sub(/^- `/, "", line); sub(/`.*/, "", line)
+      if (line != "" && line != "None") print line
+    }
+  ' "$PROPOSAL" | awk '!seen[$0]++' | jq -R . | jq -s -c .)
+fi
+```
+
+`### New Capabilities` and `### Modified Capabilities` are both `### ` (level-3) headings inside the `## Capabilities` (level-2) section, so the level-2 guard above keeps scanning across them and stops at the next `## `.
+
+### 4. Parse tasks grouped by section (§2.3)
+
+Group every `- [ ]` / `- [x]` item under its nearest preceding `##` heading. Compute the section-id by slugifying the heading text. **Exclude** a `## Dependencies` section — it carries edges, not tasks.
+
+Slug rule: lowercase, replace each run of non-alphanumeric characters with a single hyphen, trim leading/trailing hyphens.
+
+```bash
+slug() { tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//'; }
+```
+
+When parsing a `##` heading, strip any trailing inline `<!-- ... -->` comment before slugifying (the heading "`## Foo <!-- depends: bar -->`" has section-id `foo`, not `foo-depends-bar`).
+
+```bash
+TASKS=$(TASKS_BY_SECTION_via_awk "$CHANGE_DIR/tasks.md")
+```
+
+Implement the grouping in `awk`: on each `## ` line, strip `<!-- ... -->`, slug the remainder, set the current section (skipping `dependencies`); on each `- [` line, append the item text (without the `- [ ] ` / `- [x] ` prefix) to the current section's list. Emit a JSON object of `section-id → [task, ...]`, preserving heading order. If `tasks.md` has no `##` headings at all, the whole file is one implicit section (matching the swarm path's "no section headings → single grouping" contract) — key it on the change name slug.
+
+### 5. Parse inline depends markers (§2.4)
+
+For each `## ` heading, scan its text for `<!-- depends: <section-id> -->`. Each marker yields an edge `{from: <this heading's section-id>, to: <referenced section-id>}`. A heading may carry more than one marker. The referenced id is used verbatim (it is already a section-id slug by convention) — but pass it through the same slug rule defensively.
+
+### 6. Parse the Dependencies block (§2.5)
+
+Read the `## Dependencies` section. Each non-empty line matches `<Name B> blocked by <Name A>` (case-insensitive on the connector). Map both human names back to section-ids by slugifying them, then emit `{from: slug(B), to: slug(A)}`. Also accept the inverse phrasing `<Name A> blocks <Name B>`, which yields the same `{from: slug(B), to: slug(A)}`.
+
+**Resolve each operand to a real section-id**, do not blindly slug it. Block operands are written for humans (`Section 3 (apply-via-squad)`, `Section B`) and rarely slug to the exact heading slug — `Section 3 (apply-via-squad)` slugs to `section-3-apply-via-squad`, which is not the heading slug `3-apply-via-squad-skill`. Resolution rule, applied to each operand against the set of section-ids built in step 4:
+
+1. Exact match of `slug(operand)` against a known section-id.
+2. Else, if the operand contains a leading section number (`Section 3`, `3.`), match the section-id that starts with that number (`3-...`).
+3. Else, if `slug(operand)` is a substring of exactly one section-id (or vice-versa), match that one.
+4. Else, leave the operand unresolved and report it on stderr as a dangling dependency reference (do not silently drop it; an edge to a non-existent section is an authoring error worth surfacing).
+
+This keeps the block tolerant of human phrasing while still emitting edges keyed on the same section-ids the rest of the payload uses. (Author convention: write Dependencies-block names so step 1 or step 2 resolves them — e.g. keep the leading `Section N`.)
+
+### 7. Merge edges and detect cycles (§2.6)
+
+Union `inlineEdges` and `blockEdges`, deduplicating identical `{from,to}` pairs. Build the directed graph (edge `from → to`) and run a DFS/topological check. If a back-edge is found, the change has a dependency cycle:
+
+```bash
+# pseudo: nodes = sections; edges = from -> to (from is blocked by to)
+# if Kahn's algorithm cannot drain all nodes, a cycle remains.
+if HAS_CYCLE; then
+  echo "read-change: dependency cycle detected: $CYCLE_PATH (e.g. a -> b -> a). Fix the depends markers or ## Dependencies block in $CHANGE_DIR/tasks.md." >&2
+  exit 1
+fi
+```
+
+Name the offending nodes in the stderr message so the operator can find the bad marker. Refuse — do not emit a payload.
+
+### 8. Emit the payload
+
+Assemble with `jq -n` using `--arg` / `--argjson` so the output is always valid JSON. Never echo a hand-built JSON string.
+
+```bash
+jq -n \
+  --arg name "$NAME" \
+  --arg schema "$SCHEMA" \
+  --argjson caps "$CAPS" \
+  --argjson tasks "$TASKS" \
+  --argjson inline "$INLINE_EDGES" \
+  --argjson block "$BLOCK_EDGES" \
+  --argjson ready "$APPLY_READY" \
+  --argjson requires "$APPLY_REQUIRES" \
+  '{
+    changeName: $name,
+    schemaName: $schema,
+    capabilities: $caps,
+    tasksBySection: $tasks,
+    inlineEdges: $inline,
+    blockEdges: $block,
+    applyReady: $ready,
+    applyRequires: $requires
+  }'
+```
+
+## Worked example: this change itself
+
+Run against `openspec/changes/opsx-bridge/` the skill produces:
+
+- `capabilities`: `["opsx-bridge"]` (one New capability; Modified is `None`).
+- `tasksBySection`: seven sections. The headings are numbered (`## 1. Plugin Scaffolding`, ...) so the slugs preserve the number prefix: `1-plugin-scaffolding`, `2-internal-sub-skill-read-change`, `3-apply-via-squad-skill`, `4-apply-via-swarm-skill`, `5-openspec-capability-files`, `6-documentation-and-integration`, `7-validation`. The `## Dependencies` section is excluded.
+- `inlineEdges`: `[]` (this tasks.md uses no inline markers).
+- `blockEdges`: the edges from the `## Dependencies` block. The block phrases them as `Section 3 (apply-via-squad) blocked by Section 2 (read-change)`; the step-6 leading-number resolution maps each operand onto its heading section-id, yielding e.g. `{from: "3-apply-via-squad-skill", to: "2-internal-sub-skill-read-change"}`, plus the four-edge fan-in for sections 5–7.
+- `applyReady`: `true`, `applyRequires`: `["tasks"]`.
+
+No cycle, so the payload is emitted.
+
+## Notes for callers
+
+- **Apply-readiness is reported, not enforced here.** This sub-skill surfaces `applyReady` / `applyRequires`; the calling bridge skill decides whether to refuse dispatch (per the spec's apply-readiness requirement).
+- **Cycle detection is enforced here.** A cyclic dependency graph is structurally unusable for topological dispatch, so `read-change` refuses up front rather than handing a broken graph to `swarm-plus`.
+- **Edges are returned split (inline vs block), not pre-merged.** Callers that only need the union should merge-and-dedupe; the split is preserved so a caller can report provenance if it wants. Cycle detection above runs on the union regardless.


### PR DESCRIPTION
## Summary
- Added opsx-bridge to the root README plugin catalog and a short "Spec-driven workflow with opsx-bridge" teaser section that links to the plugin's which-dispatcher-to-pick table.
- Extended `openspec/README.md`'s Authoring section with an "Implementing changes" note covering `/apply-via-squad` and `/apply-via-swarm` as the multi-agent alternative to `/opsx:apply`.
- Added an opsx-bridge entry to the CLAUDE.md Plugins section plus a brief note near the canonical release sequence.

## Changes
- `README.md` — catalog row + teaser section (teaser + link, no fork of plugin README content).
- `openspec/README.md` — additive Authoring subsection; existing structure preserved.
- `CLAUDE.md` — Plugins-section entry describing the two dispatch paths + release-sequence cross-reference.

## Test plan
- [ ] All inter-doc links resolve (`./plugins/opsx-bridge/README.md`, `#which-dispatcher-to-pick`, `../plugins/opsx-bridge/README.md`).
- [ ] Plugin catalog now lists all 8 plugins; opsx-bridge row matches the house format.
- [ ] No content duplicated from the plugin README — root surfaces are teaser + link per CLAUDE.md's no-duplication rule.

Closes #994