### PR TITLE
feat(evals): L1 script-test gate + L2 skill-doc lint

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -3,7 +3,6 @@ name: Deploy site
 on:
   push:
     branches:
-      - develop
       - main
     paths:
       - 'site/**'

--- a/.github/workflows/skills-ci.yml
+++ b/.github/workflows/skills-ci.yml
@@ -1,0 +1,35 @@
+name: Skills CI
+
+on:
+  pull_request:
+    paths:
+      - 'plugins/**'
+      - 'scripts/**'
+      - 'README.md'
+      - '.claude/settings.json'
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  l1-script-tests:
+    name: L1 — script unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run skill script smoke tests
+        run: scripts/test-all-skill-scripts.sh
+
+  l2-skill-doc-lint:
+    name: L2 — skill-doc lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Lint skill docs
+        run: python3 scripts/lint-skills.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,8 @@ Skip for typo fixes, renames, and small edits that don't touch convention surfac
 
 **Skill scripts standard**: Skills that extract deterministic bash work into shell scripts must follow the convention at [`plugins/_shared/script-authoring.md`](./plugins/_shared/script-authoring.md) — folder layout, `$SKILL_DIR` resolution, bare-payload JSON, stderr errors, when to extract, and `.claude/settings.json` allowlist guidance.
 
-**README flag-matrix drift**: Any change to a SKILL.md `## Input` table needs a matching pass on the corresponding plugin README's flag matrix — these drift silently otherwise.
+**CI gates (skill evals)**: Two required checks run on every PR via `.github/workflows/skills-ci.yml` and enforce the conventions above — see [`evals/README.md`](./evals/README.md). **L1** (`scripts/test-all-skill-scripts.sh`) runs every `plugins/*/skills/*/scripts/test.sh`; a script-backed skill with a missing or failing `test.sh` blocks merge. **L2** (`scripts/lint-skills.py`) lints skill-doc structure — frontmatter, include/`_shared` citation/relative-link resolution, no stale `develop` references, and `.claude/settings.json` allowlist paths. Run `python3 scripts/lint-skills.py` locally before pushing.
+
+**README flag-matrix drift**: Any change to a SKILL.md `## Input` table needs a matching pass on the corresponding plugin README's flag matrix — these drift silently otherwise. The L2 linter surfaces undocumented flags as warnings.
 
 **Spec scope — always include docs**: When speccing any code change, the task list must include explicit tasks for updating all affected documentation and specifications (plugin READMEs, `CLAUDE.md`, OpenSpec `spec.md`, site content, `marketplace.json`). Do not treat documentation updates as implied — file them as discrete tasks so they survive the catalog and are not silently dropped.

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,98 @@
+# Skill evals
+
+A tiered evaluation strategy for the plugin suite. Cheapest and most
+deterministic layers gate every PR; LLM-in-loop layers run off the blocking
+path. Full strategy: `openspec/changes/skill-evals/` (proposal, design, tasks).
+
+```
+        ▲  L4  End-to-end smoke    few · slow · nightly        (sandbox repo, real skill)
+       ▲▲  L3  Behavioral evals    curated · LLM-in-loop        (fixture + trajectory + judge)
+      ▲▲▲  L2  Skill-doc lint      every PR · no LLM · fast     (structure + drift rules)
+     ▲▲▲▲  L1  Script unit tests   every PR · deterministic     (the test.sh you already wrote)
+```
+
+**L1 and L2 are live** and run as required checks in
+[`.github/workflows/skills-ci.yml`](../.github/workflows/skills-ci.yml). L3 and
+L4 are forthcoming (see the change's `tasks.md`).
+
+## L1 — Script unit tests
+
+Discovers and runs every `plugins/*/skills/*/scripts/test.sh`, failing on any
+non-zero exit.
+
+```bash
+scripts/test-all-skill-scripts.sh
+```
+
+`test.sh` is **mandatory** for any script-backed skill — see
+[`plugins/_shared/script-authoring.md`](../plugins/_shared/script-authoring.md#smoke-tests)
+for the contract (invalid-arg coverage, JSON happy paths, network-dependent
+limitations).
+
+## L2 — Skill-doc lint
+
+A no-LLM structural linter over `plugins/**` and root docs. Each rule reports a
+`file:line`. It freezes the 2026-06-01 cross-plugin audit findings as permanent
+ratchets.
+
+```bash
+python3 scripts/lint-skills.py            # report; fail only on ERROR
+python3 scripts/lint-skills.py --strict   # fail on WARN too
+```
+
+### Severity policy
+
+- **ERROR** — high-confidence structural violation; fails the gate (exit 1).
+- **WARN** — fuzzy/heuristic signal; reported but non-blocking, until proven
+  low-false-positive and promoted to ERROR.
+
+This split keeps the gate trustworthy: a flaky or noisy rule never blocks a
+merge. Promote a WARN rule to ERROR once it runs clean across the tree.
+
+### Rule catalog
+
+| Rule | Severity | Catches |
+|------|----------|---------|
+| `frontmatter` | ERROR | SKILL.md missing the `---` block or its `name:`/`description:` fields |
+| `include` | ERROR | `<!-- include: <path> -->` directive whose target does not resolve (repo-root or file-relative) |
+| `link` | ERROR | relative markdown link whose target file does not exist (anchors/externals/code-fences skipped) |
+| `shared-citation` | ERROR | a `plugins/_shared/*.md` citation path that does not exist |
+| `develop` | ERROR | a stale `develop` branch reference outside the migration/legacy allowlist (incl. `.github/workflows/**`) |
+| `allowlist` | ERROR | a `.claude/settings.json` permission entry pointing at a non-existent `plugins/**.sh` script |
+| `input-table` | WARN | a SKILL.md that documents `` `--flags` `` in prose but has no Input/Arguments/Flags heading |
+| `flag-matrix` | WARN | a SKILL.md flag absent from its plugin README (coarse drift heuristic) |
+| `paraphrase` | WARN | a doc that inlines the PR-body section shape without citing `_shared/pr-body.md` |
+
+### Notes on specific rules
+
+**`develop`.** A single-trunk repo (`main`) has no `develop` branch, so live
+references are drift. But many `develop` mentions are legitimate: the v3→v4
+migration surfaces, v3 legacy-detection guards, and negative phrasings ("there
+is no develop"). The rule flags only references that *look like a live branch
+target* and are not covered by:
+
+- the file allowlist in `lint-skills.py` (`DEVELOP_FILE_ALLOWLIST` — migration
+  and legacy-detection docs),
+- a negative-context phrasing (`no`/`never`/`not`/`without` near `develop`, or
+  `develop` next to `intermediary`/`split`/`probe`, or a `develop|main`
+  branch-protection alternation),
+- an inline `lint-allow-develop` marker on the line.
+
+**`flag-matrix`.** A coarse heuristic: it extracts only backtick-wrapped
+`` `--flag` `` tokens from SKILL.md prose (ignoring CLI flags inside shell
+snippets) and warns when one is absent from the plugin README. It surfaces real
+drift but also soft positives (a flag mentioned only to say it is *not* used), so
+it is WARN, not ERROR.
+
+## Adding a rule
+
+1. Add a `rule_<name>(findings)` function in `scripts/lint-skills.py` that
+   appends `Finding(severity, path, line, rule, message)` entries. Reuse the
+   `prose_lines()` / `documented_flags()` helpers to skip fenced code blocks.
+2. Register it in the `RULES` tuple.
+3. Start at `WARN`. Run `python3 scripts/lint-skills.py` against the full tree;
+   if it is clean (no false positives), promote to `ERROR`.
+4. Document it in the rule catalog above.
+
+Every new statically-checkable audit finding should become a rule here — that is
+how the one-time audit becomes a permanent ratchet.

--- a/openspec/changes/skill-evals/tasks.md
+++ b/openspec/changes/skill-evals/tasks.md
@@ -4,27 +4,27 @@ Implementation decomposition for the skill-evals strategy. Phased so the cheap, 
 
 ## 1. L1 — Script unit tests (gate the tests that already exist)
 
-- [ ] Add `scripts/run-skill-tests.sh`: discover every `plugins/*/skills/*/scripts/test.sh` (`find ... | while read`, never `for N in $(...)`), run each, fail on any non-zero exit, summarize pass/fail per skill.
-- [ ] Add `.github/workflows/skills-ci.yml` with an L1 job that runs `scripts/run-skill-tests.sh` on PRs touching `plugins/**`. Mark it a required check.
-- [ ] Backfill `test.sh` for script-backed skills that lack one (audit `plugins/*/skills/*/scripts/` for scripts without a sibling `test.sh`).
-- [ ] Update `plugins/_shared/script-authoring.md`: `test.sh` is mandatory for any script-backed skill; reference the runner + CI gate.
-- [ ] Update `CLAUDE.md` (Skill Authoring Conventions) to point at the L1 gate.
+- [x] Reuse the existing `scripts/test-all-skill-scripts.sh` runner (discovers every `plugins/*/skills/*/scripts/test.sh`, runs each, fails on any non-zero exit, summarizes pass/fail per skill) instead of adding a duplicate `run-skill-tests.sh`.
+- [x] Add `.github/workflows/skills-ci.yml` with an L1 job that runs `scripts/test-all-skill-scripts.sh` on PRs touching `plugins/**`. (Mark it a required check in branch protection.)
+- [x] Backfill `test.sh` for script-backed skills that lack one — none needed; all 6 script-backed skills already ship one.
+- [x] Update `plugins/_shared/script-authoring.md`: `test.sh` is mandatory for any script-backed skill; reference the runner + CI gate.
+- [x] Update `CLAUDE.md` (Skill Authoring Conventions) to point at the L1 gate.
 
 ## 2. L2 — Skill-doc lint (freeze the audit findings)
 
-- [ ] Add `scripts/lint-skills.sh` (or `.ts`) with one discrete, file:line-reporting rule per check:
-  - [ ] Frontmatter present (`name`, `description`) on every SKILL.md.
-  - [ ] `## Input` table present where a skill documents arguments.
-  - [ ] Every `<!-- include: <path> -->` directive resolves.
-  - [ ] Every `plugins/_shared/*.md` citation path resolves.
-  - [ ] Every relative markdown link in `plugins/**` and root `README.md` resolves.
-  - [ ] README flag-matrix rows agree with the corresponding SKILL.md `## Input` table.
-  - [ ] No `develop` branch reference outside designated migration docs (seed allowlist: `flowkit/MIGRATION-v4.md`, openspec archive). **Include `.github/workflows/**`** — `deploy-site.yml` currently trips this.
-  - [ ] Every `.claude/settings.json` allowlist script path points at an existing script.
-  - [ ] Heuristic: shared specs are cited, not paraphrased inline (flag inlined copies of `pr-body.md` / `base-resolution.md` shape).
-- [ ] Wire L2 into `skills-ci.yml` as a required per-PR job.
-- [ ] Fix the findings the new linter surfaces on first run (at minimum: `deploy-site.yml` develop triggers; any residual drift).
-- [ ] Document each rule and how to add a new one in `evals/README.md`.
+- [x] Add `scripts/lint-skills.py` (Python stdlib — table parsing is impractical in pure bash; CI has `python3`) with one discrete, file:line-reporting rule per check. Each rule carries an ERROR/WARN severity; only ERROR fails the gate (keeps a noisy rule from blocking merges until it is calibrated):
+  - [x] Frontmatter present (`name`, `description`) on every SKILL.md. (ERROR)
+  - [x] `## Input`/Arguments section present where a skill documents arguments. (WARN — args are documented under varied headings)
+  - [x] Every `<!-- include: <path> -->` directive resolves. (ERROR)
+  - [x] Every `plugins/_shared/*.md` citation path resolves. (ERROR)
+  - [x] Every relative markdown link in `plugins/**` and root `README.md` resolves. (ERROR — fenced code blocks skipped)
+  - [x] README flag-matrix agreement with SKILL.md documented flags. (WARN — coarse heuristic; README tables are skill-catalogs, not strict per-flag matrices)
+  - [x] No `develop` branch reference outside the migration/legacy allowlist (incl. `.github/workflows/**`). (ERROR — branch-ref gate + negative-context + file allowlist + `lint-allow-develop` marker)
+  - [x] Every `.claude/settings.json` allowlist script path points at an existing script. (ERROR)
+  - [x] Heuristic: shared specs are cited, not paraphrased inline (flag inlined `pr-body.md` shape). (WARN)
+- [x] Wire L2 into `skills-ci.yml` as a per-PR job. (Mark it a required check in branch protection.)
+- [x] Fix the findings the new linter surfaced on first run: `deploy-site.yml` develop trigger; `polish/SKILL.md:30` stale develop/repo-default step (closes #1068); `sweep/SKILL.md:171` stale develop auto-detect.
+- [x] Document each rule and how to add a new one in `evals/README.md`.
 
 ## 3. L3 — Behavioral eval harness (highest-blast-radius skill first)
 

--- a/plugins/_shared/script-authoring.md
+++ b/plugins/_shared/script-authoring.md
@@ -127,6 +127,8 @@ bash scripts/test-all-skill-scripts.sh
 
 It walks `plugins/*/skills/*/scripts/test.sh`, runs each with the test directory as CWD, and exits non-zero if any test fails. This is the single entry point intended for CI.
 
+This runner is the **L1 gate** in `.github/workflows/skills-ci.yml` — it runs as a required check on every PR touching `plugins/**`. A script-backed skill with no `test.sh`, or whose `test.sh` fails, blocks merge. See [`evals/README.md`](../../evals/README.md) for the full eval-layer overview (L1 script tests, L2 skill-doc lint).
+
 ## `.claude/settings.json` allowlist
 
 The harness requires explicit permission before executing each script path. Add an entry to the project `.claude/settings.json` allowlist when introducing a new script:

--- a/plugins/polishkit/skills/polish/SKILL.md
+++ b/plugins/polishkit/skills/polish/SKILL.md
@@ -27,7 +27,7 @@ Optional flags:
 - `--model <tier>` — `sonnet` (default) or `opus` for harder cross-cutting passes
 - `--agent <type>` — subagent type override (default: `general-purpose`). The skill prompt embeds the review heuristics inline, so a dedicated `code-simplifier` agent is not required.
 - `--max-files <N>` — soft cap on files the subagent should touch in one PR (default: 15). Lightweight stays lightweight.
-- `--base <branch>` — override the resolved PR base branch (see Process step 3). When set, short-circuits config / `develop` / repo-default resolution.
+- `--base <branch>` — override the resolved PR base branch (see Process step 3). When set, short-circuits the scoped-config-pin and `main` fallback resolution.
 - `--dry-run` — review and report findings without applying fixes; useful as a pre-flight before committing to a PR
 
 If `<scope>` is empty:

--- a/plugins/polishkit/skills/sweep/SKILL.md
+++ b/plugins/polishkit/skills/sweep/SKILL.md
@@ -168,4 +168,4 @@ After approval:
 1. Apply all confirmed removals and edits.
 2. For dead-code removals, verify the file still parses — run `tsc --noEmit` or the language equivalent if available.
 3. After all changes, re-run the project's verify command (typecheck/test) if one is exposed.
-4. Commit with `chore: sweep codebase` and open a PR targeting the project's base branch (auto-detect `develop` then fall back to `main`).
+4. Commit with `chore: sweep codebase` and open a PR targeting the project's base branch (the `claude.polishkit.prBase` pin if set, otherwise `main`).

--- a/plugins/swarmkit/skills/clean-worktrees/scripts/test.sh
+++ b/plugins/swarmkit/skills/clean-worktrees/scripts/test.sh
@@ -16,6 +16,12 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PASS=0
 FAIL=0
 
+# Make scratch-repo commits hermetic: fresh CI runners have no global git
+# identity, so `git commit` would fail with "Author identity unknown". These
+# env vars are honored by every commit below without per-repo config.
+export GIT_AUTHOR_NAME="skill-evals" GIT_AUTHOR_EMAIL="skill-evals@example.com"
+export GIT_COMMITTER_NAME="skill-evals" GIT_COMMITTER_EMAIL="skill-evals@example.com"
+
 red()   { printf '\033[31m%s\033[0m\n' "$*"; }
 green() { printf '\033[32m%s\033[0m\n' "$*"; }
 

--- a/scripts/lint-skills.py
+++ b/scripts/lint-skills.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""lint-skills.py — L2 skill-doc linter for the plugin monorepo.
+
+A no-LLM structural linter that asserts invariants across plugins/** and root
+docs, and freezes 2026-06-01 cross-plugin audit findings as permanent rules.
+Each rule reports a `file:line` location. See evals/README.md for the rule
+catalog, severity policy, and how to add a rule.
+
+Severity:
+  ERROR  — high-confidence structural violation; fails the gate (exit 1).
+  WARN   — fuzzy/heuristic signal; reported but does not fail (exit 0),
+           until proven low-false-positive and promoted to ERROR.
+
+Usage:
+  python3 scripts/lint-skills.py            # report; fail only on ERROR
+  python3 scripts/lint-skills.py --strict   # fail on WARN too
+
+Exit codes:
+  0  — no ERROR findings (WARN allowed unless --strict)
+  1  — at least one ERROR (or any WARN under --strict)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+ERROR = "ERROR"
+WARN = "WARN"
+
+
+@dataclass(frozen=True)
+class Finding:
+    severity: str
+    path: str
+    line: int
+    rule: str
+    message: str
+
+
+# --- file discovery -------------------------------------------------------
+
+def plugin_markdown_files() -> list[Path]:
+    return sorted(REPO_ROOT.joinpath("plugins").rglob("*.md"))
+
+
+def skill_files() -> list[Path]:
+    return sorted(REPO_ROOT.joinpath("plugins").rglob("SKILL.md"))
+
+
+def rel(path: Path) -> str:
+    return str(path.relative_to(REPO_ROOT))
+
+
+def read_lines(path: Path) -> list[str]:
+    return path.read_text(encoding="utf-8").splitlines()
+
+
+FENCE_RE = re.compile(r"^\s*(```|~~~)")
+
+
+def prose_lines(path: Path):
+    """Yield (lineno, line) for lines outside fenced code blocks."""
+    in_fence = False
+    for n, line in enumerate(read_lines(path), 1):
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            yield n, line
+
+
+def strip_fences(text: str) -> str:
+    out, in_fence = [], False
+    for line in text.splitlines():
+        if FENCE_RE.match(line):
+            in_fence = not in_fence
+            continue
+        if not in_fence:
+            out.append(line)
+    return "\n".join(out)
+
+
+BACKTICK_FLAG_RE = re.compile(r"`(--[a-z][a-z0-9-]+)`")
+
+
+def documented_flags(path: Path) -> set[str]:
+    """A skill's own flags: backtick-wrapped `--flag` tokens in prose (not in
+    shell snippets, where `--json`/`--cached` are CLI noise, not the interface)."""
+    return set(BACKTICK_FLAG_RE.findall(strip_fences(path.read_text(encoding="utf-8"))))
+
+
+# --- Rule: frontmatter present -------------------------------------------
+
+def rule_frontmatter(findings: list[Finding]) -> None:
+    for skill in skill_files():
+        lines = read_lines(skill)
+        if not lines or lines[0].strip() != "---":
+            findings.append(Finding(ERROR, rel(skill), 1, "frontmatter",
+                                    "SKILL.md must open with a YAML frontmatter block (`---`)"))
+            continue
+        end = next((i for i in range(1, len(lines)) if lines[i].strip() == "---"), None)
+        if end is None:
+            findings.append(Finding(ERROR, rel(skill), 1, "frontmatter",
+                                    "frontmatter block is not closed with `---`"))
+            continue
+        block = "\n".join(lines[1:end])
+        for key in ("name", "description"):
+            if not re.search(rf"^{key}:\s*\S", block, re.MULTILINE):
+                findings.append(Finding(ERROR, rel(skill), 1, "frontmatter",
+                                        f"frontmatter is missing required `{key}:` field"))
+
+
+# --- Rule: include directives resolve ------------------------------------
+
+INCLUDE_RE = re.compile(r"<!--\s*include:\s*(\S+?)\s*-->")
+
+
+def rule_includes(findings: list[Finding]) -> None:
+    for md in plugin_markdown_files():
+        for n, line in prose_lines(md):
+            for m in INCLUDE_RE.finditer(line):
+                target = m.group(1)
+                candidates = [REPO_ROOT / target, md.parent / target]
+                if not any(c.exists() for c in candidates):
+                    findings.append(Finding(ERROR, rel(md), n, "include",
+                                            f"include directive target not found: {target}"))
+
+
+# --- Rule: relative markdown links + _shared citations resolve -----------
+
+LINK_RE = re.compile(r"!?\[[^\]]*\]\(([^)]+)\)")
+SHARED_CITE_RE = re.compile(r"plugins/_shared/[A-Za-z0-9._/-]+\.md")
+SKIP_LINK_PREFIXES = ("http://", "https://", "mailto:", "#", "tel:")
+
+
+def _resolve_link(md: Path, target: str) -> Path | None:
+    target = target.strip()
+    if not target or target.startswith(SKIP_LINK_PREFIXES) or target.startswith("<"):
+        return None
+    target = target.split()[0]            # drop optional "title"
+    target = target.split("#", 1)[0]      # drop anchor
+    target = target.split("?", 1)[0]
+    if not target:
+        return None                       # pure in-doc anchor
+    if target.startswith("/"):
+        return REPO_ROOT / target.lstrip("/")
+    return (md.parent / target)
+
+
+def rule_links(findings: list[Finding]) -> None:
+    targets = plugin_markdown_files() + [REPO_ROOT / "README.md"]
+    for md in targets:
+        if not md.exists():
+            continue
+        for n, line in prose_lines(md):
+            for m in LINK_RE.finditer(line):
+                resolved = _resolve_link(md, m.group(1))
+                if resolved is not None and not resolved.exists():
+                    findings.append(Finding(ERROR, rel(md), n, "link",
+                                            f"relative link target not found: {m.group(1)}"))
+            for m in SHARED_CITE_RE.finditer(line):
+                cite = m.group(0)
+                if not (REPO_ROOT / cite).exists():
+                    findings.append(Finding(ERROR, rel(md), n, "shared-citation",
+                                            f"_shared citation path not found: {cite}"))
+
+
+# --- Rule: stale develop branch references -------------------------------
+# Many `develop` mentions are legitimate: the v3→v4 migration surfaces, v3
+# legacy-detection guards, and negative references ("there is no develop").
+# Flag only references that look like a live branch target and are not covered
+# by the migration/legacy allowlist, a negative-context phrasing, or an inline
+# `lint-allow-develop` marker.
+
+DEVELOP_FILE_ALLOWLIST = {
+    "plugins/flowkit/MIGRATION-v4.md",
+    "plugins/flowkit/README.md",
+    "plugins/flowkit/skills/migrate-v4/SKILL.md",
+    "plugins/flowkit/skills/ship/SKILL.md",
+    "plugins/flowkit/skills/pr/SKILL.md",
+    "plugins/sessionkit/README.md",
+    "plugins/sessionkit/skills/roadmap/SKILL.md",
+    "plugins/opsx-bridge/skills/apply-via-swarm/SKILL.md",
+}
+
+DEVELOP_BRANCHREF_RE = re.compile(
+    r"`develop`"
+    r"|\bdevelop/"
+    r"|/develop\b"
+    r"|--base\s+develop"
+    r"|\borigin\s+develop\b"
+    r"|\bdevelop\s+main\b"
+    r"|\bdevelop\|"
+    r"|^\s*-\s*develop\s*$"
+)
+DEVELOP_NEGATIVE_RE = re.compile(
+    r"\b(no|not|never|without|reintroduce)\b[^.]*develop"
+    r"|develop[^.]*\b(intermediary|split|probe)\b"
+    r"|develop\|main",  # branch-protection alternation, e.g. grep -E '^(develop|main'
+    re.IGNORECASE,
+)
+
+
+def _develop_scan_files() -> list[Path]:
+    files = plugin_markdown_files() + [REPO_ROOT / "README.md"]
+    wf = REPO_ROOT / ".github" / "workflows"
+    if wf.exists():
+        files += sorted(wf.glob("*.yml")) + sorted(wf.glob("*.yaml"))
+    return [f for f in files if f.exists()]
+
+
+def rule_develop(findings: list[Finding]) -> None:
+    for f in _develop_scan_files():
+        relpath = rel(f)
+        if relpath in DEVELOP_FILE_ALLOWLIST:
+            continue
+        scan = prose_lines(f) if f.suffix == ".md" else enumerate(read_lines(f), 1)
+        for n, line in scan:
+            if "lint-allow-develop" in line:
+                continue
+            if not DEVELOP_BRANCHREF_RE.search(line):
+                continue
+            if DEVELOP_NEGATIVE_RE.search(line):
+                continue
+            findings.append(Finding(ERROR, relpath, n, "develop",
+                                    "stale `develop` branch reference (single-trunk repo "
+                                    "targets `main`); allowlist legitimate uses in the linter "
+                                    "or add a `lint-allow-develop` marker"))
+
+
+# --- Rule: settings.json allowlist script paths exist --------------------
+
+ALLOWLIST_PATH_RE = re.compile(r"(plugins/[A-Za-z0-9._/-]+\.sh)")
+
+
+def rule_settings_allowlist(findings: list[Finding]) -> None:
+    settings = REPO_ROOT / ".claude" / "settings.json"
+    if not settings.exists():
+        return
+    data = json.loads(settings.read_text(encoding="utf-8"))
+    allow = data.get("permissions", {}).get("allow", [])
+    lines = read_lines(settings)
+    for entry in allow:
+        for m in ALLOWLIST_PATH_RE.finditer(entry):
+            script = m.group(1)
+            if not (REPO_ROOT / script).exists():
+                line_no = next((i + 1 for i, ln in enumerate(lines) if entry[:40] in ln), 1)
+                findings.append(Finding(ERROR, ".claude/settings.json", line_no,
+                                        "allowlist",
+                                        f"allowlist entry references a non-existent script: {script}"))
+
+
+# --- Rule (WARN): argument section present where flags are used ----------
+
+ARG_HEADING_RE = re.compile(r"^#{2,3}\s+.*\b(Input|Arguments?|Flags?|Usage|Options?)\b", re.IGNORECASE)
+
+
+def rule_input_present(findings: list[Finding]) -> None:
+    for skill in skill_files():
+        flags = documented_flags(skill)
+        if not flags:
+            continue
+        if any(ARG_HEADING_RE.match(ln) for ln in read_lines(skill)):
+            continue
+        findings.append(Finding(WARN, rel(skill), 1, "input-table",
+                                f"documents flags ({', '.join(sorted(flags)[:4])}) but has no "
+                                "Input/Arguments/Flags section"))
+
+
+# --- Rule (WARN): README flag drift --------------------------------------
+
+def rule_flag_matrix(findings: list[Finding]) -> None:
+    for plugin_dir in sorted(REPO_ROOT.joinpath("plugins").iterdir()):
+        readme = plugin_dir / "README.md"
+        if not readme.exists():
+            continue
+        readme_text = readme.read_text(encoding="utf-8")
+        for skill in sorted(plugin_dir.rglob("SKILL.md")):
+            skill_flags = documented_flags(skill)
+            missing = sorted(f for f in skill_flags if f not in readme_text)
+            if missing:
+                findings.append(Finding(WARN, rel(skill), 1, "flag-matrix",
+                                        f"flags not mentioned in {rel(readme)}: {', '.join(missing[:6])}"))
+
+
+# --- Rule (WARN): shared specs cited, not paraphrased --------------------
+
+PR_BODY_MARKERS = ("## Summary", "## Changes", "## Test plan")
+
+
+def rule_paraphrase(findings: list[Finding]) -> None:
+    for md in plugin_markdown_files():
+        relpath = rel(md)
+        if relpath.endswith("_shared/pr-body.md"):
+            continue
+        text = md.read_text(encoding="utf-8")
+        if all(marker in text for marker in PR_BODY_MARKERS) and "pr-body.md" not in text:
+            findings.append(Finding(WARN, relpath, 1, "paraphrase",
+                                    "inlines the PR-body section shape without citing "
+                                    "plugins/_shared/pr-body.md"))
+
+
+RULES = (
+    rule_frontmatter,
+    rule_includes,
+    rule_links,
+    rule_develop,
+    rule_settings_allowlist,
+    rule_input_present,
+    rule_flag_matrix,
+    rule_paraphrase,
+)
+
+
+def main(argv: list[str]) -> int:
+    strict = "--strict" in argv
+    findings: list[Finding] = []
+    for rule in RULES:
+        rule(findings)
+
+    findings.sort(key=lambda f: (f.severity != ERROR, f.path, f.line, f.rule))
+    errors = [f for f in findings if f.severity == ERROR]
+    warns = [f for f in findings if f.severity == WARN]
+
+    for f in findings:
+        print(f"{f.severity}: {f.path}:{f.line} [{f.rule}] {f.message}")
+
+    print()
+    print(f"lint-skills: {len(errors)} error(s), {len(warns)} warning(s)")
+
+    if errors or (strict and warns):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Implements the **L1** and **L2** layers of the `skill-evals` OpenSpec change — the deterministic, per-PR layers of the eval pyramid. L1 gates the script `test.sh` suite that already existed but never ran in CI; L2 adds a no-LLM skill-doc linter that freezes the 2026-06-01 cross-plugin audit findings as permanent rules. L3 (behavioral evals) and L4 (e2e smoke) remain open in the change for follow-up.

## Changes

- **L2 linter** (`scripts/lint-skills.py`, `evals/README.md`) — Python stdlib, one file:line rule per check, ERROR/WARN severities (only ERROR fails the gate, so a noisy rule can't block merges until calibrated). ERROR: frontmatter, include resolution, `_shared` citations, relative links, stale-`develop`, settings allowlist. WARN: input-section presence, README flag-matrix drift, paraphrase-not-cited.
- **CI** (`.github/workflows/skills-ci.yml`) — two jobs on PRs touching `plugins/**`: L1 runs `scripts/test-all-skill-scripts.sh`; L2 runs the linter.
- **Findings fixed** (surfaced by the linter on first run): `deploy-site.yml` dead `develop` push trigger; `polish/SKILL.md:30` + `sweep/SKILL.md:171` stale `develop`/repo-default base-resolution prose.
- **Docs** — `script-authoring.md` ties the runner to the required L1 check; `CLAUDE.md` gains a CI-gates entry; `tasks.md` checks off L1/L2.

L1 reused the existing `scripts/test-all-skill-scripts.sh` runner (no duplicate added) and needed no `test.sh` backfill — all 6 script-backed skills already ship one.

## Test plan

- [x] `python3 scripts/lint-skills.py` → 0 errors, 11 warnings (genuine flag-matrix drift), exit 0
- [x] `scripts/test-all-skill-scripts.sh` → 6 passed, 0 failed
- [ ] CI green on both jobs

Closes #1068. Implements L1+L2 of `openspec/changes/skill-evals/`.
