### PR TITLE
fix(swarmkit): guarantee prBase pin clearance on all swarm exit paths

### DIFF
--- a/openspec/specs/swarmkit-swarm/spec.md
+++ b/openspec/specs/swarmkit-swarm/spec.md
@@ -51,8 +51,8 @@ The skill SHALL compute whether to run in epic mode before any setup work, and w
 
 #### Scenario: Conflicting pinned epic guard
 
-- **WHEN** a pinned base is already set to a different epic branch than the one about to be cut
-- **THEN** the skill SHALL refuse to run and instruct the operator to pass `--no-epic` or reuse the pinned slug
+- **WHEN** the preflight is invoked to scope the pinned base and a pinned base is already set to a different epic branch (one starting with `feature/`) than the one about to be pinned
+- **THEN** the preflight SHALL refuse to run, exit non-zero, and instruct the operator to pass `--no-epic` or reuse the pinned slug — the guard is enforced in the preflight script so any direct caller is protected
 
 #### Scenario: Empty board at loop entry
 
@@ -244,7 +244,7 @@ In loop mode the skill SHALL repeatedly select a safely-parallelizable batch and
 #### Scenario: Unrecoverable failure halts the loop
 
 - **WHEN** an agent crashes producing no PR, or the base branch is deleted or corrupted externally
-- **THEN** the skill SHALL exit the loop immediately
+- **THEN** the skill SHALL halt the loop and route through teardown before terminating so the pinned base is cleared, never exiting in place
 
 ### Requirement: Cleanup and teardown
 
@@ -259,6 +259,11 @@ The skill SHALL clean up agent worktrees and orphaned branches after a run and r
 
 - **WHEN** teardown runs and epic mode was off
 - **THEN** the skill SHALL restore the base branch and unset the pinned base configuration
+
+#### Scenario: Teardown runs on every exit path
+
+- **WHEN** a run ends in one-shot mode, or a loop ends by board-clear, user stop, or unrecoverable failure
+- **THEN** the skill SHALL run teardown before terminating so the pinned base configuration is always cleared (or preserved via the epic-keep flag in epic mode) — no exit path bypasses teardown
 
 #### Scenario: Epic branch preserved
 

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -57,7 +57,7 @@ else:                                              EPIC_MODE=on
 
 **Empty-board edge case (loop mode only)**: defer the inline cut until the first cycle that selects ≥1 issue. If the board is clear at loop entry, announce "Board is clear" and exit without cutting any branch.
 
-**Cross-pin defensive guard**: before cutting, read `claude.flowkit.prBase`. If it is set AND starts with `feature/` AND the value differs from the branch about to be cut, exit with:
+**Cross-pin defensive guard**: the durable enforcement lives in `preflight.sh` — when invoked with `--scope-pr-base`, it reads `claude.flowkit.prBase` and, if the pin is set AND starts with `feature/` AND differs from the branch about to be pinned, exits non-zero with the guidance message below. This protects any direct caller of `preflight --scope-pr-base`, not just this prose path. The expected message is:
 
 > `swarm: an epic is already pinned (\`<existing>\`); pass \`--no-epic\` to swarm against main, or \`--epic <existing-slug>\` to reuse the pinned branch.`
 
@@ -74,6 +74,8 @@ else
   git checkout -B "$EPIC_BRANCH" origin/main
   git push -u origin "$EPIC_BRANCH"
 fi
+# Setup's `preflight.sh --scope-pr-base` re-asserts this pin under the
+# cross-pin guard; this inline write keeps the resume path consistent.
 git config claude.flowkit.prBase "$EPIC_BRANCH"
 ```
 
@@ -443,6 +445,18 @@ For PRs with no fix round (clean reviewer verdict), no further action is needed.
 
 Run `/clean-worktrees` to remove agent worktrees and orphaned branches. This frees local `worktree-agent-*` branches so the merge step can use `--delete-branch` without conflicts.
 
+Then run `scripts/teardown.sh` to clear the `claude.flowkit.prBase` pin set during Setup. Leaving it set would cause subsequent PR creation (even in unrelated workflows) to target the wrong base, so this clearance is critical. Mirror the Loop-Mode teardown invocation pattern — in epic mode pass `--keep-pr-base` so the epic branch and pin survive for the final epic-to-`main` ship step; off epic mode, unset unconditionally:
+
+```bash
+if [ "$EPIC_MODE" = "on" ]; then
+  "$SKILL_DIR/scripts/teardown.sh" --base "$BASE" --keep-pr-base
+else
+  "$SKILL_DIR/scripts/teardown.sh" --base "$BASE"
+fi
+```
+
+Parse the returned JSON and confirm `base_restored: true`. If `config_unset: false` and `config_kept_for_epic` is absent, the pin was already clear — this is not a failure. When `config_kept_for_epic: true` appears, the pin is intentionally preserved for the ship-epic step; announce the same epic-handoff guidance as Loop Mode's Teardown.
+
 ### 8. Report
 
 ```
@@ -481,7 +495,7 @@ Follow `gh-fetch-issues` to fetch open issues (apply label filter if given), the
 - No unresolved dependencies within the batch
 - Present the batch in the standard next-issue table format; note any deferred issues and why
 
-If no open issues remain, announce "Board is clear" and exit.
+If no open issues remain, announce "Board is clear" and fall through to the Teardown section (do not `exit` here — the pin must be cleared first).
 
 **Step 2 — Swarm**
 
@@ -498,7 +512,7 @@ Run the one-shot swarm flow above on the batch. Independent issues target `$BASE
 ──────────────────────────────────────────────
 ```
 
-Proceed immediately to the next cycle after printing the checkpoint summary. The loop halts only on unrecoverable failures: an agent crash with no PR produced.
+Proceed immediately to the next cycle after printing the checkpoint summary. The loop halts only on unrecoverable failures: an agent crash with no PR produced. When the loop halts for any reason — board clear, user stop, or unrecoverable failure — it MUST fall through to the Teardown section below before terminating. Never `exit` directly from inside the loop; the Teardown is the single exit funnel that clears the pin.
 
 ### Teardown
 
@@ -542,6 +556,8 @@ When an issue fails at any point:
 2. Mark those as blocked; continue with all unblocked issues
 3. Report blocked issues at each checkpoint
 
-**Unrecoverable failures** (exit loop immediately):
+**Unrecoverable failures** (halt the loop, then run Teardown before terminating):
 - Agent produced no PR (crash, timeout, no push)
 - `$BASE` branch deleted or corrupted externally
+
+Even on an unrecoverable failure, the loop does not exit in place — it breaks out of the cycle and proceeds to the Teardown section so `scripts/teardown.sh` always runs and the `claude.flowkit.prBase` pin is cleared (or preserved via `--keep-pr-base` in epic mode). This is the trap/finally equivalent: there is no early-exit path that bypasses teardown.

--- a/plugins/swarmkit/skills/swarm/scripts/preflight.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/preflight.sh
@@ -77,6 +77,15 @@ if gh auth status >/dev/null 2>&1; then
 fi
 
 if [[ "$SCOPE_PR_BASE" -eq 1 ]]; then
+  # Cross-pin defensive guard — runs alongside the durable write so any direct
+  # caller of `preflight --scope-pr-base` is protected, not just the SKILL prose.
+  # Refuse to overwrite an existing epic pin that differs from the branch about
+  # to be pinned.
+  existing_pin="$(git config --local --get claude.flowkit.prBase 2>/dev/null || true)"
+  if [[ -n "$existing_pin" && "$existing_pin" == feature/* && "$existing_pin" != "$BASE" ]]; then
+    echo "swarm: an epic is already pinned (\`$existing_pin\`); pass \`--no-epic\` to swarm against main, or \`--epic <existing-slug>\` to reuse the pinned branch." >&2
+    exit 1
+  fi
   if ! git config --local claude.flowkit.prBase "$BASE" >/dev/null 2>&1; then
     echo "preflight: failed to set claude.flowkit.prBase via 'git config --local'" >&2
     exit 1


### PR DESCRIPTION
## Summary
The swarm skill leaked the `claude.flowkit.prBase` pin on three paths: one-shot epic completion had no teardown call, loop-mode early exits bypassed the trailing Teardown section, and the cross-pin guard lived only in SKILL prose so direct callers of `preflight --scope-pr-base` were unprotected. This adds a teardown step to the One-Shot runbook, makes Teardown the single exit funnel for every loop halt, and moves the cross-pin guard into `preflight.sh` so the durable write is the enforcement point.

## Test plan
- One-shot epic completion: confirm Step 7 now invokes `teardown.sh --keep-pr-base` when EPIC_MODE=on (epic branch + pin preserved for ship-epic) and `teardown.sh` unconditionally when EPIC_MODE=off (pin cleared).
- Loop early-exit: confirm board-clear at Step 1, user stop, and unrecoverable-failure paths all fall through to the Teardown section instead of exiting in place, so `teardown.sh` always runs.
- Cross-pin guard: ran the guard predicate in a temp repo — fires (exit non-zero) when the existing pin starts with `feature/` and differs from the branch about to be pinned; stays silent for a matching pin and for a non-`feature/` pin. `bash -n` passes on both scripts.

Closes #1046