### PR TITLE
fix(flowkit): exclude per-plugin --v tags from release-tag resolution

### DIFF
--- a/plugins/flowkit/skills/pipeline-status/SKILL.md
+++ b/plugins/flowkit/skills/pipeline-status/SKILL.md
@@ -37,7 +37,8 @@ gh pr list --base main --state open \
   --limit 50
 
 # Released — most recent v* tag (commits since it on main = unreleased)
-LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
+# grep -v '--v' excludes per-plugin tags (e.g. vaultkit--v1.1.8) that otherwise leak into the v* glob
+LAST_TAG=$(git tag --list 'v*' | grep -v -- '--v' | sort -V | tail -1)
 if [ -n "$LAST_TAG" ]; then
   UNRELEASED=$(git log "$LAST_TAG"..origin/main --oneline | wc -l | tr -d ' ')
 else

--- a/plugins/flowkit/skills/pipeline-status/SKILL.md
+++ b/plugins/flowkit/skills/pipeline-status/SKILL.md
@@ -38,6 +38,8 @@ gh pr list --base main --state open \
 
 # Released — most recent v* tag (commits since it on main = unreleased)
 # grep -v '--v' excludes per-plugin tags (e.g. vaultkit--v1.1.8) that otherwise leak into the v* glob
+# selects globally highest calver tag; assumes linear main history where the latest tag is always
+# reachable from HEAD — safe to prefer over git describe's ancestry-based selection in this topology
 LAST_TAG=$(git tag --list 'v*' | grep -v -- '--v' | sort -V | tail -1)
 if [ -n "$LAST_TAG" ]; then
   UNRELEASED=$(git log "$LAST_TAG"..origin/main --oneline | wc -l | tr -d ' ')

--- a/plugins/flowkit/skills/ship/SKILL.md
+++ b/plugins/flowkit/skills/ship/SKILL.md
@@ -62,7 +62,8 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
 fi
 
 # At least one commit since the last v* tag (or no prior tag at all)
-LAST_TAG=$(git tag --list 'v*' --sort=-v:refname | head -1)
+# grep -v '--v' excludes per-plugin tags (e.g. vaultkit--v1.1.8) that otherwise leak into the v* glob
+LAST_TAG=$(git tag --list 'v*' | grep -v -- '--v' | sort -V | tail -1)
 if [ -n "$LAST_TAG" ]; then
   COMMITS_SINCE=$(git rev-list --count "${LAST_TAG}..HEAD")
   if [ "$COMMITS_SINCE" -eq 0 ]; then


### PR DESCRIPTION
## Summary
- Both `flowkit:ship` and `flowkit:pipeline-status` resolved the previous release tag using a `v*` glob that inadvertently matched per-plugin tags like `vaultkit--v1.1.8` (plugin names starting with "v"), corrupting the release baseline
- `ship` now uses `git tag --list 'v*' | grep -v -- '--v' | sort -V | tail -1` instead of `git tag --list 'v*' --sort=-v:refname | head -1`
- `pipeline-status` now uses the same idiom instead of `git describe --tags --abbrev=0 --match 'v*'`, which had the same leakage problem

## Changes
- `plugins/flowkit/skills/ship/SKILL.md`: replaced `LAST_TAG` resolution with `grep -v '--v'` exclusion idiom; added inline comment explaining why
- `plugins/flowkit/skills/pipeline-status/SKILL.md`: replaced `git describe` with the same `grep -v '--v'` idiom for consistency; added inline comment

## Test plan
- With a `vaultkit--v1.1.8` tag present, run `LAST_TAG=$(git tag --list 'v*' | grep -v -- '--v' | sort -V | tail -1)` locally — confirm it resolves to the most recent calver `v*` tag (e.g. `v2026.5.30`), not `vaultkit--v1.1.8`
- Confirm `ship` no longer derives a nonsensical `v2026.6.0` based on a plugin tag as the baseline
- Confirm the exclusion idiom matches what `bump-versions` uses for per-plugin tag detection

Closes #1036