### PR TITLE
docs(shared): update base-resolution spec to flowkit-v4 single-trunk reality

### DIFF
--- a/plugins/_shared/base-resolution.md
+++ b/plugins/_shared/base-resolution.md
@@ -1,19 +1,24 @@
 # Base Branch Resolution
 
-Canonical specification for PR base-branch resolution. Every plugin that calls `gh pr create` MUST resolve `$BASE` via this algorithm so the resolution order is consistent across the monorepo.
+Canonical specification for PR base-branch resolution. Every plugin that opens a PR (or cuts a branch that a PR will later target) MUST resolve `$BASE` via this chain so the resolution order stays consistent across the monorepo.
+
+This monorepo runs a **single-trunk** workflow: `main` is the integration branch and the repo default. There is no `develop`. The resolution chain below reflects that reality — the terminal fallback is a hardcoded `main`, not a `develop` probe or a `gh repo view` default lookup.
 
 ## Algorithm
 
 Resolve `$BASE` in this order, stopping at the first non-empty result:
 
 1. **Explicit caller arg** — if `$ARGUMENTS` contains a `--base <branch>` flag, extract and use it.
-2. **Plugin-scoped config key** — read `git config claude.<plugin>.prBase`. Each plugin substitutes its own name (e.g. `claude.flowkit.prBase`, `claude.polishkit.prBase`).
-3. **`develop` if it exists on the remote** — check with `git ls-remote --heads origin develop | grep -q 'refs/heads/develop'`.
-4. **Repo default** — `gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name'`. Emit a one-line stderr warning before using this fallback.
+2. **Plugin-scoped config key** — read `git config claude.<plugin>.prBase`. Each plugin substitutes its own name (e.g. `claude.flowkit.prBase`, `claude.polishkit.prBase`). Epic flows (squadkit `--epic`, flowkit `cut-epic`) pin this key to the long-lived feature branch so member PRs target the epic automatically.
+3. **`main`** — the single-trunk default. Hardcoded; no `develop` probe and no `gh repo view` default lookup.
+
+A plugin MAY accept `main` as a build-time default rather than resolving it at step 3 (swarmkit's preflight sets `BASE="main"` before parsing args, then lets `--base` override it). The observable precedence is identical: explicit arg wins, then the scoped pin, then `main`.
 
 ## Post-condition
 
-`$BASE` is always non-empty after step 4; consumers MUST pass `--base "$BASE"` to `gh pr create`. Never call `gh pr create` without an explicit `--base` — without it, gh falls through to the GitHub default branch (often `main`), which silently produces wrong-base PRs against repos that develop on a non-default branch.
+`$BASE` is always non-empty after step 3; consumers MUST pass `--base "$BASE"` to `gh pr create`. Never call `gh pr create` without an explicit `--base` — without it, gh falls through to the GitHub default branch, which is fine today (it is `main`) but couples the PR target to repo settings instead of this contract.
+
+Consumers SHOULD also guard that the resolved `$BASE` is not the current HEAD branch. This catches the case where an epic branch has `claude.flowkit.prBase` pinned to itself — opening a PR from a branch against itself is always wrong. flowkit's open-pr errors out with remediation hints (override with `--base main`, or unset the pin) when `$BASE` equals HEAD.
 
 ## Plugin-scoped key naming rule
 
@@ -21,16 +26,19 @@ Each plugin owns exactly one key under its own namespace: `claude.<plugin>.prBas
 
 ## Cross-plugin courtesy interop (optional)
 
-A consuming plugin MAY check a sibling plugin's scoped key as a courtesy slot — **after** its own scoped key (step 2) and **before** the `develop` fallback (step 3). This is an opt-in deviation; document it explicitly in the consuming skill. Example: polishkit checks `claude.flowkit.prBase` if its own `claude.polishkit.prBase` is unset, so a flowkit session pin propagates automatically when both plugins are installed together. The courtesy read is best-effort only — the consuming plugin works correctly without the sibling key present.
+A consuming plugin MAY check a sibling plugin's scoped key as a courtesy slot — **after** its own scoped key (step 2) and **before** the `main` default (step 3). This is an opt-in deviation; document it explicitly in the consuming skill. Example: polishkit checks `claude.flowkit.prBase` if its own `claude.polishkit.prBase` is unset, so a flowkit session pin propagates automatically when both plugins are installed together. The courtesy read is best-effort only — the consuming plugin works correctly without the sibling key present.
 
-## Reference implementations
+## Reference implementations and consumers
 
-- [`plugins/flowkit/skills/open-pr/SKILL.md`](../flowkit/skills/open-pr/SKILL.md) — flowkit implementation.
-- [`plugins/polishkit/skills/polish/SKILL.md`](../polishkit/skills/polish/SKILL.md) — polishkit implementation (includes optional flowkit courtesy interop slot).
+- [`plugins/flowkit/skills/open-pr/SKILL.md`](../flowkit/skills/open-pr/SKILL.md) — faithful reference for the three-step chain: `--base` arg → `claude.flowkit.prBase` → hardcoded `main`, plus the HEAD-equals-base guard.
+- [`plugins/polishkit/skills/polish/SKILL.md`](../polishkit/skills/polish/SKILL.md) — resolves base before dispatching its worker, with its own `claude.polishkit.prBase` at step 2 and the optional `claude.flowkit.prBase` courtesy interop slot.
+- [`plugins/swarmkit/skills/swarm/scripts/preflight.sh`](../swarmkit/skills/swarm/scripts/preflight.sh) — defaults `BASE="main"` and accepts `--base <branch>` (no scoped-key read). It additionally seeds the base branch on origin from the repo default if the resolved base is missing. The swarm flow passes the resolved base through to `gh pr create --base` directly.
+- [`plugins/squadkit/skills/spawn-team/SKILL.md`](../squadkit/skills/spawn-team/SKILL.md) — reads `baseBranch` from `.squadkit/config.json` (defaulting to `main`), cuts the epic `feature/<slug>-<issue>` branch from `origin/main`, and pins `claude.flowkit.prBase` to the epic so each member's `flowkit:open-pr` resolves the epic at step 2. Squadkit itself does not call `gh pr create`; it defers PR creation to flowkit via the pinned key.
 
 ## Anti-patterns
 
-- **Do not hardcode `develop`** — always use the resolution algorithm so repos without a `develop` branch fall through gracefully.
-- **Do not skip the `$BASE` non-empty check** — an empty `$BASE` silently targets the GitHub default, which is almost always wrong in a feature-branch workflow.
+- **Do not reintroduce a `develop` probe or `gh repo view` default lookup** — this repo is single-trunk on `main`. The terminal fallback is a hardcoded `main`. Hardcoding `main` at step 3 is correct and intentional, not an anti-pattern.
+- **Do not skip the `$BASE` non-empty check** — although step 3 always yields `main`, consumers must still pass `--base "$BASE"` explicitly rather than relying on gh's implicit default.
+- **Do not target a non-`main` branch implicitly** — only an explicit `--base` arg or a deliberately set scoped pin may redirect away from `main`. Never infer the base from ambient repo state.
 - **Do not write to or rely on `claude.prBase`** — the unscoped legacy key is no longer read by any plugin. All writes go to `claude.<plugin>.prBase`.
-- **Do not add new fallback layers without updating this doc first** — the algorithm is the contract; undocumented layers create invisible precedence conflicts across plugins.
+- **Do not add new fallback layers without updating this doc first** — the chain is the contract; undocumented layers create invisible precedence conflicts across plugins.


### PR DESCRIPTION
## Summary
Rewrites `plugins/_shared/base-resolution.md` to match flowkit's v4 single-trunk reality, replacing the stale v3-era four-step algorithm (develop probe + gh repo view default) with the actual three-step chain that ends in a hardcoded `main`. Reconciles the now-false "never hardcode develop" anti-pattern, and expands the reference/consumer list to include swarmkit and squadkit alongside flowkit and polishkit, describing what each actually does.

## Test plan
- [ ] Confirm the documented chain matches `plugins/flowkit/skills/open-pr/SKILL.md` step 2 (lines 39-65): `--base` arg -> `claude.flowkit.prBase` -> hardcoded `main`, plus the HEAD-equals-base guard.
- [ ] Confirm the swarmkit entry matches `plugins/swarmkit/skills/swarm/scripts/preflight.sh` (line 19 `BASE="main"`, `--base` override, repo-default seeding) and that swarm passes the base to `gh pr create --base` directly.
- [ ] Confirm the squadkit entry matches `plugins/squadkit/skills/spawn-team/SKILL.md` (line 69 `.squadkit/config.json` baseBranch default `main`; epic cut from `origin/main`; pins `claude.flowkit.prBase`).
- [ ] Confirm no consumer skill (open-pr, preflight.sh, spawn-team, polish) was modified — `git diff --name-only origin/main` lists only `plugins/_shared/base-resolution.md`.

Closes #1050