### PR TITLE
docs(flowkit): update cross-cutting docs for v4 GitHub Flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,18 +25,13 @@ Run it before staging and committing the release.
 
 ### Canonical bubble-free release sequence
 
-The full operator-controlled release flow is four explicit steps, with a verify gate sitting between integration and promotion:
-
 ```
-/swarmkit:merge-stack            # land all open worktree-agent-* PRs into the epic (or develop)
-# verify on the integrated branch — run typecheck/test/lint
-/flowkit:ship-epic               # rebase-merge the epic to develop, unset prBase, delete epic branch
-/flowkit:ship                    # cut → release: develop → main
+/swarmkit:merge-stack            # land all open worktree-agent-* PRs into main
+# verify on main — run typecheck/test/lint as appropriate
+/flowkit:ship                    # tag HEAD of main, push tag, create GitHub Release
 ```
 
-`/flowkit:ship` is the release closer only — it chains `cut → release`. It refuses to run while open `worktree-agent-*` PRs target the resolved base, which is what makes the verify step between `merge-stack` and `ship-epic` mandatory in practice. Operators who skip the verify step and try to ship anyway will be turned around by ship's preflight.
-
-For a release with no swarm in flight (no epic, no open `worktree-agent-*` PRs), `/flowkit:ship` runs unconditionally — it is just `cut → release`.
+`/flowkit:ship` refuses to run while open `worktree-agent-*` PRs target main — operators land those via `/swarmkit:merge-stack` first so the verify gate can run against the integrated snapshot before shipping. For releases with no swarm in flight, `/flowkit:ship` runs unconditionally.
 
 When work originates as an OpenSpec change, `opsx-bridge` can dispatch its implementation into the squad or swarm flow that produces the epic and `worktree-agent-*` PRs this sequence later integrates and ships (see the Plugins section below).
 
@@ -46,9 +41,7 @@ When work originates as an OpenSpec change, `opsx-bridge` can dispatch its imple
 
 **Crew shapes.** Crew profiles carry an optional `kind:` field — `execution` (default) for crews that ship code, `discovery` for read-only research crews that produce blueprint comments on GitHub issues instead of PRs. Discovery crews skip worktree provisioning, epic-branch cutting, and `claude.flowkit.prBase` pinning. See [`plugins/squadkit/docs/patterns/discovery-coordination.md`](./plugins/squadkit/docs/patterns/discovery-coordination.md) for the architect-led coordination pattern.
 
-**Base-branch convention.** Execution crews always work on a `feature/<slug>-<issue>` branch cut from `develop`, owned by `spawn-team`. They never commit directly to `develop`. Discovery crews stay on `develop` since they don't produce code. The supporting flow primitive lives in flowkit:
-
-- `flowkit:cut-epic` — cut the long-lived feature branch standalone (the primitive that `spawn-team --epic` invokes).
+**Base-branch convention.** Execution crews always work on a `feature/<slug>-<issue>` branch cut from `main`, owned by `spawn-team`. They never commit directly to `main`. Discovery crews stay on `main` since they don't produce code.
 
 `opsx-bridge` connects OpenSpec changes to those same dispatchers. It is purely additive — it leaves opsx, squadkit, and swarmkit untouched, calling them through their existing skill surface. Given a proposed `openspec/changes/<name>/`, `opsx-bridge:apply-via-squad <change>` derives a squad profile from the proposal's `## Capabilities` and dispatches via `/squadkit:spawn-team`, while `opsx-bridge:apply-via-swarm <change>` maps each `tasks.md` section to a GitHub issue and dispatches via `/swarmkit:swarm-plus`. These are the multi-agent alternative to stock single-agent `/opsx:apply`. See [`plugins/opsx-bridge/README.md`](./plugins/opsx-bridge/README.md).
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ A short walkthrough that takes you from idea to shipped change using `/spec` and
 - [Claude Code](https://docs.anthropic.com/en/docs/claude-code) installed and signed in
 - [GitHub CLI](https://cli.github.com/) authenticated (`gh auth status` should return green)
 - A GitHub repository you can push to
-- A `develop` branch on that repo (swarmkit targets it by default)
 
 ### 1. Install speckit and swarmkit
 
@@ -123,16 +122,14 @@ Once the PRs look right, merge and release them however you normally would. If y
 /plugin install flowkit@smallorbit-plugins
 ```
 
-For a multi-issue epic (the default when `/swarm` receives more than one issue), the stack lands on a feature branch. Promote it in four commands:
+Merge the stack and ship in two commands:
 
 ```
-/merge-stack     # merge swarm PRs bottom-up into the feature branch
-/ship-epic       # rebase-merge the feature branch onto develop (linear)
-/cut             # create a release candidate from develop
-/release         # promote to main, tag the release, close referenced issues
+/merge-stack     # merge swarm PRs bottom-up into main
+/ship            # tag HEAD of main and create a GitHub Release
 ```
 
-Or collapse all four into a single `/ship`. For single-issue or `--no-epic` runs, `/merge-stack` lands directly on `develop` and `/ship-epic` is skipped automatically. See the [flowkit README](./plugins/flowkit/README.md) for the full lifecycle.
+See the [flowkit README](./plugins/flowkit/README.md) for the full lifecycle.
 
 ## How the Plugins Compose
 
@@ -143,12 +140,12 @@ The development-lifecycle plugins form a complete loop from idea to release:
 /spec          → plan the feature, file issues (speckit)
 /swarm         → resolve issues with parallel agents (swarmkit)
 /appraise      → assess quality; /sweep to clean up (polishkit)
-/release       → ship merged work to production (flowkit)
+/ship          → tag HEAD of main, create a GitHub Release (flowkit)
 ```
 
 **swarmkit** runs a built-in `simplify-loop` after each agent finishes — iterative `/simplify` passes that tighten the code before opening the PR. This is a lightweight pre-PR sanity check, not a code review.
 
-**polishkit** sits between `/swarm` and `/release` as a quality gate: use `/appraise` to assess elegance and craft, `/sweep` to remove dead code and accumulated cruft (unused exports, stale files, build artifacts) in one pass, and `/polish` to polish cross-cutting code-quality issues (reuse, quality, efficiency) across a path or themed scope before shipping.
+**polishkit** sits between `/swarm` and `/ship` as a quality gate: use `/appraise` to assess elegance and craft, `/sweep` to remove dead code and accumulated cruft (unused exports, stale files, build artifacts) in one pass, and `/polish` to polish cross-cutting code-quality issues (reuse, quality, efficiency) across a path or themed scope before shipping.
 
 **sessionkit** acts as connective tissue throughout: use `/handoff` to preserve state across agent context limits, `/skillit` to capture reusable patterns after a swarm, and `/suggest-permissions` to reduce approval friction over time.
 

--- a/plugins/_shared/pr-body.md
+++ b/plugins/_shared/pr-body.md
@@ -53,7 +53,7 @@ Standardize the PR body shape across flowkit and swarmkit so reviewers see the s
 
 - [ ] Open a PR via `flowkit:open-pr` and confirm the body has `## Summary`, `## Changes`, and `## Test plan`.
 - [ ] Include `Closes #123` in a commit message; confirm it appears in the PR footer.
-- [ ] Run `flowkit:release` and confirm ref aggregation still collects `Closes` tokens from merged PRs.
+- [ ] Run `flowkit:ship` and confirm the GitHub Release includes the expected `Closes` references from merged PRs.
 - [ ] Spawn a `swarmkit:swarm` agent and confirm its PR emits `## Summary` + `## Test plan` + `Closes #<issue>`.
 
 Closes #521

--- a/plugins/flowkit/MIGRATION-v4.md
+++ b/plugins/flowkit/MIGRATION-v4.md
@@ -1,0 +1,147 @@
+# Flowkit v3 → v4 Migration Guide
+
+Flowkit v4 replaces the develop/RC/main multi-branch model with single-trunk [GitHub Flow](https://docs.github.com/en/get-started/using-github/github-flow): feature branches → squash-merge to `main` → tag for release. This guide covers both the automated migration helper and the manual steps.
+
+## What Changed
+
+### Skills removed in v4
+
+| Removed skill | v4 replacement |
+|---------------|---------------|
+| `/create-branch` | `git checkout -b <name>` directly |
+| `/cut` | removed — no RC branches in v4 |
+| `/release` | `/flowkit:ship` |
+| `/ship-epic` | merge the epic branch PR via `/merge-pr`, then `/ship` |
+| `/cut-epic` | `git checkout -b feature/<slug>-<N>` + `git config claude.flowkit.prBase` |
+| `/pr-base-scope` | removed — set `claude.flowkit.prBase` directly |
+| `/default-branch-prompt` | removed — v4 always uses `main` |
+| `/restack` | removed — squash-merge doesn't need mid-stack rebasing |
+
+### Skills updated in v4
+
+| Skill | What changed |
+|-------|-------------|
+| `/ship` | Rewritten: preflight (main + sync + clean + commits since last tag) → semver derivation → annotated tag → GitHub Release. No release branch, no release PR. |
+| `/merge-pr` | Squash-only. Drops rebase-onto-base and stacked-PR retargeting machinery. |
+| `/pr` | One-shot: commit-if-dirty → open-pr against `main`. No `create-branch` step. |
+| `/open-pr` | Default base is `main`; drops default-branch-prompt invocation. |
+| `/sync` | Main-sync semantics: checkout `main`, pull, prune, delete merged locals. |
+| `/pipeline-status` | Collapsed to in-flight PRs + released stages. No awaiting-cut or awaiting-release. |
+
+### New in v4
+
+| Skill | What it does |
+|-------|-------------|
+| `/migrate-v4` | Interactive migration helper — detects v3 state, presents a plan, executes with per-step confirmation. |
+
+## Automated Migration
+
+Run the interactive helper from any repo that still uses the v3 flow:
+
+```
+/flowkit:migrate-v4
+```
+
+The helper:
+1. Detects legacy state (GitHub default = `develop`, `origin/develop` present, stale config keys, `rc/*` branches).
+2. Presents the full migration plan (steps to run + informational items) and gates on a single "Proceed?" confirmation.
+3. Executes per-step with individual confirmation on every destructive operation.
+
+It is idempotent — running it on an already-migrated repo prints "Nothing to do — repo is on single-trunk main." and exits without mutation.
+
+## Manual Migration
+
+If you prefer to run the steps yourself:
+
+### 1. Ensure `main` is current
+
+```bash
+git checkout main
+git pull origin main
+```
+
+If your repo only has `develop` (no `main`), create it:
+
+```bash
+git checkout -b main develop
+git push origin main
+```
+
+### 2. Merge `develop` into `main` (fast-forward if possible)
+
+```bash
+git merge develop --ff-only
+git push origin main
+```
+
+If `develop` and `main` have diverged (non-fast-forward), check the bidirectional diff first:
+
+```bash
+git log main..develop --oneline   # commits on develop not on main
+git log develop..main --oneline   # commits on main not on develop
+```
+
+Resolve any divergence manually before proceeding.
+
+### 3. Switch the GitHub default branch to `main`
+
+```bash
+gh repo edit --default-branch main
+```
+
+This makes `Closes #N` keywords in PR bodies auto-close issues on merge to `main` going forward.
+
+### 4. Delete `develop` remotely and locally
+
+```bash
+git push origin --delete develop
+git branch -d develop
+git fetch --prune
+```
+
+### 5. Clean up stale config keys
+
+```bash
+git config --unset claude.flowkit.defaultBranchPrompted 2>/dev/null || true
+# Only unset prBase if it still points at develop (not an active epic):
+git config --get claude.flowkit.prBase | grep -q develop && git config --unset claude.flowkit.prBase || true
+```
+
+### 6. Archive leftover `rc/*` and `feature/*` branches
+
+`/migrate-v4` never auto-deletes these — they may contain unfinished work. Review manually:
+
+```bash
+git ls-remote --heads origin 'rc/*'
+git ls-remote --heads origin 'feature/*'
+```
+
+For finished epics, delete them explicitly:
+
+```bash
+git push origin --delete feature/my-epic-1234
+```
+
+## Post-Migration Verification
+
+After migrating, confirm:
+
+```bash
+# GitHub default branch is main
+gh repo view --json defaultBranchRef -q '.defaultBranchRef.name'
+# → main
+
+# No develop on origin
+git ls-remote --heads origin develop
+# → (empty)
+
+# /flowkit:ship accepts the repo
+# (dry-run: just read the preflight output before confirming the tag)
+```
+
+## Notes for Operators
+
+- **Calver tags**: `/ship` can read and increment calver-style tags (`v2026.5.29`, `v2026.5.29.1`). No special handling needed.
+- **Per-plugin tags**: The `{plugin}--v{version}` tags used by the smallorbit-plugins marketplace are unaffected. `/bump-versions` still creates them.
+- **Open `feature/<slug>-<N>` branches**: Finish them (open the epic→main PR and merge) before or after migration. `/migrate-v4` surfaces them as informational; it never deletes them.
+- **opsx-bridge / squadkit**: Both are updated in v4 to cut epic branches from `main` and default to `main` as the base branch. No operator action needed.

--- a/plugins/flowkit/README.md
+++ b/plugins/flowkit/README.md
@@ -1,8 +1,10 @@
 # Flowkit
 
-A Claude Code plugin that manages the full git lifecycle from branch to release. Commit, open PRs, merge, cut release candidates, and ship to main — all from slash commands.
+A Claude Code plugin that manages the full git lifecycle from commit to release. Commit, open PRs, merge, and ship to main — all from slash commands. Flowkit v4 uses single-trunk [GitHub Flow](https://docs.github.com/en/get-started/using-github/github-flow): feature branches → squash-merge to `main` → tag for release.
 
 > **New to smallorbit-plugins?** Start with the [Getting Started walkthrough](../../README.md#getting-started) — it covers the plan → execute → ship loop and where flowkit fits in.
+>
+> **Upgrading from v3?** See [MIGRATION-v4.md](./MIGRATION-v4.md) for the automated migration helper and manual steps.
 
 ## Installation
 
@@ -31,189 +33,116 @@ claude --plugin-dir /path/to/flowkit
 
 | Skill | Invoke | What it does |
 |-------|--------|--------------|
-| **commit** | `/commit` | Stage and commit changes with conventional commit format. Infers logical groupings and writes `type(scope): description` messages. |
-| **create-branch** | `/create-branch` | Create a new git branch off `develop` with an inferred or provided name. |
-| **cut-epic** | `/cut-epic` | Cut a long-lived `feature/<slug>-<issue>` branch from `develop`, push it, and pin `claude.flowkit.prBase` so subsequent PRs target it. |
-| **ship-epic** | `/ship-epic` | Promote a `feature/<slug>-<N>` epic to `develop` via rebase-merge, unset `claude.flowkit.prBase`, delete the epic branch. Closer for `cut-epic`. |
-| **open-pr** | `/open-pr` | Push current branch and open a GitHub PR. Respects `claude.flowkit.prBase` for branch targeting. |
-| **pr** | `/pr` | Combined: `create-branch` → `commit` → `open-pr` in one step. |
-| **merge-pr** | `/merge-pr` | Rebase-merge the open PR for the current branch and delete the remote branch (retargets stacked children; clears blocking swarm worktrees). |
-| **restack** | `/restack` | Rebase open descendant PRs of a parent PR onto its updated head and force-push, recursing through the subtree. Use mid-review after revising a stacked PR. |
-| **sync** | `/sync` | Checkout `develop`, pull latest, prune stale branches. |
-| **cut** | `/cut` | Create a `rc/YYYY-MM-DD.N` release candidate from `develop`. |
-| **release** | `/release` | Merge the newest RC to `main`, tag, close issues, clean up RC branches. |
-| **ship** | `/ship` | Release closer. Chains `cut → release` to promote `develop` to `main`. Aborts if open `worktree-agent-*` PRs target the resolved base — run `/swarmkit:merge-stack` (and `/ship-epic` when an epic is in flight) first. |
-| **pipeline-status** | `/pipeline-status` | Show the full release pipeline: open PRs in flight, `develop` awaiting a cut, RCs awaiting release, and the most recent tag. |
+| **commit** | `/commit` | Stage and commit changes — infers `type(scope): description` from the staged diff. |
+| **pr** | `/pr` | One-shot: commit if dirty, then push and open a PR against `main` (or `claude.flowkit.prBase` when set). |
+| **open-pr** | `/open-pr` | Push current branch and open a PR. Base resolution: `--base` → `claude.flowkit.prBase` → `main`. |
+| **merge-pr** | `/merge-pr` | Squash-merge the open PR for the current branch and delete the remote branch. |
+| **ship** | `/ship` | Tag HEAD of `main`, push the tag, and create a GitHub Release. Derives the next semver from conventional commits since the last `v*` tag. |
+| **sync** | `/sync` | Checkout `main`, pull latest, prune stale branches. |
+| **pipeline-status** | `/pipeline-status` | Show open PRs targeting `main` and the most recent release tag. |
+| **migrate-v4** | `/migrate-v4` | Migrate a v3 repo (develop/RC/main) to single-trunk GitHub Flow. Interactive, with per-step confirmation. Idempotent. |
 
 ### Sub-Skills (internal)
 
-These are called by the skills above — you don't invoke them directly.
-
 | Skill | Used by | Purpose |
 |-------|---------|---------|
-| **default-branch-prompt** | open-pr | One-time first-run nudge: if the GitHub default branch is `main`, offers to switch it to `develop`. Persists the choice via `claude.flowkit.defaultBranchPrompted`. |
-| **git-sync-main** | release | Checkout `main` and pull latest from origin. |
-| **pr-base-scope** | swarm | Set/unset `claude.flowkit.prBase` git config for scoped PR targeting. |
-| **push-or-pr** | bump-versions, release | Publish commits on a shared branch (`develop`/`main`) safely — branches off, pushes a dated feature branch, opens a PR. Never pushes directly to the checked-out branch. |
-| **with-clean-workspace** | merge-pr, release | Auto-stash dirty workspace around implicit post-merge pull via `scripts/with_clean_workspace.sh -- <command ...>`. |
+| **git-sync-main** | internal | Checkout `main` and pull latest from origin. |
+| **push-or-pr** | bump-versions | Publish commits on a shared branch safely — branches off, pushes, opens a PR. Never pushes directly to the checked-out branch. |
+| **with-clean-workspace** | merge-pr | Auto-stash dirty workspace around implicit post-merge pulls. |
 
 ## Typical Workflows
 
-### After a swarm run (canonical bubble-free release)
+### After a swarm run
 
 ```
-/swarmkit:merge-stack            # land all open worktree-agent-* PRs into the epic (or develop)
-# verify on the integrated branch — run your project's typecheck/test/lint
-/ship-epic                       # rebase-merge the epic to develop, unset prBase, delete epic branch
-/ship                            # cut → release: develop → main
+/swarmkit:merge-stack            # land all open worktree-agent-* PRs into main
+# verify on main — run your project's typecheck/test/lint
+/ship                            # tag HEAD of main, create GitHub Release
 ```
 
-The operator-controlled stop between `merge-stack` and `ship-epic` is where the verify gate runs against the cumulative integrated state. `/ship` itself is the release closer only — it refuses to run while open `worktree-agent-*` PRs target the resolved base, pointing the operator back at `merge-stack`.
+`/ship` refuses to run while open `worktree-agent-*` PRs target `main` — that's the mechanism that makes the verify gate mandatory.
 
 ### Standard release (no swarm)
 
 ```
-/ship                            # cut → release: develop → main
+/ship
 ```
 
-Or run the underlying steps directly:
-
-```
-/cut                             # cut a release candidate from develop
-/release                         # ship to main, tag, close issues
-```
+`/ship` derives the next semver from conventional commits since the last `v*` tag, confirms with the operator, then creates an annotated tag and a GitHub Release with auto-generated notes.
 
 ### Pre-flight check
 
 ```
-/pipeline-status                 # see open PRs, develop, RCs, and last release at a glance
+/pipeline-status                 # see open PRs and last release tag at a glance
 ```
-
-### Epic flow (long-lived feature branch)
-
-When a feature spans multiple PRs and needs to stay isolated from `develop` until ready to ship, cut an epic branch and let sub-PRs target it instead of `develop`.
-
-```
-/cut-epic 1264                   # creates feature/<slug>-1264 from develop, pins claude.flowkit.prBase
-# ... loop ...
-/pr add CSV exporter             # sub-PR opened against feature/<slug>-1264 (not develop)
-/pr wire exporter into UI        # next sub-PR, also targets the epic branch
-# When ready to ship:
-/ship-epic                       # rebase-merge to develop, unset prBase, delete epic branch
-```
-
-The epic branch composes with `swarmkit:swarm`: agents spawned while `claude.flowkit.prBase` is set will open PRs against the epic branch automatically. Use `swarmkit:merge-stack` to fan the child PRs into the epic, then open the final epic-to-`develop` PR for review.
-
-To verify the integrated state of an epic locally before promotion, check out the feature branch and run your project's verify commands directly — after `swarmkit:merge-stack` lands every sub-PR onto the feature branch, the branch HEAD already is the integrated state, so no synthesis step is needed.
-
-> `/ship` is a develop→main release closer; it does not promote epics. From an epic in flight, run `/swarmkit:merge-stack`, verify on the integrated feature branch, run `/ship-epic` to rebase-merge the epic into `develop`, then run `/ship`. `/ship` aborts if any open `worktree-agent-*` PRs still target the resolved base — that abort is what makes the verify gate between `merge-stack` and `ship-epic` mandatory in practice.
-
-### Mid-review restack
-
-After pushing new commits to a parent PR in a stack, bring every still-open descendant PR up to date in one command:
-
-```
-/restack --pr <N>       # rebase all open descendants of PR N and force-push
-/restack                # auto-resolve the PR for the current branch
-```
-
-The subtree is walked breadth-first: siblings continue independently if one branch hits a conflict. Conflicted branches are reported; the operator resolves by hand and re-runs `/restack`.
 
 ### Feature flow
 
 ```
-/create-branch feat/my-feature   # branch off develop
-# ... make changes ...
+# ... make changes on a feature branch ...
 /commit                          # stage + commit with conventional format
-/open-pr                         # push + open PR targeting develop
-/merge-pr                        # rebase-merge, delete remote branch
-/sync                            # pull develop, prune branches
-/cut                             # create rc/2026-04-16.1
-/release                         # promote to main, tag v2026.4.16, close issues
+/open-pr                         # push + open PR targeting main
+/merge-pr                        # squash-merge, delete remote branch
+/sync                            # pull main, prune branches
+/ship                            # tag and release
 ```
 
-## Ship boundaries
+### Epic flow (long-lived feature branch)
 
-`/ship` is the release closer only: it chains `cut → release` to promote `develop` to `main`. It does not merge open swarm PRs (`/swarmkit:merge-stack`) and does not promote epics (`/ship-epic`). Operator runs those beforehand so a verify gate sits between integration and release — `/ship` aborts if any open `worktree-agent-*` PRs still target the resolved base. If any step fails, `/ship` stops before the next step; state is left recoverable for re-run.
+For work spanning multiple PRs that needs to stay isolated until ready:
+
+```
+git checkout -b feature/my-epic-1234     # cut from main
+git config claude.flowkit.prBase feature/my-epic-1234
+# ... loop: /pr for each sub-feature ...
+# When ready:
+git config --unset claude.flowkit.prBase
+gh pr create --base main                 # epic → main PR
+/merge-pr
+/ship
+```
+
+squadkit's `spawn-team --epic` handles the branch-cut and pin automatically for multi-builder crews.
+
+## Ship
+
+`/ship` is the single release command:
+
+1. **Preflight**: must be on `main`, in sync with origin, workspace clean, at least one commit since the last `v*` tag. Refuses on v3-configured repos (develops-default); direct those to `/migrate-v4`.
+2. **Semver derivation**: scans `git log` since the last `v*` tag. Any `BREAKING CHANGE` or `!:` → major. Any `feat` → minor. Else → patch. First release (no prior `v*` tag) defaults to `v0.1.0`.
+3. **Operator confirmation**: shows the proposed tag + version bump type and waits.
+4. **Tag + release**: creates an annotated tag, pushes it, runs `gh release create --generate-notes`.
 
 ## Configuration
 
-Flowkit reads one repo-local git config key:
-
 | Key | Purpose | Default |
 |-----|---------|---------|
-| `claude.flowkit.prBase` | Target base branch for `/open-pr` when no override is passed. Set automatically by `/cut-epic`, `/swarm` (loop mode), and `squadkit:spawn-team --epic`; unset by `/ship-epic`. | `develop` |
-
-Inspect or set manually:
+| `claude.flowkit.prBase` | Target base branch for `/open-pr` when no `--base` override is passed. Set by `squadkit:spawn-team --epic`; unset after the epic merges. | `main` |
 
 ```bash
-# Show the effective setting (empty = falls through to default)
+# Inspect
 git config claude.flowkit.prBase
 
-# Pin PRs to a non-default base for the current repo
-git config claude.flowkit.prBase main
+# Pin to an epic branch
+git config claude.flowkit.prBase feature/my-epic-1234
 
-# Revert to the default
+# Revert
 git config --unset claude.flowkit.prBase
 ```
 
-### Release scope grouping
+## Conventions
 
-`/release` groups `### Release notes` bullets by conventional-commit scope. By default, scopes are auto-detected from the commit range being released — `/release` extracts the `type(scope):` tokens from `git log origin/main..origin/$SOURCE`, normalizes sub-scopes (`flowkit:open-pr` → `flowkit`), and uses the deduplicated set. No configuration needed; it adapts to whatever scopes the repo actually uses.
+### Branching model: single-trunk on `main`
 
-To pin an explicit scope list (e.g. to enforce naming, exclude noisy one-off scopes, or guarantee a stable rendering order), drop a `.flowkit/scopes.txt` file at the repo root:
+Feature branches merge into `main` via squash. `main` always reflects the latest shipped state. No `develop`, no `rc/*` branches.
 
-```
-# .flowkit/scopes.txt — one scope per line, blank lines and # comments ignored
-cmdk
-cache
-library
-visualizer
-providers
-queue
-```
+### Semver tags: `vMAJOR.MINOR.PATCH`
 
-When the file is present, `/release` uses it verbatim and skips auto-detection. Use the same token you put in commit messages and PR titles.
+Flowkit v4 uses conventional semver derived from the commit log. The first release defaults to `v0.1.0`.
 
-> **Migrating from `claude.prBase`?** The unscoped legacy key is no longer read (removed in [#896](https://github.com/smallorbit/smallorbit-plugins/issues/896)). Run `git config --unset claude.prBase && git config claude.flowkit.prBase develop` to move to the scoped key.
+> **Migrating from calver tags?** `/ship`'s first-ever run in a repo with no existing `v*` tags starts at `v0.1.0`. If you have calver tags like `v2026.5.29`, `/ship` will read them and use the next calver increment — the derivation only applies to `vMAJOR.MINOR.PATCH` shaped tags. Calver repos are fine without migration.
 
-## Assumptions & Conventions
-
-Flowkit is opinionated. Understanding these assumptions upfront will save you friction.
-
-### Branching Model: `develop` → `main`
-
-Feature work merges into `develop`. Release candidates are cut from `develop`. `main` always reflects what's in production.
-
-### Default Branch
-
-Flowkit works with either GitHub default-branch configuration — `main` (the historical assumption) or `develop` (recommended for new adopters, aligning with modern Gitflow-on-GitHub).
-
-**Why it matters.** GitHub's `Closes #N` keywords only fire when a PR merges into the default branch. With `develop` as default, per-feature PRs close their issues at merge time. With `main` as default, those keywords fire only at release time on the RC→`main` merge. To work safely under either configuration, `/release` runs an explicit `gh issue close` loop after the merge — closing every aggregated issue idempotently regardless of which branch GitHub considers default.
-
-**First-run nudge.** The first time you run `/open-pr` in a repo whose default branch is `main`, flowkit surfaces a one-time prompt offering to switch the default to `develop` (via `gh repo edit --default-branch develop`). Options:
-
-- **Switch to develop** — runs `gh repo edit --default-branch develop` after a second confirmation.
-- **Keep main as default** — keeps the current configuration; the prompt won't reappear.
-- **Don't ask again** — silences the prompt without recording a deliberate choice.
-
-The choice persists via `claude.flowkit.defaultBranchPrompted`. To re-surface the prompt:
-
-```bash
-git config --unset claude.flowkit.defaultBranchPrompted
-```
-
-The nudge is **never automatic** — every default-branch change requires explicit user confirmation, and existing `main`-as-default setups continue to work without modification.
-
-### RC Naming: `rc/YYYY-MM-DD.N`
-
-Release candidates are named by date and sequence number (e.g., `rc/2026-04-16.1`). A second cut on the same day becomes `rc/2026-04-16.2`.
-
-### Tag Format: `vYYYY.M.D`
-
-Production releases are tagged with a calendar-versioned tag (e.g., `v2026.4.16`). Multiple releases on the same day append a counter (e.g., `v2026.4.16.1`).
-
-### Commit Format: Conventional Commits
+### Commit format: Conventional Commits
 
 All commits follow [Conventional Commits](https://www.conventionalcommits.org/):
 
@@ -223,23 +152,16 @@ type(scope): description
 
 Common types: `feat`, `fix`, `chore`, `refactor`, `docs`, `test`.
 
-### Issue Lifecycle
-
-`/merge-pr` never closes issues — that's intentional. Issues are closed by `/release` when work actually ships to `main`. This keeps them visible on the board until the feature is in production.
-
 ## Pairing with Other Plugins
-
-Flowkit works on its own. The companion plugins referenced below are siblings in the [smallorbit-plugins](../../README.md#available-plugins) marketplace — install them separately to use the composed workflows.
 
 Flowkit handles the shipping half of the development loop. Use it with speckit and swarmkit for the full planning-to-production cycle:
 
 ```
 /spec add CSV export              # Plan the feature, file issues  (speckit)
 /swarm                            # Resolve issues with parallel agents  (swarmkit)
-/swarmkit:merge-stack             # Land the swarm PRs into the epic branch
-# verify on the epic branch
-/ship-epic                        # Promote epic → develop  (flowkit)
-/ship                             # cut → release: develop → main  (flowkit)
+/swarmkit:merge-stack             # Land the swarm PRs into main
+# verify on main
+/ship                             # tag HEAD of main, create GitHub Release  (flowkit)
 ```
 
-The natural sequence is **speckit → swarmkit → flowkit**: speckit defines the work, swarmkit executes it, flowkit ships it. The operator-controlled stop between `merge-stack` and `ship-epic` is the verify gate against the cumulative integrated state — `/ship` itself refuses to run while swarm PRs are still open against the resolved base. Use [sessionkit](../sessionkit)'s `/handoff` if a release session runs long, and `/skillit` afterwards to capture any new conventions or one-off scripts worth keeping.
+The natural sequence is **speckit → swarmkit → flowkit**: speckit defines the work, swarmkit executes it, flowkit ships it. Use [sessionkit](../sessionkit)'s `/handoff` if a release session runs long, and `/skillit` afterwards to capture any new conventions or one-off scripts worth keeping.

--- a/plugins/opsx-bridge/skills/apply-via-squad/SKILL.md
+++ b/plugins/opsx-bridge/skills/apply-via-squad/SKILL.md
@@ -145,7 +145,7 @@ Show the operator the constructed argument string before dispatching. Example (t
   --mode none
 ```
 
-spawn-team owns the rest: epic-branch cut (via `flowkit:cut-epic`), worktree provisioning, member spawn, and the dispatch loop. The bridge does not micromanage the crew.
+spawn-team owns the rest: epic-branch cut (inline `git`/`gh` block since flowkit v4 removed `cut-epic`), worktree provisioning, member spawn, and the dispatch loop. The bridge does not micromanage the crew.
 
 ### 7. Post-completion reconciliation
 

--- a/plugins/polishkit/skills/sweep/SKILL.md
+++ b/plugins/polishkit/skills/sweep/SKILL.md
@@ -139,7 +139,7 @@ Run these checks in parallel and compile findings:
   | OPEN | Preserve | Active PR; deleting would close the PR. |
   | NO PR | Preserve, flag for manual inspection | No record of intent; easy to lose work. |
 
-  When deleting, **always use the disambiguated refspec form** (`git push origin :refs/heads/<branch>`). The unqualified `git push origin --delete <branch>` fails with `src refspec matches more than one` whenever a same-named tag exists (the `rc/YYYY-MM-DD.N` shape from `flowkit:cut` is the canonical example). Batch into a single push:
+  When deleting, **always use the disambiguated refspec form** (`git push origin :refs/heads/<branch>`). The unqualified `git push origin --delete <branch>` fails with `src refspec matches more than one` whenever a same-named tag exists (a branch and tag sharing the same name is the canonical footgun). Batch into a single push:
 
   ```bash
   git push origin :refs/heads/branch-a :refs/heads/branch-b

--- a/plugins/sessionkit/skills/drive/SKILL.md
+++ b/plugins/sessionkit/skills/drive/SKILL.md
@@ -38,7 +38,7 @@ Repeat until the chain is empty:
 1. **Pick the next task.** `TaskList` → take the lowest-ID task whose `status` is `pending` and whose `blockedBy` array is empty (or whose blockers are already `completed`). Ties broken by ID. If multiple `in_progress` tasks exist, finish them before picking a new one.
 2. **Mark `in_progress`.** Call `TaskUpdate` with `status: in_progress` *before* doing any work for the task. One task in_progress at a time.
 3. **Execute the task.** Read the task's `description` (use `TaskGet` if needed). Three execution shapes:
-   - **Named skill** — description references a skill (e.g. "Run `/flowkit:merge-pr`", "Use `flowkit:cut`"): invoke it via the `Skill` tool. Pass arguments mentioned in the description verbatim.
+   - **Named skill** — description references a skill (e.g. "Run `/flowkit:merge-pr`", "Use `flowkit:ship`"): invoke it via the `Skill` tool. Pass arguments mentioned in the description verbatim.
    - **Explicit command** — description gives a shell command or sequence: run via `Bash`.
    - **Open-ended work** — description describes an outcome (e.g. "Self-review the diff and confirm X"): perform the work using whatever tools fit. Read, edit, search — whatever the description implies.
 4. **Mark `completed`.** Immediately after the task's outcome is achieved, `TaskUpdate` with `status: completed`. Never batch — completing two tasks before updating either is a contract violation.

--- a/plugins/sessionkit/skills/roadmap/SKILL.md
+++ b/plugins/sessionkit/skills/roadmap/SKILL.md
@@ -83,25 +83,22 @@ Compose the entry sub-chains into a single ordered chain. Standard step library 
 | Merge a single PR | `/flowkit:merge-pr` |
 | Merge a stacked PR set | `/swarmkit:merge-stack` |
 | Verify the integrated state | manual: project's typecheck/test/lint on the feature branch |
-| Promote epic → develop | `/flowkit:ship-epic` |
-| Sync local develop with origin | `/flowkit:sync` |
+| Sync local main with origin | `/flowkit:sync` |
 | Bump per-plugin versions + tags | `/bump-versions` |
-| Cut a release candidate | `/flowkit:cut` |
-| Promote RC → main, tag, close issues | `/flowkit:release` |
-| Cut + release in one shot (develop → main) | `/flowkit:ship` |
+| Tag HEAD of main + GitHub Release | `/flowkit:ship` |
 | Verify post-release pipeline state | `/flowkit:pipeline-status` |
 
-**Canonical bubble-free release sequence.** When an epic is in flight (open `worktree-agent-*` PRs targeting a `feature/<slug>-<N>` branch), the standard chain is:
+**Canonical bubble-free release sequence.** When a swarm is in flight (open `worktree-agent-*` PRs targeting `main`), the standard chain is:
 
 ```
-/swarmkit:merge-stack → verify (manual) → /flowkit:ship-epic → /flowkit:ship
+/swarmkit:merge-stack → verify (manual) → /flowkit:ship
 ```
 
-`/flowkit:ship` aborts if open `worktree-agent-*` PRs still target the resolved base, so the verify step between `merge-stack` and `ship-epic` is a hard prerequisite — operators cannot collapse the chain into a single step. For releases with no epic in flight, `/flowkit:ship` alone (cut → release) is the entire chain.
+`/flowkit:ship` aborts if open `worktree-agent-*` PRs still target `main`, so the verify step between `merge-stack` and `ship` is a hard prerequisite. For releases with no swarm in flight, `/flowkit:ship` alone is the entire chain.
 
 For each step in the chain, write a task with:
 
-- **subject** — imperative title (e.g. `Merge PR #777 to develop`).
+- **subject** — imperative title (e.g. `Merge PR #777 to main`).
 - **description** — exact skill invocation (e.g. `Run /flowkit:merge-pr.`) or, for non-skill work, the concrete outcome (e.g. `Self-review the final diff. Confirm: bug fix is correct, no flowkit dependencies remain, PR body matches plugins/_shared/pr-body.md.`). Drive parses the description, so be unambiguous.
 - **activeForm** — present-continuous form for the spinner.
 
@@ -147,7 +144,7 @@ If only one step exists, fall back to plain text — the structured prompt is ov
 
 - **Read-only during steps 1–3.** Never mutate the repo, branches, tags, or PRs while planning. The plan is a proposal until the user approves.
 - **Tasks created before approval are provisional.** If the user picks "Cancel", delete every task this invocation created.
-- **Don't invent steps the project doesn't have.** Only reference skills and commands that exist in this repo / installed plugins. If the natural step is missing (no `/flowkit:cut` because flowkit isn't installed), surface that as a gap rather than silently stepping over it.
+- **Don't invent steps the project doesn't have.** Only reference skills and commands that exist in this repo / installed plugins. If the natural step is missing (no `/flowkit:ship` because flowkit isn't installed), surface that as a gap rather than silently stepping over it.
 - **Never assume universal driving rules.** The driving contract lives in `/sessionkit:drive`'s SKILL.md and in this skill — do not assume the user has any global directive in `CLAUDE.md`. The skill must work for any installer.
 - **One chain per invocation.** If the survey turns up two unrelated work threads (e.g. an in-flight PR *and* a separate untracked feature branch), ask which one to plan rather than producing a fork. The user can run roadmap again for the other thread.
-- **Use named skills, not raw commands, where possible.** A task description that says "Run `/flowkit:cut`" is unambiguous to drive; a description that pastes the cut script is brittle.
+- **Use named skills, not raw commands, where possible.** A task description that says "Run `/flowkit:ship`" is unambiguous to drive; a description that pastes the ship script is brittle.


### PR DESCRIPTION
## Summary

- Updates `CLAUDE.md` canonical release sequence and base-branch convention for v4 (removes `/flowkit:ship-epic`, `cut-epic` references; GitHub Flow sequence).
- Updates root `README.md`: drops `develop` prerequisite, updates Step 4 ship flow, compose diagram, and polishkit blurb.
- Rewrites `plugins/flowkit/README.md` for the v4 skill surface (removed skills gone, new `/ship` semantics, no RC/develop sections).
- Creates `plugins/flowkit/MIGRATION-v4.md` with automated and manual v3→v4 migration paths.
- Fixes dangling v3 skill references in `sessionkit/roadmap`, `sessionkit/drive`, `opsx-bridge/apply-via-squad`, `polishkit/sweep`, and `_shared/pr-body.md`.

## Changes

- `CLAUDE.md` — canonical release sequence → `merge-stack → verify → /flowkit:ship`; base-branch convention updated to main.
- `README.md` — prerequisites, Step 4, compose diagram, polishkit blurb.
- `plugins/flowkit/README.md` — full v4 rewrite; removed v3 skill table entries; updated workflows.
- `plugins/flowkit/MIGRATION-v4.md` — new file: removed skills table, automated `/migrate-v4` walkthrough, manual steps, post-migration verification.
- `plugins/sessionkit/skills/roadmap/SKILL.md` — step library table, canonical sequence, constraint examples.
- `plugins/sessionkit/skills/drive/SKILL.md` — example skill name in step 3.
- `plugins/opsx-bridge/skills/apply-via-squad/SKILL.md` — cut-epic reference updated.
- `plugins/polishkit/skills/sweep/SKILL.md` — `flowkit:cut` example generalized.
- `plugins/_shared/pr-body.md` — `flowkit:release` test step updated to `flowkit:ship`.

## Test plan

- [ ] `CLAUDE.md` canonical sequence has no `ship-epic`, `cut`, or `release` references.
- [ ] `README.md` getting-started has no `develop` prerequisite and the 4-command ship block is gone.
- [ ] `plugins/flowkit/README.md` skill table has no removed v3 skills; workflows reflect GitHub Flow.
- [ ] `plugins/flowkit/MIGRATION-v4.md` exists and covers removed skills, automated helper, manual steps.
- [ ] `grep -rn "flowkit:(cut-epic|cut|release|ship-epic|restack|pr-base-scope|default-branch-prompt|create-branch)" plugins/ CLAUDE.md README.md` returns zero hits outside of MIGRATION-v4.md.

Closes #985
Refs #987