### PR TITLE
docs(swarmkit): align PR-body Summary and METHODOLOGY Closes with canonical spec

### DIFF
--- a/plugins/swarmkit/METHODOLOGY.md
+++ b/plugins/swarmkit/METHODOLOGY.md
@@ -141,7 +141,7 @@ The canonical release sequence from this point is three steps, run by the operat
 
 The epic→main promotion is a single squash-merge:
 
-1. Open the `feature/<slug>-<N> → main` PR with aggregated `Closes #N` (already carried by each child PR's squash commit message).
+1. Open the `feature/<slug>-<N> → main` PR with aggregated `Closes #N` (already carried by each child PR's squash commit message). Emit one `Closes #N` token per line — GitHub only parses the first closing reference on a line, so `Closes #A #B #C` leaves `#B` and `#C` open (see `plugins/_shared/pr-body.md` for the full footer spec).
 2. Squash-merge (one final commit on `main` summarizing the epic).
 3. Unset `claude.flowkit.prBase`.
 4. Delete the feature branch on origin.

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -296,7 +296,7 @@ Each agent prompt MUST include these **workflow steps** (in order):
    git add <files> && git commit -m "<type>(<scope>): <description>"
 4. Push the branch:
    git push -u origin worktree-agent-<issue>
-5. Create PR targeting the appropriate base — `main` (or the pinned `feature/<slug>-<N>` branch via `claude.flowkit.prBase`) for independent issues, `worktree-agent-<dependency-issue>` for dependent ones. The body MUST be a richer summary, not just `Closes #<issue>` — synthesize the `## Summary` bullets from the issue's acceptance criteria and your diff, and describe the `## Test plan` in terms of those acceptance criteria. Fill in the angle-bracket placeholders; do not copy them literally.
+5. Create PR targeting the appropriate base — `main` (or the pinned `feature/<slug>-<N>` branch via `claude.flowkit.prBase`) for independent issues, `worktree-agent-<dependency-issue>` for dependent ones. The body MUST be a richer summary, not just `Closes #<issue>` — synthesize the `## Summary` sentences from the issue's acceptance criteria and your diff, and describe the `## Test plan` in terms of those acceptance criteria. Fill in the angle-bracket placeholders; do not copy them literally.
 
    <!-- include: plugins/_shared/pr-body.md -->
    <!-- Summary-content rules derive from the canonical doc; `## Changes` is intentionally omitted for single-issue swarm PRs — Summary is sufficient when the scope is one issue. -->
@@ -305,7 +305,7 @@ Each agent prompt MUST include these **workflow steps** (in order):
      --title "<type>(<scope>): <description>" \
      --body "$(cat <<'EOF'
    ## Summary
-   <1–3 bullets synthesizing what was changed, derived from the issue acceptance criteria and the diff>
+   <1–3 sentences (no bullets) synthesizing what was changed, derived from the issue acceptance criteria and the diff>
 
    ## Test plan
    <how to verify the changes satisfy the acceptance criteria>


### PR DESCRIPTION
## Summary

The swarm SKILL.md PR-body template said "1–3 bullets" for the Summary section, contradicting the canonical "1–3 sentences (no bullets)" rule in `plugins/_shared/pr-body.md`. This PR corrects the template and its surrounding prose to say "sentences (no bullets)". It also adds a one-per-line reminder to `METHODOLOGY.md` at the epic→main PR step so operators know each `Closes #N` must appear on its own line (GitHub only closes the first reference per line).

## Test plan

- [ ] Read `plugins/swarmkit/skills/swarm/SKILL.md` Step 5 — confirm the `## Summary` placeholder reads "1–3 sentences (no bullets)" and the prose above says "sentences", not "bullets".
- [ ] Grep `plugins/swarmkit/skills/swarm/SKILL.md` for "bullet" — only the parenthetical "(no bullets)" should remain; no standalone "bullets" guidance.
- [ ] Read `plugins/swarmkit/METHODOLOGY.md` Epic→Main Handoff step 1 — confirm it includes the one-per-line `Closes #N` note referencing `plugins/_shared/pr-body.md`.
- [ ] Confirm no changes to teardown/preflight sections (unchanged from the upstream `worktree-agent-1046` branch).

Closes #1051