### PR TITLE
fix(speckit): register post-approval phase tasks at route classification

### DIFF
--- a/plugins/speckit/skills/spec/SKILL.md
+++ b/plugins/speckit/skills/spec/SKILL.md
@@ -138,9 +138,14 @@ ambiguous prompt) — short-circuit the rest of this skill:
    team-readiness assessment is full-path only.
 
 **On Full interview** (clearly-full narration, or `Full interview` picked in
-the ambiguous prompt): fall through to step 2 (invoke `/speckit:interview`)
-unchanged. **On `Cancel`** (only reachable from the ambiguous prompt): abort
-the skill.
+the ambiguous prompt): immediately call `TaskCreate` to register the five
+post-approval phases as `pending` todos — `file-children`,
+`create-epic-tracking-issue`, `wire-sub-issues`, `wire-blocked-by-edges`,
+`final-report` — then fall through to step 2 (invoke `/speckit:interview`).
+Registering the phases here (before any possible diversion) ensures the
+Pre-end self-check has tasks to detect even if the agent diverts from the
+prescribed flow before step 3 fires. **On `Cancel`** (only reachable from the
+ambiguous prompt): abort the skill.
 
 ### 2.5. Derive the epic slug
 
@@ -230,7 +235,7 @@ Do not proceed to step 4 until the user has answered via `AskUserQuestion`. If t
 
 The slug the user approves in this step is the single source of truth for the epic label and must be used verbatim in step 4 (catalog handoff for children) and step 5 (epic tracking issue).
 
-**On approval (full path only)**: immediately after the user approves the plan, and before invoking `/catalog`, call `TaskCreate` to register the five remaining post-approval phases as todos: file-children, create-epic-tracking-issue, wire-sub-issues, wire-blocked-by-edges, final-report. Subsequent steps open with `TaskUpdate` to `in_progress` and close with `TaskUpdate` to `completed`. Skip this on the simple path — single-issue plans do not need phase tracking.
+**On approval (full path only)**: the five post-approval phase tasks were already registered as `pending` in step 2a. Immediately after the user approves, open step 4 with `TaskUpdate(file-children, status: "in_progress")` and proceed. Subsequent steps open with `TaskUpdate` to `in_progress` and close with `TaskUpdate` to `completed`. Skip this on the simple path — single-issue plans do not need phase tracking.
 
 ### 4. File child issues
 

--- a/plugins/speckit/skills/spec/SKILL.md
+++ b/plugins/speckit/skills/spec/SKILL.md
@@ -214,9 +214,13 @@ full-path epic. `AskUserQuestion` supports max 4 options total (including
   short-circuit in step 2a). Question: "Approve this plan and file the issue?"
   Options: `Approve and file`, `Run full interview instead`, `Adjust`,
   `Cancel`.
-  - On `Run full interview instead`: discard the single-issue draft and fall
-    through to step 2 (invoke `/speckit:interview`). Do not re-ask the step 2a
-    routing prompt.
+  - On `Run full interview instead`: discard the single-issue draft, call
+    `TaskCreate` to register the five post-approval phases as `pending` todos —
+    `file-children`, `create-epic-tracking-issue`, `wire-sub-issues`,
+    `wire-blocked-by-edges`, `final-report` — then fall through to step 2
+    (invoke `/speckit:interview`). Do not re-ask the step 2a routing prompt.
+    (Step 2a is not re-entered on this re-route, so `TaskCreate` must fire
+    here to keep the Pre-end self-check armed.)
   - On `Adjust`: let the user revise the plan, then re-show the plan with the
     same options in a new turn.
 - **Full-path plan** (epic). Question: "Approve this plan and file the
@@ -224,7 +228,11 @@ full-path epic. `AskUserQuestion` supports max 4 options total (including
   `Adjust plan`, `Cancel`. Epic-label edits happen through `Adjust plan` — the
   user asks for a label change and the skill revises the `Epic label:` line
   before re-asking.
-  - On `Condense to single issue`: discard the epic plan and re-run the
+  - On `Condense to single issue`: call `TaskUpdate` to mark each of the five
+    registered phase tasks (`file-children`, `create-epic-tracking-issue`,
+    `wire-sub-issues`, `wire-blocked-by-edges`, `final-report`) as `cancelled`
+    — they were registered in step 2a but are now stale since the run is
+    switching to the simple path. Then discard the epic plan and re-run the
     simple-path drafting inline — one lightweight `AskUserQuestion` interview
     round (if needed to tighten scope), draft a single-issue plan with exactly
     one task, then re-show using the simple-path option set above.


### PR DESCRIPTION
## Summary
Moves the `TaskCreate` batch that registers the five post-approval spec phases (`file-children`, `create-epic-tracking-issue`, `wire-sub-issues`, `wire-blocked-by-edges`, `final-report`) from step 3 (post-approval) to step 2a (at Full-interview route classification). The tasks are registered as `pending` before `/speckit:interview` is invoked, so the Pre-end self-check has entries to detect even when the agent is diverted before the approval gate fires. The step 3 "On approval" paragraph is updated to remove the now-redundant `TaskCreate` call and instead open step 4 with `TaskUpdate`.

Also fixes two edge cases surfaced in review:
- "Run full interview instead" (simple→full re-route at step 3) now calls `TaskCreate` before falling through to step 2, since step 2a is not re-entered on this path.
- "Condense to single issue" now cancels the five stale phase tasks before switching to the simple path, preventing the Pre-end self-check from blocking turn-end indefinitely.

## Changes
- `plugins/speckit/skills/spec/SKILL.md` — step 2a "On Full interview": call `TaskCreate` for five phases before falling through
- `plugins/speckit/skills/spec/SKILL.md` — step 3 "On approval": reference tasks registered in step 2a, open step 4 with `TaskUpdate` directly
- `plugins/speckit/skills/spec/SKILL.md` — step 3 "Run full interview instead": call `TaskCreate` before re-routing to step 2
- `plugins/speckit/skills/spec/SKILL.md` — step 3 "Condense to single issue": cancel stale phase tasks before switching to simple path

## Test plan
- Read step 2a "On Full interview": should instruct `TaskCreate` for five phases before falling through.
- Read step 3 "On approval": should reference tasks from step 2a and open with `TaskUpdate(file-children, in_progress)`.
- Read step 3 "Run full interview instead": should call `TaskCreate` before step 2.
- Read step 3 "Condense to single issue": should cancel the five phase tasks before switching paths.
- Confirm Pre-end self-check section is unchanged.

Closes #988