### PR TITLE
feat(sessionkit/handoff): simplify to inline-write flow (#1017)

### DIFF
--- a/openspec/specs/sessionkit-handoff/spec.md
+++ b/openspec/specs/sessionkit-handoff/spec.md
@@ -1,86 +1,49 @@
 # Handoff
 
 ## Purpose
-Handoff captures the current session's goal, progress, git state, task list, remaining work, and key context into `.sessionkit/HANDOFF.md` so another agent can resume the work without losing momentum. It minimizes cost by reusing unchanged sections from a prior handoff via fingerprint-based caching.
+Handoff captures the current session's goal, progress, remaining work, context, and task list into `.sessionkit/HANDOFF.md` so another agent can resume the work without losing momentum. The entire skill runs inline — no sub-agent dispatch, no fingerprinting, no delta/full routing.
 
 ## Requirements
 
-### Requirement: Model dispatch
-Handoff SHALL run its document synthesis on a Haiku-class sub-agent regardless of the parent session's active model. The sub-agent SHALL gather git state, compute fingerprints, decide delta vs full, and write the document to disk. The outer tier SHALL retain the responsibilities a sub-agent cannot fulfill: summarizing the live conversation arc (which only the parent session can observe), gathering the task list (a sub-agent's `TaskList`/`TaskGet` resolve to a different task store than the session's), and resolving the user-facing `.gitignore` prompt. The outer tier SHALL pass the conversation summary and the serialized task list to the sub-agent as data, and SHALL pass all operating instructions inline as a self-contained prompt that MUST NOT reference the skill by name (which would cause infinite re-dispatch).
+### Requirement: Inline synthesis
+Handoff SHALL synthesize the document in the active session without dispatching a sub-agent. The session SHALL gather the task list via `TaskList`/`TaskGet`, derive all document sections from the live conversation, and write the document directly to disk.
 
-#### Scenario: Invoked on any model
-- **WHEN** Handoff is invoked from a session running any model (Opus, Sonnet, or Haiku)
-- **THEN** fingerprinting, delta/full routing, and document synthesis occur inside a Haiku sub-agent; the parent session contributes the conversation summary, the serialized task list, and the `.gitignore` decision
-
-#### Scenario: Task list reflects the session
-- **WHEN** the parent session has tracked tasks
-- **THEN** the outer tier gathers them via `TaskList`/`TaskGet` and passes the serialized JSON to the sub-agent, so the `## Task List` section reflects this session's tasks rather than the sub-agent's isolated task store
-
-#### Scenario: No skill self-reference in dispatch prompt
-- **WHEN** the outer tier builds the sub-agent prompt
-- **THEN** the prompt contains direct operating instructions and never names the skill, preventing recursive re-dispatch
+#### Scenario: Always inline
+- **WHEN** Handoff is invoked from any session
+- **THEN** the document is synthesized and written inline, with no sub-agent dispatched
 
 ### Requirement: Context collection
-Handoff SHALL gather git state (HEAD SHA, branch, staged files, unstaged files, recent commits) and the task list before synthesizing the document. The outer tier gathers the task list; the sub-agent gathers git state. Each tier MAY run its own reads in parallel.
+Handoff SHALL collect the task list before synthesizing the document. The session MUST call `TaskList`, then `TaskGet` once per task ID, before writing any section. All sections are derived from the live conversation and the collected task list.
 
-#### Scenario: Context gathered
+#### Scenario: Task list collected
 - **WHEN** Handoff is invoked
-- **THEN** the task list is collected by the outer tier and git state by the sub-agent, both before any synthesis begins
-
-### Requirement: Fingerprint-based section reuse
-Handoff SHALL compute a `gitFingerprint` (HEAD SHA + sorted staged/unstaged file hashes) and a `taskFingerprint` (SHA-1 of the canonicalized task list JSON). Each fingerprint governs its own pair of sections independently: `gitFingerprint` controls `## Git State` and `## Progress`; `taskFingerprint` controls `## Task List` and `## Remaining Work`. Sections whose fingerprint matches the prior header SHALL be reused byte-for-byte. `## Goal` and `## Context` SHALL always be regenerated.
-
-#### Scenario: Git fingerprint matches
-- **WHEN** the prior handoff's `gitFingerprint` matches the current one
-- **THEN** `## Git State` and `## Progress` are reused verbatim; only `## Goal` and `## Context` are regenerated
-
-#### Scenario: Task fingerprint matches
-- **WHEN** the prior handoff's `taskFingerprint` matches the current one
-- **THEN** `## Task List` and `## Remaining Work` are reused verbatim
-
-#### Scenario: Both fingerprints match
-- **WHEN** both fingerprints match the prior header
-- **THEN** all four reusable sections come straight from the prior file and no sub-agent is dispatched
-
-### Requirement: Routing to delta or full path
-Handoff SHALL use the delta path when all four conditions hold: a prior HANDOFF.md parsed cleanly, the prior HEAD is an ancestor of the current HEAD, at most two reusable sections need regeneration, and `--full` is not present. Otherwise Handoff SHALL use the full regenerate path.
-
-#### Scenario: Delta path selected
-- **WHEN** all four delta-mode conditions hold
-- **THEN** Handoff surgically edits the existing file in place without dispatching a sub-agent
-
-#### Scenario: Full path selected
-- **WHEN** any delta-mode condition fails or `--full` is passed
-- **THEN** Handoff dispatches a sub-agent for full synthesis
+- **THEN** `TaskList` and `TaskGet` are called to collect non-deleted tasks before synthesis begins
 
 ### Requirement: Document structure
-The handoff document SHALL follow a fixed section order: meta header → Goal → Progress → Git State → Remaining Work → Task List → Context. All content in Progress, Remaining Work, and Context SHALL be bullets only — no narrative paragraphs. The meta header SHALL be the first line and SHALL contain both fingerprints.
+The handoff document SHALL follow a fixed section order: Goal → Progress → Remaining Work → Context → Task List. All content in Progress, Remaining Work, and Context SHALL be bullets only — no narrative paragraphs. The document header SHALL include **Project**, **Date**, and **Branch** as informational metadata lines (not a section heading).
 
 #### Scenario: Section order
-- **WHEN** a handoff document is written (delta or full)
-- **THEN** sections appear in the canonical order: Goal → Progress → Git State → Remaining Work → Task List → Context
+- **WHEN** a handoff document is written
+- **THEN** sections appear in canonical order: Goal → Progress → Remaining Work → Context → Task List
 
 #### Scenario: Bullet-only sections
 - **WHEN** Progress, Remaining Work, or Context content is generated
 - **THEN** every entry is a bullet — no narrative paragraphs
 
+#### Scenario: Header metadata
+- **WHEN** a handoff document is written
+- **THEN** the document begins with `# Handoff` followed by **Project**, **Date**, and **Branch** metadata lines before the first section heading
+
 ### Requirement: Task list serialization
-The `## Task List` section SHALL contain a single fenced `json` code block. Each task object SHALL include only `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, and `blocks`. Deleted tasks SHALL be excluded. The original task `id` SHALL be preserved so `/pickup` can wire `blockedBy` relationships.
+The `## Task List` section SHALL contain exactly one fenced `json` code block. Each task object SHALL include only `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, and `blocks`. Deleted tasks SHALL be excluded. The original task `id` SHALL be preserved so `/pickup` can rewire `blockedBy` relationships. The block SHALL emit `[]` when there are no tasks.
 
 #### Scenario: Task list in JSON block
 - **WHEN** the document is written
 - **THEN** `## Task List` contains a fenced `json` block with one object per non-deleted task, using the original task IDs
 
-### Requirement: Sub-agent synthesis
-When the full path is selected, Handoff SHALL delegate document synthesis to a Haiku-class sub-agent. If the sub-agent call fails or returns output missing `## Task List`, Handoff SHALL fall back to inline synthesis and prepend a warning comment to the document.
-
-#### Scenario: Sub-agent succeeds
-- **WHEN** the full path is selected and the sub-agent returns a valid document
-- **THEN** the synthesized document is written to disk
-
-#### Scenario: Sub-agent fails
-- **WHEN** the sub-agent call fails or returns output missing `## Task List`
-- **THEN** Handoff synthesizes the document inline and prepends `<!-- handoff-warning: haiku sub-agent unavailable, synthesized in-line -->`
+#### Scenario: No tasks
+- **WHEN** the session has no non-deleted tasks
+- **THEN** `## Task List` contains a fenced `json` block containing `[]`
 
 ### Requirement: Gitignore coverage
 Before writing, Handoff SHALL check whether `.sessionkit/` is covered by `.gitignore`. If `.gitignore` is absent or does not cover `.sessionkit/`, Handoff SHALL ask the user before adding coverage. Handoff MUST NOT modify `.gitignore` without user confirmation.
@@ -105,8 +68,8 @@ Handoff SHALL write the document exclusively to `<working-dir>/.sessionkit/HANDO
 - **THEN** the document is at `.sessionkit/HANDOFF.md` in the current working directory
 
 ### Requirement: Completion report
-After writing, Handoff SHALL report the absolute file path, the chosen mode (delta or full), which sections were regenerated vs. reused, and suggest running `/pickup` to resume.
+After writing, Handoff SHALL report the absolute file path and suggest running `/pickup` to resume.
 
 #### Scenario: Handoff confirmed
 - **WHEN** the document is written
-- **THEN** Handoff reports the path, mode, section reuse outcome, and suggests `/pickup`
+- **THEN** Handoff reports the absolute path and suggests `/pickup`

--- a/openspec/specs/sessionkit-handoff/spec.md
+++ b/openspec/specs/sessionkit-handoff/spec.md
@@ -20,7 +20,7 @@ Handoff SHALL collect the task list before synthesizing the document. The sessio
 - **THEN** `TaskList` and `TaskGet` are called to collect non-deleted tasks before synthesis begins
 
 ### Requirement: Document structure
-The handoff document SHALL follow a fixed section order: Goal → Progress → Remaining Work → Context → Task List. All content in Progress, Remaining Work, and Context SHALL be bullets only — no narrative paragraphs. The document header SHALL include **Project**, **Date**, and **Branch** as informational metadata lines (not a section heading).
+The handoff document SHALL follow a fixed section order: Goal → Progress → Remaining Work → Context → Task List. All content in Progress, Remaining Work, and Context SHALL be bullets only — no narrative paragraphs. The document SHALL start with `# Handoff` followed immediately by the first section heading — no metadata lines between the title and `## Goal`.
 
 #### Scenario: Section order
 - **WHEN** a handoff document is written
@@ -29,10 +29,6 @@ The handoff document SHALL follow a fixed section order: Goal → Progress → R
 #### Scenario: Bullet-only sections
 - **WHEN** Progress, Remaining Work, or Context content is generated
 - **THEN** every entry is a bullet — no narrative paragraphs
-
-#### Scenario: Header metadata
-- **WHEN** a handoff document is written
-- **THEN** the document begins with `# Handoff` followed by **Project**, **Date**, and **Branch** metadata lines before the first section heading
 
 ### Requirement: Task list serialization
 The `## Task List` section SHALL contain exactly one fenced `json` code block. Each task object SHALL include only `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, and `blocks`. Deleted tasks SHALL be excluded. The original task `id` SHALL be preserved so `/pickup` can rewire `blockedBy` relationships. The block SHALL emit `[]` when there are no tasks.

--- a/plugins/sessionkit/skills/handoff/SKILL.md
+++ b/plugins/sessionkit/skills/handoff/SKILL.md
@@ -55,12 +55,6 @@ test -f .gitignore && grep -qE '^\.sessionkit/?$' .gitignore && echo "covered" |
 
 ### 5. Write the document
 
-Get the current branch:
-
-```bash
-git branch --show-current
-```
-
 Run `mkdir -p .sessionkit`, then `Write` the document to `.sessionkit/HANDOFF.md` using the template below. Report the absolute path and suggest:
 
 > Start a new session and run `/pickup` to resume.
@@ -69,10 +63,6 @@ Run `mkdir -p .sessionkit`, then `Write` the document to `.sessionkit/HANDOFF.md
 
 ```markdown
 # Handoff
-
-**Project**: <absolute path of working directory>
-**Date**: <ISO 8601 date, e.g. 2026-05-30>
-**Branch**: <current git branch>
 
 ## Goal
 - <one bullet, one sentence>

--- a/plugins/sessionkit/skills/handoff/SKILL.md
+++ b/plugins/sessionkit/skills/handoff/SKILL.md
@@ -1,59 +1,47 @@
 ---
 name: handoff
-description: Capture session context to a handoff document so another agent can take over seamlessly. Run it after every meaningful state change (PR opened, task completed, decision made) — delta mode keeps the cost trivial so you don't have to wait for context pressure.
+description: Capture session context to a handoff document so another agent can take over seamlessly. Run it when context is running low or after completing a meaningful chunk of work.
 triggers:
   - "/handoff"
   - "write a handoff"
   - "create handoff"
   - "save handoff"
   - "context is running low"
-allowed-tools: Bash, Read, Write, TaskList, TaskGet, AskUserQuestion, Skill, Agent
+allowed-tools: Bash, Read, Write, TaskList, TaskGet, AskUserQuestion
 ---
 
 # Handoff
 
 ## Input
 
-`$ARGUMENTS` — optional freeform notes to fold into the handoff (e.g. "focus on the auth refactor, skip the docs work"). If omitted, auto-infer everything from session state.
-
-Recognized flags (parsed from `$ARGUMENTS`):
-
-- `--full` — force the full-regenerate path even if delta mode would otherwise apply. Use when you want a fresh narrative pass (e.g. Goal/Context have meaningfully drifted but the structural fingerprints haven't).
-
-If `--full` is present, strip it from `$ARGUMENTS` before folding the remaining text into Goal/Context.
-
-## Execution model
-
-Handoff runs its synthesis on Haiku regardless of the session's active model — the document is structured output and Haiku is materially faster for it. The work is split:
-
-- **Outer tier (this skill, any model)** — does what the live session is uniquely able to do or what must reach the user: summarize the conversation arc, gather the task list (a sub-agent's `TaskList`/`TaskGet` see a different task store, not this session's — see step 2.5), and resolve the user-facing `.gitignore` prompt.
-- **Haiku sub-agent** — gathers git state, computes fingerprints, decides delta vs full, and writes the document to disk, using the task JSON the outer tier hands it.
-
-The outer tier MUST pass full self-contained instructions to the sub-agent inline. It MUST NOT tell the sub-agent to "run the handoff skill" or reference this skill by name — that would re-trigger the skill and recurse.
+`$ARGUMENTS` — optional freeform notes to fold into Goal or Context (e.g. "focus on the auth refactor, skip the docs work"). If omitted, auto-infer everything from session state.
 
 ## Process
 
-### 1. Parse arguments
+### 1. Fold arguments
 
-Detect and strip `--full` from `$ARGUMENTS`. Keep the remaining freeform text for step 2.
+If `$ARGUMENTS` is non-empty, incorporate the freeform text into Goal or Context where it fits naturally. No flags are recognized.
 
 ### 2. Summarize conversation context
 
-Produce the bullets only the live session can derive — the sub-agent has no view of this conversation. Keep them tight (bullets, no prose):
+Derive the following from the live session — keep everything as bullets, no prose:
 
 - **Goal** — one bullet: what this session is fundamentally trying to accomplish.
 - **Progress** — what was completed, decided, or abandoned this session.
+- **Remaining Work** — what still needs doing, in priority order.
 - **Context** — key decisions, gotchas, dead ends, external references the next agent needs.
 
-Fold the remaining `$ARGUMENTS` text into Goal or Context where it fits. This summary becomes an input to the sub-agent in step 4.
+### 3. Gather the task list
 
-### 2.5. Gather the task list (outer tier)
+Call `TaskList`, then `TaskGet` once per task ID. Collect every task whose `status` is not `"deleted"` and serialize to a JSON array. Each object MUST include only these fields:
 
-Call `TaskList`, then `TaskGet` once per task ID. Collect every task whose `status !== "deleted"` and serialize them to a JSON array containing only `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, `blocks` (empty array `[]` if none). This becomes the `taskListJson` input to the sub-agent in step 4.
+```
+id, subject, description, activeForm, status, blockedBy, blocks
+```
 
-This MUST run in the outer tier: a sub-agent's `TaskList`/`TaskGet` resolve to a different task store and will not return this session's tasks — passing the serialized JSON as data is the only reliable way to capture the live task list.
+Use `[]` for `blockedBy` / `blocks` when empty. Preserve the original task `id` so `/pickup` can rewire `blockedBy` relationships.
 
-### 3. Resolve `.gitignore` coverage (outer tier — user-facing)
+### 4. Resolve `.gitignore` coverage
 
 Check coverage:
 
@@ -61,109 +49,61 @@ Check coverage:
 test -f .gitignore && grep -qE '^\.sessionkit/?$' .gitignore && echo "covered" || echo "not-covered"
 ```
 
-- **`.gitignore` absent**: ask via `AskUserQuestion` "No `.gitignore` found. Create one with `.sessionkit/` to keep handoff docs out of version control?". On yes, write `.gitignore` containing only `.sessionkit/`. On no, proceed.
-- **`.gitignore` present but not covered**: ask via `AskUserQuestion` "`.gitignore` doesn't cover `.sessionkit/`. Append it?". On yes, append `.sessionkit/`. On no, proceed.
+- **`.gitignore` absent**: ask via `AskUserQuestion` — "No `.gitignore` found. Create one with `.sessionkit/` to keep handoff docs out of version control?". On yes, write `.gitignore` containing only `.sessionkit/`. On no, proceed.
+- **`.gitignore` present but not covered**: ask via `AskUserQuestion` — "`.gitignore` doesn't cover `.sessionkit/`. Append it?". On yes, append `.sessionkit/`. On no, proceed.
 - **Already covered**: proceed silently.
 
-This stays in the outer tier because a sub-agent cannot prompt the user.
+### 5. Write the document
 
-### 4. Dispatch the Haiku sub-agent
+Get the current branch:
 
-Invoke the `Agent` tool with:
+```bash
+git branch --show-current
+```
 
-- `subagent_type`: `"general-purpose"`
-- `model`: `"haiku"`
-- `prompt`: a single self-contained message containing (a) the conversation summary from step 2, (b) the `taskListJson` from step 2.5, (c) the `--full` flag state, and (d) the verbatim operating instructions below. Do not reference this skill by name anywhere in the prompt.
-
-> You are writing a session handoff document to `.sessionkit/HANDOFF.md`. Follow these steps exactly and report the outcome. Do not ask the user anything — you have no user access. The task list has been gathered for you and provided as `taskListJson`; do NOT call `TaskList` or `TaskGet` yourself — your task context differs from the session's, so those tools would return the wrong tasks.
->
-> **A. Gather git state.** Run in parallel:
-> ```bash
-> git rev-parse HEAD 2>/dev/null || echo "no-head"
-> git branch --show-current
-> git diff --cached --name-only
-> git diff --name-only
-> git log --oneline -5
-> git diff --cached
-> ```
-> Use the provided `taskListJson` as the task list — it already excludes deleted tasks.
->
-> **B. Compute fingerprints.**
-> - `gitFingerprint` = `<HEAD-sha>:<sorted-staged-files-hash>:<sorted-unstaged-files-hash>`.
-> - `taskFingerprint` = SHA-1 of the canonicalized `taskListJson` (sorted by `id`, fields stripped to `id,subject,status,blockedBy`). Compute via `printf %s "$json" | shasum -a 1 | cut -d' ' -f1`.
->
-> **C. Skip-unchanged check.** If `.sessionkit/HANDOFF.md` exists, Read it and find the first-line meta header `<!-- handoff-meta gitFingerprint=<sha> taskFingerprint=<sha> -->`. Compare with two independent reuse decisions:
-> - `gitFingerprint` matches → reuse `## Git State` and `## Progress` verbatim, else regenerate them.
-> - `taskFingerprint` matches → reuse `## Task List` and `## Remaining Work` verbatim, else regenerate them.
-> `## Goal` and `## Context` are always taken from the conversation summary provided to you. If no prior file or no meta header, regenerate all sections.
->
-> **D. Delta-vs-full decision.** Use the **delta** path when ALL hold: (1) a prior file parsed cleanly (meta header, all six canonical sections in order, `## Task List` json block parses); (2) the prior HEAD-sha is an ancestor of current HEAD — `git merge-base --is-ancestor <prior-head-sha> HEAD` exits 0; (3) at most two of the four reusable sections need regeneration; (4) `--full` was not passed. Otherwise use the **full** path.
->
-> **E-delta. Delta mechanics.** Surgically Edit the existing file: refresh `## Goal` and `## Context` from the conversation summary; regenerate only the flagged reusable sections; update the meta header's `gitFingerprint` / `taskFingerprint` to the step-B values and refresh `**Date**`; leave verbatim-reuse sections byte-exact.
->
-> **E-full. Full mechanics.** `mkdir -p .sessionkit` and Write the whole document per the template below.
->
-> **F. Template** (emit exactly this structure; bullets only in Progress / Remaining Work / Context; meta header on line 1 is mandatory):
-> ````markdown
-> <!-- handoff-meta gitFingerprint=<sha> taskFingerprint=<sha> -->
-> # Handoff
->
-> **Project**: <working directory>
-> **Date**: <ISO date>
-> **Branch**: <current git branch>
->
-> ## Goal
-> - <one bullet, one sentence>
->
-> ## Progress
-> - <completed item>
-> - <decision made>
-> - <thread abandoned>
->
-> ## Git State
-> - Branch: <branch>
-> - Staged: <list of staged files or "none">
-> - Unstaged: <list of unstaged files or "none">
-> - Recent commits (last 5):
->   - <sha> <subject>
->
-> ## Remaining Work
-> - <next step in priority order>
-> - <next step>
->
-> ## Task List
-> ```json
-> [
->   {
->     "id": "<task-id>",
->     "subject": "<subject>",
->     "description": "<description>",
->     "activeForm": "<activeForm>",
->     "status": "<status>",
->     "blockedBy": [],
->     "blocks": []
->   }
-> ]
-> ```
->
-> ## Context
-> - <key decision>
-> - <gotcha>
-> - <external reference>
-> ````
->
-> **G. Inference rules.**
-> - **Progress** — bullets from staged/unstaged file lists, recent commits, plus the conversation summary's progress bullets.
-> - **Remaining Work** — bullets in priority order from the Task List plus unfinished threads in the conversation summary.
-> - **Task List** — emit `taskListJson` as one fenced `json` block, preserving each task's original `id` so pickup can rewire `blockedBy`. It is already filtered to the right fields and excludes deleted tasks; emit `[]` if it is empty.
-> - **Goal** / **Context** — take from the conversation summary provided to you.
->
-> **H. Report back.** Return one line stating the chosen mode and reuse outcome, e.g. `delta — refreshed Goal/Context, regenerated Git State + Progress` or `full — regenerated all sections`. Confirm the document was written to `.sessionkit/HANDOFF.md`.
-
-**Fallback**: if the Agent call fails, returns empty output, or the file it wrote is missing the `## Task List` heading, synthesize the document yourself inline using the same template, prepend `<!-- handoff-warning: haiku sub-agent unavailable, synthesized in-line -->`, and write it to `.sessionkit/HANDOFF.md`.
-
-### 5. Report
-
-Relay the sub-agent's reported mode and reuse outcome, state the absolute path of the written file, and suggest:
+Run `mkdir -p .sessionkit`, then `Write` the document to `.sessionkit/HANDOFF.md` using the template below. Report the absolute path and suggest:
 
 > Start a new session and run `/pickup` to resume.
+
+## Document template
+
+```markdown
+# Handoff
+
+**Project**: <absolute path of working directory>
+**Date**: <ISO 8601 date, e.g. 2026-05-30>
+**Branch**: <current git branch>
+
+## Goal
+- <one bullet, one sentence>
+
+## Progress
+- <completed item or decision>
+
+## Remaining Work
+- <next step in priority order>
+
+## Context
+- <key decision, gotcha, or external reference>
+
+## Task List
+```json
+[
+  {
+    "id": "<task-id>",
+    "subject": "<subject>",
+    "description": "<description>",
+    "activeForm": "<activeForm>",
+    "status": "<status>",
+    "blockedBy": [],
+    "blocks": []
+  }
+]
+```
+```
+
+**Constraints:**
+- Sections MUST appear in this exact order: Goal → Progress → Remaining Work → Context → Task List.
+- Progress, Remaining Work, and Context MUST contain bullets only — no narrative paragraphs.
+- The Task List section MUST contain exactly one fenced `json` block. Emit `[]` if there are no tasks.
+- Do NOT write any other files or sections beyond what the template specifies.


### PR DESCRIPTION
## Summary
- Remove sub-agent dispatch, fingerprint/delta routing, and the `## Git State` section from the handoff skill
- Handoff now synthesises the document entirely inline in the active session across five fixed sections: Goal → Progress → Remaining Work → Context → Task List
- Spec updated to drop all sub-agent/fingerprint requirements and align with the simplified flow

## Changes
- `plugins/sessionkit/skills/handoff/SKILL.md` — rewritten: drops `Agent`/`Skill` from allowed-tools, removes `--full` flag, delta/full routing, fingerprint computation, and sub-agent prompt; new 5-step inline process
- `openspec/specs/sessionkit-handoff/spec.md` — rewritten: removes Model dispatch, Fingerprint-based section reuse, Routing, and Sub-agent synthesis requirements; adds Inline synthesis requirement; aligns document structure to 5-section format

## Test plan
- [ ] Run `/handoff` in a session with tasks — verify `.sessionkit/HANDOFF.md` is written with the five sections in canonical order
- [ ] Verify Task List section contains a valid fenced `json` block with all non-deleted tasks and original IDs
- [ ] Verify no `## Git State` section appears in output
- [ ] Run in a repo without `.gitignore` — confirm `AskUserQuestion` fires before any write
- [ ] Run `/pickup` against the written document — confirm orientation loads and tasks hydrate correctly

Closes #1017