### PR TITLE
chore(plugins): bump opsx-bridge@0.2.0, polishkit@3.0.6, sessionkit@1.11.0, speckit@1.7.3, vaultkit@1.1.8

### DIFF
--- a/plugins/opsx-bridge/.claude-plugin/plugin.json
+++ b/plugins/opsx-bridge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "opsx-bridge",
   "description": "Bridge OpenSpec changes to squadkit/swarmkit dispatchers. Drive `/squadkit:spawn-team` or `/swarmkit:swarm-plus` from a single `openspec/changes/<name>/` proposal — additive only, leaves opsx/squadkit/swarmkit untouched.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/polishkit/.claude-plugin/plugin.json
+++ b/plugins/polishkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polishkit",
   "description": "Codebase quality toolkit. Appraise code craft with a connoisseur's eye, sweep dead code and cruft in one pass, and polish cross-cutting code-quality issues — three focused skills for improving what you've already built.",
-  "version": "3.0.5",
+  "version": "3.0.6",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/sessionkit/.claude-plugin/plugin.json
+++ b/plugins/sessionkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "sessionkit",
   "description": "Session continuity, planning, and meta-learning for Claude Code. Hand off context between sessions, resume seamlessly, map work-in-flight into an approved task chain and drive it to completion, discover reusable skills, and reduce permission noise.",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/speckit/.claude-plugin/plugin.json
+++ b/plugins/speckit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "speckit",
   "description": "Define and capture work as GitHub issues. Interview a feature into existence with /spec, bulk-convert findings with /catalog, or quickly file a single issue with /issue.",
-  "version": "1.7.2",
+  "version": "1.7.3",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/vaultkit/.claude-plugin/plugin.json
+++ b/plugins/vaultkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "vaultkit",
   "description": "Obsidian vault skills for Claude Code. Read, search, edit notes, manage projects, capture decisions, and archive conversations — all via the Obsidian CLI.",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Bump plugin.json versions for 5 plugins with changes since their last per-plugin tag, ahead of the v2026.5.29.2 release.

## Changes

- opsx-bridge 0.1.0 → 0.2.0 (minor — new since first tag, 7 commits)
- polishkit 3.0.5 → 3.0.6 (patch)
- sessionkit 1.10.1 → 1.11.0 (minor — adds roadmap/drive v4-aware step library)
- speckit 1.7.2 → 1.7.3 (patch)
- vaultkit 1.1.7 → 1.1.8 (patch)

## Test plan

- [ ] Each `plugin.json` version field matches the per-plugin tag that will be created after merge.

Refs #987