### PR TITLE
feat(sessionkit,speckit): simplify handoff/pickup + fix speckit:spec gates (#1019)

### DIFF
--- a/openspec/specs/sessionkit-handoff/spec.md
+++ b/openspec/specs/sessionkit-handoff/spec.md
@@ -1,86 +1,45 @@
 # Handoff
 
 ## Purpose
-Handoff captures the current session's goal, progress, git state, task list, remaining work, and key context into `.sessionkit/HANDOFF.md` so another agent can resume the work without losing momentum. It minimizes cost by reusing unchanged sections from a prior handoff via fingerprint-based caching.
+Handoff captures the current session's goal, progress, remaining work, context, and task list into `.sessionkit/HANDOFF.md` so another agent can resume the work without losing momentum. The entire skill runs inline — no sub-agent dispatch, no fingerprinting, no delta/full routing.
 
 ## Requirements
 
-### Requirement: Model dispatch
-Handoff SHALL run its document synthesis on a Haiku-class sub-agent regardless of the parent session's active model. The sub-agent SHALL gather git state, compute fingerprints, decide delta vs full, and write the document to disk. The outer tier SHALL retain the responsibilities a sub-agent cannot fulfill: summarizing the live conversation arc (which only the parent session can observe), gathering the task list (a sub-agent's `TaskList`/`TaskGet` resolve to a different task store than the session's), and resolving the user-facing `.gitignore` prompt. The outer tier SHALL pass the conversation summary and the serialized task list to the sub-agent as data, and SHALL pass all operating instructions inline as a self-contained prompt that MUST NOT reference the skill by name (which would cause infinite re-dispatch).
+### Requirement: Inline synthesis
+Handoff SHALL synthesize the document in the active session without dispatching a sub-agent. The session SHALL gather the task list via `TaskList`/`TaskGet`, derive all document sections from the live conversation, and write the document directly to disk.
 
-#### Scenario: Invoked on any model
-- **WHEN** Handoff is invoked from a session running any model (Opus, Sonnet, or Haiku)
-- **THEN** fingerprinting, delta/full routing, and document synthesis occur inside a Haiku sub-agent; the parent session contributes the conversation summary, the serialized task list, and the `.gitignore` decision
-
-#### Scenario: Task list reflects the session
-- **WHEN** the parent session has tracked tasks
-- **THEN** the outer tier gathers them via `TaskList`/`TaskGet` and passes the serialized JSON to the sub-agent, so the `## Task List` section reflects this session's tasks rather than the sub-agent's isolated task store
-
-#### Scenario: No skill self-reference in dispatch prompt
-- **WHEN** the outer tier builds the sub-agent prompt
-- **THEN** the prompt contains direct operating instructions and never names the skill, preventing recursive re-dispatch
+#### Scenario: Always inline
+- **WHEN** Handoff is invoked from any session
+- **THEN** the document is synthesized and written inline, with no sub-agent dispatched
 
 ### Requirement: Context collection
-Handoff SHALL gather git state (HEAD SHA, branch, staged files, unstaged files, recent commits) and the task list before synthesizing the document. The outer tier gathers the task list; the sub-agent gathers git state. Each tier MAY run its own reads in parallel.
+Handoff SHALL collect the task list before synthesizing the document. The session MUST call `TaskList`, then `TaskGet` once per task ID, before writing any section. All sections are derived from the live conversation and the collected task list.
 
-#### Scenario: Context gathered
+#### Scenario: Task list collected
 - **WHEN** Handoff is invoked
-- **THEN** the task list is collected by the outer tier and git state by the sub-agent, both before any synthesis begins
-
-### Requirement: Fingerprint-based section reuse
-Handoff SHALL compute a `gitFingerprint` (HEAD SHA + sorted staged/unstaged file hashes) and a `taskFingerprint` (SHA-1 of the canonicalized task list JSON). Each fingerprint governs its own pair of sections independently: `gitFingerprint` controls `## Git State` and `## Progress`; `taskFingerprint` controls `## Task List` and `## Remaining Work`. Sections whose fingerprint matches the prior header SHALL be reused byte-for-byte. `## Goal` and `## Context` SHALL always be regenerated.
-
-#### Scenario: Git fingerprint matches
-- **WHEN** the prior handoff's `gitFingerprint` matches the current one
-- **THEN** `## Git State` and `## Progress` are reused verbatim; only `## Goal` and `## Context` are regenerated
-
-#### Scenario: Task fingerprint matches
-- **WHEN** the prior handoff's `taskFingerprint` matches the current one
-- **THEN** `## Task List` and `## Remaining Work` are reused verbatim
-
-#### Scenario: Both fingerprints match
-- **WHEN** both fingerprints match the prior header
-- **THEN** all four reusable sections come straight from the prior file and no sub-agent is dispatched
-
-### Requirement: Routing to delta or full path
-Handoff SHALL use the delta path when all four conditions hold: a prior HANDOFF.md parsed cleanly, the prior HEAD is an ancestor of the current HEAD, at most two reusable sections need regeneration, and `--full` is not present. Otherwise Handoff SHALL use the full regenerate path.
-
-#### Scenario: Delta path selected
-- **WHEN** all four delta-mode conditions hold
-- **THEN** Handoff surgically edits the existing file in place without dispatching a sub-agent
-
-#### Scenario: Full path selected
-- **WHEN** any delta-mode condition fails or `--full` is passed
-- **THEN** Handoff dispatches a sub-agent for full synthesis
+- **THEN** `TaskList` and `TaskGet` are called to collect non-deleted tasks before synthesis begins
 
 ### Requirement: Document structure
-The handoff document SHALL follow a fixed section order: meta header → Goal → Progress → Git State → Remaining Work → Task List → Context. All content in Progress, Remaining Work, and Context SHALL be bullets only — no narrative paragraphs. The meta header SHALL be the first line and SHALL contain both fingerprints.
+The handoff document SHALL follow a fixed section order: Goal → Progress → Remaining Work → Context → Task List. All content in Progress, Remaining Work, and Context SHALL be bullets only — no narrative paragraphs. The document SHALL start with `# Handoff` followed immediately by the first section heading — no metadata lines between the title and `## Goal`.
 
 #### Scenario: Section order
-- **WHEN** a handoff document is written (delta or full)
-- **THEN** sections appear in the canonical order: Goal → Progress → Git State → Remaining Work → Task List → Context
+- **WHEN** a handoff document is written
+- **THEN** sections appear in canonical order: Goal → Progress → Remaining Work → Context → Task List
 
 #### Scenario: Bullet-only sections
 - **WHEN** Progress, Remaining Work, or Context content is generated
 - **THEN** every entry is a bullet — no narrative paragraphs
 
 ### Requirement: Task list serialization
-The `## Task List` section SHALL contain a single fenced `json` code block. Each task object SHALL include only `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, and `blocks`. Deleted tasks SHALL be excluded. The original task `id` SHALL be preserved so `/pickup` can wire `blockedBy` relationships.
+The `## Task List` section SHALL contain exactly one fenced `json` code block. Each task object SHALL include only `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, and `blocks`. Deleted tasks SHALL be excluded. The original task `id` SHALL be preserved so `/pickup` can rewire `blockedBy` relationships. The block SHALL emit `[]` when there are no tasks.
 
 #### Scenario: Task list in JSON block
 - **WHEN** the document is written
 - **THEN** `## Task List` contains a fenced `json` block with one object per non-deleted task, using the original task IDs
 
-### Requirement: Sub-agent synthesis
-When the full path is selected, Handoff SHALL delegate document synthesis to a Haiku-class sub-agent. If the sub-agent call fails or returns output missing `## Task List`, Handoff SHALL fall back to inline synthesis and prepend a warning comment to the document.
-
-#### Scenario: Sub-agent succeeds
-- **WHEN** the full path is selected and the sub-agent returns a valid document
-- **THEN** the synthesized document is written to disk
-
-#### Scenario: Sub-agent fails
-- **WHEN** the sub-agent call fails or returns output missing `## Task List`
-- **THEN** Handoff synthesizes the document inline and prepends `<!-- handoff-warning: haiku sub-agent unavailable, synthesized in-line -->`
+#### Scenario: No tasks
+- **WHEN** the session has no non-deleted tasks
+- **THEN** `## Task List` contains a fenced `json` block containing `[]`
 
 ### Requirement: Gitignore coverage
 Before writing, Handoff SHALL check whether `.sessionkit/` is covered by `.gitignore`. If `.gitignore` is absent or does not cover `.sessionkit/`, Handoff SHALL ask the user before adding coverage. Handoff MUST NOT modify `.gitignore` without user confirmation.
@@ -105,8 +64,8 @@ Handoff SHALL write the document exclusively to `<working-dir>/.sessionkit/HANDO
 - **THEN** the document is at `.sessionkit/HANDOFF.md` in the current working directory
 
 ### Requirement: Completion report
-After writing, Handoff SHALL report the absolute file path, the chosen mode (delta or full), which sections were regenerated vs. reused, and suggest running `/pickup` to resume.
+After writing, Handoff SHALL report the absolute file path and suggest running `/pickup` to resume.
 
 #### Scenario: Handoff confirmed
 - **WHEN** the document is written
-- **THEN** Handoff reports the path, mode, section reuse outcome, and suggests `/pickup`
+- **THEN** Handoff reports the absolute path and suggests `/pickup`

--- a/openspec/specs/sessionkit-pickup/spec.md
+++ b/openspec/specs/sessionkit-pickup/spec.md
@@ -1,24 +1,16 @@
 # Pickup
 
 ## Purpose
-Pickup loads `.sessionkit/HANDOFF.md` at the start of a new session, orients the agent by summarizing its contents, hydrates the task list from the snapshot, checks for branch mismatches, and asks what to tackle first. It is the complement to Handoff.
+Pickup loads `.sessionkit/HANDOFF.md` at the start of a new session, orients the agent by summarising its contents, hydrates the task list from the snapshot, and asks what to tackle first. It is the complement to Handoff. The entire skill runs inline — no sub-agent dispatch.
 
 ## Requirements
 
-### Requirement: Model dispatch
-Pickup SHALL run its reading, parsing, and orientation synthesis on a Haiku-class sub-agent regardless of the parent session's active model. The sub-agent SHALL read and parse `.sessionkit/HANDOFF.md`, produce the orientation summary, extract the task snapshot, and derive the readiness options, returning them as structured output. The outer tier SHALL retain only the operations that must affect this session or reach the user: the absent-file guard, `TaskCreate`/`TaskUpdate` hydration, the branch-mismatch suggestion, and the final `AskUserQuestion`. The outer tier SHALL pass all operating instructions to the sub-agent inline as a self-contained prompt and MUST NOT reference the skill by name (which would cause infinite re-dispatch).
+### Requirement: Inline execution
+Pickup SHALL read, parse, and synthesise orientation entirely in the active session without dispatching a sub-agent. Task hydration via `TaskCreate`/`TaskUpdate` SHALL also run inline so the created tasks appear in the current session's task list.
 
-#### Scenario: Invoked on any model
-- **WHEN** Pickup is invoked from a session running any model (Opus, Sonnet, or Haiku)
-- **THEN** parsing and orientation synthesis occur inside a Haiku sub-agent; the parent session only performs the absent-file guard, task hydration, branch suggestion, and readiness prompt using the sub-agent's structured return
-
-#### Scenario: Task hydration lands in the live session
-- **WHEN** the sub-agent returns a non-empty task snapshot
-- **THEN** the outer tier performs the `TaskCreate`/`TaskUpdate` calls so the hydrated tasks appear in the parent session's task list, not the sub-agent's isolated context
-
-#### Scenario: No skill self-reference in dispatch prompt
-- **WHEN** the outer tier builds the sub-agent prompt
-- **THEN** the prompt contains direct operating instructions and never names the skill, preventing recursive re-dispatch
+#### Scenario: Always inline
+- **WHEN** Pickup is invoked from any session
+- **THEN** parsing, orientation, and task hydration occur in the active session with no sub-agent dispatched
 
 ### Requirement: Graceful absent-file handling
 Pickup SHALL check for `.sessionkit/HANDOFF.md` before proceeding. If the file does not exist, Pickup MUST report the absence and stop — it MUST NOT attempt to orient, hydrate tasks, or ask what to do next.
@@ -32,18 +24,18 @@ Pickup SHALL check for `.sessionkit/HANDOFF.md` before proceeding. If the file d
 - **THEN** Pickup reads and parses it, then continues with the remaining steps
 
 ### Requirement: Open-ended section parsing
-Pickup SHALL parse all standard sections (Project, Date, Branch, Goal, Progress, Git State, Remaining Work, Context). Unknown headings SHALL be silently ignored — section parsing is open-ended. Legacy section names from prior versions SHALL not cause errors.
+Pickup SHALL parse the canonical sections (Goal, Progress, Remaining Work, Context, Task List). Unknown headings SHALL be silently ignored — section parsing is open-ended. Legacy section names or header metadata lines from prior handoff versions SHALL not cause errors.
 
 #### Scenario: Unknown heading encountered
 - **WHEN** the handoff file contains a heading not in the standard section list
 - **THEN** Pickup ignores it without error and continues parsing
 
 ### Requirement: Orientation summary
-Pickup SHALL produce a structured orientation summary from the parsed content. The summary SHALL cover: Goal (restated clearly), Progress (what was done and decided), Git State (branch, staged/unstaged, recent commits), Remaining Work (in priority order), and Context (gotchas and notes). The summary SHALL be concise — it MUST NOT reproduce the document verbatim.
+Pickup SHALL produce a structured orientation summary from the parsed content. The summary SHALL cover: Goal (restated clearly), Progress (what was done and decided), Remaining Work (in priority order), and Context (gotchas and notes). The summary SHALL be concise — it MUST NOT reproduce the document verbatim.
 
 #### Scenario: Orientation presented
 - **WHEN** the handoff file is successfully parsed
-- **THEN** Pickup outputs a structured summary covering all five areas without reproducing the document verbatim
+- **THEN** Pickup outputs a structured summary covering Goal, Progress, Remaining Work, and Context without reproducing the document verbatim
 
 ### Requirement: Task list hydration — two-pass
 Pickup SHALL locate the fenced `json` block following `## Task List`. If the block is absent or unparseable, Pickup SHALL emit one line noting the skip and continue. For tasks with `status` `pending` or `in_progress`, Pickup SHALL create new tasks via `TaskCreate` (pass 1), record old-ID → new-ID mappings, then restore `blockedBy` edges via `TaskUpdate` using remapped IDs (pass 2). Completed tasks SHALL be skipped. Pickup MUST NOT wire the `blocks` direction — only `blockedBy`.
@@ -54,22 +46,11 @@ Pickup SHALL locate the fenced `json` block following `## Task List`. If the blo
 
 #### Scenario: Task list absent or unparseable
 - **WHEN** the JSON block is missing or cannot be parsed
-- **THEN** Pickup emits "No task list snapshot — skipping hydration" and continues to step 5
+- **THEN** Pickup emits "No task list snapshot — skipping hydration" and continues
 
 #### Scenario: Completed tasks skipped
 - **WHEN** a task in the snapshot has `status: completed`
 - **THEN** Pickup skips creating that task — it is surfaced only in the orientation summary
-
-### Requirement: Branch mismatch detection
-Pickup SHALL compare the handoff branch against the current branch. If they differ, Pickup MUST suggest the checkout command. Pickup MUST NOT switch branches automatically.
-
-#### Scenario: Branch matches
-- **WHEN** the current branch matches the handoff branch
-- **THEN** Pickup makes no branch suggestion
-
-#### Scenario: Branch mismatch
-- **WHEN** the current branch differs from the handoff branch
-- **THEN** Pickup suggests `git checkout <branch-from-handoff>` and does not switch automatically
 
 ### Requirement: Readiness confirmation via structured prompt
 Pickup SHALL end by asking the user what to tackle first via `AskUserQuestion`. The question SHALL reference the handoff Goal. Options SHALL be derived from the top items in Remaining Work (highest-priority first), up to four options. If fewer than two actionable items exist in Remaining Work, Pickup SHALL fall back to plain text.
@@ -81,6 +62,9 @@ Pickup SHALL end by asking the user what to tackle first via `AskUserQuestion`. 
 #### Scenario: Fewer than two actionable items
 - **WHEN** Remaining Work has fewer than two actionable items
 - **THEN** Pickup asks what to do next in plain text
+
+### Note: Branch-mismatch step deliberately removed
+The branch-mismatch detection and `git checkout` suggestion that appeared in prior versions of this spec have been removed. The simplified handoff document format no longer records branch metadata, so the check had no reliable input and was dropped.
 
 ### Requirement: Read-only operation
 Pickup SHALL NOT modify `.sessionkit/HANDOFF.md` under any circumstances. Pickup MUST NOT re-execute commands referenced in the handoff.

--- a/plugins/sessionkit/skills/handoff/SKILL.md
+++ b/plugins/sessionkit/skills/handoff/SKILL.md
@@ -1,59 +1,47 @@
 ---
 name: handoff
-description: Capture session context to a handoff document so another agent can take over seamlessly. Run it after every meaningful state change (PR opened, task completed, decision made) — delta mode keeps the cost trivial so you don't have to wait for context pressure.
+description: Capture session context to a handoff document so another agent can take over seamlessly. Run it when context is running low or after completing a meaningful chunk of work.
 triggers:
   - "/handoff"
   - "write a handoff"
   - "create handoff"
   - "save handoff"
   - "context is running low"
-allowed-tools: Bash, Read, Write, TaskList, TaskGet, AskUserQuestion, Skill, Agent
+allowed-tools: Bash, Read, Write, TaskList, TaskGet, AskUserQuestion
 ---
 
 # Handoff
 
 ## Input
 
-`$ARGUMENTS` — optional freeform notes to fold into the handoff (e.g. "focus on the auth refactor, skip the docs work"). If omitted, auto-infer everything from session state.
-
-Recognized flags (parsed from `$ARGUMENTS`):
-
-- `--full` — force the full-regenerate path even if delta mode would otherwise apply. Use when you want a fresh narrative pass (e.g. Goal/Context have meaningfully drifted but the structural fingerprints haven't).
-
-If `--full` is present, strip it from `$ARGUMENTS` before folding the remaining text into Goal/Context.
-
-## Execution model
-
-Handoff runs its synthesis on Haiku regardless of the session's active model — the document is structured output and Haiku is materially faster for it. The work is split:
-
-- **Outer tier (this skill, any model)** — does what the live session is uniquely able to do or what must reach the user: summarize the conversation arc, gather the task list (a sub-agent's `TaskList`/`TaskGet` see a different task store, not this session's — see step 2.5), and resolve the user-facing `.gitignore` prompt.
-- **Haiku sub-agent** — gathers git state, computes fingerprints, decides delta vs full, and writes the document to disk, using the task JSON the outer tier hands it.
-
-The outer tier MUST pass full self-contained instructions to the sub-agent inline. It MUST NOT tell the sub-agent to "run the handoff skill" or reference this skill by name — that would re-trigger the skill and recurse.
+`$ARGUMENTS` — optional freeform notes to fold into Goal or Context (e.g. "focus on the auth refactor, skip the docs work"). If omitted, auto-infer everything from session state.
 
 ## Process
 
-### 1. Parse arguments
+### 1. Fold arguments
 
-Detect and strip `--full` from `$ARGUMENTS`. Keep the remaining freeform text for step 2.
+If `$ARGUMENTS` is non-empty, incorporate the freeform text into Goal or Context where it fits naturally. No flags are recognized.
 
 ### 2. Summarize conversation context
 
-Produce the bullets only the live session can derive — the sub-agent has no view of this conversation. Keep them tight (bullets, no prose):
+Derive the following from the live session — keep everything as bullets, no prose:
 
 - **Goal** — one bullet: what this session is fundamentally trying to accomplish.
 - **Progress** — what was completed, decided, or abandoned this session.
+- **Remaining Work** — what still needs doing, in priority order.
 - **Context** — key decisions, gotchas, dead ends, external references the next agent needs.
 
-Fold the remaining `$ARGUMENTS` text into Goal or Context where it fits. This summary becomes an input to the sub-agent in step 4.
+### 3. Gather the task list
 
-### 2.5. Gather the task list (outer tier)
+Call `TaskList`, then `TaskGet` once per task ID. Collect every task whose `status` is not `"deleted"` and serialize to a JSON array. Each object MUST include only these fields:
 
-Call `TaskList`, then `TaskGet` once per task ID. Collect every task whose `status !== "deleted"` and serialize them to a JSON array containing only `id`, `subject`, `description`, `activeForm`, `status`, `blockedBy`, `blocks` (empty array `[]` if none). This becomes the `taskListJson` input to the sub-agent in step 4.
+```
+id, subject, description, activeForm, status, blockedBy, blocks
+```
 
-This MUST run in the outer tier: a sub-agent's `TaskList`/`TaskGet` resolve to a different task store and will not return this session's tasks — passing the serialized JSON as data is the only reliable way to capture the live task list.
+Use `[]` for `blockedBy` / `blocks` when empty. Preserve the original task `id` so `/pickup` can rewire `blockedBy` relationships.
 
-### 3. Resolve `.gitignore` coverage (outer tier — user-facing)
+### 4. Resolve `.gitignore` coverage
 
 Check coverage:
 
@@ -61,109 +49,51 @@ Check coverage:
 test -f .gitignore && grep -qE '^\.sessionkit/?$' .gitignore && echo "covered" || echo "not-covered"
 ```
 
-- **`.gitignore` absent**: ask via `AskUserQuestion` "No `.gitignore` found. Create one with `.sessionkit/` to keep handoff docs out of version control?". On yes, write `.gitignore` containing only `.sessionkit/`. On no, proceed.
-- **`.gitignore` present but not covered**: ask via `AskUserQuestion` "`.gitignore` doesn't cover `.sessionkit/`. Append it?". On yes, append `.sessionkit/`. On no, proceed.
+- **`.gitignore` absent**: ask via `AskUserQuestion` — "No `.gitignore` found. Create one with `.sessionkit/` to keep handoff docs out of version control?". On yes, write `.gitignore` containing only `.sessionkit/`. On no, proceed.
+- **`.gitignore` present but not covered**: ask via `AskUserQuestion` — "`.gitignore` doesn't cover `.sessionkit/`. Append it?". On yes, append `.sessionkit/`. On no, proceed.
 - **Already covered**: proceed silently.
 
-This stays in the outer tier because a sub-agent cannot prompt the user.
+### 5. Write the document
 
-### 4. Dispatch the Haiku sub-agent
-
-Invoke the `Agent` tool with:
-
-- `subagent_type`: `"general-purpose"`
-- `model`: `"haiku"`
-- `prompt`: a single self-contained message containing (a) the conversation summary from step 2, (b) the `taskListJson` from step 2.5, (c) the `--full` flag state, and (d) the verbatim operating instructions below. Do not reference this skill by name anywhere in the prompt.
-
-> You are writing a session handoff document to `.sessionkit/HANDOFF.md`. Follow these steps exactly and report the outcome. Do not ask the user anything — you have no user access. The task list has been gathered for you and provided as `taskListJson`; do NOT call `TaskList` or `TaskGet` yourself — your task context differs from the session's, so those tools would return the wrong tasks.
->
-> **A. Gather git state.** Run in parallel:
-> ```bash
-> git rev-parse HEAD 2>/dev/null || echo "no-head"
-> git branch --show-current
-> git diff --cached --name-only
-> git diff --name-only
-> git log --oneline -5
-> git diff --cached
-> ```
-> Use the provided `taskListJson` as the task list — it already excludes deleted tasks.
->
-> **B. Compute fingerprints.**
-> - `gitFingerprint` = `<HEAD-sha>:<sorted-staged-files-hash>:<sorted-unstaged-files-hash>`.
-> - `taskFingerprint` = SHA-1 of the canonicalized `taskListJson` (sorted by `id`, fields stripped to `id,subject,status,blockedBy`). Compute via `printf %s "$json" | shasum -a 1 | cut -d' ' -f1`.
->
-> **C. Skip-unchanged check.** If `.sessionkit/HANDOFF.md` exists, Read it and find the first-line meta header `<!-- handoff-meta gitFingerprint=<sha> taskFingerprint=<sha> -->`. Compare with two independent reuse decisions:
-> - `gitFingerprint` matches → reuse `## Git State` and `## Progress` verbatim, else regenerate them.
-> - `taskFingerprint` matches → reuse `## Task List` and `## Remaining Work` verbatim, else regenerate them.
-> `## Goal` and `## Context` are always taken from the conversation summary provided to you. If no prior file or no meta header, regenerate all sections.
->
-> **D. Delta-vs-full decision.** Use the **delta** path when ALL hold: (1) a prior file parsed cleanly (meta header, all six canonical sections in order, `## Task List` json block parses); (2) the prior HEAD-sha is an ancestor of current HEAD — `git merge-base --is-ancestor <prior-head-sha> HEAD` exits 0; (3) at most two of the four reusable sections need regeneration; (4) `--full` was not passed. Otherwise use the **full** path.
->
-> **E-delta. Delta mechanics.** Surgically Edit the existing file: refresh `## Goal` and `## Context` from the conversation summary; regenerate only the flagged reusable sections; update the meta header's `gitFingerprint` / `taskFingerprint` to the step-B values and refresh `**Date**`; leave verbatim-reuse sections byte-exact.
->
-> **E-full. Full mechanics.** `mkdir -p .sessionkit` and Write the whole document per the template below.
->
-> **F. Template** (emit exactly this structure; bullets only in Progress / Remaining Work / Context; meta header on line 1 is mandatory):
-> ````markdown
-> <!-- handoff-meta gitFingerprint=<sha> taskFingerprint=<sha> -->
-> # Handoff
->
-> **Project**: <working directory>
-> **Date**: <ISO date>
-> **Branch**: <current git branch>
->
-> ## Goal
-> - <one bullet, one sentence>
->
-> ## Progress
-> - <completed item>
-> - <decision made>
-> - <thread abandoned>
->
-> ## Git State
-> - Branch: <branch>
-> - Staged: <list of staged files or "none">
-> - Unstaged: <list of unstaged files or "none">
-> - Recent commits (last 5):
->   - <sha> <subject>
->
-> ## Remaining Work
-> - <next step in priority order>
-> - <next step>
->
-> ## Task List
-> ```json
-> [
->   {
->     "id": "<task-id>",
->     "subject": "<subject>",
->     "description": "<description>",
->     "activeForm": "<activeForm>",
->     "status": "<status>",
->     "blockedBy": [],
->     "blocks": []
->   }
-> ]
-> ```
->
-> ## Context
-> - <key decision>
-> - <gotcha>
-> - <external reference>
-> ````
->
-> **G. Inference rules.**
-> - **Progress** — bullets from staged/unstaged file lists, recent commits, plus the conversation summary's progress bullets.
-> - **Remaining Work** — bullets in priority order from the Task List plus unfinished threads in the conversation summary.
-> - **Task List** — emit `taskListJson` as one fenced `json` block, preserving each task's original `id` so pickup can rewire `blockedBy`. It is already filtered to the right fields and excludes deleted tasks; emit `[]` if it is empty.
-> - **Goal** / **Context** — take from the conversation summary provided to you.
->
-> **H. Report back.** Return one line stating the chosen mode and reuse outcome, e.g. `delta — refreshed Goal/Context, regenerated Git State + Progress` or `full — regenerated all sections`. Confirm the document was written to `.sessionkit/HANDOFF.md`.
-
-**Fallback**: if the Agent call fails, returns empty output, or the file it wrote is missing the `## Task List` heading, synthesize the document yourself inline using the same template, prepend `<!-- handoff-warning: haiku sub-agent unavailable, synthesized in-line -->`, and write it to `.sessionkit/HANDOFF.md`.
-
-### 5. Report
-
-Relay the sub-agent's reported mode and reuse outcome, state the absolute path of the written file, and suggest:
+Run `mkdir -p .sessionkit`, then `Write` the document to `.sessionkit/HANDOFF.md` using the template below. Report the absolute path and suggest:
 
 > Start a new session and run `/pickup` to resume.
+
+## Document template
+
+```markdown
+# Handoff
+
+## Goal
+- <one bullet, one sentence>
+
+## Progress
+- <completed item or decision>
+
+## Remaining Work
+- <next step in priority order>
+
+## Context
+- <key decision, gotcha, or external reference>
+
+## Task List
+```json
+[
+  {
+    "id": "<task-id>",
+    "subject": "<subject>",
+    "description": "<description>",
+    "activeForm": "<activeForm>",
+    "status": "<status>",
+    "blockedBy": [],
+    "blocks": []
+  }
+]
+```
+```
+
+**Constraints:**
+- Sections MUST appear in this exact order: Goal → Progress → Remaining Work → Context → Task List.
+- Progress, Remaining Work, and Context MUST contain bullets only — no narrative paragraphs.
+- The Task List section MUST contain exactly one fenced `json` block. Emit `[]` if there are no tasks.
+- Do NOT write any other files or sections beyond what the template specifies.

--- a/plugins/sessionkit/skills/pickup/SKILL.md
+++ b/plugins/sessionkit/skills/pickup/SKILL.md
@@ -7,101 +7,64 @@ triggers:
   - "load handoff"
   - "resume from handoff"
   - "continue previous session"
-allowed-tools: Bash, Read, TaskCreate, TaskUpdate, TaskList, AskUserQuestion, Skill, Agent
+allowed-tools: Bash, Read, TaskCreate, TaskUpdate, TaskList, AskUserQuestion
 ---
 
 # Pickup
 
-## Execution model
-
-Pickup runs its reading, parsing, and orientation synthesis on Haiku regardless of the session's active model — Haiku is materially faster and the work is mechanical. The work is split:
-
-- **Haiku sub-agent** — reads and parses `.sessionkit/HANDOFF.md`, produces the orientation summary, extracts the task snapshot, and derives the readiness question/options. It returns this as structured output; it does not touch session state or the user.
-- **Outer tier (this skill, any model)** — performs only the operations that must land in *this* session or reach the user: the absent-file guard, `TaskCreate`/`TaskUpdate` hydration, the branch-mismatch suggestion, and the final `AskUserQuestion`.
-
-The outer tier MUST pass full self-contained instructions to the sub-agent inline. It MUST NOT tell the sub-agent to "run the pickup skill" or reference this skill by name — that would re-trigger the skill and recurse.
-
 ## Process
 
-### 1. Absent-file guard (outer tier)
-
-Check for `.sessionkit/HANDOFF.md` in the current working directory:
+### 1. Absent-file guard
 
 ```bash
 test -f .sessionkit/HANDOFF.md && echo "found" || echo "missing"
 ```
 
-If missing, report and stop — do not dispatch the sub-agent:
+If missing, report and stop — do not continue:
 
 > No handoff file found at `.sessionkit/HANDOFF.md`. Either `/handoff` was not run in the previous session, or you're in a different working directory.
 
-### 2. Dispatch the Haiku sub-agent
+### 2. Read and parse
 
-Invoke the `Agent` tool with:
+`Read` `.sessionkit/HANDOFF.md` inline. Parse these sections: **Goal**, **Progress**, **Remaining Work**, **Context**, and the fenced `json` block under **Task List**. Ignore any unknown or legacy headings silently — parsing is open-ended.
 
-- `subagent_type`: `"general-purpose"`
-- `model`: `"haiku"`
-- `prompt`: the verbatim operating instructions below. Do not reference this skill by name anywhere in the prompt.
+### 3. Extract task snapshot
 
-> You are parsing a session handoff document to orient the next agent. Read `.sessionkit/HANDOFF.md`, then return the structured result described below. Do not call any task tools and do not ask the user anything — you have no session-state or user access. Your returned text IS the result.
->
-> **A. Read and parse.** Read the full file. Parse the standard sections: **Project**, **Date**, **Branch**, **Goal**, **Progress**, **Git State**, **Remaining Work**, **Context**. Ignore unknown headings silently — parsing is open-ended, so legacy or future section names must not cause errors.
->
-> **B. Task snapshot.** Locate the fenced `json` block immediately following the `## Task List` heading. If the section is missing or the block is absent/unparseable, set `tasksToCreate` to `[]` and `taskListMissing` to `true`. Otherwise, for each object whose `status` is `pending` or `in_progress`, include it in `tasksToCreate` with its `id` (as `oldId`), `subject`, `description`, `activeForm`, `status`, and `blockedBy`. Skip `completed` tasks.
->
-> **C. Current branch.** Run `git branch --show-current` and record it as `currentBranch`. Record the handoff's branch as `handoffBranch`.
->
-> **D. Readiness.** Derive 2–4 concrete next-action options from `Remaining Work` (highest priority first). Each option is `{label, description}`. If fewer than 2 actionable items exist, set `options` to `[]`.
->
-> **E. Return** exactly one markdown orientation summary followed by one fenced `json` block — nothing else. The orientation summary covers Goal (restated in 1–2 sentences), Progress (what was done/decided), Git State (branch, staged/unstaged, recent commits), Remaining Work (priority order), and Context (gotchas/notes) — concise, not the document verbatim. The json block:
-> ```json
-> {
->   "goal": "<one-line goal>",
->   "taskListMissing": false,
->   "tasksToCreate": [
->     { "oldId": "<id>", "subject": "<s>", "description": "<d>", "activeForm": "<a>", "status": "<pending|in_progress>", "blockedBy": ["<oldId>"] }
->   ],
->   "currentBranch": "<branch>",
->   "handoffBranch": "<branch>",
->   "options": [ { "label": "<short>", "description": "<scope/effort>" } ]
-> }
-> ```
+Locate the fenced `json` block immediately following the `## Task List` heading. For each object whose `status` is `pending` or `in_progress`, collect:
+- `oldId` (the task's `id` from the snapshot)
+- `subject`, `description`, `activeForm`, `status`, `blockedBy`
 
-**Fallback**: if the Agent call fails or returns no parseable json block, read and parse `.sessionkit/HANDOFF.md` yourself inline using the same rules, then continue.
+Skip objects with `status: completed`. If the block is absent, empty, or unparseable, set `tasksToCreate` to `[]` and note it.
 
-### 3. Present orientation (outer tier)
+### 4. Present orientation
 
-Print the sub-agent's orientation summary to the user.
+Print a concise orientation summary — bullets, not a verbatim copy of the document:
 
-### 4. Hydrate task list (outer tier)
+- **Goal** — restated in 1–2 sentences
+- **Progress** — what was done and decided
+- **Remaining Work** — priority order
+- **Context** — gotchas and notes
 
-Using the sub-agent's `tasksToCreate`:
+Do NOT add a section for git state — the handoff document does not contain one.
 
-- If `taskListMissing` is true (or `tasksToCreate` is empty), emit one line: `No task list snapshot — skipping hydration` and skip to step 5.
-- **Pass 1 — create tasks.** For each entry, call `TaskCreate` with its `subject`, `description`, and `activeForm`. `TaskCreate` always creates as `pending` — do not force `in_progress`. Record `oldId → newId`.
-- **Pass 2 — restore edges.** For each entry with a non-empty `blockedBy`, remap each old ID to its new ID and call `TaskUpdate` with `addBlockedBy`. Do not wire `blocks` — the inverse is implicit and would double-write the graph.
+### 5. Hydrate task list
 
-These calls run in the outer tier so the tasks land in *this* session's list.
+If `tasksToCreate` is empty, emit one line: `No task list snapshot — skipping hydration` and move to step 6.
 
-### 5. Restore git state (outer tier)
+**Pass 1 — create tasks.** For each entry, call `TaskCreate` with its `subject`, `description`, and `activeForm`. `TaskCreate` always creates as `pending` — do not force `in_progress`. Record `oldId → newId`.
 
-If `currentBranch` differs from `handoffBranch`, suggest (do not run):
+**Pass 2 — restore edges.** For each entry with a non-empty `blockedBy`, remap each old ID to its new ID and call `TaskUpdate` with `addBlockedBy`. Do NOT wire `blocks` — the inverse is implicit.
 
-```bash
-git checkout <handoffBranch>
-```
+### 6. Confirm readiness
 
-Only suggest on mismatch. Never switch branches automatically.
+Derive 2–4 concrete next-action options from the top items in **Remaining Work** (highest-priority first). Each option should have a short label and a brief scope/effort note.
 
-### 6. Confirm readiness (outer tier)
-
-If the sub-agent returned 2 or more `options`, ask via `AskUserQuestion`:
-
+If 2 or more options exist, use `AskUserQuestion`:
 - **question**: `Context loaded. Ready to continue work on: <goal>. What would you like to tackle first?`
 - **header**: `Next action`
-- **options**: the sub-agent's `options` (label + description)
+- **options**: the derived options
 
-If fewer than 2 options, fall back to plain text:
+If fewer than 2 options, use plain text:
 
 > Context loaded. Ready to continue work on: `<goal>`. What would you like to tackle first?
 

--- a/plugins/speckit/skills/spec/SKILL.md
+++ b/plugins/speckit/skills/spec/SKILL.md
@@ -56,6 +56,19 @@ from here: step 3 is the only approval gate.
 Do not proceed to step 3 until `/speckit:interview` has produced a complete,
 unambiguous output with all five sections present.
 
+### Post-interview handoff gate
+
+`/speckit:interview` is a sub-skill. When it returns, the sub-skill's job is done; the orchestrator's job is not. **After `/speckit:interview` returns, do not pause and do not wait for user input.** Parse the five sections from the output and immediately advance to step 2.5 / step 3 in the same turn — emitting the plan and the `AskUserQuestion` approval call before ending the turn.
+
+Any turn that prints or references the interview output and ends without the plan and `AskUserQuestion` is a defect.
+
+| Legitimate end of turn at this boundary | Illegitimate end of turn at this boundary |
+|-----------------------------------------|-------------------------------------------|
+| User has explicitly halted the run. | Silent wait after the interview sections print. |
+| | Prose offer ("shall I proceed to planning?") in place of running step 3. |
+| | Status update with no tool call. |
+| | Ending the turn after parsing the interview output with no further action. |
+
 ### 2a. Classify simple vs. full path
 
 **Execution order**: this step runs BEFORE step 2. Numbered 2a to keep later
@@ -182,15 +195,11 @@ Always append the following documentation task as the final row, unless the spec
 
 Include the `## Epic label` section **only when the plan produces an epic** (2+ tasks). Omit it for single-issue plans. Render the derived label as a single, editable line, for example: `Epic label: epic:catalog-epic-labels`.
 
-**Required turn shape**: the turn that presents the plan MUST contain, in
-this exact order, (a) the plan markdown and (b) exactly one `AskUserQuestion`
-tool call. Any turn that emits the plan and ends without the tool call is a
-defect and must be corrected by immediately emitting the `AskUserQuestion`
-call. This is non-negotiable — no prose ending (silent wait, `/catalog`
-hand-off suggestion, encouragement to reply, or any other text) is acceptable
-in place of the tool call. The `AskUserQuestion` call is the only valid
-approval gate and is the sole plan-filing approval for the skill on both
-paths.
+#### Required turn shape
+
+This rule applies to both the post-interview case (full path) and the inline-draft case (simple path).
+
+The turn that presents the plan MUST contain, in this exact order, (a) the plan markdown and (b) exactly one `AskUserQuestion` tool call. Any turn that emits the plan and ends without the tool call is a defect and must be corrected by immediately emitting the `AskUserQuestion` call. This is non-negotiable — no prose ending (silent wait, `/catalog` hand-off suggestion, encouragement to reply, or any other text) is acceptable in place of the tool call. The `AskUserQuestion` call is the only valid approval gate and is the sole plan-filing approval for the skill on both paths.
 
 The options depend on whether the plan is a simple-path single issue or a
 full-path epic. `AskUserQuestion` supports max 4 options total (including
@@ -308,9 +317,14 @@ After creating the epic, wire up relationships:
 1. **Add sub-issues**: Open with `TaskUpdate(wire-sub-issues, status: "in_progress")`. For each child issue, add it as a sub-issue of the epic:
    ```bash
    gh api repos/{owner}/{repo}/issues/{epic_number}/sub_issues \
-     -X POST -F sub_issue_id={child_issue_id}
+     -X POST -F sub_issue_id={child_database_id}
    ```
-   Use the numeric `id` (not the issue number) — fetch it from `gh issue view {number} --json id`. Close with `TaskUpdate(wire-sub-issues, status: "completed")` once every child has been attached.
+   `sub_issue_id` requires the integer **databaseId**, not the GraphQL node ID that `gh issue view --json id` returns (which causes a 422). Fetch the databaseId via GraphQL:
+   ```bash
+   gh api graphql -f query='query { repository(owner:"OWNER",name:"REPO") { issue(number:N){ databaseId } } }' \
+     --jq '.data.repository.issue.databaseId'
+   ```
+   Replace `OWNER`, `REPO`, and `N` with the actual values for each child issue. Close with `TaskUpdate(wire-sub-issues, status: "completed")` once every child has been attached.
 
 2. **Wire blocked-by relationships**: Open with `TaskUpdate(wire-blocked-by-edges, status: "in_progress")`. For each task with a `Depends On` value in the plan, set the GitHub blocked-by relationship:
    ```bash


### PR DESCRIPTION
## Summary

Simplifies the sessionkit handoff/pickup pair and fixes two speckit:spec bugs (epic #1019). Net change across the epic: **+140 / −290 lines** — a substantial reduction in machinery.

The handoff/pickup skills previously used a two-tier model: an outer session plus a dispatched Haiku sub-agent, fingerprint-based section reuse (`gitFingerprint`/`taskFingerprint`), and delta-vs-full routing. That complexity bought little for a feature whose core job is "write session state to a file and read it back." This collapses both skills to a single inline pass over a lean 5-section document.

## Changes

### sessionkit — handoff (#1017)
- Rewrites `handoff` to write `.sessionkit/HANDOFF.md` **entirely inline** — no sub-agent dispatch, no fingerprint/delta/`--full` routing. Always a full rewrite.
- Gathers the task list via `TaskList`/`TaskGet` in the session before writing.
- New 5-section document, fixed order: **Goal → Progress → Remaining Work → Context → Task List**. No metadata header, no Git State section. `## Task List` holds a fenced `json` block of all non-deleted tasks (id/subject/description/activeForm/status/blockedBy/blocks).
- Retains the `.gitignore` coverage check (asks before modifying).
- `allowed-tools` trimmed to `Bash, Read, Write, TaskList, TaskGet, AskUserQuestion`.

### sessionkit — pickup (#1018)
- Rewrites `pickup` to read and parse `HANDOFF.md` **inline** — no sub-agent dispatch.
- Parses the same 5 sections; silently ignores unknown/legacy headings (backwards-compatible with old-format handoffs).
- Two-pass task hydration: `TaskCreate` per pending/in_progress task (records old→new IDs), then `TaskUpdate addBlockedBy` to restore edges.
- Drops the branch-mismatch / `git checkout` step entirely (Git State is gone).
- `allowed-tools` trimmed to `Bash, Read, TaskCreate, TaskUpdate, TaskList, AskUserQuestion`.

### speckit — spec (#1020, #1021)
- **#1020**: adds a hard post-interview approval gate — after `/speckit:interview` returns, the orchestrator must emit the plan and call `AskUserQuestion` before any other tool call. "Required turn shape" now governs both the post-interview and inline-draft paths.
- **#1021**: step 5 sub-issue wiring now resolves `sub_issue_id` via the GraphQL `databaseId` instead of `gh issue view --json id` (which returns the node ID and 422s). Correct invocation documented inline.

### specs
- `openspec/specs/sessionkit-handoff/spec.md` and `sessionkit-pickup/spec.md` rewritten to match the simplified behavior; the deliberate removal of the branch-mismatch step is recorded.

## Test plan

This is a SKILL.md / markdown / spec monorepo with no automated test suite. Verification was done via grep gates and review:
- Both rewritten SKILL.md files: **0 matches** for `Agent|subagent_type|Haiku|fingerprint|delta|--full|Git State` (and `handoffBranch|branch.mismatch` for pickup).
- Section order confirmed once-and-in-order; `allowed-tools` frontmatter verified per skill.
- handoff template and `sessionkit-handoff/spec.md` confirmed consistent (no metadata header).
- All three component PRs (#1024, #1025, #1026) were reviewer-cleared before merge into this epic branch.

Closes #1017
Closes #1018
Closes #1019
Closes #1020
Closes #1021
