### PR TITLE
chore(squadkit): apply team-retro contract edits

### DIFF
--- a/plugins/squadkit/agents/builder.md
+++ b/plugins/squadkit/agents/builder.md
@@ -32,6 +32,8 @@ If the lead returns `revise:`, update the contract and resend before any impleme
 3. **Surface interface contracts.** See above. Wait for ack.
 4. **Implement step by step.** Work through the blueprint's sequence. After each step run the verify command the blueprint specified — typically `${verify.typecheck}` for structural changes and `${verify.test}` for behavioural changes.
 5. **Final verify.** Before opening the PR, run the full verify gate end-to-end: `${install}` (if applicable), `${verify.typecheck}`, `${verify.test}`. All must pass. Do not open a PR with red gates.
+
+   **When verify commands are unconfigured.** If `.squadkit/config.json` is absent or a given `${verify.*}` key is null, the command does not exist for this repo — do not invent one or treat the gap as a blocker. Fall back to a manual coherence check appropriate to the changed files (for a docs/markdown/SKILL.md repo this is reading the diff for self-consistency and running any grep gates the blueprint named) and note in your completion-ack that automated verify was unconfigured.
 6. **Open the PR** against `${baseBranch}` following the canonical PR body shape (Summary / Changes / Test plan + issue footer).
 7. **Notify the lead.** Deliver the PR URL. Wait for ack and reviewer verdict.
 8. **Address review.** If the reviewer returns blockers, fix them in the same branch, re-run the verify gate, push, and notify the lead again.
@@ -57,6 +59,8 @@ If the lead's ack arrives after you've started bodies but before you've pushed:
 
 - **Non-blocking suggestion** (typing refinement, scope tightening, naming): apply if cheap (≤5 LOC additional change); otherwise note it in the completion-ack and defer to a follow-up. Do NOT block the push.
 - **Blocking adjustment** (interface change, scope expansion, contract revision): halt, push a WIP commit if any work is committable, and `SendMessage` the lead with current state and the question "block-and-revise vs ship-and-iterate?".
+
+**Carrying partial work when a superseding blueprint arrives.** If a revised blueprint changes scope while you have uncommitted edits in flight, commit that in-progress state to a scratch branch — never `git stash` and switch branches. Stashing across a branch switch reapplies the diff against a different base and produces avoidable merge conflicts. Commit to a scratch branch, then cherry-pick or rebase the relevant pieces once the new blueprint is confirmed.
 
 ## Task list discipline
 

--- a/plugins/squadkit/agents/tester.md
+++ b/plugins/squadkit/agents/tester.md
@@ -49,7 +49,7 @@ You produce one of two artifacts per task, depending on the lead's brief:
 1. **Acknowledge the brief.** Read the blueprint and the PR diff (if reviewing).
 2. **Post-rebase pre-flight.** After any rebase that pulls in a sibling builder's commit, run `${install}` and `${verify.typecheck}` before authoring or running tests. Missing transitive dependencies otherwise surface as test-collection errors that look like flakes.
 3. **Author or update tests** per the plan.
-4. **Run `${verify.test}`.** Record pass/fail counts.
+4. **Run `${verify.test}`.** Record pass/fail counts. If `.squadkit/config.json` is absent or `verify.test` is null, no test command exists for this repo — do not invent one or treat the gap as a blocker. Fall back to manual coherence review (read the diff and specs for self-consistency) and report that automated verify was unconfigured.
 5. **Run `${verify.typecheck}`** if your test files introduce new types or imports.
 6. **Deliver the report** to the lead. Wait for ack.
 


### PR DESCRIPTION
## Summary

Applies two role-contract improvements surfaced by the `squadkit:agent-team-retro` on team `smallorbit-plugins-alpha` (the squad that shipped epic #1019). Approved findings only — H1 and M3.

## Changes

- **H1 — verify-config fallback** (raised by tester + architect). `builder.md` and `tester.md` now state that when `.squadkit/config.json` is absent or a `${verify.*}` key is null, the command does not exist for the repo — fall back to manual coherence review rather than treating the gap as a blocker.
- **M3 — scratch-branch over stash** (raised by builder-1). `builder.md` now mandates committing in-flight work to a scratch branch (never `git stash` across a branch switch) when a superseding blueprint changes scope mid-implementation.

## Test plan

Docs-only contract edits (no automated suite in this repo). Verified by reading the diffs for self-consistency and confirming the new clauses sit in the correct contract sections.

Findings deferred to issues (not applied here): H2 reviewer cross-PR consistency, M1 architect spec enumeration, M2 builder same-file→one-PR, L1 explorer no-op session.