### PR TITLE
chore(plugins): bump flowkit@4.0.1

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Single-trunk GitHub Flow with squash-merge: commit, open PRs, merge, sync, and tag releases via /flowkit:ship.",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Bump plugin.json version for flowkit, changed since its last release (#1037 — exclude per-plugin tags from release-tag resolution).

## Changes

- flowkit@4.0.1

## Test plan

- [ ] Confirm the flowkit version bump matches the per-plugin tag created after merge.