### PR TITLE
chore(plugins): bump squadkit@0.11.2, swarmkit@6.0.1

### DIFF
--- a/plugins/squadkit/.claude-plugin/plugin.json
+++ b/plugins/squadkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "squadkit",
   "description": "Multi-agent team coordination for Claude Code. Roles, squads, and crews \u2014 interview-driven setup, no per-stack presets, reusable across any repo.",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Bump squadkit and swarmkit plugin.json versions for the fix/docs changes merged since their last per-plugin tags, ahead of cutting a release.

## Changes

- squadkit@0.11.2 (patch) — prBase pin teardown fix + doc alignment (#1054, #1055, #1057)
- swarmkit@6.0.1 (patch) — prBase pin clearance on all exit paths + PR-body doc alignment (#1059, #1061)

## Test plan

- [ ] Each `plugin.json` version matches the per-plugin tag created after merge (squadkit--v0.11.2, swarmkit--v6.0.1).
