### PR TITLE
feat(swarmkit): resolve epic mode for a single epic argument

### DIFF
--- a/openspec/changes/swarm-epic-arg-mode/tasks.md
+++ b/openspec/changes/swarm-epic-arg-mode/tasks.md
@@ -4,21 +4,21 @@ Implementation decomposition for making a single epic argument enable epic mode 
 
 ## 1. Resolution logic
 
-- [ ] Update `plugins/swarmkit/skills/swarm/SKILL.md` Epic Mode Resolution: for the one-shot single-argument case, consult epic membership (via `gather_issues.sh` `epics_expanded` / `is_epic`) before finalizing. A single argument that is an epic expanding to ≥2 wired children resolves `EPIC_MODE=on`; a standalone non-epic issue (or an epic with <2 wired children, or `epics_unwired`) stays off. Preserve `--base` / `--no-epic` as forcing off.
-- [ ] Ensure the "compute before any setup work" guidance still holds for all cases except the single-arg probe, and document that gather runs before the cut in that one case.
-- [ ] Reuse the existing slug-derivation rule (epic, or lowest-numbered child, via `gh issue view`) for the cut.
+- [x] Update `plugins/swarmkit/skills/swarm/SKILL.md` Epic Mode Resolution: for the one-shot single-argument case, consult epic membership (via `gather_issues.sh` `epics_expanded` / `is_epic`) before finalizing. A single argument that is an epic expanding to ≥2 wired children resolves `EPIC_MODE=on`; a standalone non-epic issue (or an epic with <2 wired children, or `epics_unwired`) stays off. Preserve `--base` / `--no-epic` as forcing off.
+- [x] Ensure the "compute before any setup work" guidance still holds for all cases except the single-arg probe, and document that gather runs before the cut in that one case.
+- [x] Reuse the existing slug-derivation rule (epic, or lowest-numbered child, via `gh issue view`) for the cut.
 
 ## 2. Docs + spec
 
-- [ ] Update `plugins/swarmkit/METHODOLOGY.md` to describe the single-epic-arg → epic-mode behavior alongside the existing multi-issue epic example.
-- [ ] Update `plugins/swarmkit/README.md` if its flag/mode description states the single-issue-one-shot → flat rule.
-- [ ] Update the baseline spec `openspec/specs/swarmkit-swarm/spec.md` "Epic mode resolution" requirement (this change's delta is the source of truth).
+- [x] Update `plugins/swarmkit/METHODOLOGY.md` to describe the single-epic-arg → epic-mode behavior alongside the existing multi-issue epic example.
+- [x] Update `plugins/swarmkit/README.md` if its flag/mode description states the single-issue-one-shot → flat rule.
+- [ ] Update the baseline spec `openspec/specs/swarmkit-swarm/spec.md` "Epic mode resolution" requirement — applied by `openspec archive` from this change's delta (not a manual edit).
 
 ## 3. Tests
 
-- [ ] Extend `plugins/swarmkit/skills/swarm/scripts/test.sh` (or the gather test) with a single-epic-arg fixture asserting `epics_expanded` is populated and `is_epic` is true for the argument.
-- [ ] Add a standalone-issue fixture asserting it is NOT treated as an epic (regression guard for the off path).
+- [x] Extend `plugins/swarmkit/skills/swarm/scripts/test.sh` (or the gather test) with a single-epic-arg fixture asserting `epics_expanded` is populated and `is_epic` is true for the argument.
+- [x] Add a standalone-issue fixture asserting it is NOT treated as an epic (regression guard for the off path).
 
 ## 4. Dependency note
 
-- [ ] The `skill-evals` change's L3 EPIC_MODE eval (`evals/l3/swarm/epic-mode-single-arg`) asserts this behavior — coordinate so the eval lands after this change.
+- [x] The `skill-evals` change's L3 EPIC_MODE eval (`evals/l3/swarm/epic-mode-single-arg`) asserts this behavior — coordinate so the eval lands after this change.

--- a/plugins/swarmkit/METHODOLOGY.md
+++ b/plugins/swarmkit/METHODOLOGY.md
@@ -91,13 +91,14 @@ Loop mode sets `claude.flowkit.prBase` as a local git config at the start and un
 
 ### Trigger Rule
 
-Swarm automatically cuts a feature branch whenever a run will spawn two or more agents. A run that spawns only one agent (a single-issue one-shot) stays flat — it targets `$BASE` directly, the same as before this feature landed. The trigger fires for:
+Swarm automatically cuts a feature branch whenever a run will spawn two or more agents. A run that spawns only one agent (a standalone single-issue one-shot) stays flat — it targets `$BASE` directly, the same as before this feature landed. The trigger fires for:
 
 - **One-shot multi-issue**: `/swarm 12 15 18` — three issues → epic cut.
+- **Single epic argument**: `/swarm 42` where #42 is an epic that expands to ≥2 wired children → epic cut. The single argument expands to multiple agents, so it forms a stack just like a multi-issue run; the slug derives from the epic's lowest-numbered child.
 - **Loop mode (all issues)**: `/swarm` — any board with ≥1 issue → epic cut at first non-empty cycle.
 - **Loop mode (label filter)**: `/swarm bug` — same trigger as loop mode.
 
-Single-issue one-shot (`/swarm 12`) always stays flat. The logic is: a standalone issue, by definition, cannot form a stack that needs isolation from `main`.
+Single-issue one-shot for a **standalone** (non-epic) issue (`/swarm 12`) always stays flat. The logic is: a standalone issue, by definition, cannot form a stack that needs isolation from `main`. A single *epic* argument is the exception above — it is not standalone, it expands into a child stack, so it cuts a feature branch. (An epic argument with fewer than two wired children, or with unwired children, stays flat.)
 
 ### What Happens at Epic Cut
 

--- a/plugins/swarmkit/README.md
+++ b/plugins/swarmkit/README.md
@@ -50,7 +50,7 @@ Swarmkit is designed to run best when agents don't have to pause for per-command
 
 | Skill | Invoke | What it does |
 |-------|--------|--------------|
-| **swarm** | `/swarm` | Spawn parallel isolated-worktree agents to resolve GitHub issues, then run an automatic review/fix pass on each PR. Multi-issue/loop/label runs auto-cut a `feature/<slug>-<N>` branch from `main` and route all child PRs to it (operator squash-merges epic→main to close out). Single-issue one-shot runs target `main` directly. |
+| **swarm** | `/swarm` | Spawn parallel isolated-worktree agents to resolve GitHub issues, then run an automatic review/fix pass on each PR. Multi-issue/loop/label runs — and a single epic argument that expands to ≥2 children — auto-cut a `feature/<slug>-<N>` branch from `main` and route all child PRs to it (operator squash-merges epic→main to close out). A standalone single-issue one-shot targets `main` directly. |
 | **next-issue** | `/next-issue` | Fetches open issues, ranks them by priority, specificity, and architectural impact, and recommends what to work on next. |
 | **merge-stack** | `/merge-stack` | Merges all open swarm PRs bottom-up (root PRs first, leaves last) after retargeting non-root PRs to `$BASE`. Pre-scans worktrees to flag merge-set branches still held locally and tails the report with a `/clean-worktrees` follow-up when any `worktree-agent-*` paths remain. |
 | **clean-worktrees** | `/clean-worktrees` | Removes all agent worktrees and their orphaned `worktree-agent-*` branches. |
@@ -89,8 +89,15 @@ Swarmkit vendors a specialized reviewer agent used by `/swarm`'s automatic revie
 ### Single issue (flat to main)
 
 ```
-/swarm 12                            # No epic cut — PR targets main directly
+/swarm 12                            # Standalone issue — no epic cut, PR targets main directly
 /merge-pr                            # Squash-merge the one PR (flowkit skill)
+```
+
+### Single epic argument (auto epic cut)
+
+```
+/swarm 42                            # #42 is an epic → expands to its children, cuts feature/<slug>-<N>
+/merge-stack                         # Squash-merge the child stack, then epic→main
 ```
 
 ### Loop mode (clear the board)
@@ -112,7 +119,8 @@ Swarmkit vendors a specialized reviewer agent used by `/swarm`'s automatic revie
 8. Cleans up worktrees and orphaned branches
 
 **One-shot mode**: `/swarm 12 15 18` — auto-cuts epic branch, opens PRs against it; use `/merge-stack` then a final epic→main squash to land.
-**Single issue (one-shot)**: `/swarm 12` — flat to `main`, no epic cut; use `/merge-pr` to merge.
+**Single issue (one-shot)**: `/swarm 12` — standalone issue, flat to `main`, no epic cut; use `/merge-pr` to merge.
+**Single epic argument**: `/swarm 42` where #42 is an epic expanding to ≥2 wired children — auto-cuts the epic branch and opens PRs against it (use `/merge-stack` then epic→main); an epic with <2 wired or unwired children stays flat.
 **Loop mode**: `/swarm` — fetch, swarm, open PRs, repeat until the board is clear; epic branch is cut once and reused across cycles.
 **Label filter**: `/swarm bug` — loop mode, but only `bug`-labeled issues.
 

--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -37,21 +37,25 @@ Parse `$ARGUMENTS` to determine the mode:
 
 ## Epic Mode Resolution
 
-Compute `EPIC_MODE` before any setup work:
+Compute `EPIC_MODE` before any setup work. The one-shot single-argument case is the only one that needs a pre-check, because a single argument may be a standalone issue or an epic that expands to children — see **Single epic argument** below:
 
 ```
-if --base is set:                                  EPIC_MODE=off
-elif --no-epic is set:                             EPIC_MODE=off
-elif arg-mode == one-shot AND issue_count == 1:    EPIC_MODE=off
-else:                                              EPIC_MODE=on
+if --base is set:                                            EPIC_MODE=off
+elif --no-epic is set:                                       EPIC_MODE=off
+elif one-shot AND a single argument that is an epic
+     expanding to >=2 wired children:                        EPIC_MODE=on
+elif one-shot AND issue_count == 1 (standalone non-epic):    EPIC_MODE=off
+else:                                                        EPIC_MODE=on
 ```
+
+**Single epic argument**: when exactly one argument is given, probe its membership before finalizing `EPIC_MODE` — run `"$SKILL_DIR/scripts/gather_issues.sh" <arg>` and read `epics_expanded` / `is_epic`. If the argument is an epic that expands to **two or more wired children**, set `EPIC_MODE=on` and **reuse that gather output** for the One-Shot flow below (do not gather twice). If it expands to fewer than two children, or its children are unwired (`epics_unwired`), keep `EPIC_MODE=off` and apply the existing unwired-epic announcement where relevant. A genuine standalone (non-epic) single issue stays `EPIC_MODE=off` — a standalone issue cannot form a stack. `--base` and `--no-epic` still force `EPIC_MODE=off` regardless. Every other case keeps the "compute before any setup work" ordering with no pre-check.
 
 ### When EPIC_MODE=on
 
 **Resolve the branch name** `EPIC_BRANCH` (in order):
 
 1. `--epic <slug>` arg → if it already starts with `feature/`, use verbatim; otherwise prepend `feature/`.
-2. One-shot multi-issue → derive slug from the lowest issue number's title (`gh issue view <N> --json title --jq '.title'`), kebab-case it (lowercase; non-alphanumerics → `-`; collapse runs; trim leading/trailing `-`), and form `feature/<slug>-<lowest-issue>`.
+2. One-shot multi-issue, or a single epic argument → derive slug from the lowest issue number's title (for a single epic argument, the lowest-numbered expanded child; `gh issue view <N> --json title --jq '.title'`), kebab-case it (lowercase; non-alphanumerics → `-`; collapse runs; trim leading/trailing `-`), and form `feature/<slug>-<lowest-issue>`.
 3. Loop mode (no label) → `feature/swarm-$(date +%Y-%m-%d)`.
 4. Loop mode + label → `feature/<label>-$(date +%Y-%m-%d)`.
 
@@ -142,6 +146,8 @@ Run the gather script once with all requested issue numbers. It batches title, b
 ```bash
 "$SKILL_DIR/scripts/gather_issues.sh" <number> [<number> ...]
 ```
+
+If the single-epic-argument probe in **Epic Mode Resolution** already ran `gather_issues.sh` for this run, reuse that output here instead of gathering again — the expanded children in `epics_expanded` / `work_items` are the issues to act on.
 
 On success the script exits 0 and emits one JSON object on stdout:
 

--- a/plugins/swarmkit/skills/swarm/scripts/test.sh
+++ b/plugins/swarmkit/skills/swarm/scripts/test.sh
@@ -147,6 +147,56 @@ STUB
 )
 
 echo
+echo "swarm: gather_issues epic-expansion contract (stubbed gh)"
+echo
+
+# These back the single-epic-argument EPIC_MODE resolution: gather must expose
+# epics_expanded/work_items so the skill can tell an expandable epic from a
+# standalone issue. Network-free — gh is stubbed with canned GraphQL responses.
+gstub="$(mktemp -d)"
+cat >"$gstub/canned-epic.json" <<'JSON'
+{"data":{"repository":{"i42":{"number":42,"title":"epic: thing","body":"","state":"OPEN","labels":{"nodes":[{"name":"epic"}]},"subIssues":{"totalCount":2,"nodes":[{"number":101,"title":"a","body":"","state":"OPEN","labels":{"nodes":[]},"blockedBy":{"nodes":[]}},{"number":102,"title":"b","body":"","state":"OPEN","labels":{"nodes":[]},"blockedBy":{"nodes":[{"number":101}]}}]},"blockedBy":{"nodes":[]}}}}}
+JSON
+cat >"$gstub/canned-standalone.json" <<'JSON'
+{"data":{"repository":{"i12":{"number":12,"title":"standalone","body":"","state":"OPEN","labels":{"nodes":[]},"subIssues":{"totalCount":0,"nodes":[]},"blockedBy":{"nodes":[]}}}}}
+JSON
+cat >"$gstub/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "$1" == "repo" && "$2" == "view" ]]; then printf 'octo/repo\n'; exit 0; fi
+if [[ "$1" == "api" && "$2" == "graphql" ]]; then cat "$GATHER_STUB_CANNED"; exit 0; fi
+exit 1
+STUB
+chmod +x "$gstub/gh"
+
+# Single epic argument #42 → expands to two wired children (EPIC_MODE=on path).
+out="$(GATHER_STUB_CANNED="$gstub/canned-epic.json" PATH="$gstub:$PATH" "$SCRIPT_DIR/gather_issues.sh" 42 2>/dev/null)"; rc=$?
+children="$(printf '%s' "$out" | jq -c '.epics_expanded[0].children' 2>/dev/null)"
+n_items="$(printf '%s' "$out" | jq '.work_items | length' 2>/dev/null)"
+src="$(printf '%s' "$out" | jq -c '[.work_items[].source_epic] | unique' 2>/dev/null)"
+if [[ $rc -eq 0 && "$children" == "[101,102]" && "$n_items" == "2" && "$src" == "[42]" ]]; then
+  green "  PASS [gather_issues single-epic-arg]: #42 expands → children [101,102], 2 work_items, source_epic 42"
+  PASS=$((PASS + 1))
+else
+  red   "  FAIL [gather_issues single-epic-arg]: rc=$rc children=$children items=$n_items src=$src"
+  FAIL=$((FAIL + 1))
+fi
+
+# Standalone issue #12 → not an epic, no expansion (EPIC_MODE=off path).
+out="$(GATHER_STUB_CANNED="$gstub/canned-standalone.json" PATH="$gstub:$PATH" "$SCRIPT_DIR/gather_issues.sh" 12 2>/dev/null)"; rc=$?
+n_exp="$(printf '%s' "$out" | jq '.epics_expanded | length' 2>/dev/null)"
+n_items="$(printf '%s' "$out" | jq '.work_items | length' 2>/dev/null)"
+num="$(printf '%s' "$out" | jq '.work_items[0].number' 2>/dev/null)"
+src="$(printf '%s' "$out" | jq '.work_items[0].source_epic' 2>/dev/null)"
+if [[ $rc -eq 0 && "$n_exp" == "0" && "$n_items" == "1" && "$num" == "12" && "$src" == "null" ]]; then
+  green "  PASS [gather_issues standalone-issue]: #12 flat, no epic expansion"
+  PASS=$((PASS + 1))
+else
+  red   "  FAIL [gather_issues standalone-issue]: rc=$rc epics=$n_exp items=$n_items num=$num src=$src"
+  FAIL=$((FAIL + 1))
+fi
+rm -rf "$gstub"
+
+echo
 echo "swarm: ${PASS} passed, ${FAIL} failed"
 [[ $FAIL -eq 0 ]] || exit 1
 exit 0


### PR DESCRIPTION
## Summary

Implements the `swarm-epic-arg-mode` OpenSpec change: `/swarm <epic#>` with a single argument that is an epic expanding to ≥2 wired children now resolves `EPIC_MODE=on` (cuts `feature/<slug>-<N>`, stacks the children) instead of going flat-to-`main`. A standalone single issue, an epic with <2 wired children, or unwired children all stay flat, and `--base`/`--no-epic` still force epic mode off.

## Changes

- `plugins/swarmkit/skills/swarm/SKILL.md` — Epic Mode Resolution gains a single-argument membership probe (runs `gather_issues.sh` first for that one case, reads `epics_expanded`/`is_epic`, reuses the output for the One-Shot flow); slug-derivation rule extended to the single-epic-arg case.
- `plugins/swarmkit/METHODOLOGY.md`, `plugins/swarmkit/README.md` — document the new trigger and nuance the "single issue stays flat" wording to "standalone single issue".
- `plugins/swarmkit/skills/swarm/scripts/test.sh` — two network-free stubbed tests: a single epic argument expands to its children; a standalone issue does not.
- `openspec/changes/swarm-epic-arg-mode/tasks.md` — checkboxes (baseline spec is applied on `openspec archive`).

## Test plan

- `bash plugins/swarmkit/skills/swarm/scripts/test.sh` → 15 passed, 0 failed (incl. the 2 new epic-expansion tests).
- `openspec validate swarm-epic-arg-mode` → valid.

Implements the `swarm-epic-arg-mode` change (proposed in #1062).