### PR TITLE
chore(plugins): bump swarmkit@6.0.0, opsx-bridge@0.2.1

### DIFF
--- a/plugins/opsx-bridge/.claude-plugin/plugin.json
+++ b/plugins/opsx-bridge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "opsx-bridge",
   "description": "Bridge OpenSpec changes to squadkit/swarmkit dispatchers. Drive `/squadkit:spawn-team` or `/swarmkit:swarm` from a single `openspec/changes/<name>/` proposal — additive only, leaves opsx/squadkit/swarmkit untouched.",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "5.7.0",
+  "version": "6.0.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Bump plugin.json versions for plugins changed since their last release.

## Changes

- swarmkit@6.0.0 (major — removed the public /swarmkit:swarm-plus skill; review/fix is now always-on in /swarmkit:swarm)
- opsx-bridge@0.2.1 (patch — dispatch target rewired from swarmkit:swarm-plus to swarmkit:swarm)

## Test plan

- [ ] Confirm each `plugin.json` version bump matches the per-plugin tag that will be created after merge.