### PR TITLE
feat(swarmkit): update for flowkit v4 — inline cut-epic, squash merge-stack

### DIFF
--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "5.6.4",
+  "version": "5.7.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/swarmkit/METHODOLOGY.md
+++ b/plugins/swarmkit/METHODOLOGY.md
@@ -44,8 +44,8 @@ When `/swarm` receives a batch of issues, it parses each issue body for `Depends
 Concretely, an independent agent starts like this:
 
 ```bash
-git checkout develop && git pull origin develop
-git checkout -b worktree-agent-<issue>
+git fetch origin main
+git checkout -B worktree-agent-<issue> origin/main
 ```
 
 A dependent agent starts like this instead:
@@ -61,7 +61,7 @@ The dependent agent's pull request then targets the dependency's branch rather t
 gh pr create --base worktree-agent-<dependency-issue> --head worktree-agent-<issue> ...
 ```
 
-This is the stack. Each pull request in a chain has a head branch and a base branch that is the head branch of the pull request below it. The lowest PR in a chain targets `develop` (or whatever base was configured). GitHub understands this relationship natively and, critically, automatically retargets the dependent PR to the base branch when the dependency merges.
+This is the stack. Each pull request in a chain has a head branch and a base branch that is the head branch of the pull request below it. The lowest PR in a chain targets `main` (or the pinned `feature/<slug>-<N>` epic branch when one was cut). GitHub understands this relationship natively and, critically, automatically retargets the dependent PR to the base branch when the dependency merges.
 
 The reason this works as a concurrency primitive is that the dependent agent already has access to everything the upstream agent produced — the upstream output is in the working tree from the moment the dependent branch is created. The dependent agent never needs to wait for the upstream pull request to merge. That is also why swarmkit forbids merging a dependency PR mid-swarm "to unblock" a downstream agent: the downstream agent is already unblocked by virtue of branching from the upstream tip, and an early merge would bypass your review gate for no gain.
 
@@ -71,7 +71,7 @@ The naive way to merge a stack bottom-up fails badly on GitHub: when the root PR
 
 `/merge-stack` sidesteps this with an up-front retarget. Before any merge runs, every non-root PR in a multi-PR chain is retargeted to the base branch with `gh pr edit <N> --base $BASE`. Once a child's base is the base branch, deleting its predecessor's branch no longer looks like abandonment — the auto-close cascade never fires. This is the direction used by Graphite, git-spice, Sapling, and Phabricator, and it means the diff a reviewer approves is the diff that lands: no successive rebases into the root, no CI re-runs on a growing stack, no ref-juggling to preserve closing metadata.
 
-With retargeting in place, every PR merges uniformly with `gh pr merge <N> --squash --delete-branch`. There is no per-role strategy matrix and no intermediate-branch sweep — `--delete-branch` handles cleanup inline. Each PR's own body closes its own `Closes #N` references natively as it merges. Chains merge from the root upward to the leaf; independent PRs (whose base is already `develop` and that have nothing stacked on them) may merge in any order.
+With retargeting in place, every PR merges uniformly with `gh pr merge <N> --squash --delete-branch`. There is no per-role strategy matrix and no intermediate-branch sweep — `--delete-branch` handles cleanup inline. Each PR's own body closes its own `Closes #N` references natively as it merges. Chains merge from the root upward to the leaf; independent PRs (whose base is already `$BASE` and that have nothing stacked on them) may merge in any order. Squash-merge does not require fast-forward, so GitHub's tree-based diff transparently drops already-applied predecessor commits — no per-merge downstream rebase is needed.
 
 If a merge halts partway up a chain (for example, because of a conflict), the remaining PRs above the halt point are marked blocked and reported at the end. Each PR above the halt still targets the base branch after the retarget, so the user can resolve the conflict and re-run `/merge-stack` without re-threading the stack.
 
@@ -97,75 +97,76 @@ Swarm automatically cuts a feature branch whenever a run will spawn two or more 
 - **Loop mode (all issues)**: `/swarm` — any board with ≥1 issue → epic cut at first non-empty cycle.
 - **Loop mode (label filter)**: `/swarm bug` — same trigger as loop mode.
 
-Single-issue one-shot (`/swarm 12`) always stays flat. The logic is: a standalone issue, by definition, cannot form a stack that needs isolation from `develop`.
+Single-issue one-shot (`/swarm 12`) always stays flat. The logic is: a standalone issue, by definition, cannot form a stack that needs isolation from `main`.
 
 ### What Happens at Epic Cut
 
-When the trigger fires, swarm invokes `flowkit:cut-epic` via the Skill tool before any agent spawns. `cut-epic` is idempotent — if the branch already exists on origin it is reused and the pin is refreshed. After `cut-epic` completes:
+When the trigger fires, swarm cuts the feature branch inline with `git`/`gh` before any agent spawns — no external skill dependency. The cut is idempotent: if the branch already exists on origin it is fetched and reused and the pin is refreshed. After the cut:
 
-- The feature branch `feature/<slug>-<N>` exists on origin.
+- The feature branch `feature/<slug>-<N>` exists on origin (forked from `origin/main`).
 - `claude.flowkit.prBase` is pinned to that branch in the local repo config.
 - Every subsequent `/open-pr` invocation in this repo (and every spawned agent's `gh pr create`) auto-targets the feature branch.
 
-The slug is derived as follows:
+The branch name is derived as follows:
 
-| Run shape | Slug argument to cut-epic |
+| Run shape | Branch name |
 |---|---|
-| One-shot multi-issue | Lowest issue number (cut-epic resolves slug from the issue title) |
-| Loop mode, no label | `feature/swarm-<YYYY-MM-DD>` (full branch name; cut-epic accepts it directly) |
+| One-shot multi-issue | `feature/<slug>-<lowest-issue>` (slug derived from the lowest issue's title, kebab-cased) |
+| Loop mode, no label | `feature/swarm-<YYYY-MM-DD>` |
 | Loop mode + label | `feature/<label>-<YYYY-MM-DD>` |
-| `--epic <slug>` explicit | The given slug verbatim |
+| `--epic <slug>` explicit | The given slug verbatim (with `feature/` prepended if missing) |
 
 ### Inheritance
 
-Every spawned agent's PR targets the feature branch automatically via `claude.flowkit.prBase`. Stack-root PRs (independent issues) target the feature branch; stack-leaf PRs still target their predecessor, which ultimately roots at the feature branch. When `/merge-stack` later retargets non-root PRs, it retargets them to the feature branch (not `develop`), maintaining the same stack shape — just rooted at the epic instead of `develop`.
+Every spawned agent's PR targets the feature branch automatically via `claude.flowkit.prBase`. Stack-root PRs (independent issues) target the feature branch; stack-leaf PRs still target their predecessor, which ultimately roots at the feature branch. When `/merge-stack` later retargets non-root PRs, it retargets them to the feature branch (not `main`), maintaining the same stack shape — just rooted at the epic instead of `main`.
 
 ### Loop-Mode Reuse
 
 In loop mode the feature branch is cut once — at the first cycle that selects ≥1 issue. Subsequent cycles reuse the same branch. A cycle that selects zero issues does not cut anything. If the board is clear at loop entry, the loop exits "Board is clear" before any cut happens.
 
-### Ship-Epic Handoff
+### Epic→Main Handoff
 
 After all child PRs are merged into the feature branch via `/merge-stack`, the feature branch carries N squash commits — one per merged-from-stack PR. Swarm's responsibility ends here: PRs are open (or merged into the feature branch), and the pin is intact.
 
-The canonical release sequence from this point is four steps, run by the operator with a verify gate between integration and promotion:
+The canonical release sequence from this point is three steps, run by the operator with a verify gate between integration and promotion:
 
 ```
 /swarmkit:merge-stack            # land the open worktree-agent-* PRs into the feature branch
 # verify on the feature branch — run typecheck/test/lint against the integrated state
-/flowkit:ship-epic               # rebase-merge the feature branch to develop, unset prBase, delete it
-/flowkit:ship                    # cut → release: develop → main
+# open + squash-merge a single epic→main PR; then:
+#   git config --unset claude.flowkit.prBase
+#   git push origin --delete feature/<slug>-<N>
+/flowkit:ship                    # tag main + create GitHub Release
 ```
 
-`/flowkit:ship-epic` does the develop promotion:
+The epic→main promotion is a single squash-merge:
 
-1. Open the feature→`develop` PR with aggregated `Closes #N` from the squash commits.
-2. Rebase-merge (so the squash commits replay onto `develop` linearly, no merge bubbles).
+1. Open the `feature/<slug>-<N> → main` PR with aggregated `Closes #N` (already carried by each child PR's squash commit message).
+2. Squash-merge (one final commit on `main` summarizing the epic).
 3. Unset `claude.flowkit.prBase`.
 4. Delete the feature branch on origin.
-5. Fast-forward local `develop`.
 
-`/flowkit:ship` then handles the develop→main release: cut a release candidate, merge to main, tag, close issues. It is the release closer only — it does not invoke `merge-stack` or `ship-epic`, and aborts up front if any open `worktree-agent-*` PRs still target the resolved base.
+`/flowkit:ship` then handles the release: preflight on `main`, derive next semver from conventional commits, tag, push, and create a GitHub Release. It is the release closer only — it does not invoke `merge-stack`, and aborts up front if any open `worktree-agent-*` PRs still target the resolved base.
 
-Swarm never invokes `/ship-epic` or `/ship`. The operator must explicitly trigger promotion and release.
+Swarm never invokes `/flowkit:ship`. The operator must explicitly trigger promotion and release.
 
 ### Escape Hatches
 
-- **`--no-epic`** — suppress the cut for a single run; PRs target `$BASE` directly. Use when you want the old flat-to-`develop` shape for a specific multi-issue run.
-- **`--base <branch>`** — overrides targeting entirely and suppresses the cut. Use for trunk-based dev (`--base main`) or any explicit targeting assertion.
+- **`--no-epic`** — suppress the cut for a single run; PRs target `$BASE` directly. Use when you want every PR to target `main` directly for a specific multi-issue run.
+- **`--base <branch>`** — overrides targeting entirely and suppresses the cut. Use for any explicit targeting assertion.
 - **`--epic <slug>`** — provide an explicit slug instead of the derived one. Useful when the lowest issue title produces an unwieldy slug, or when you want to resume an existing epic by name.
 
 ### Cross-Pin Guard
 
-Before invoking `cut-epic`, swarm reads `claude.flowkit.prBase`. If it is set, starts with `feature/`, and differs from the branch about to be cut, swarm exits with:
+Before cutting the epic branch, swarm reads `claude.flowkit.prBase`. If it is set, starts with `feature/`, and differs from the branch about to be cut, swarm exits with:
 
-> `swarm: an epic is already pinned (\`<existing>\`); pass \`--no-epic\` to swarm against develop, or \`--epic <existing-slug>\` to reuse the pinned branch.`
+> `swarm: an epic is already pinned (\`<existing>\`); pass \`--no-epic\` to swarm against main, or \`--epic <existing-slug>\` to reuse the pinned branch.`
 
 This prevents silently overwriting an in-flight epic from a parallel `squadkit:spawn-team --epic` run or a previous swarm session.
 
 ### Symmetry with squadkit
 
-`swarmkit:swarm --epic` and `squadkit:spawn-team --epic` share the same primitive stack: `flowkit:cut-epic` cuts the branch and sets the pin; spawned PRs target the epic; `flowkit:ship-epic` is the operator-driven closer. The difference is orchestration: swarm dispatches fire-and-forget parallel agents against a list of issues; spawn-team dispatches an interactive team-lead + builder crew against a blueprint.
+`swarmkit:swarm --epic` and `squadkit:spawn-team --epic` share the same inline-cut pattern: both cut `feature/<slug>-<N>` from `origin/main` and pin `claude.flowkit.prBase`; spawned PRs target the epic; the operator drives the final epic→main squash. The difference is orchestration: swarm dispatches fire-and-forget parallel agents against a list of issues; spawn-team dispatches an interactive team-lead + builder crew against a blueprint.
 
 ## End-to-End Walkthrough
 
@@ -175,9 +176,9 @@ Consider a small epic with three issues.
 - **#102** — adds a CSV exporter that uses `ReportSerializer`. Depends on #101.
 - **#103** — adds a CLI flag that calls the CSV exporter. Depends on #102.
 
-You invoke `/swarm 101 102 103`. Because three issues are given, `EPIC_MODE=on`. Swarmkit derives the slug from issue #101's title — the lowest number in the batch. It invokes `flowkit:cut-epic` with `101`, which creates `feature/report-serializer-101` on origin and pins `claude.flowkit.prBase` to it. Swarmkit then fetches the three issue bodies, parses `Depends on` and `Blocked by` references, and produces a topological order: #101 is independent, #102 depends on #101, #103 depends on #102. The swarm plan is presented before any agent runs, showing three agents, their branches (`worktree-agent-101`, `worktree-agent-102`, `worktree-agent-103`), the files affected, and the proposed model per agent.
+You invoke `/swarm 101 102 103`. Because three issues are given, `EPIC_MODE=on`. Swarmkit derives the slug from issue #101's title — the lowest number in the batch. It cuts `feature/report-serializer-101` from `origin/main` inline via `git`/`gh` and pins `claude.flowkit.prBase` to it. Swarmkit then fetches the three issue bodies, parses `Depends on` and `Blocked by` references, and produces a topological order: #101 is independent, #102 depends on #101, #103 depends on #102. The swarm plan is presented before any agent runs, showing three agents, their branches (`worktree-agent-101`, `worktree-agent-102`, `worktree-agent-103`), the files affected, and the proposed model per agent.
 
-Agent 101 spawns first. It branches from `origin/develop`, writes the `ReportSerializer` class, commits with `feat(reports): add ReportSerializer`, pushes `worktree-agent-101`, and opens PR #201 with base `feature/report-serializer-101` and head `worktree-agent-101`.
+Agent 101 spawns first. It branches from `origin/feature/report-serializer-101`, writes the `ReportSerializer` class, commits with `feat(reports): add ReportSerializer`, pushes `worktree-agent-101`, and opens PR #201 with base `feature/report-serializer-101` and head `worktree-agent-101`.
 
 Agent 102 waits for #201 to exist, then spawns. It does not wait for #201 to merge. It fetches `origin/worktree-agent-101` and branches from that tip, so the new `ReportSerializer` class is already in its working tree. It adds the CSV exporter on top, commits, pushes `worktree-agent-102`, and opens PR #202 with base `worktree-agent-101` and head `worktree-agent-102`.
 
@@ -198,7 +199,7 @@ Chain 1:  feature/report-serializer-101 ← PR #201 ← PR #202 ← PR #203
 
 Step 1 squash-merges #201 into the epic branch and deletes `worktree-agent-101`. Because #202 was already retargeted, GitHub does not auto-close it. Steps 2 and 3 do the same for #202 and #203. Each PR carries its own `Closes #10N` reference, so each issue closes natively on merge. The epic branch now carries three squash commits.
 
-You run `/ship-epic`. It opens a PR from `feature/report-serializer-101` to `develop`, rebase-merges it (so the three squash commits replay onto `develop` linearly — no merge bubble), deletes the epic branch on origin, unsets `claude.flowkit.prBase`, and fast-forwards local `develop`. The result: `git log --first-parent origin/develop` shows three new squash commits in order, exactly one commit per issue, with no merge commits.
+You open one final PR from `feature/report-serializer-101` to `main`, verify the integrated state, and squash-merge it. The aggregated `Closes #101 / #102 / #103` references from the child PRs' squash commit messages close the issues natively. You then unset `claude.flowkit.prBase` (`git config --unset claude.flowkit.prBase`) and delete the epic branch (`git push origin --delete feature/report-serializer-101`). The result: one new squash commit on `main` covering the whole epic, with `Closes #101`, `Closes #102`, `Closes #103` baked into its body.
 
 Finally `/clean-worktrees` removes the three worktree directories and the three local `worktree-agent-*` branches.
 

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -50,7 +50,7 @@ Swarmkit is designed to run best when agents don't have to pause for per-command
 
 | Skill | Invoke | What it does |
 |-------|--------|--------------|
-| **swarm** | `/swarm` | Spawn parallel isolated-worktree agents to resolve GitHub issues. Multi-issue/loop/label runs auto-cut a `feature/<slug>-<N>` branch and route all child PRs to it (run `/ship-epic` to close out). Single-issue one-shot runs target `develop` directly. |
+| **swarm** | `/swarm` | Spawn parallel isolated-worktree agents to resolve GitHub issues. Multi-issue/loop/label runs auto-cut a `feature/<slug>-<N>` branch from `main` and route all child PRs to it (operator squash-merges epic→main to close out). Single-issue one-shot runs target `main` directly. |
 | **swarm-plus** | `/swarm-plus` | Wraps `/swarm` with an automatic review/fix pass. After each swarm PR opens, dispatches the vendored `swarm-reviewer` agent per PR; if the reviewer flags blockers or concerns, dispatches a worker to push follow-up commits. Single pass per PR. |
 | **next-issue** | `/next-issue` | Fetches open issues, ranks them by priority, specificity, and architectural impact, and recommends what to work on next. |
 | **merge-stack** | `/merge-stack` | Merges all open swarm PRs bottom-up (root PRs first, leaves last) after retargeting non-root PRs to `$BASE`. Pre-scans worktrees to flag merge-set branches still held locally and tails the report with a `/clean-worktrees` follow-up when any `worktree-agent-*` paths remain. |
@@ -81,16 +81,17 @@ Swarmkit vendors a specialized reviewer agent used by `/swarm-plus`. It is not a
 
 ```
 /next-issue                          # See what's ready to work on
-/swarm 12 15 18                      # Auto-cuts feature branch, opens PRs against it
-/merge-stack                         # Fan child PRs into the epic branch bottom-up
-/ship-epic                           # Rebase-merge epic → develop, clear pin, delete epic branch
+/swarm 12 15 18                      # Auto-cuts feature/<slug>-<N> from main, opens PRs against it
+/merge-stack                         # Squash-merge child PRs into the epic branch bottom-up
+# verify on the epic branch          # typecheck/test/lint
+# open + squash-merge epic→main PR   # then unset claude.flowkit.prBase and delete epic branch
 ```
 
-### Single issue (flat to develop)
+### Single issue (flat to main)
 
 ```
-/swarm 12                            # No epic cut — PR targets develop directly
-/merge-pr                            # Merge the one PR (flowkit skill)
+/swarm 12                            # No epic cut — PR targets main directly
+/merge-pr                            # Squash-merge the one PR (flowkit skill)
 ```
 
 ### Loop mode (clear the board)
@@ -102,23 +103,23 @@ Swarmkit vendors a specialized reviewer agent used by `/swarm-plus`. It is not a
 
 ## How Swarm Works
 
-1. Ensures a `develop` branch exists (creates from `main` if needed)
+1. Verifies `main` exists on origin and the working tree is ready
 2. Fetches issues, analyzes dependencies, and presents a swarm plan
-3. If the run will spawn ≥2 agents, cuts a `feature/<slug>-<N>` branch via `flowkit:cut-epic` and pins `claude.flowkit.prBase` to it — all spawned PRs target the epic branch
+3. If the run will spawn ≥2 agents, cuts a `feature/<slug>-<N>` branch from `origin/main` inline (idempotent — resumes the branch if it already exists on origin) and pins `claude.flowkit.prBase` to it — all spawned PRs target the epic branch
 4. Spawns one agent per issue (or grouped set) in isolated git worktrees
 5. Each agent: creates branch, makes changes, commits, pushes, opens PR — then stops
-6. Use `/merge-pr` (1 PR, from [flowkit](../flowkit)) or `/merge-stack` (2+ PRs) to merge child PRs into the epic branch bottom-up; then run `/ship-epic` to rebase-merge the epic onto `develop`
+6. Use `/merge-pr` (1 PR, from [flowkit](../flowkit)) or `/merge-stack` (2+ PRs) to squash-merge child PRs into the epic branch bottom-up; then open a single PR from the epic to `main`, squash-merge it, unpin, and delete the epic branch
 7. Cleans up worktrees and orphaned branches
 
-**One-shot mode**: `/swarm 12 15 18` — auto-cuts epic branch, opens PRs against it; use `/merge-stack → /ship-epic` to land.
-**Single issue (one-shot)**: `/swarm 12` — flat to `develop`, no epic cut; use `/merge-pr` to merge.
+**One-shot mode**: `/swarm 12 15 18` — auto-cuts epic branch, opens PRs against it; use `/merge-stack` then a final epic→main squash to land.
+**Single issue (one-shot)**: `/swarm 12` — flat to `main`, no epic cut; use `/merge-pr` to merge.
 **Loop mode**: `/swarm` — fetch, swarm, open PRs, repeat until the board is clear; epic branch is cut once and reused across cycles.
 **Label filter**: `/swarm bug` — loop mode, but only `bug`-labeled issues.
 
 ### Flags
 
 - `--model <sonnet|opus>` — override model selection for all agents
-- `--base <branch>` — override the default base branch (`develop`); also suppresses the epic cut
+- `--base <branch>` — override the default base branch (`main`); also suppresses the epic cut
 - `--no-epic` — suppress feature-branch mode for this run; PRs target `$BASE` directly
 - `--epic <slug>` — explicit slug for the auto-cut epic branch
 
@@ -130,7 +131,7 @@ Swarmkit vendors a specialized reviewer agent used by `/swarm-plus`. It is not a
 2. As each swarm agent finishes, immediately dispatches `swarm-reviewer` against that PR in the background — no waiting for other swarm agents.
 3. The reviewer compares the PR diff against the originating issue's acceptance criteria and returns findings inline (never as a `gh pr comment`).
 4. If the reviewer's verdict is clean (Approve, no blockers, no concerns, no recommended coverage gaps), the PR is left as-is.
-5. If the reviewer surfaces blockers or concerns, a worker agent is spawned to address them. The worker branches from the existing PR head — never from `develop` — so its commits stack directly onto the PR.
+5. If the reviewer surfaces blockers or concerns, a worker agent is spawned to address them. The worker branches from the existing PR head — never from `main` — so its commits stack directly onto the PR.
 6. After all workers finish, a final table summarizes verdict and worker action per PR.
 
 **Single pass** — there is no reviewer-after-worker re-review. Use `/review <pr>` manually if a second pass is desired.
@@ -147,17 +148,17 @@ All `/swarm` flags are inherited. Swarm-plus adds:
 
 Swarmkit is opinionated. Understanding these assumptions upfront will save you friction.
 
-### Branching Model: `develop` → `main`
+### Branching Model: Single-Trunk GitHub Flow
 
-By default, all PRs target a `develop` branch. If `develop` doesn't exist, `/swarm` creates it from `main` automatically.
+By default, all PRs target `main`. Multi-issue runs auto-cut a short-lived `feature/<slug>-<N>` branch from `main` and route the swarm's PRs through it, but the trunk is always `main` — no `develop` intermediary.
 
-This assumes a **release-branch workflow**: feature work merges into `develop`, and a release process promotes `develop` → `main`. Issues are intentionally left open after their PRs merge to `develop`; they're closed when the release ships.
+Issues close natively via each PR's `Closes #N` footer the moment the PR merges to `main` (directly or via the epic→main squash).
 
-**If you use trunk-based development** (everything goes to `main`):
+**To bypass the epic cut** (every PR targets `main` directly):
 
 ```bash
-/swarm --base main 12 15 18   # one-shot, targeting main
-/swarm --base main            # loop mode, targeting main
+/swarm --no-epic 12 15 18   # one-shot, no epic branch
+/swarm --no-epic            # loop mode, no epic branch
 ```
 
 ### Branch Naming: `worktree-agent-<issue>`
@@ -181,7 +182,7 @@ When an agent is spawned for an issue, swarmkit applies `status:in-progress` to 
 
 ### Issue Lifecycle
 
-Swarmkit **never closes issues** — that's intentional. Closing is left to the release process (when your base branch merges to `main`). This keeps issues open and visible on the board until the work is actually shipped.
+Swarmkit **never closes issues explicitly** — closing is left to GitHub. Each PR's body carries a `Closes #N` footer that GitHub honors natively when the PR merges to `main` (whether directly, or via the epic→main squash). No manual `gh issue close` is required.
 
 ## Configuration Notes
 

--- a/plugins/swarmkit/skills/clean-worktrees/SKILL.md
+++ b/plugins/swarmkit/skills/clean-worktrees/SKILL.md
@@ -27,7 +27,7 @@ On success the script exits 0 and emits a single JSON object on stdout:
 
 ```json
 {
-  "caller_branch": "develop",
+  "caller_branch": "main",
   "main_worktree": "/abs/path/to/repo",
   "worktrees_to_remove": [{"path": "/abs/path/to/repo/.claude/worktrees/worktree-agent-42"}],
   "branches_to_delete": ["worktree-agent-42", "worktree-agent-43"],

--- a/plugins/swarmkit/skills/merge-stack/SKILL.md
+++ b/plugins/swarmkit/skills/merge-stack/SKILL.md
@@ -7,7 +7,7 @@ description: Merge all open swarm PRs bottom-up after retargeting every non-root
 
 Merges all open swarm PRs bottom-up — root PRs first, then their former children, up to the leaves. Before any merge happens, every non-root PR in a multi-PR chain is retargeted to `$BASE` so GitHub never fires its auto-close cascade. Every PR then merges uniformly with `gh pr merge <N> --squash --delete-branch`, and each PR closes its own `Closes/Fixes/Resolves/Refs` references on merge.
 
-Between merges, each still-open downstream branch is locally rebased onto the freshly-updated `$BASE` and force-pushed. Git's patch-id matching drops the predecessor commits (which are already on `$BASE` in squashed form under a different SHA), leaving only the downstream PR's own new commits. Without this rebase, the next PR would flip to `CONFLICTING` the moment its predecessor merges, because the old predecessor commits in its history collide with the new squash commit on `$BASE`.
+Because the underlying merge mode is squash, GitHub's tree-based diff handles already-applied predecessor commits automatically — no per-merge downstream rebase is required. If a downstream PR genuinely conflicts with the freshly-merged predecessor's content, the existing conflict-stops-chain rule (5d) marks it blocked and the operator resolves it manually.
 
 ## When to use
 
@@ -38,7 +38,7 @@ MERGE_SET_BRANCHES=$(gh pr list --state open --json headRefName \
 Model the PRs as a directed graph where an edge A → B means "A's head branch is B's base branch" (A sits on top of B). Build this from the `headRefName` / `baseRefName` fields — no issue-body parsing needed for ordering.
 
 Identify:
-- **Root PRs**: PRs whose `baseRefName` is `$BASE` (e.g. `develop`) and that have at least one other PR stacked on top — these merge first in their chain.
+- **Root PRs**: PRs whose `baseRefName` is `$BASE` (e.g. `main`, or a `feature/<slug>-<N>` epic branch) and that have at least one other PR stacked on top — these merge first in their chain.
 - **Leaves**: PRs whose `headRefName` is not the `baseRefName` of any other open PR — these are the tops of chains and merge last.
 - **Independent PRs**: PRs whose `baseRefName` is already `$BASE` and that no other PR sits on top of — these have no stack relationship and can merge in any order.
 
@@ -84,16 +84,14 @@ Show the plan before proceeding. When `HELD_BY_WORKTREE` is non-empty, prepend t
 
 ```
 Merge order (bottom-up per chain):
-  Chain 1:  develop ← PR #103 ← PR #104 ← PR #105
-  Chain 2:  develop ← PR #108  (independent)
+  Chain 1:  main ← PR #103 ← PR #104 ← PR #105
+  Chain 2:  main ← PR #108  (independent)
 
-  Retargeted 2 non-root PRs to develop: #104, #105
-  Step 1. Merge PR #103 into develop (squash, delete branch)
-  Step 2. Rebase #104, #105 onto develop (drop #103's commits via patch-id)
-  Step 3. Merge PR #104 into develop (squash, delete branch)
-  Step 4. Rebase #105 onto develop (drop #104's commits via patch-id)
-  Step 5. Merge PR #105 into develop (squash, delete branch)
-  Step 6. Merge PR #108 into develop (squash, delete branch)
+  Retargeted 2 non-root PRs to main: #104, #105
+  Step 1. Merge PR #103 into main (squash, delete branch)
+  Step 2. Merge PR #104 into main (squash, delete branch)
+  Step 3. Merge PR #105 into main (squash, delete branch)
+  Step 4. Merge PR #108 into main (squash, delete branch)
 
   Note: 2 branches are held by worktrees (worktree-agent-1361, worktree-agent-1393).
   `gh pr merge --delete-branch` will warn but the merges will succeed.
@@ -112,7 +110,7 @@ For each chain, work from the root up to the leaf. For each PR in order:
 gh pr view <N> --json mergeable,mergeStateStatus,baseRefName
 ```
 
-If `mergeStateStatus` is `BEHIND` (or `UNKNOWN` — retry after a short sleep): run the local rebase step from 5e against this branch, then re-check.
+If `mergeStateStatus` is `UNKNOWN`, retry after a short sleep. If it is `DIRTY` or `CONFLICTING`, fall through to 5d (conflict handling) — squash-merge does not require fast-forward, so `BEHIND` alone is not blocking and the merge proceeds.
 
 #### 5b. Warn on broken closing-keyword footers
 
@@ -141,33 +139,16 @@ Each PR's own body closes its own issues natively on merge. No ref injection, no
 
 #### 5d. Conflict handling
 
-If a merge fails with `CONFLICTING`, or if the rebase in 5e fails with a genuine content conflict (not a patch-id-matchable duplicate):
+If a merge fails with `CONFLICTING` (or returns `DIRTY` from 5a):
 - Stop the chain at this PR
 - Report the conflict with the PR number and branch names
 - Mark all PRs above it in the same chain as blocked
 - Continue with any independent PRs or unrelated chains
 - At the end, list all stopped and blocked PRs so the user can resolve and re-run
 
-#### 5e. Rebase downstream PRs before merging the next one
+Squash-merge does not require predecessor commits to be present in the downstream branch's history — GitHub's tree-based diff drops already-applied predecessor content automatically. No per-merge downstream rebase is required.
 
-After merging a non-leaf PR in a chain, every still-open downstream PR in that chain has its predecessor's commits in its history under the old (pre-squash) SHAs. `$BASE` now carries the same content under a new squash SHA, so GitHub will flag the next PR as `DIRTY`/`CONFLICTING` even though the content overlap is benign. `gh pr update-branch` cannot resolve this — it fails with `Cannot update PR branch due to conflicts`. A local rebase is required because only `git rebase`'s patch-id matching drops the already-applied commits.
-
-For every still-open PR in the chain, from closest-to-root to leaf:
-
-```bash
-RESTACK_SH="plugins/flowkit/skills/restack/scripts/restack.sh"
-bash "$RESTACK_SH" --branch "<head-branch>" --upstream "origin/$BASE"
-```
-
-Implementation lives at [`flowkit:restack`](../../../flowkit/skills/restack/SKILL.md). The same script powers `/restack --pr N` for mid-review use.
-
-`git rebase` will emit `warning: skipped previously applied commit <sha>` for each predecessor commit it drops via patch-id — that's the expected happy path, not an error. A non-zero exit from `git rebase` means a real merge conflict git could not auto-resolve; handle it per 5d. Always `git rebase --abort` before falling through so the branch returns to its pre-rebase state and no partial work is pushed.
-
-After the rebases, re-query `mergeStateStatus` for the next PR to merge and proceed to 5c. GitHub may report `UNKNOWN` briefly after a force-push; poll with `sleep 3` until it resolves to `CLEAN`, `BEHIND`, or `DIRTY`.
-
-For independent PRs (no chain), skip this step — they target `$BASE` directly and have no predecessor commits to drop.
-
-#### 5f. Pause between merges
+#### 5e. Pause between merges
 
 ```bash
 sleep 3
@@ -182,7 +163,7 @@ git checkout $BASE
 git pull origin $BASE
 ```
 
-Where `$BASE` is the base branch of the root PRs (typically `develop`).
+Where `$BASE` is the base branch of the root PRs (typically `main`, or the `feature/<slug>-<N>` branch when swarmkit pinned one).
 
 ### 7. Report
 
@@ -199,9 +180,9 @@ fi
 
 ```
 ── merge-stack complete ──────────────────────────────
-✓ Retargeted 2 non-root PRs to develop
-✓ Merged (chain 1): PR #103 → PR #104 → PR #105 → develop
-✓ Merged (independent): PR #108 → develop
+✓ Retargeted 2 non-root PRs to main
+✓ Merged (chain 1): PR #103 → PR #104 → PR #105 → main
+✓ Merged (independent): PR #108 → main
 ✗ Conflicted: PR #107 — stopped mid-chain
 ⊘ Blocked: PR #106 — depends on #107
 

--- a/plugins/swarmkit/skills/swarm-plus/SKILL.md
+++ b/plugins/swarmkit/skills/swarm-plus/SKILL.md
@@ -26,9 +26,9 @@ The harness terminates builder agents shortly after they emit their final task n
 
 Identical to `/swarmkit:swarm`:
 
-- No args → loop mode, all open issues → `develop`
-- Label text (e.g. `bug`, `priority:high`) → loop mode filtered by label → `develop`
-- Issue numbers (`12 15 18`, `#12 #15 #18`, range `12-18`) → one-shot mode → `develop`
+- No args → loop mode, all open issues → `main`
+- Label text (e.g. `bug`, `priority:high`) → loop mode filtered by label → `main`
+- Issue numbers (`12 15 18`, `#12 #15 #18`, range `12-18`) → one-shot mode → `main`
 - `--model <tier>` (`sonnet`, `opus`) — model override for swarm agents (reviewer + worker have their own defaults; see below)
 - `--base <branch>` — override default base branch
 - `--review-only` — review only; never spawn a fix-round worker (useful for triage). The reviewer's findings stay inline in the final report.
@@ -68,7 +68,7 @@ Record `(issue, pr_number, head_branch, base_branch)` for each PR as it is produ
 > 2. `"Review-only run. Terminate."` — exit cleanly without acting on anything.
 > 3. A `REVIEWER FINDINGS` payload with explicit scope — apply the in-scope items (blockers, concerns, `[recommended]` coverage gaps), skip the out-of-scope items (nits, `[optional]`), run `<verify_command>` and the relevant test scope, commit (conventional-commit format, no Claude mentions, no co-author lines), `git push origin <head_branch>`, and optionally `gh pr comment <pr_number>` summarizing what was addressed and what was deferred. Then terminate.
 >
-> All swarm constraints still apply: never branch off `develop` for the fix round (you are already on the PR's head branch in your worktree), never force-push, never close the issue manually.
+> All swarm constraints still apply: never branch off `main` for the fix round (you are already on the PR's head branch in your worktree), never force-push, never close the issue manually.
 
 Do NOT block on every swarm agent before spawning reviewers. As each swarm agent's task notification arrives:
 
@@ -128,7 +128,7 @@ The fix-round worker prompt MUST:
   - **In scope**: blockers (mandatory), concerns (address or explicitly defer with stated reason in a PR comment), reviewer-recommended coverage gaps.
   - **Out of scope**: nits (skip unless trivially co-located with a fix), `[optional]` coverage gaps, unrelated cleanups, scope creep.
 - Instruct the worker to:
-  1. Branch from the **existing PR branch**, NOT from `develop`:
+  1. Branch from the **existing PR branch**, NOT from `main`:
      ```bash
      git fetch origin <head_branch>
      git checkout -B <head_branch> origin/<head_branch>
@@ -141,7 +141,7 @@ The fix-round worker prompt MUST:
      ```bash
      gh pr comment <pr_number> --body "Addressed reviewer feedback: <summary>. Deferred: <items with reasons>."
      ```
-- Forbid: branching off `develop`, force-pushing, rewriting prior commits, closing the issue manually.
+- Forbid: branching off `main`, force-pushing, rewriting prior commits, closing the issue manually.
 - Termination: report the new commit SHAs and confirm `gh pr view <pr_number> --json commits` includes them.
 
 ### 5. Wait for all fix-round workers

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -13,13 +13,13 @@ Spawn parallel agents for GitHub issues: $ARGUMENTS
 
 Parse `$ARGUMENTS` to determine the mode:
 
-- **No arguments** → **loop mode**, all open issues → `develop`
-- **Label text** (non-numeric, e.g. `bug`, `priority:high`) → **loop mode**, filtered by label → `develop`
-- **Issue numbers** (`12 15 18`, `#12 #15 #18`, range `12-18`) → **one-shot mode**, specific issues → `develop`
+- **No arguments** → **loop mode**, all open issues → `main`
+- **Label text** (non-numeric, e.g. `bug`, `priority:high`) → **loop mode**, filtered by label → `main`
+- **Issue numbers** (`12 15 18`, `#12 #15 #18`, range `12-18`) → **one-shot mode**, specific issues → `main`
 - `--model <tier>` (`sonnet`, `opus`) → model override for all agents
 - `--base <branch>` → override default base branch
 - `--no-epic` → suppress feature-branch mode for this run; PRs target `$BASE` directly
-- `--epic <slug>` → explicit slug for the auto-cut epic branch (verbatim; `flowkit:cut-epic` enforces the `feature/` prefix)
+- `--epic <slug>` → explicit slug for the auto-cut epic branch (the inline cut enforces the `feature/<slug>-<N>` shape)
 
 ---
 
@@ -36,20 +36,40 @@ else:                                              EPIC_MODE=on
 
 ### When EPIC_MODE=on
 
-**Resolve the slug** (in order):
+**Resolve the branch name** `EPIC_BRANCH` (in order):
 
-1. `--epic <slug>` arg → pass verbatim to `flowkit:cut-epic` (`cut-epic` enforces the `feature/` prefix).
-2. One-shot multi-issue → pass the lowest issue number to `cut-epic`; it resolves the slug from the issue title via `gh issue view`.
-3. Loop mode (no issues, no label) → pass `feature/swarm-$(date +%Y-%m-%d)` as the full branch name (cut-epic accepts the `feature/…` input shape directly).
-4. Loop mode + label → pass `feature/<label>-$(date +%Y-%m-%d)` as the full branch name.
+1. `--epic <slug>` arg → if it already starts with `feature/`, use verbatim; otherwise prepend `feature/`.
+2. One-shot multi-issue → derive slug from the lowest issue number's title (`gh issue view <N> --json title --jq '.title'`), kebab-case it (lowercase; non-alphanumerics → `-`; collapse runs; trim leading/trailing `-`), and form `feature/<slug>-<lowest-issue>`.
+3. Loop mode (no label) → `feature/swarm-$(date +%Y-%m-%d)`.
+4. Loop mode + label → `feature/<label>-$(date +%Y-%m-%d)`.
 
-**Empty-board edge case (loop mode only)**: defer the cut-epic invocation until the first cycle that selects ≥1 issue. If the board is clear at loop entry, announce "Board is clear" and exit without cutting any branch.
+**Empty-board edge case (loop mode only)**: defer the inline cut until the first cycle that selects ≥1 issue. If the board is clear at loop entry, announce "Board is clear" and exit without cutting any branch.
 
-**Cross-pin defensive guard**: before invoking `cut-epic`, read `claude.flowkit.prBase`. If it is set AND starts with `feature/` AND the value differs from the branch about to be cut, exit with:
+**Cross-pin defensive guard**: before cutting, read `claude.flowkit.prBase`. If it is set AND starts with `feature/` AND the value differs from the branch about to be cut, exit with:
 
-> `swarm: an epic is already pinned (\`<existing>\`); pass \`--no-epic\` to swarm against develop, or \`--epic <existing-slug>\` to reuse the pinned branch.`
+> `swarm: an epic is already pinned (\`<existing>\`); pass \`--no-epic\` to swarm against main, or \`--epic <existing-slug>\` to reuse the pinned branch.`
 
-**Invoke `flowkit:cut-epic`** via the Skill tool: `Skill("flowkit:cut-epic", "<resolved-arg>")`. `cut-epic` is idempotent — if the branch already exists locally or on origin it is reused and the pin is refreshed. Capture `EPIC_BRANCH` from cut-epic's report output (the resolved branch name, e.g. `feature/report-serializer-101`).
+**Cut the feature branch inline** with `git`/`gh`. This is idempotent — if the branch already exists on origin, fetch and check it out instead of recreating, and refresh the pin:
+
+```bash
+git fetch origin main
+if git ls-remote --exit-code --heads origin "$EPIC_BRANCH" >/dev/null 2>&1; then
+  # Resume path — branch exists on origin
+  git fetch origin "$EPIC_BRANCH"
+  git checkout -B "$EPIC_BRANCH" "origin/$EPIC_BRANCH"
+else
+  # First cut — branch off main and push
+  git checkout -B "$EPIC_BRANCH" origin/main
+  git push -u origin "$EPIC_BRANCH"
+fi
+git config claude.flowkit.prBase "$EPIC_BRANCH"
+```
+
+Announce the result:
+
+> Cut `<EPIC_BRANCH>` from `origin/main` and pinned `claude.flowkit.prBase`. All PRs will target `<EPIC_BRANCH>`.
+
+(If the branch already existed and was reused, swap the verb: `Resumed <EPIC_BRANCH> on origin and refreshed pin.`)
 
 ### When EPIC_MODE=off
 
@@ -74,12 +94,12 @@ fi
 On success the script exits 0 and emits a single JSON object on stdout:
 
 ```json
-{"base": "develop", "base_existed": true, "base_created": false, "gh_authenticated": true, "repo": "owner/name"}
+{"base": "main", "base_existed": true, "base_created": false, "gh_authenticated": true, "repo": "owner/name"}
 ```
 
 Parse the JSON. If `gh_authenticated` is `false`, **stop immediately** and surface the script's stderr to the user — no swarm work can proceed without `gh` auth. If `base_created` is `true`, announce:
 
-> Created `<base>` branch from `main`. All PRs will target `<base>`.
+> Created `<base>` branch from the repo's default branch. All PRs will target `<base>`.
 
 If the script exits non-zero, stdout will be empty and stderr will carry a human-readable error — surface it and stop.
 
@@ -185,11 +205,11 @@ GitHub will automatically remove `status:in-progress` visibility when the issue 
 
 Apply the hybrid spawn strategy based on the dependency graph from Step 2:
 
-In epic mode, agents still branch from `origin/$BASE` (e.g. `origin/develop`) for their initial worktree, but their PRs target `$EPIC_BRANCH` because `claude.flowkit.prBase` is pinned to it. Stack-root PRs target `$EPIC_BRANCH` instead of `$BASE`; stack-leaf PRs still target their predecessor (which ultimately roots at `$EPIC_BRANCH`).
+In epic mode, agents branch from `$EPIC_BRANCH` (which was cut from `origin/main` in the epic-mode resolution step) for their initial worktree, and their PRs target `$EPIC_BRANCH` because `claude.flowkit.prBase` is pinned to it. Stack-root PRs target `$EPIC_BRANCH` instead of `$BASE`; stack-leaf PRs still target their predecessor (which ultimately roots at `$EPIC_BRANCH`).
 
 **Independent issues** (no dependencies within this batch):
 - Spawn all in parallel
-- Each agent branches from `$BASE` (e.g., `develop`)
+- Each agent branches from `$BASE` (e.g., `main`, or `$EPIC_BRANCH` when epic mode is on)
 - Use `run_in_background: true`
 
 **Dependent chains** (issues with dependencies):
@@ -220,12 +240,12 @@ Each agent prompt MUST include:
 2. **EXPECTED OUTCOME**: branch name, commit format, PR closing the issue(s)
 3. **MUST DO**: concrete file changes from the issue body
 4. **MUST NOT DO**: scope boundaries
-5. **CONTEXT**: Instruct agents that their CWD is the repo root — use **relative paths only** for all file operations (e.g., `plugins/flowkit/skills/release/SKILL.md`). Do NOT include the absolute repo path — agents will resolve it into absolute paths that bypass the worktree and edit the main directory instead.
+5. **CONTEXT**: Instruct agents that their CWD is the repo root — use **relative paths only** for all file operations (e.g., `plugins/flowkit/skills/ship/SKILL.md`). Do NOT include the absolute repo path — agents will resolve it into absolute paths that bypass the worktree and edit the main directory instead.
 
 Each agent prompt MUST include these **workflow steps** (in order):
 
 ```
-1. Create and check out branch from the appropriate base. Use `origin/<base>` as the starting point so this works inside an isolated worktree — a plain `git checkout develop` would fail if `develop` is already checked out in the main repo. `<base>` is `develop` for independent issues and `worktree-agent-<dependency-issue>` for dependent ones.
+1. Create and check out branch from the appropriate base. Use `origin/<base>` as the starting point so this works inside an isolated worktree — a plain `git checkout <base>` would fail if `<base>` is already checked out in the main repo. `<base>` is `main` (or the `feature/<slug>-<N>` epic branch when one was cut) for independent issues and `worktree-agent-<dependency-issue>` for dependent ones.
 
    git fetch origin <base>
    git checkout -B worktree-agent-<issue> origin/<base>
@@ -249,7 +269,7 @@ Each agent prompt MUST include these **workflow steps** (in order):
    git add <files> && git commit -m "<type>(<scope>): <description>"
 4. Push the branch:
    git push -u origin worktree-agent-<issue>
-5. Create PR targeting the appropriate base — `develop` for independent issues, `worktree-agent-<dependency-issue>` for dependent ones. The body MUST be a richer summary, not just `Closes #<issue>` — synthesize the `## Summary` bullets from the issue's acceptance criteria and your diff, and describe the `## Test plan` in terms of those acceptance criteria. Fill in the angle-bracket placeholders; do not copy them literally.
+5. Create PR targeting the appropriate base — `main` (or the pinned `feature/<slug>-<N>` branch via `claude.flowkit.prBase`) for independent issues, `worktree-agent-<dependency-issue>` for dependent ones. The body MUST be a richer summary, not just `Closes #<issue>` — synthesize the `## Summary` bullets from the issue's acceptance criteria and your diff, and describe the `## Test plan` in terms of those acceptance criteria. Fill in the angle-bracket placeholders; do not copy them literally.
 
    <!-- include: plugins/_shared/pr-body.md -->
    <!-- Summary-content rules derive from the canonical doc; `## Changes` is intentionally omitted for single-issue swarm PRs — Summary is sufficient when the scope is one issue. -->
@@ -287,7 +307,7 @@ On success the script exits 0 and emits a single JSON object on stdout:
   "pushed_now": false,
   "pr_exists": true,
   "pr_url": "https://github.com/owner/name/pull/210",
-  "pr_base": "develop"
+  "pr_base": "main"
 }
 ```
 
@@ -315,7 +335,7 @@ Run `/clean-worktrees` to remove agent worktrees and orphaned branches. This fre
 | #18, #19 | #26 | chore/clean-hooks   | Open |
 ```
 
-All PRs are left open for review. If 1 PR open: use `/merge-pr` to merge it. If 2+ PRs: use `/merge-stack` — retargets non-root PRs to the stack root's base and merges bottom-up: root PRs first, leaves last. In epic mode, after all child PRs are merged into the epic branch via `/merge-stack`, run `/ship-epic` to rebase-merge the epic branch onto `develop`, clear the pin, and delete the epic branch.
+All PRs are left open for review. If 1 PR open: use `/merge-pr` to merge it. If 2+ PRs: use `/merge-stack` — retargets non-root PRs to the stack root's base and merges bottom-up: root PRs first, leaves last. In epic mode, after all child PRs are merged into the epic branch via `/merge-stack`, open a single PR from the epic branch to `main` and squash-merge it (verify the integrated state first); then unset `claude.flowkit.prBase` and delete the epic branch.
 
 ---
 
@@ -380,7 +400,7 @@ Parse the returned JSON and confirm `base_restored: true`. If `config_unset: fal
 
 When `config_kept_for_epic: true` appears in the JSON, announce:
 
-> Epic branch `<EPIC_BRANCH>` is left in place with `claude.flowkit.prBase` pinned. Run `/ship-epic` to promote it to `develop` and clear the pin.
+> Epic branch `<EPIC_BRANCH>` is left in place with `claude.flowkit.prBase` pinned. After all child PRs land via `/merge-stack`, open a final PR from `<EPIC_BRANCH>` to `main` and squash-merge it; then unset `claude.flowkit.prBase` and delete the epic branch.
 
 Optionally, run `swarmkit:clean-remote-worktrees` afterwards to sweep orphaned remote `worktree-agent-*` branches left behind by merged PRs. This is not automatic — invoke it when you want to tidy up.
 
@@ -394,7 +414,7 @@ Issues remaining: #25
 Open PRs: #31, #32, #33
 
 Open PRs are ready for review. If 1 PR open: use `/merge-pr` to merge it. If 2+ PRs: use `/merge-stack` — retargets non-root PRs to the stack root's base and merges bottom-up: root PRs first, leaves last.
-In epic mode: after /merge-stack fans child PRs into the epic branch, run /ship-epic to promote the epic to develop and clear the pin.
+In epic mode: after /merge-stack fans child PRs into the epic branch, open a final epic-to-main PR, squash-merge it, then unset `claude.flowkit.prBase` and delete the epic branch.
 ─────────────────────────────────────────────
 ```
 

--- a/plugins/swarmkit/skills/swarm/scripts/preflight.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/preflight.sh
@@ -16,7 +16,7 @@ set -euo pipefail
 # write to the wrong worktree's config.
 cd "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")" || exit 1
 
-BASE="develop"
+BASE="main"
 SCOPE_PR_BASE=0
 
 while [[ $# -gt 0 ]]; do

--- a/plugins/swarmkit/skills/swarm/scripts/teardown.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/teardown.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 # `<base>` is already checked out in the main worktree.
 cd "$(dirname "$(git rev-parse --path-format=absolute --git-common-dir)")" || exit 1
 
-BASE="develop"
+BASE="main"
 KEEP_PR_BASE=0
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
## Summary

- Replace `Skill({skill: "flowkit:cut-epic", ...})` invocation in `swarm` (and the swarm-flow inheritance in `swarm-plus`) with inline `git`/`gh` calls that cut `feature/<slug>-<N>` from `origin/main`, push it, and pin `claude.flowkit.prBase`. Preserves the cross-pin guard and idempotent-resume semantics.
- Switch `merge-stack` to uniform squash-merge (`gh pr merge <N> --squash --delete-branch`); drop the per-merge downstream-rebase step (former 5e) entirely — squash-merge's tree-based diff handles already-applied predecessor commits automatically, so the restack-after-merge dance only mattered under the rebase-merge invariant.
- Flip the default base from `develop` to `main` across `swarm`/`swarm-plus` SKILL.md prose, agent prompt templates, the preflight/teardown scripts' `BASE` default, plugin-local README, and METHODOLOGY narrative. Replace `/flowkit:ship-epic` references with the operator-driven epic→main squash-merge recipe.
- Bump `swarmkit` to `5.7.0` (minor) to reflect the v4-compat update.

## Changes

- `plugins/swarmkit/skills/swarm/SKILL.md` — inline epic cut; default base `main`; agent prompt template references updated; `/ship-epic` handoff prose replaced with the epic→main squash recipe.
- `plugins/swarmkit/skills/swarm-plus/SKILL.md` — `develop` → `main` in input grammar, fix-round worker constraints, and forbid-list.
- `plugins/swarmkit/skills/merge-stack/SKILL.md` — drop 5e restack step; preamble rewritten; merge plan example updated; conflict handling simplified.
- `plugins/swarmkit/skills/swarm/scripts/preflight.sh` and `teardown.sh` — `BASE="develop"` → `BASE="main"`.
- `plugins/swarmkit/README.md` and `METHODOLOGY.md` — single-trunk GitHub Flow narrative; epic→main handoff replaces `/ship-epic`.
- `plugins/swarmkit/skills/clean-worktrees/SKILL.md` — example JSON's `caller_branch` updated.
- `plugins/swarmkit/.claude-plugin/plugin.json` — `5.6.4` → `5.7.0`.

`clean-worktrees` and `clean-remote-worktrees` scripts confirmed to require no functional changes (verified via grep).

## Test plan

- [ ] **Feature-Branch Mode spec scenarios**: read `openspec/changes/flowkit-v4-github-flow/specs/swarmkit/spec.md` lines 3–37 and walk each scenario against the updated `swarm/SKILL.md` Epic Mode Resolution block:
  - Multi-issue one-shot cuts feature branch (inline `git checkout -B`/`git push`)
  - Loop mode cuts at first non-empty cycle (deferred until ≥1 issue selected)
  - Single-issue one-shot stays flat (`EPIC_MODE=off` branch)
  - `--no-epic` and `--base` suppress the cut
  - Empty board in loop mode skips cut entirely
  - Cross-pin guard message naming the existing pin
  - Idempotent on resume — `git ls-remote --exit-code` branch + `git fetch`/`git checkout -B` + pin refresh
- [ ] **Bottom-Up Stack Merge spec scenarios**: lines 38–63:
  - Only `worktree-agent-*` PRs are included (unchanged in step 1)
  - Non-root PRs retargeted before any merge (unchanged in step 3)
  - Independent PRs may merge in any order (unchanged)
  - Malformed closing-keyword footer warned (unchanged in 5b)
  - Conflict stops chain (5d, simplified)
  - No PR found stops cleanly (unchanged)
- [ ] Smoke-test against a sandbox repo: cut an epic with `/swarm 12 15 18`, confirm the branch lands on origin from `origin/main`, the pin is set, and child PRs target the epic; then re-run `/swarm 12 15 18` to confirm idempotent resume.
- [ ] `grep -rn -E "flowkit:(cut-epic|cut|release|restack|ship-epic|pr-base-scope|default-branch-prompt)" plugins/swarmkit/` returns zero hits.

Closes #983
Refs #987