### PR TITLE
chore(ship-plugins): rewrite for flowkit v4

### DIFF
--- a/.claude/skills/ship-plugins/SKILL.md
+++ b/.claude/skills/ship-plugins/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ship-plugins
-description: Project-local skill that chains merge-stack → bump-versions → cut → release for this plugin monorepo. Reentrant — each stage gracefully skips if there's nothing to do, so an interrupted run can be resumed by re-invoking.
+description: Project-local skill that chains merge-stack → bump-versions → flowkit:ship for this plugin monorepo on flowkit v4. Reentrant — each stage gracefully skips if there's nothing to do, so an interrupted run can be resumed by re-invoking.
 triggers:
   - "/ship-plugins"
   - "ship plugins"
@@ -8,25 +8,24 @@ triggers:
 
 # Ship Plugins
 
-Project-local wrapper that combines `swarmkit:merge-stack`, the repo-local `/bump-versions` skill, and `flowkit:cut` + `flowkit:release` into one reentrant command.
+Project-local wrapper that combines `swarmkit:merge-stack`, the repo-local `/bump-versions` skill, and `flowkit:ship` into one reentrant command for flowkit v4 (single-trunk main).
 
 Lives in `.claude/skills/` because this chain only makes sense for this monorepo — `/bump-versions` is project-specific and wouldn't apply to other repos that use flowkit. Don't generalize it into flowkit.
 
 ## When to use
 
-- After a swarm: merge the stack, bump affected plugins, cut an RC, ship to main
-- After merging PRs manually: catch up the bump / cut / release tail
+- After a swarm: merge the stack, bump affected plugins, ship to main
+- After merging PRs manually: catch up the bump / ship tail
 - To resume an interrupted run: re-invoke and each stage detects whether its work is done
 
 ## Reentrancy contract
 
 Every stage performs a precondition check. If the check says "nothing to do", the stage announces a skip and the chain continues. No stage errors on an empty input.
 
-Three things never happen:
+Two things never happen:
 
-1. `/bump-versions` is never run when an RC already exists — the RC has the bumps baked in; a second bump would drift develop.
-2. `/cut` is never run when develop is in sync with main and there's no existing RC.
-3. `/release` is never run when there's no RC.
+1. `/bump-versions` is never run when main is in sync with origin/main and there's no epic in flight — there's nothing to ship.
+2. `flowkit:ship` is never run when main is in sync with origin/main and there's no epic in flight — there's nothing to ship.
 
 ## Process
 
@@ -35,7 +34,7 @@ Three things never happen:
 Check:
 
 ```bash
-OPEN_SWARM=$(gh pr list --base develop --state open \
+OPEN_SWARM=$(gh pr list --base main --state open \
   --json headRefName --limit 100 \
   | jq '[.[] | select(.headRefName | startswith("worktree-agent-"))] | length')
 ```
@@ -43,18 +42,44 @@ OPEN_SWARM=$(gh pr list --base develop --state open \
 - If `OPEN_SWARM > 0`: follow `swarmkit:merge-stack`.
 - Else: announce `"Stage 1 skipped: no open swarm PRs"` and continue.
 
-### Stage 2 — Skip-ahead guard: existing RC
+### Stage 2 — Early-exit guard: nothing to ship
+
+Resolve whether there's work to ship (this is an optimization — Stage 3 will recompute changed plugins):
 
 ```bash
-EXISTING_RC=$(git ls-remote --heads origin "rc/*" | head -1)
+# Check if there are any changed plugins since their last per-plugin tag
+CHANGED_PLUGINS=()
+for P in $(ls plugins); do
+  [ -f "plugins/${P}/.claude-plugin/plugin.json" ] || continue
+  TAG=$(git tag --list "${P}--v*" | sort -V | tail -1)
+  if [ -z "$TAG" ]; then
+    CHANGED_PLUGINS+=("$P")
+    continue
+  fi
+  COUNT=$(git log "${TAG}..origin/main" --oneline -- "plugins/${P}/" | wc -l | tr -d ' ')
+  [ "$COUNT" != "0" ] && CHANGED_PLUGINS+=("$P")
+done
+
+# Check if there's an epic in flight
+EPIC_BRANCH=""
+PINNED=$(git config --get claude.flowkit.prBase 2>/dev/null || true)
+if [[ -n "$PINNED" && "$PINNED" =~ ^feature/ ]]; then
+  EPIC_BRANCH="$PINNED"
+fi
+if [[ -z "$EPIC_BRANCH" ]]; then
+  CURRENT=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+  if [[ "$CURRENT" =~ ^feature/ ]]; then
+    EPIC_BRANCH="$CURRENT"
+  fi
+fi
 ```
 
-- If an RC exists: announce `"RC already cut — skipping bump-versions and /cut"` and jump to Stage 5.
+- If no plugins have changed AND `$EPIC_BRANCH` is empty: announce `"Stage 2 skipped: no changed plugins and no epic in flight — nothing to ship"` and **stop the chain**.
 - Else: continue to Stage 3.
 
 ### Stage 3 — Bump plugin versions
 
-Check whether any plugin has commits on `origin/develop` since its most recent per-plugin tag. Only consider plugins that have an existing tag or no tag yet:
+Check whether any plugin has commits on `origin/main` since its most recent per-plugin tag. Only consider plugins that have an existing tag or no tag yet:
 
 ```bash
 CHANGED_PLUGINS=()
@@ -65,7 +90,7 @@ for P in $(ls plugins); do
     CHANGED_PLUGINS+=("$P")
     continue
   fi
-  COUNT=$(git log "${TAG}..origin/develop" --oneline -- "plugins/${P}/" | wc -l | tr -d ' ')
+  COUNT=$(git log "${TAG}..origin/main" --oneline -- "plugins/${P}/" | wc -l | tr -d ' ')
   [ "$COUNT" != "0" ] && CHANGED_PLUGINS+=("$P")
 done
 ```
@@ -94,36 +119,21 @@ fi
 - If `$EPIC_BRANCH` is non-empty: follow `flowkit:ship-epic`.
 - Else: announce `"Stage 3.5 skipped: no epic in flight"` and continue.
 
-### Stage 4 — Cut a release candidate
+### Stage 4 — Ship
 
-```bash
-AHEAD=$(git log origin/main..origin/develop --oneline | wc -l | tr -d ' ')
-```
+Follow `flowkit:ship` to tag HEAD of main, push the tag, and create a GitHub Release.
 
-- If `AHEAD == 0`: announce `"Stage 4 skipped: develop in sync with main — nothing to cut"` and **stop the chain** (there's nothing for Stage 5 either).
-- Else: follow `flowkit:cut`.
-
-### Stage 5 — Release
-
-```bash
-HAS_RC=$(git ls-remote --heads origin "rc/*" | head -1)
-```
-
-- If `HAS_RC` is empty: announce `"Stage 5 skipped: no RC to release"` and stop.
-- Else: follow `flowkit:release`.
-
-### Stage 6 — Report
+### Stage 5 — Report
 
 Print a per-stage summary. Use `—` for skipped stages:
 
 ```
 ── Ship Plugins ───────────────────────────────────
 1.   merge-stack     : merged 3 PRs (#471 #472 #473)
-2.   rc skip-ahead   : no existing RC
-3.   bump-versions   : swarmkit 2.7.1→2.7.2, flowkit 2.0.4→2.1.0
-3.5  ship-epic       : skipped (no epic in flight)
-4.   cut             : rc/2026-04-19.15
-5.   release         : v2026.4.19.13 (closed #471 #472 #473)
+2.   early-exit      : —
+3.   bump-versions   : sessionkit 1.10.0→1.11.0, speckit 1.7.2→1.7.3
+3.5  ship-epic       : feature/simplify-handoff-pickup-1019 shipped
+4.   ship            : v2026.5.30.1 (closed #471 #472 #473)
 ───────────────────────────────────────────────────
 ```
 
@@ -131,9 +141,8 @@ Include a one-line reason for every skipped stage so the user can reason about w
 
 ## Constraints
 
-- Never run `/bump-versions` when an RC already exists on origin
-- Never cut when develop is in sync with main and there is no existing RC
-- Never release when there's no RC
+- Never run `/bump-versions` when main is in sync with origin/main and there's no epic in flight
+- Never run the full chain when main is in sync with origin/main and there's no epic in flight — stop early at Stage 2
 - Always continue past a stage with nothing to do; never error on "empty input"
 - Always print a final report listing every stage and its outcome (ran / skipped + reason)
 - Project-scoped: this skill is specific to `smallorbit-plugins`. Do not move it into flowkit — other flowkit consumers don't have `/bump-versions`


### PR DESCRIPTION
## Summary

Rewrite ship-plugins skill for flowkit v4 (single-trunk main).

## Changes

- Replace develop/rc/* logic with main-based flow
- Stage 1: merge-stack (check for open worktree-agent-* PRs on main)
- Stage 2: early-exit guard (check for changed plugins or epic)
- Stage 3: bump-versions (conditional on plugin changes)
- Stage 3.5: ship-epic (conditional on epic in flight)
- Stage 4: flowkit:ship (replaces old cut + release)
- Remove all references to develop and rc/* branches

## Test plan

- [x] Skill runs through all stages correctly
- [x] Early-exit works when nothing changed
- [x] Plugin version bumps work correctly
- [x] flowkit:ship creates release tags