### PR TITLE
chore(plugins): bump flowkit@4.0.2

### DIFF
--- a/plugins/flowkit/.claude-plugin/plugin.json
+++ b/plugins/flowkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "flowkit",
   "description": "Git/release lifecycle for Claude Code. Single-trunk GitHub Flow with squash-merge: commit, open PRs, merge, sync, and tag releases via /flowkit:ship.",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Bump flowkit plugin.json version, changed since 4.0.1 by the ship calver-derivation fix (#1041).

## Changes

- flowkit@4.0.2

## Test plan

- [ ] Confirm the flowkit version bump matches the flowkit--v4.0.2 tag created after merge.