### PR TITLE
docs: purge stale develop references from single-trunk surfaces

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -27,7 +27,7 @@
     {
       "name": "squadkit",
       "source": "./plugins/squadkit",
-      "description": "Multi-agent team coordination with the roles → squads → crews vocabulary. Spawn role-aware crews (team-lead, architect, builder, reviewer, tester, explorer, designer) on a feature/<slug>-<issue> branch cut from develop."
+      "description": "Multi-agent team coordination with the roles → squads → crews vocabulary. Spawn role-aware crews (team-lead, architect, builder, reviewer, tester, explorer, designer) on a feature/<slug>-<issue> branch cut from main."
     },
     {
       "name": "polishkit",

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ swarmkit spawns one isolated-worktree agent per ready issue, each on its own `wo
 ```
 Cycle 1 — #102 spawned (no unmet deps).
 
-  #210 feat(notes): extend Note schema with tags field        → develop
+  #210 feat(notes): extend Note schema with tags field        → main
 
 Cycle 2 — #103, #104, #105 spawned (deps on #102 satisfied).
 

--- a/plugins/squadkit/README.md
+++ b/plugins/squadkit/README.md
@@ -181,7 +181,7 @@ Run `/squadkit:init` once per repo. The wizard is fully interview-driven — the
 2. **Test command** — e.g. `npm test`, `pytest`, `cargo test`. Empty answer means "no test step."
 3. **Lint command** — optional. e.g. `npm run lint`, `ruff check`, `cargo clippy`. Empty answer means "no lint step." The reviewer uses this to scope lint errors to PR-touched files.
 4. **Install command** — e.g. `npm install`, `pip install -e .`, `cargo fetch`. Empty answer means "no install step."
-5. **Base branch** — defaults to `develop`. Most repos accept the default.
+5. **Base branch** — defaults to `main`. Most repos accept the default.
 
 The wizard then writes `.squadkit/config.json` (pretty-printed, two-space indent) to the **main repo root** — never to a worktree, even when invoked from inside one. If the file already exists, the wizard surfaces its current contents and prompts before overwriting.
 
@@ -206,7 +206,7 @@ The wizard then writes `.squadkit/config.json` (pretty-printed, two-space indent
 | `verify.test` | Command a role agent runs to validate behavior before opening a PR (e.g. `npm test`, `pytest`, `cargo test`). Empty string if the project has no test step. |
 | `verify.lint` | Optional. Command the reviewer runs to scope lint errors to PR-touched files (e.g. `npm run lint`, `ruff check`, `cargo clippy`). Omit or set to empty string if the project has no lint step. |
 | `install` | Command a fresh worktree runs to install dependencies (e.g. `npm install`, `pip install -e .`, `cargo fetch`). Empty string if no install step is needed. |
-| `baseBranch` | Default base branch for PRs opened by squad members. Most repos use `develop` or `main`. |
+| `baseBranch` | Default base branch for PRs opened by squad members. Defaults to `main`. |
 | `worktreeSeed` | Optional. Explicit list of repo-relative paths to copy into every per-builder worktree at spawn time. When present, overrides `spawn-team`'s auto-detection of ignored env files. Use for projects that need non-env files seeded too (certificates, config snippets, etc.). When absent, `spawn-team` auto-detects ignored env files matching `^(\.env(\.local|\.[a-z-]+\.local)?\|\.env-[a-z-]+)$` via `git ls-files --others --ignored --exclude-standard`. |
 
 Future role contracts and crew profiles will reference these values rather than hardcoding stack-specific commands, making the same role definitions reusable across every repo.

--- a/plugins/squadkit/skills/init/SKILL.md
+++ b/plugins/squadkit/skills/init/SKILL.md
@@ -48,7 +48,7 @@ If the user picks `Cancel`, exit with a one-line message naming the existing fil
 
 ### 3. Interview
 
-Ask each question via `AskUserQuestion`. **No stack presets, no auto-detection** — the user types the exact command. An empty answer is valid for `verify.typecheck`, `verify.test`, `verify.lint`, and `install` (treated as "this repo has no such step"). For `baseBranch`, default to `develop` if the user accepts the default.
+Ask each question via `AskUserQuestion`. **No stack presets, no auto-detection** — the user types the exact command. An empty answer is valid for `verify.typecheck`, `verify.test`, `verify.lint`, and `install` (treated as "this repo has no such step"). For `baseBranch`, default to `main` if the user accepts the default.
 
 Ask the five questions sequentially, surfacing the running config back to the user after each answer so they see what's accumulated.
 
@@ -58,9 +58,9 @@ Ask the five questions sequentially, surfacing the running config back to the us
 | 2 | `verify.test` | `Command to run the test suite? (e.g. \`npm test\`, \`pytest\`, \`cargo test\`. Empty = no test step.)` | none |
 | 3 | `verify.lint` | `Command to run the linter? (e.g. \`npm run lint\`, \`ruff check\`, \`cargo clippy\`. Optional — empty = no lint step. The reviewer uses this to scope errors to PR-touched files.)` | none |
 | 4 | `install` | `Command to install dependencies in a fresh worktree? (e.g. \`npm install\`, \`pip install -e .\`. Empty = no install step.)` | none |
-| 5 | `baseBranch` | `Default base branch for PRs opened by squad members?` | `develop` |
+| 5 | `baseBranch` | `Default base branch for PRs opened by squad members?` | `main` |
 
-Trim whitespace from every answer. Treat the literal string `develop` as the accepted default if the user confirms question 5 without typing; for any other value of `baseBranch`, accept what the operator provides verbatim — do not validate it against the remote. Omit `verify.lint` from the written JSON entirely if the user leaves it blank — the field is optional and downstream roles check for its presence before using it.
+Trim whitespace from every answer. Treat the literal string `main` as the accepted default if the user confirms question 5 without typing; for any other value of `baseBranch`, accept what the operator provides verbatim — do not validate it against the remote. Omit `verify.lint` from the written JSON entirely if the user leaves it blank — the field is optional and downstream roles check for its presence before using it.
 
 ### 4. Write the config
 


### PR DESCRIPTION
## Summary
The repo migrated to single-trunk GitHub Flow on `main` (flowkit v4), but several surfaces still referenced the old `develop` branch. This PR updates all four affected sites to reflect the current model: squads cut `feature/<slug>-<issue>` branches from `main`, swarmkit PRs target `main` directly, and the `init` wizard defaults `baseBranch` to `main`.

## Test plan
- `.claude-plugin/marketplace.json` line ~30: squadkit description now reads "branch cut from main" — no `develop` present.
- `README.md` line ~104: Getting Started swarm diagram arrow now shows `→ main` instead of `→ develop`.
- `plugins/squadkit/skills/init/SKILL.md` lines ~51 and ~61: both `baseBranch` default references now read `main`; the inline instruction also updated.
- `plugins/squadkit/README.md` lines ~184 and ~209: wizard walkthrough step 5 and schema table both now say `main`.
- Run `grep -rn "develop" .claude-plugin/marketplace.json README.md plugins/squadkit/skills/init/SKILL.md plugins/squadkit/README.md` — only hit is the word "development" in a prose sentence, not a branch reference.

Closes #1049