### PR TITLE
docs(CLAUDE.md): add spec-scope docs-inclusion rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,3 +62,5 @@ Skip for typo fixes, renames, and small edits that don't touch convention surfac
 **Skill scripts standard**: Skills that extract deterministic bash work into shell scripts must follow the convention at [`plugins/_shared/script-authoring.md`](./plugins/_shared/script-authoring.md) — folder layout, `$SKILL_DIR` resolution, bare-payload JSON, stderr errors, when to extract, and `.claude/settings.json` allowlist guidance.
 
 **README flag-matrix drift**: Any change to a SKILL.md `## Input` table needs a matching pass on the corresponding plugin README's flag matrix — these drift silently otherwise.
+
+**Spec scope — always include docs**: When speccing any code change, the task list must include explicit tasks for updating all affected documentation and specifications (plugin READMEs, `CLAUDE.md`, OpenSpec `spec.md`, site content, `marketplace.json`). Do not treat documentation updates as implied — file them as discrete tasks so they survive the catalog and are not silently dropped.


### PR DESCRIPTION
## Summary
Adds a standing project rule to `CLAUDE.md` requiring documentation and specification updates to be filed as explicit tasks whenever speccing a code change.

## Changes
- Add **"Spec scope — always include docs"** convention under Skill Authoring Conventions: speccing any code change must enumerate doc/spec update tasks (plugin READMEs, `CLAUDE.md`, OpenSpec `spec.md`, site content, `marketplace.json`) as discrete catalog items rather than treating them as implied.

## Test plan
- [ ] Confirm the new rule renders correctly in `CLAUDE.md` under the Skill Authoring Conventions section
- [ ] No other files modified (single-file docs change)