### PR TITLE
chore(bump-versions): add opsx-bridge to the plugin-locations table

### DIFF
--- a/.claude/skills/bump-versions/SKILL.md
+++ b/.claude/skills/bump-versions/SKILL.md
@@ -13,17 +13,18 @@ Bumps `plugin.json` version fields for plugins that have changed since their las
 
 ## Plugin locations
 
-Every kit under `plugins/*` that ships a manifest at `.claude-plugin/plugin.json` participates in version bumps. The root [README `#available-plugins`](../../../README.md#available-plugins) is the canonical plugin catalog — keep this table in sync when adding or removing kits.
+Every kit under `plugins/*` that ships a manifest at `.claude-plugin/plugin.json` participates in version bumps — including unlisted kits not advertised in the catalog. The root [README `#available-plugins`](../../../README.md#available-plugins) is the canonical catalog of *listed* plugins; keep this table in sync when adding or removing kits, but note it is a superset of the catalog (unlisted kits appear here only).
 
-| Plugin | plugin.json |
-|--------|-------------|
-| flowkit | `plugins/flowkit/.claude-plugin/plugin.json` |
-| polishkit | `plugins/polishkit/.claude-plugin/plugin.json` |
-| sessionkit | `plugins/sessionkit/.claude-plugin/plugin.json` |
-| speckit | `plugins/speckit/.claude-plugin/plugin.json` |
-| squadkit | `plugins/squadkit/.claude-plugin/plugin.json` |
-| swarmkit | `plugins/swarmkit/.claude-plugin/plugin.json` |
-| vaultkit | `plugins/vaultkit/.claude-plugin/plugin.json` |
+| Plugin | plugin.json | Listed |
+|--------|-------------|--------|
+| flowkit | `plugins/flowkit/.claude-plugin/plugin.json` | yes |
+| opsx-bridge | `plugins/opsx-bridge/.claude-plugin/plugin.json` | no (unlisted) |
+| polishkit | `plugins/polishkit/.claude-plugin/plugin.json` | yes |
+| sessionkit | `plugins/sessionkit/.claude-plugin/plugin.json` | yes |
+| speckit | `plugins/speckit/.claude-plugin/plugin.json` | yes |
+| squadkit | `plugins/squadkit/.claude-plugin/plugin.json` | yes |
+| swarmkit | `plugins/swarmkit/.claude-plugin/plugin.json` | yes |
+| vaultkit | `plugins/vaultkit/.claude-plugin/plugin.json` | yes |
 
 ## Git tag format
 


### PR DESCRIPTION
## Summary

Record opsx-bridge in the bump-versions skill's plugin-locations table. It was unlisted from the marketplace but still ships a `plugin.json` under `plugins/*`, so it participates in version bumps and should be documented as such.

## Changes

- Add the opsx-bridge row to the plugin-locations table in `.claude/skills/bump-versions/SKILL.md`.
- Add a `Listed` column (opsx-bridge = no/unlisted, all others = yes) and clarify the table is a superset of the README catalog, so the "keep in sync" guidance doesn't prune the unlisted-but-tracked row.

## Test plan

- [ ] Table lists all eight `plugins/*` kits with a manifest, opsx-bridge marked `no (unlisted)`.
- [ ] `bash .claude/skills/bump-versions/scripts/detect_changed.sh` still detects the same plugin set (table is documentation only; no behavior change).
