### PR TITLE
chore: fix opsx-bridge root-spec claim and remove dead allowlist entries

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -31,13 +31,7 @@
       "Bash(*/plugins/flowkit/skills/with-clean-workspace/scripts/with_clean_workspace.sh:*)",
       "Bash($SKILL_DIR/scripts/merge_pr.sh:*)",
       "Bash(plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh:*)",
-      "Bash(*/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh:*)",
-      "Bash($SKILL_DIR/scripts/ship_epic.sh:*)",
-      "Bash(plugins/flowkit/skills/ship-epic/scripts/ship_epic.sh:*)",
-      "Bash(*/plugins/flowkit/skills/ship-epic/scripts/ship_epic.sh:*)",
-      "Bash($SKILL_DIR/scripts/restack.sh:*)",
-      "Bash(plugins/flowkit/skills/restack/scripts/restack.sh:*)",
-      "Bash(*/plugins/flowkit/skills/restack/scripts/restack.sh:*)"
+      "Bash(*/plugins/flowkit/skills/merge-pr/scripts/merge_pr.sh:*)"
     ]
   }
 }

--- a/plugins/opsx-bridge/README.md
+++ b/plugins/opsx-bridge/README.md
@@ -90,7 +90,7 @@ For the swarm path, each `##` heading in `tasks.md` becomes one GitHub issue. Th
 
 ## Spec
 
-The behavioral spec for this plugin lives at `openspec/specs/opsx-bridge/spec.md` (within the plugin) and is mirrored in the repo-level baseline at the root `openspec/specs/opsx-bridge/spec.md`.
+The behavioral spec for this plugin lives at `plugins/opsx-bridge/openspec/specs/opsx-bridge/spec.md`.
 
 ## See also
 


### PR DESCRIPTION
## Summary
Corrects the opsx-bridge README spec path, which falsely claimed a root-level mirror at `openspec/specs/opsx-bridge/spec.md` (that path does not exist); the spec is only at `plugins/opsx-bridge/openspec/specs/opsx-bridge/spec.md`. Also removes six dead `.claude/settings.json` allowlist entries for `ship_epic.sh` and `restack.sh` whose skill directories no longer exist.

## Test plan
- Confirm `openspec/specs/opsx-bridge/` does not exist at the repo root (`ls openspec/specs/opsx-bridge/ 2>/dev/null` returns nothing).
- Confirm `plugins/opsx-bridge/openspec/specs/opsx-bridge/spec.md` exists.
- Run `python3 -m json.tool .claude/settings.json` and verify it exits 0 with no errors.
- Grep `.claude/settings.json` for `ship_epic` and `restack` and confirm no results.

Closes #1052