### PR TITLE
docs(openspec): baseline specs for all vaultkit skills

### DIFF
--- a/openspec/specs/vaultkit-archive-export/spec.md
+++ b/openspec/specs/vaultkit-archive-export/spec.md
@@ -1,0 +1,110 @@
+# Archive Export
+
+## Purpose
+Archive Export picks up the latest conversation export produced by `/export session` in the current working directory and files it into the active Obsidian project's `Conversations/` folder. It writes two same-named copies — a plain-text `.txt` source of truth and an Obsidian-renderable `.md` that embeds the `.txt` and records the resumable session ID — then removes the source export.
+
+## Requirements
+
+### Requirement: Invocation Triggers
+The skill SHALL activate when the user expresses intent to archive or file the latest conversation export. It SHOULD recognize phrasing such as "archive the export", "save the conversation", "file the export", or "archive this conversation", and is intended for use after the user has run `/export session` from the workspace root.
+
+#### Scenario: Explicit archive phrasing
+- **WHEN** the user says "archive the export", "save the conversation", "file the export", or "archive this conversation"
+- **THEN** the skill activates and proceeds to file the latest export
+
+### Requirement: Export File Convention
+The skill SHALL expect the export to exist as `./session.txt` in the current working directory, produced by the user running `/export session` from that directory.
+
+#### Scenario: Export present in working directory
+- **WHEN** `./session.txt` exists in the current working directory
+- **THEN** the skill treats it as the source export to archive
+
+### Requirement: Source File Existence Check
+The skill SHALL confirm that `./session.txt` exists before proceeding. When it is missing, the skill SHALL remind the user to run `/export session` from the current directory first rather than archiving anything.
+
+#### Scenario: Source file present
+- **WHEN** the skill checks for `./session.txt` and the file exists
+- **THEN** the skill continues with the archive flow
+
+#### Scenario: Source file missing
+- **WHEN** the skill checks for `./session.txt` and the file does not exist
+- **THEN** the skill reminds the user to run `/export session` from the current directory and does not archive anything
+
+#### Scenario: Export run from the wrong directory
+- **WHEN** `./session.txt` is not in the current directory because the user ran `/export` elsewhere
+- **THEN** the skill MAY locate the file by searching for `session.txt` under the working tree to help recover it
+
+### Requirement: Active Project Resolution
+The skill SHALL determine the active Obsidian project to file the export under. It SHALL use conversation context when the active project is clear, and otherwise SHALL list the projects under the vault's `Projects` folder and ask the user which project to file the export under.
+
+#### Scenario: Project clear from context
+- **WHEN** the active project is evident from conversation context
+- **THEN** the skill files the export under that project without prompting
+
+#### Scenario: Project unclear
+- **WHEN** the active project cannot be determined from context
+- **THEN** the skill lists the projects under the vault's `Projects` folder and asks the user which project to file the export under
+
+### Requirement: Session ID Resolution
+The skill SHALL resolve the active session's UUID so the archive can record how to resume the conversation. It SHALL derive the session ID from the most recent per-session record associated with the current working directory.
+
+#### Scenario: Session record present
+- **WHEN** a per-session record exists for the current working directory
+- **THEN** the skill resolves the session ID from the most recent such record
+
+#### Scenario: Session record absent
+- **WHEN** no per-session record can be found for the current working directory
+- **THEN** the skill proceeds without a resolved session ID
+
+### Requirement: Conversations Folder Provisioning
+The skill SHALL ensure a `Conversations/` folder exists under the chosen project, creating it when it does not already exist, before writing any archive files.
+
+#### Scenario: Conversations folder absent
+- **WHEN** the chosen project has no `Conversations/` folder
+- **THEN** the skill creates the `Conversations/` folder before writing files
+
+#### Scenario: Conversations folder present
+- **WHEN** the chosen project already has a `Conversations/` folder
+- **THEN** the skill writes into the existing folder
+
+### Requirement: Canonical Filename Format
+The skill SHALL derive a single base name shared by both output files using the format `YYYY-MM-DD-HHMM-<slug>`, where the date and time are the current date and time (hours and minutes) and the slug is a 2–4 word hyphenated summary of the session topic. The two output files SHALL differ only by extension.
+
+#### Scenario: Base name derived
+- **WHEN** the skill prepares to write the archive
+- **THEN** it derives a base name of the form `YYYY-MM-DD-HHMM-<slug>` from the current date/time and a hyphenated topic slug
+- **AND** both output files share that base name, differing only by `.txt` versus `.md` extension
+
+### Requirement: Plain-Text Copy
+The skill SHALL write a `.txt` copy of `./session.txt` into the project's `Conversations/` folder under the canonical base name, and SHALL stamp the copied file's filesystem birth time following the `vaultkit:file-edit` new-file guidance.
+
+#### Scenario: Plain-text copy written
+- **WHEN** the source export is archived
+- **THEN** the skill writes `<base>.txt` into the project's `Conversations/` folder as a copy of `./session.txt`
+- **AND** the skill stamps that file's birth time per the `vaultkit:file-edit` new-file guidance
+
+### Requirement: Obsidian Markdown Copy
+The skill SHALL write a `.md` copy into the project's `Conversations/` folder under the same base name. The markdown file SHALL include the resumable session ID line, a resume command line, an Obsidian attachment embed of the `.txt` file, and the full conversation text inlined in a `plaintext` fenced code block for search indexing. The skill SHALL stamp the markdown file's birth time following the `vaultkit:file-edit` new-file guidance.
+
+#### Scenario: Markdown copy written
+- **WHEN** the source export is archived
+- **THEN** the skill writes `<base>.md` into the project's `Conversations/` folder containing the session ID, a resume command, an attachment embed of `<base>.txt`, and the full conversation text in a `plaintext` fenced block
+- **AND** the skill stamps that file's birth time per the `vaultkit:file-edit` new-file guidance
+
+#### Scenario: Resume affordance recorded
+- **WHEN** the markdown copy is written and a session ID was resolved
+- **THEN** the markdown records how to resume the conversation using `claude --resume <session-id>`
+
+### Requirement: Source Cleanup
+After both archive copies have been written, the skill SHALL remove the source `./session.txt` from the working directory.
+
+#### Scenario: Cleanup after archive
+- **WHEN** both the `.txt` and `.md` copies have been written into the project's `Conversations/` folder
+- **THEN** the skill removes the source `./session.txt`
+
+### Requirement: Confirmation Report
+After archiving, the skill SHALL report both destination paths and the session ID to the user.
+
+#### Scenario: Successful archive
+- **WHEN** the export has been archived into the project's `Conversations/` folder
+- **THEN** the skill reports the destination paths of both the `.txt` and `.md` copies and the session ID

--- a/openspec/specs/vaultkit-file-edit/spec.md
+++ b/openspec/specs/vaultkit-file-edit/spec.md
@@ -1,0 +1,72 @@
+# Obsidian File Edit
+
+## Purpose
+Obsidian File Edit modifies an existing file in an Obsidian vault while preserving the file's filesystem birth time. It exists because Claude's `Edit` and `Write` tools use a temp-file-rename strategy on macOS that resets birth time, which corrupts the `created` field Obsidian derives from birth time for dataview queries, sort orders, and plugin behaviors.
+
+## Requirements
+
+### Requirement: Applicability to existing vault files
+The skill SHALL be used whenever an existing file in an Obsidian vault is modified. It SHALL NOT be used for creating new files, where there is no prior birth time to preserve.
+
+#### Scenario: Editing an existing vault file
+- **WHEN** an existing file in an Obsidian vault needs to be modified
+- **THEN** the skill is invoked to apply the change in place so the existing birth time is preserved
+
+#### Scenario: Creating a new vault file
+- **WHEN** a new vault file is being created rather than an existing one edited
+- **THEN** the `Write` tool is used directly, followed by `SetFile -d "$(date '+%m/%d/%Y %H:%M:%S')" "$PATH"`, because there is no prior birth time to preserve
+
+#### Scenario: Append or prepend via the Obsidian CLI
+- **WHEN** content is added through the `obsidian append` or `obsidian prepend` CLI commands
+- **THEN** the skill does not apply, because those commands preserve metadata natively
+
+### Requirement: Birth-time preservation via in-place inode write
+The skill SHALL modify the existing file's inode so its filesystem birth time is unchanged after the edit. It SHALL NOT use the `Edit` or `Write` tools in the primary flow, because their temp-file-rename strategy resets birth time on macOS.
+
+#### Scenario: In-place write preserves birth time
+- **WHEN** the skill writes new content through an in-place mechanism such as shell `>` redirect, `cat > file <<EOF`, `python3 open(p, "w")`, or `node fs.writeFileSync`
+- **THEN** the existing inode is modified and the file's birth time is preserved
+
+#### Scenario: Rename-based tools are avoided in the primary flow
+- **WHEN** the primary in-place write flow is used
+- **THEN** the `Edit` and `Write` tools are not used, because they reset birth time
+
+### Requirement: Happy-path in-place write sequence
+The skill SHALL read the current file contents, compute the new content in memory, write the full new content in place via a shell mechanism that modifies the existing inode, and then verify the birth time is unchanged.
+
+#### Scenario: Reading current contents first
+- **WHEN** an edit begins
+- **THEN** the current file contents are loaded with the `Read` tool before changes are computed
+
+#### Scenario: Writing the full new content in place
+- **WHEN** the new content has been computed in memory
+- **THEN** the full new file content is piped to the target path via a shell redirect heredoc (`cat > "$PATH" <<'VAULTKIT_EOF' ... VAULTKIT_EOF`)
+
+#### Scenario: Heredoc-marker-safe or binary-safe write
+- **WHEN** the content may contain the heredoc marker, or a binary-safe write is required
+- **THEN** the content is written via `python3 -c 'import sys; open(sys.argv[1], "w").write(sys.stdin.read())' "$PATH"` instead
+
+### Requirement: Verification of preserved birth time
+After writing, the skill SHALL verify that the file's birth time matches its value before the edit.
+
+#### Scenario: Verifying birth time after write
+- **WHEN** the in-place write has completed
+- **THEN** `stat -f "Birth: %SB | %N" "$PATH"` is run and the reported birth time matches what it was before the edit
+
+### Requirement: Large-file fallback using SetFile
+The skill SHALL provide a fallback for cases where rewriting the whole file is measurably wasteful, such as a multi-megabyte note where only a handful of lines change. In that fallback the skill SHALL capture the birth time, apply a targeted change with the `Edit` tool, and restore the captured birth time with `SetFile`. The skill SHALL prefer the in-place write for typical files and reach for the fallback only when whole-file rewriting is genuinely expensive.
+
+#### Scenario: Large file with a small targeted change
+- **WHEN** the file is large enough that reading and re-writing the whole thing is measurably expensive and only a few lines change
+- **THEN** the birth time is captured with `stat`, the targeted change is applied with the `Edit` tool, and the captured birth time is restored with `SetFile -d "$BIRTH" "$PATH"`
+
+#### Scenario: Typical file size
+- **WHEN** the file is of typical size
+- **THEN** the in-place write happy path is used in preference to the fallback
+
+### Requirement: Vault path resolution
+The skill SHALL operate on the file relative to the vault root, which is obtained via the `obsidian vault=<VAULT> vault` command and referenced as `$VAULT_PATH`.
+
+#### Scenario: Resolving the vault root
+- **WHEN** the target file path is constructed
+- **THEN** the vault root `$VAULT_PATH` obtained via `obsidian vault=<VAULT> vault` is used as the base for the file path

--- a/openspec/specs/vaultkit-jot/spec.md
+++ b/openspec/specs/vaultkit-jot/spec.md
@@ -1,0 +1,65 @@
+# Jot
+
+## Purpose
+Jot is a quick-capture entry point for the active Obsidian project. It records a decision, task, note, or progress update mid-conversation by delegating to the `vaultkit:project` skill's Update Project Files operation, so the user can persist a thought without invoking the full project workflow directly.
+
+## Requirements
+
+### Requirement: Invocation Triggers
+The skill SHALL activate when the user expresses an intent to quickly capture or update project notes. It SHOULD recognize phrasing such as "jot this down", "update my notes", "record this decision", "save progress", or "update the project notes".
+
+#### Scenario: Quick-capture phrasing
+- **WHEN** the user says "jot this down", "update my notes", "record this decision", "save progress", or "update the project notes"
+- **THEN** the skill activates to capture the content into the active project
+
+### Requirement: Argument Handling
+When invocation arguments are provided, the skill SHALL treat that argument text as the specific note, decision, or task to record.
+
+#### Scenario: Arguments supplied
+- **WHEN** the skill is invoked with argument text
+- **THEN** the skill treats that text as the specific note, decision, or task to record
+
+#### Scenario: No arguments supplied
+- **WHEN** the skill is invoked without argument text
+- **THEN** the skill still proceeds via the delegated operation, which determines what to capture from conversation context
+
+### Requirement: Delegation to Project Update
+The skill SHALL delegate to the `vaultkit:project` skill's Update Project Files operation (Operation 3) rather than implementing the capture logic itself.
+
+#### Scenario: Hand off to project update
+- **WHEN** content is to be captured
+- **THEN** the skill invokes the `vaultkit:project` skill's Update Project Files operation
+- **AND** the skill does not perform the update logic directly
+
+### Requirement: Active Project Resolution
+The skill SHALL rely on the delegated operation to identify the active project, either from conversation context or by prompting the user.
+
+#### Scenario: Active project resolved from context
+- **WHEN** an active project can be inferred from conversation context
+- **THEN** the delegated operation targets that project
+
+#### Scenario: Active project not in context
+- **WHEN** no active project can be inferred from conversation context
+- **THEN** the delegated operation prompts the user to identify the project
+
+### Requirement: Birth-Time-Preserving Edits
+The skill SHALL ensure edits to existing project files are written in place via the `vaultkit:file-edit` path so the file's filesystem birth time is preserved, and SHALL ensure the relevant file is read before being edited.
+
+#### Scenario: Editing an existing project file
+- **WHEN** the delegated operation modifies an existing project file
+- **THEN** the relevant file is read before editing
+- **AND** the edit is written in place to preserve the file's birth time
+
+### Requirement: Change Classification
+The skill SHALL, through the delegated operation, determine what kind of change is being recorded — a decision, a task, a status update, or a blocker — and capture it accordingly.
+
+#### Scenario: Classifying the captured change
+- **WHEN** content is captured
+- **THEN** the delegated operation classifies it as a decision, task, status update, or blocker
+
+### Requirement: Concise Recall Entries
+The skill SHALL keep captured entries concise — recall notes rather than full documentation.
+
+#### Scenario: Recording an entry
+- **WHEN** an entry is written to a project file
+- **THEN** the entry is kept concise as a recall note rather than expanded into documentation

--- a/openspec/specs/vaultkit-list-projects/spec.md
+++ b/openspec/specs/vaultkit-list-projects/spec.md
@@ -1,0 +1,70 @@
+# List Projects
+
+## Purpose
+List Projects enumerates every project in an Obsidian vault's `Projects/` folder and presents them as a status-sorted table followed by a count summary. It is a read-only sub-skill used by `vaultkit:load-project` to surface the projects a user can load, optionally highlighting one recommended project.
+
+## Requirements
+
+### Requirement: Obsidian dependency
+List Projects SHALL invoke the `vaultkit:obsidian` skill before performing any operation, because it depends on that skill's vault connection details and command reference.
+
+#### Scenario: Skill is invoked
+- **WHEN** List Projects begins
+- **THEN** it invokes the `vaultkit:obsidian` skill first, before listing any projects
+
+### Requirement: Vault parameter required
+List Projects SHALL require a vault name for all operations and SHALL expect the caller to supply it explicitly. When no vault name is given, List Projects SHALL list the available vaults, present them to the user, and ask which vault to use before continuing.
+
+#### Scenario: Vault name supplied
+- **WHEN** the caller supplies a vault name
+- **THEN** List Projects proceeds against that vault
+
+#### Scenario: Vault name omitted
+- **WHEN** no vault name is supplied
+- **THEN** List Projects lists the available vaults, presents them to the user, and asks which vault to use before continuing
+
+### Requirement: Enumerate vault projects
+List Projects SHALL enumerate every project folder under the selected vault's `Projects/` folder.
+
+#### Scenario: Projects folder contains projects
+- **WHEN** the vault's `Projects/` folder contains one or more project folders
+- **THEN** List Projects produces an entry for each project found
+
+### Requirement: Resolve per-project status
+List Projects SHALL determine each project's status from the `status` field of that project's `Overview.md`. It SHALL read the status for every enumerated project.
+
+#### Scenario: Status read for each project
+- **WHEN** the project folders have been enumerated
+- **THEN** List Projects reads the `status` field from each project's `Overview.md`
+
+### Requirement: Status-sorted table output
+List Projects SHALL display the projects as a formatted table with a Project column and a Status column, sorted by status in the order active first, then on-hold, then done.
+
+#### Scenario: Table rendered in status order
+- **WHEN** the projects and their statuses are known
+- **THEN** List Projects renders a Project/Status table ordered active, then on-hold, then done
+
+### Requirement: Recommended-project highlighting
+When the caller passes a `recommended` project name, List Projects SHALL bold that project's row and append a `← recommended` marker to it. When no recommended name is passed, no row is highlighted.
+
+#### Scenario: Recommended name passed
+- **WHEN** the caller passes a `recommended` project name
+- **THEN** the matching row is bolded and marked with `← recommended`
+
+#### Scenario: No recommended name passed
+- **WHEN** the caller passes no recommended project name
+- **THEN** no row is bolded or marked as recommended
+
+### Requirement: Count summary
+List Projects SHALL display a count summary after the table, breaking down how many projects fall into each status (for example `5 active · 2 on-hold · 1 done`).
+
+#### Scenario: Summary follows the table
+- **WHEN** the table has been rendered
+- **THEN** List Projects shows a count summary of projects per status beneath it
+
+### Requirement: Read-only sub-skill role
+List Projects SHALL operate as a read-only sub-skill consumable by `vaultkit:load-project`, producing only the listing as output and leaving the vault unchanged.
+
+#### Scenario: Invoked as a sub-skill
+- **WHEN** `vaultkit:load-project` invokes List Projects to discover available projects
+- **THEN** List Projects returns the listing without creating, modifying, or deleting any vault files

--- a/openspec/specs/vaultkit-load-project/spec.md
+++ b/openspec/specs/vaultkit-load-project/spec.md
@@ -1,0 +1,56 @@
+# Load Project
+
+## Purpose
+Load Project brings an Obsidian project's context into the current conversation. When the caller names a project, it loads that project directly; when no name is given, it lists the available projects, recommends the most contextually relevant one, and loads the project the user confirms.
+
+## Requirements
+
+### Requirement: Obsidian connection prerequisite
+Load Project SHALL invoke the `vaultkit:obsidian` skill before any other step. It depends on that skill for vault connection details and the command reference, so this invocation MUST happen first regardless of whether a project name was supplied.
+
+#### Scenario: Obsidian invoked first with a project name
+- **WHEN** Load Project is invoked with a project name
+- **THEN** the `vaultkit:obsidian` skill is invoked before the named project is loaded
+
+#### Scenario: Obsidian invoked first without a project name
+- **WHEN** Load Project is invoked without a project name
+- **THEN** the `vaultkit:obsidian` skill is invoked before any project listing or recommendation occurs
+
+### Requirement: Named project load
+When a project name is provided, Load Project SHALL load that project's context using the `vaultkit:project` skill's load operation, passing through the vault parameter, without listing projects or asking the user to choose.
+
+#### Scenario: Project name supplied
+- **WHEN** Load Project is invoked with an explicit project name
+- **THEN** it loads the named project via the `vaultkit:project` load-context operation, forwarding the vault parameter, and does not prompt the user to select a project
+
+### Requirement: Context-based recommendation when no name is given
+When no project name is provided, Load Project SHALL infer the most likely applicable project from the current conversation context — recent topics, files mentioned, and tasks discussed — and SHALL surface the available projects with that inferred project marked as the recommendation.
+
+#### Scenario: No name supplied
+- **WHEN** Load Project is invoked without a project name
+- **THEN** it infers a candidate project from conversation context and invokes the `vaultkit:list-projects` skill, passing the vault parameter and the inferred project name as the `recommended` value
+
+### Requirement: Confirmation prompt before loading the recommendation
+When no project name is provided, Load Project SHALL ask the user which project to load, stating its recommended guess and the basis for it, rather than loading the inferred project automatically.
+
+#### Scenario: User is prompted to confirm
+- **WHEN** Load Project has produced a recommendation for an unnamed request
+- **THEN** it asks the user which project to load and names the recommended project as its current-context guess
+
+### Requirement: Load the confirmed selection
+After the user confirms the recommendation or chooses a different project, Load Project SHALL load that project's context using the `vaultkit:project` skill's load operation, passing through the vault parameter.
+
+#### Scenario: User confirms the recommendation
+- **WHEN** the user confirms the recommended project
+- **THEN** Load Project loads that project via the `vaultkit:project` load-context operation, forwarding the vault parameter
+
+#### Scenario: User selects a different project
+- **WHEN** the user selects a project other than the recommendation
+- **THEN** Load Project loads the user's chosen project via the `vaultkit:project` load-context operation, forwarding the vault parameter
+
+### Requirement: Vault parameter pass-through
+Load Project SHALL forward the vault parameter to every downstream skill it invokes so that all operations target the same vault.
+
+#### Scenario: Vault propagated to downstream skills
+- **WHEN** Load Project invokes `vaultkit:list-projects` or `vaultkit:project`
+- **THEN** it passes the vault parameter through to that skill

--- a/openspec/specs/vaultkit-obsidian/spec.md
+++ b/openspec/specs/vaultkit-obsidian/spec.md
@@ -1,0 +1,206 @@
+# Obsidian
+
+## Purpose
+Obsidian governs how to interact with Obsidian vaults on the user's behalf through the Obsidian CLI binary. It covers reading and discovery, full-text search, tag and property management, graph/link inspection, template access, daily notes, note writing (append, prepend, create, rename, move, delete), plugin management, and vault-maintenance workflows — while preserving each vault file's filesystem birth time so Obsidian's `created` metadata stays intact.
+
+## Requirements
+
+### Requirement: CLI access model
+Obsidian SHALL perform all vault access through the Obsidian CLI binary, invoked as `obsidian vault=<VAULT> <command> [options]`. Obsidian MUST be running for CLI commands to work.
+
+#### Scenario: Issuing a vault command
+- **WHEN** any vault operation is performed
+- **THEN** it is executed via the Obsidian CLI binary using the `obsidian vault=<VAULT> <command>` invocation form
+
+### Requirement: Mandatory vault parameter
+Every operation SHALL require an explicit vault name supplied by the caller. When no vault name is given, Obsidian SHALL list the available vaults (`obsidian vaults`), present them to the user, and ask which vault to use before continuing.
+
+#### Scenario: Vault name supplied
+- **WHEN** the caller supplies a vault name
+- **THEN** Obsidian uses that vault for the operation
+
+#### Scenario: Vault name missing
+- **WHEN** no vault name is supplied
+- **THEN** Obsidian lists the available vaults, presents them to the user, and asks which vault to use before continuing
+
+### Requirement: Vault-not-found recovery
+When a vault command returns "Vault not found", Obsidian SHALL list the available vaults, present them to the user, confirm the correct name, and flag any stale caller reference (such as memory files or hardcoded vault names in sub-skills) before retrying. Obsidian SHALL NOT silently retry with a guessed vault name.
+
+#### Scenario: Vault not found
+- **WHEN** a command returns "Vault not found"
+- **THEN** Obsidian lists the available vaults, asks the user to confirm the correct name, flags any stale caller reference, and does not silently retry with a guess
+
+### Requirement: Vault path resolution
+Obsidian SHALL resolve the vault's filesystem root path (via `obsidian vault=<VAULT> vault`) when filesystem operations such as `stat`, `SetFile`, or `mkdir` are needed, and SHALL treat all CLI file paths as relative to that vault root.
+
+#### Scenario: Filesystem operation needed
+- **WHEN** a filesystem operation requires the vault's absolute path
+- **THEN** Obsidian resolves the vault root path before running the filesystem command
+
+#### Scenario: Interpreting a CLI path
+- **WHEN** a path is passed to a CLI command
+- **THEN** it is interpreted relative to the vault root
+
+### Requirement: Reading and discovery
+Obsidian SHALL read note contents and surface discovery information including file listings, folder listings, recents, per-file info, heading outlines, and word counts.
+
+#### Scenario: Read a note
+- **WHEN** the user requests a note's contents by path
+- **THEN** Obsidian outputs that note's contents
+
+#### Scenario: Discover vault structure
+- **WHEN** the user requests file listings, folder listings, recents, file info, an outline, or a word count
+- **THEN** Obsidian returns the corresponding discovery information
+
+### Requirement: Full-text search
+Obsidian SHALL search note contents by query text, optionally with surrounding context. Obsidian SHALL NOT use full-text search to resolve tag membership, because broad text matching produces false positives for tag queries.
+
+#### Scenario: Search by text
+- **WHEN** the user provides a search query
+- **THEN** Obsidian returns matching notes, optionally with surrounding context
+
+#### Scenario: Tag membership requested
+- **WHEN** the precise set of files carrying a tag is needed
+- **THEN** Obsidian uses the tag command rather than full-text search to avoid false positives
+
+### Requirement: Tag inspection
+Obsidian SHALL list all tags with occurrence counts and SHALL list the files containing a specific tag.
+
+#### Scenario: List all tags
+- **WHEN** the user requests the vault's tags
+- **THEN** Obsidian returns the tags with their occurrence counts
+
+#### Scenario: Files for a specific tag
+- **WHEN** the user requests the files carrying a specific tag
+- **THEN** Obsidian returns the precise per-tag file list
+
+### Requirement: Property and frontmatter management
+Obsidian SHALL read all properties of a file, read a single named property, and set a property value. Property writes SHALL use the CLI's YAML-safe in-place writer so the file's birth time is preserved.
+
+#### Scenario: Read properties
+- **WHEN** the user requests a file's properties
+- **THEN** Obsidian returns the file's properties
+
+#### Scenario: Set a property
+- **WHEN** the user sets a frontmatter property on a file
+- **THEN** Obsidian writes the property value in place via the CLI's YAML-safe writer, preserving the file's birth time
+
+### Requirement: Graph and link inspection
+Obsidian SHALL report backlinks to a file, outgoing links from a file, orphan files with no incoming links, dead-end files with no outgoing links, and unresolved wikilinks.
+
+#### Scenario: Inspect links for a file
+- **WHEN** the user requests backlinks or outgoing links for a file
+- **THEN** Obsidian returns the corresponding link set
+
+#### Scenario: Inspect vault-wide link health
+- **WHEN** the user requests orphans, dead-ends, or unresolved wikilinks
+- **THEN** Obsidian returns the corresponding vault-wide link report
+
+### Requirement: Template access
+Obsidian SHALL list all templates and read a template's content.
+
+#### Scenario: List or read templates
+- **WHEN** the user requests the available templates or a specific template's content
+- **THEN** Obsidian returns the template listing or the requested template's content
+
+### Requirement: Daily notes
+Obsidian SHALL read today's daily note, report its path, and append content to it in place.
+
+#### Scenario: Read or locate today's daily note
+- **WHEN** the user requests today's daily note or its path
+- **THEN** Obsidian returns the daily note's content or path
+
+#### Scenario: Append to today's daily note
+- **WHEN** the user appends content to today's daily note
+- **THEN** Obsidian appends the content in place, preserving the file's birth time
+
+### Requirement: Note writing operations
+Obsidian SHALL append to a file, prepend to a file, create a new file with content, rename a file, move a file, and delete a file (moving it to trash). Append, prepend, rename, and move SHALL write in place and preserve birth time; rename and move SHALL additionally update wikilinks across the vault.
+
+#### Scenario: Append or prepend
+- **WHEN** the user appends or prepends content to an existing file
+- **THEN** Obsidian writes the content in place, preserving the file's birth time
+
+#### Scenario: Create a file
+- **WHEN** the user creates a new file with content
+- **THEN** Obsidian creates the file populated with that content
+
+#### Scenario: Rename or move
+- **WHEN** the user renames or moves a file
+- **THEN** Obsidian relocates the file in place, preserves its birth time, and updates wikilinks across the vault
+
+#### Scenario: Delete a file
+- **WHEN** the user deletes a file
+- **THEN** Obsidian removes it to trash
+
+### Requirement: Write-approval awareness
+Obsidian SHALL treat read-only commands as pre-approved and non-prompting, and SHALL recognize that CLI write operations (`append`, `prepend`, `create`, `delete`, `rename`, `move`, `property:set`) prompt the user for approval unless explicitly pre-approved.
+
+#### Scenario: Read-only command
+- **WHEN** a read-only vault command is run
+- **THEN** it executes without prompting the user
+
+#### Scenario: Write command
+- **WHEN** a CLI write operation is run that is not pre-approved
+- **THEN** the user is prompted to approve it
+
+### Requirement: Plugin management
+Obsidian SHALL list enabled plugins, list community plugins, report plugin details, and install-and-enable a plugin by id.
+
+#### Scenario: Inspect plugins
+- **WHEN** the user requests enabled plugins, community plugins, or details for a plugin id
+- **THEN** Obsidian returns the corresponding plugin information
+
+#### Scenario: Install a plugin
+- **WHEN** the user installs a plugin by id
+- **THEN** Obsidian installs and enables that plugin
+
+### Requirement: Birth-time-preserving write strategy
+Obsidian SHALL select a write tool by whether it writes in place. In-place writers (the CLI write commands, `python3` open-for-write, `node fs.writeFileSync`, shell redirect) preserve a vault file's filesystem birth time; tools that atomic-rename (Claude's `Edit`/`Write`) reset birth time on macOS. For in-body content edits, which the CLI cannot perform directly, Obsidian SHALL prefer an in-place writer so birth time is preserved without a follow-up step.
+
+#### Scenario: In-body content edit
+- **WHEN** an in-body content edit (find-and-replace, tag rename, structural rewrite) is needed and no CLI command performs it
+- **THEN** Obsidian prefers an in-place writer so the file's birth time is preserved without a follow-up step
+
+### Requirement: Birth-time restore after atomic-rename edits
+When Claude's `Edit` or `Write` is used on a vault file, Obsidian SHALL pair the operation with a `SetFile` restore. For an existing file, the birth time SHALL be captured before editing and restored afterward; for a newly created file, the birth time SHALL be set to the current time.
+
+#### Scenario: Editing an existing vault file with Edit/Write
+- **WHEN** Claude's `Edit` or `Write` modifies an existing vault file
+- **THEN** Obsidian captures the file's birth time before the edit and restores it with `SetFile` afterward
+
+#### Scenario: Creating a vault file with Write
+- **WHEN** Claude's `Write` creates a new vault file
+- **THEN** Obsidian sets the file's birth time to the current time with `SetFile`
+
+### Requirement: Action-tag verb/noun convention
+Obsidian SHALL enforce a verb/noun order for action tags (such as `#ask/<person>` and `#todo/<context>`) and SHALL migrate any old noun/verb-format action tags to the verb/noun order when scanning for or creating them.
+
+#### Scenario: Encountering an old-format action tag
+- **WHEN** an action tag is found in the old noun/verb order (e.g. `#person/ask`)
+- **THEN** Obsidian migrates it to the verb/noun order (e.g. `#ask/person`)
+
+### Requirement: Tag standardization workflow
+When asked to standardize tags, Obsidian SHALL obtain the full tag list, identify non-standard patterns, obtain the exact per-tag file list via the tag command (not full-text search), read each file before editing it, and preserve each edited file's birth time.
+
+#### Scenario: Standardizing tags
+- **WHEN** the user asks to standardize tags
+- **THEN** Obsidian enumerates the tags, resolves the precise per-tag file lists via the tag command, reads each file before editing, and preserves each edited file's birth time
+
+### Requirement: Vault health check workflow
+Obsidian SHALL support periodic vault maintenance by reporting orphan notes, dead-end notes, unresolved wikilinks, and a tag-usage audit.
+
+#### Scenario: Running a health check
+- **WHEN** the user requests vault maintenance information
+- **THEN** Obsidian reports orphans, dead-ends, unresolved wikilinks, and tag usage
+
+### Requirement: Path and value conventions
+Obsidian SHALL prefer exact `path=` references when the location is known over name-based resolution, and SHALL quote any value containing spaces.
+
+#### Scenario: Known exact location
+- **WHEN** the exact location of a file is known
+- **THEN** Obsidian references it via `path=` rather than name-based resolution
+
+#### Scenario: Value contains spaces
+- **WHEN** a command value contains spaces
+- **THEN** Obsidian quotes the value

--- a/openspec/specs/vaultkit-project/spec.md
+++ b/openspec/specs/vaultkit-project/spec.md
@@ -1,0 +1,126 @@
+# Project
+
+## Purpose
+Project manages a `Projects/` second brain inside any Obsidian vault. It supports three operations — loading an existing project's context at the start of a session, initializing a new project from a template, and updating a project's files after work — while preserving Obsidian vault metadata conventions.
+
+## Requirements
+
+### Requirement: Obsidian dependency
+Project SHALL invoke the `vaultkit:obsidian` skill first, since every operation depends on that skill's vault connection details and command reference.
+
+#### Scenario: Operation begins
+- **WHEN** any Project operation starts
+- **THEN** Project invokes `vaultkit:obsidian` before performing vault commands
+
+### Requirement: Vault parameter resolution
+Every operation SHALL require a vault name supplied explicitly by the caller. If no vault name is given, Project SHALL list available vaults (via `obsidian vaults`) and ask the user which vault to use before continuing. To resolve the vault's filesystem path for `mkdir` and direct file edits, Project SHALL run `obsidian vault="<VAULT>" vault` and store the result for use in filesystem commands.
+
+#### Scenario: Vault name provided
+- **WHEN** the caller supplies a vault name
+- **THEN** Project uses that vault and resolves its filesystem path via `obsidian vault="<VAULT>" vault`
+
+#### Scenario: Vault name missing
+- **WHEN** no vault name is supplied
+- **THEN** Project lists the available vaults and asks the user which to use before continuing
+
+### Requirement: Project folder convention
+Project SHALL treat each project as living under `<vault>/Projects/<ProjectName>/`, with `Overview.md` as the project hub. Project folder names SHALL match what the user calls the project verbatim, with no slugifying. When unsure about a project's casing or spelling, Project SHALL check existing folders (e.g. `obsidian vault="<VAULT>" folders`) rather than guess.
+
+#### Scenario: Project hub location
+- **WHEN** Project references a project's primary content
+- **THEN** it uses `<vault>/Projects/<ProjectName>/Overview.md` as the hub file
+
+#### Scenario: Folder name maps verbatim
+- **WHEN** a project name contains spaces or mixed case
+- **THEN** the folder name matches the project name verbatim without slugifying
+
+#### Scenario: Uncertain name casing
+- **WHEN** Project is unsure of a project's casing or spelling
+- **THEN** it lists existing project folders rather than guessing the name
+
+### Requirement: Load project context
+The load operation SHALL restore full project context before any session work. It SHALL confirm the project folder exists, read `Overview.md` first and any sibling files that exist (such as `Tasks.md`, `Ideas.md`, `Architecture.md`), then summarize the current status, active tasks, and any noted blockers to the user before proceeding.
+
+#### Scenario: Existing project loaded
+- **WHEN** load runs for a project folder that exists
+- **THEN** Project reads `Overview.md` first, reads any existing sibling files, and summarizes status, active tasks, and blockers before proceeding with work
+
+#### Scenario: Missing sibling files
+- **WHEN** an optional sibling file such as `Tasks.md` does not exist
+- **THEN** Project skips that file and continues loading from the files that do exist
+
+### Requirement: Initialize a new project
+The init operation SHALL create a project that does not yet exist from the template. It SHALL resolve the vault path, read the template at `Projects/_TEMPLATE_/Overview.md`, create the destination folder with `mkdir -p` (because the CLI `move` does not auto-create directories), and write a new `Overview.md` filling in the project name as the H1, a one-sentence description (asking the user if unknown), `started:` set to today, `status: active`, and any known goals or context.
+
+#### Scenario: New project created from template
+- **WHEN** init runs for a project that does not exist
+- **THEN** Project reads the template, creates the destination folder with `mkdir -p`, and writes an `Overview.md` with the project name, description, today's `started:` date, and `status: active`
+
+#### Scenario: Description unknown
+- **WHEN** init has no description for the project
+- **THEN** Project asks the user for a one-sentence description before writing `Overview.md`
+
+### Requirement: Projects Index maintenance
+On init, Project SHALL add a row for the new project to the Projects Index table in `_README.md`, formatted as a wikilink to the project's `Overview` with its status and date. This edit SHALL be made with birth-time preservation via the `vaultkit:file-edit` sub-skill. The Projects Index in `_README.md` SHALL be kept current as the master list.
+
+#### Scenario: Index row added on init
+- **WHEN** init finishes creating a project
+- **THEN** Project adds an Index row to `_README.md` linking the project's `Overview` with its status and date, edited via `vaultkit:file-edit`
+
+### Requirement: Update project files
+The update operation SHALL append to or modify the relevant project files after work, decisions, or status changes. Status or phase changes go to the `Overview.md` Status section; task changes to the Tasks section (or `Tasks.md` if split); design decisions to the Architecture section (or `Architecture.md` if split); ideas to the Ideas section (or `Ideas.md` if split); blockers to Status > Blockers. Project SHALL read a file before editing it, and SHALL also update `Last updated:` in `Overview.md` whenever any project file is edited.
+
+#### Scenario: Status change
+- **WHEN** update records a project phase or overall status change
+- **THEN** Project updates the Status section of `Overview.md`
+
+#### Scenario: Task change
+- **WHEN** update records a completed or new task
+- **THEN** Project updates the Tasks section of `Overview.md`, or `Tasks.md` if that section is split out
+
+#### Scenario: Last-updated stamp
+- **WHEN** update edits any project file
+- **THEN** Project also updates `Last updated:` in `Overview.md`
+
+#### Scenario: Read before edit
+- **WHEN** update is about to modify a file
+- **THEN** Project reads the file first before editing it
+
+### Requirement: Section splitting
+When a section grows beyond roughly 30 lines or becomes hard to navigate, Project SHALL split it into its own file (`Tasks.md`, `Ideas.md`, or `Architecture.md`), then remove the section from `Overview.md` and replace it with a wikilink such as `See [[Tasks]]`.
+
+#### Scenario: Oversized section split
+- **WHEN** a section in `Overview.md` grows beyond roughly 30 lines
+- **THEN** Project moves it to its own file, removes it from `Overview.md`, and leaves a wikilink to the new file
+
+### Requirement: Folder creation before move
+Because the Obsidian CLI `move` command does not auto-create missing destination directories, Project SHALL create a destination folder with `mkdir -p` before moving files into it.
+
+#### Scenario: Moving into a new folder
+- **WHEN** Project needs to move files into a folder that does not exist
+- **THEN** it creates the folder with `mkdir -p` before running the `move` command
+
+### Requirement: Birth-time-preserving edits
+When editing an existing vault file, Project SHALL follow the `vaultkit:file-edit` sub-skill to preserve the file's birth time. For new files created with the Write tool, Project SHALL follow that sub-skill's new-file guidance to stamp the birth time.
+
+#### Scenario: Editing an existing vault file
+- **WHEN** update modifies an existing vault file
+- **THEN** Project performs the edit via `vaultkit:file-edit` to preserve birth time
+
+#### Scenario: Creating a new vault file
+- **WHEN** Project writes a new vault file
+- **THEN** it follows the `vaultkit:file-edit` new-file guidance to stamp the birth time
+
+### Requirement: Frontmatter and status values
+Project SHALL maintain `Overview.md` frontmatter with `tags: [project]`, a `status` field, and a `started:` date. The `status` value SHALL be one of `active` (currently being worked on), `on-hold` (paused, not abandoned), or `done` (completed).
+
+#### Scenario: Status value used
+- **WHEN** Project records or updates a project's status
+- **THEN** the value is one of `active`, `on-hold`, or `done`
+
+### Requirement: Concise, recall-oriented notes
+Project SHALL keep updates concise — these are notes for recall, not documentation. Project SHALL always load context before starting work and never assume remembered project state.
+
+#### Scenario: Starting work
+- **WHEN** Project begins work on a project
+- **THEN** it loads the project context first rather than assuming remembered state


### PR DESCRIPTION
## Summary

vaultkit was the only plugin with zero coverage under `openspec/specs/`. This adds behavioral OpenSpec specs for all seven of its skills, reverse-engineered from each skill's `SKILL.md` (spec-only baseline — no `REFERENCES.md`, per the per-skill convention used by polishkit/sessionkit/speckit/squadkit).

## Changes

Seven new `openspec/specs/vaultkit-<skill>/spec.md` files, each passing `bash scripts/openspec validate <capability> --type spec --strict` with 0 warnings:

| Capability | Requirements | Scenarios |
|---|---|---|
| `vaultkit-archive-export` | 11 | 22 |
| `vaultkit-file-edit` | 6 | 11 |
| `vaultkit-jot` | 7 | 10 |
| `vaultkit-list-projects` | 8 | 10 |
| `vaultkit-load-project` | 6 | 9 |
| `vaultkit-obsidian` | 20 | 37 |
| `vaultkit-project` | 12 | 23 |

`opsx-bridge` is intentionally left unbaselined — it has a pending change proposal under `openspec/changes/`, so baselining current behavior now would conflict with the in-flight change.

## Test plan

- [x] `scripts/openspec validate <capability> --type spec --strict` passes (0 warnings) for all 7 capabilities
- [x] Specs follow the house format (`# Title`, `## Purpose`, `## Requirements`, `### Requirement:`, `#### Scenario:` WHEN/THEN, RFC 2119 keywords)
- [x] Verified `archive-export` references no phantom scripts (skill has only `SKILL.md`)