### PR TITLE
fix(speckit:spec): enforce approval gate + databaseId sub-issue wiring

### DIFF
--- a/plugins/speckit/skills/spec/SKILL.md
+++ b/plugins/speckit/skills/spec/SKILL.md
@@ -56,6 +56,19 @@ from here: step 3 is the only approval gate.
 Do not proceed to step 3 until `/speckit:interview` has produced a complete,
 unambiguous output with all five sections present.
 
+### Post-interview handoff gate
+
+`/speckit:interview` is a sub-skill. When it returns, the sub-skill's job is done; the orchestrator's job is not. **After `/speckit:interview` returns, do not pause and do not wait for user input.** Parse the five sections from the output and immediately advance to step 2.5 / step 3 in the same turn — emitting the plan and the `AskUserQuestion` approval call before ending the turn.
+
+Any turn that prints or references the interview output and ends without the plan and `AskUserQuestion` is a defect.
+
+| Legitimate end of turn at this boundary | Illegitimate end of turn at this boundary |
+|-----------------------------------------|-------------------------------------------|
+| User has explicitly halted the run. | Silent wait after the interview sections print. |
+| | Prose offer ("shall I proceed to planning?") in place of running step 3. |
+| | Status update with no tool call. |
+| | Ending the turn after parsing the interview output with no further action. |
+
 ### 2a. Classify simple vs. full path
 
 **Execution order**: this step runs BEFORE step 2. Numbered 2a to keep later
@@ -182,15 +195,11 @@ Always append the following documentation task as the final row, unless the spec
 
 Include the `## Epic label` section **only when the plan produces an epic** (2+ tasks). Omit it for single-issue plans. Render the derived label as a single, editable line, for example: `Epic label: epic:catalog-epic-labels`.
 
-**Required turn shape**: the turn that presents the plan MUST contain, in
-this exact order, (a) the plan markdown and (b) exactly one `AskUserQuestion`
-tool call. Any turn that emits the plan and ends without the tool call is a
-defect and must be corrected by immediately emitting the `AskUserQuestion`
-call. This is non-negotiable — no prose ending (silent wait, `/catalog`
-hand-off suggestion, encouragement to reply, or any other text) is acceptable
-in place of the tool call. The `AskUserQuestion` call is the only valid
-approval gate and is the sole plan-filing approval for the skill on both
-paths.
+#### Required turn shape
+
+This rule applies to both the post-interview case (full path) and the inline-draft case (simple path).
+
+The turn that presents the plan MUST contain, in this exact order, (a) the plan markdown and (b) exactly one `AskUserQuestion` tool call. Any turn that emits the plan and ends without the tool call is a defect and must be corrected by immediately emitting the `AskUserQuestion` call. This is non-negotiable — no prose ending (silent wait, `/catalog` hand-off suggestion, encouragement to reply, or any other text) is acceptable in place of the tool call. The `AskUserQuestion` call is the only valid approval gate and is the sole plan-filing approval for the skill on both paths.
 
 The options depend on whether the plan is a simple-path single issue or a
 full-path epic. `AskUserQuestion` supports max 4 options total (including

--- a/plugins/speckit/skills/spec/SKILL.md
+++ b/plugins/speckit/skills/spec/SKILL.md
@@ -317,9 +317,14 @@ After creating the epic, wire up relationships:
 1. **Add sub-issues**: Open with `TaskUpdate(wire-sub-issues, status: "in_progress")`. For each child issue, add it as a sub-issue of the epic:
    ```bash
    gh api repos/{owner}/{repo}/issues/{epic_number}/sub_issues \
-     -X POST -F sub_issue_id={child_issue_id}
+     -X POST -F sub_issue_id={child_database_id}
    ```
-   Use the numeric `id` (not the issue number) — fetch it from `gh issue view {number} --json id`. Close with `TaskUpdate(wire-sub-issues, status: "completed")` once every child has been attached.
+   `sub_issue_id` requires the integer **databaseId**, not the GraphQL node ID that `gh issue view --json id` returns (which causes a 422). Fetch the databaseId via GraphQL:
+   ```bash
+   gh api graphql -f query='query { repository(owner:"OWNER",name:"REPO") { issue(number:N){ databaseId } } }' \
+     --jq '.data.repository.issue.databaseId'
+   ```
+   Replace `OWNER`, `REPO`, and `N` with the actual values for each child issue. Close with `TaskUpdate(wire-sub-issues, status: "completed")` once every child has been attached.
 
 2. **Wire blocked-by relationships**: Open with `TaskUpdate(wire-blocked-by-edges, status: "in_progress")`. For each task with a `Depends On` value in the plan, set the GitHub blocked-by relationship:
    ```bash


### PR DESCRIPTION
## Summary

Two bug fixes to `speckit:spec` SKILL.md, each in its own commit:

1. **#1020** — orchestrator could end a turn after `/speckit:interview` returned without emitting the plan or calling `AskUserQuestion`, leaving the user in a silent wait.
2. **#1021** — step 5's sub-issue wiring passed the GraphQL node ID (from `gh issue view --json id`) where the sub_issues API requires the integer `databaseId`, causing a 422.

## Changes

**Commit 1 — approval gate (#1020)**
- Added **Post-interview handoff gate** section immediately after step 2's completion rule, mirroring the Continuation Gate pattern used after `/catalog`. Includes a legitimate/illegitimate table.
- Elevated **Required turn shape** in step 3 to a named `####` sub-section; prepended a sentence clarifying it governs both the full-path post-interview handoff and the simple-path inline-draft case.

**Commit 2 — databaseId (#1021)**
- Updated step 5 to fetch `databaseId` via GraphQL instead of using `gh issue view --json id` (which returns the node ID).
- Documented the correct `gh api graphql` invocation inline with `OWNER`, `REPO`, `N` placeholders.

## Test plan

- [ ] `/spec` full path: confirm agent emits plan + `AskUserQuestion` in the same turn `/speckit:interview` returns — no silent wait.
- [ ] `/spec` simple path: confirm inline-draft turn ends with `AskUserQuestion` (unchanged behaviour, verify formatting intact).
- [ ] Epic flow step 5: confirm sub-issue wiring completes without a 422; verify GraphQL query returns integer databaseId.
- [ ] No other sections of `SKILL.md` modified.

Closes #1020
Closes #1021