### PR TITLE
chore(plugins): bump opsx-bridge@0.2.2

### DIFF
--- a/plugins/opsx-bridge/.claude-plugin/plugin.json
+++ b/plugins/opsx-bridge/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "opsx-bridge",
   "description": "Bridge OpenSpec changes to squadkit/swarmkit dispatchers. Drive `/squadkit:spawn-team` or `/swarmkit:swarm` from a single `openspec/changes/<name>/` proposal — additive only, leaves opsx/squadkit/swarmkit untouched.",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Bump opsx-bridge plugin.json from 0.2.1 to 0.2.2 so clients pick up the SKILL tightening and spec relocation merged in #1063.

## Changes

- opsx-bridge@0.2.2 (patch)

## Test plan

- [ ] Confirm the `plugin.json` version bump matches the per-plugin tag (opsx-bridge--v0.2.2) created after merge.