### PR TITLE
fix(squadkit): clear claude.flowkit.prBase pin on spawn-team teardown

### DIFF
--- a/plugins/squadkit/skills/spawn-team/SKILL.md
+++ b/plugins/squadkit/skills/spawn-team/SKILL.md
@@ -636,3 +636,15 @@ ps aux \
 ```
 
 Replace `<team-name>` with the team name passed to `TeamDelete`. Run this sweep immediately after `TeamDelete` returns — the zombie processes consume no dispatch but do hold open file descriptors and tmux panes.
+
+## Epic teardown — clear the prBase pin
+
+Step 6 sets the session-scoped pin `git config claude.flowkit.prBase "$EPIC"` unconditionally when an epic is cut, so every member's `flowkit:open-pr` retargets to the epic branch. That pin is local git config — it survives the session and silently redirects the base branch of every later PR unless it is cleared. Tearing the team down via `TeamDelete` MUST also clear the pin; do not rely on the operator running the documented `git config --unset` by hand.
+
+Run this immediately alongside the zombie-subprocess sweep above, whenever the epic-mode crew is torn down (mirrors swarmkit's `teardown.sh`, which conditionally unsets the same key on loop-mode teardown):
+
+```bash
+git config --unset claude.flowkit.prBase 2>/dev/null || true
+```
+
+The `--unset` is a no-op (and the `|| true` swallows the non-zero exit) when no pin is set — safe to run even for non-epic or discovery crews. After clearing, the next `flowkit:open-pr` falls back to the repo's default base branch.


### PR DESCRIPTION
## Summary
spawn-team sets `claude.flowkit.prBase` unconditionally when an epic is cut but no code path ever clears it, so the session-scoped pin leaks into local git config and silently redirects the base branch of every later PR. This adds a code-backed `git config --unset claude.flowkit.prBase` (non-failing form) to the epic-teardown path alongside the existing TeamDelete zombie-subprocess sweep, mirroring swarmkit's `teardown.sh`, so the pin is actually cleared rather than merely documented.

## Test plan
- Cut an epic via `/squadkit:spawn-team --epic <slug> <issue>`, then confirm `git config --local --get claude.flowkit.prBase` returns the epic branch.
- Tear the team down and run the new `git config --unset claude.flowkit.prBase 2>/dev/null || true` step; confirm `git config --local --get claude.flowkit.prBase` now returns nothing (empty) and that a subsequent `flowkit:open-pr` falls back to the repo default base branch.
- Confirm the unset is a safe no-op when run for a non-epic / discovery crew (no pin set): the command exits 0 and prints nothing.

Closes #1045