### PR TITLE
chore(plugins): bump sessionkit@1.10.0

### DIFF
--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sessionkit",
   "description": "Session continuity, planning, and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, map work-in-flight into an approved task chain and drive it to completion, discover reusable skills, and reduce permission noise.",
-  "version": "1.9.3",
+  "version": "1.10.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Bump plugin.json versions for plugins changed since their last release.

## Changes

- sessionkit@1.10.0

## Test plan

- [ ] Confirm each `plugin.json` version bump matches the per-plugin tag that will be created after merge.