### PR TITLE
feat(squadkit): add clean-stale-teams skill

### DIFF
--- a/plugins/squadkit/.claude-plugin/plugin.json
+++ b/plugins/squadkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "squadkit",
   "description": "Multi-agent team coordination for Claude Code. Roles, squads, and crews \u2014 interview-driven setup, no per-stack presets, reusable across any repo.",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/squadkit/README.md
+++ b/plugins/squadkit/README.md
@@ -69,6 +69,7 @@ If you author a project-local overlay at `.claude/agents/<role>.md`, preserve bo
 | **init** | `/squadkit:init` | Interview-driven generator that writes `.squadkit/config.json` to the repo root. No per-stack presets — the wizard asks you for the commands directly. |
 | **spawn-team** | `/squadkit:spawn-team` | Spawn a crew from a profile. Resolves a phonetic team name, optionally cuts an epic feature branch, provisions per-builder worktrees, registers the team via `TeamCreate`, and waits for one idle notification per spawned member (the harness's readiness signal) before the orchestrator (which IS the lead) enters its dispatch loop. |
 | **agent-team-retro** | `/squadkit:agent-team-retro` | Run a retrospective on the currently-spawned squad. Polls each active member with three fixed questions, aggregates findings into severity-grouped action items, applies approved edits to role contracts, and optionally hands findings off to `speckit:catalog` as GitHub issues. |
+| **clean-stale-teams** | `/squadkit:clean-stale-teams` | Prune orphaned team registries under `~/.claude/teams/`. Classifies each session dir by member type, current-session, and live-worktree refs, shows the verdict, then removes the safe ones (`TeamDelete`, falling back to `rm` for dead-session dirs). Complements `swarmkit:clean-worktrees`, which handles git state. |
 
 ## Crews
 

--- a/plugins/squadkit/skills/clean-stale-teams/SKILL.md
+++ b/plugins/squadkit/skills/clean-stale-teams/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: clean-stale-teams
+description: Prune stale squadkit team registries under ~/.claude/teams/. Scans each session team dir, classifies which are safe to remove (only an in-process lead, no spawned members, no live worktrees), shows the verdict, and deletes the orphans. Complements clean-worktrees (git state) by cleaning the team registry itself.
+triggers:
+  - "/squadkit:clean-stale-teams"
+  - "clean up stale squads"
+  - "delete stale team"
+  - "remove squad remnants"
+  - "prune ~/.claude/teams"
+allowed-tools: Bash, Read, TeamDelete, AskUserQuestion
+---
+
+# Squadkit Clean Stale Teams
+
+Remove orphaned team registries left under `~/.claude/teams/<name>/`. Each entry is a `config.json` describing a squad's lead and members. When a session ends without tearing its squad down — or a SessionStart hook flags remnants — the dir lingers and the auto-mode classifier later flags ad-hoc `rm` of it as unscoped destruction. This skill makes the prune legible: classify, show, then delete.
+
+## Input
+
+`$ARGUMENTS` — optional. A specific team name to target (e.g. `session-604893df`). When omitted, scan and classify every dir under `~/.claude/teams/`.
+
+## Process
+
+### 1. Enumerate team dirs
+
+List `~/.claude/teams/`. For each subdir, Read its `config.json`. If the dir has no `config.json`, treat it as malformed-but-removable and note it.
+
+### 2. Classify each team
+
+For every team, derive a verdict from its config and live state:
+
+- **Members** — count entries in `members[]` whose `backendType` is not `in-process`. A team with only the in-process lead has zero real members.
+- **Current session** — compare `leadSessionId` against the running session id. Never remove the team for the *current* live session unless the user explicitly named it (e.g. a SessionStart hook asked to tear it down).
+- **Worktrees** — run `git worktree list` in the lead's `cwd` and check `.claude/worktrees/` there. A team referencing a live worktree is **not** safe to auto-remove.
+
+A team is **safe to prune** when: only an in-process lead, zero spawned members, and no live worktree references.
+
+### 3. Present the verdict
+
+Show a compact table: team name, lead session, member count, worktree refs, and verdict (`prune` / `keep` / `needs confirmation`). For anything ambiguous (real members present, or it's the current session), use AskUserQuestion before touching it — never batch a risky delete into a safe sweep.
+
+### 4. Remove the orphans
+
+For each `prune` team:
+
+- Prefer `TeamDelete` when the team is still registered with the running harness.
+- Otherwise `rm -rf ~/.claude/teams/<name>` for a dead-session dir the harness no longer tracks.
+
+Echo each removal. If the classifier blocks a delete the user already authorized, retry once so the user gets an approval prompt — do not silently skip it.
+
+### 5. Report
+
+List what was removed and what was kept (with the reason). Note whether `~/.claude/teams/` is now empty of session remnants.
+
+## Constraints
+
+- **Never remove a team with real (non-in-process) members** without explicit user confirmation — those may be live agents.
+- **Never remove the current session's team** unless the user (or a SessionStart hook) explicitly named it for teardown.
+- **Never delete a team whose lead `cwd` has a live worktree** referencing it; clean the worktree first (`swarmkit:clean-worktrees`).
+- **Always show the verdict before deleting.** No silent sweeps.
+- **One concern per delete.** Do not fold a risky removal into a batch of safe ones.


### PR DESCRIPTION
## What

Adds a new squadkit skill, **`/squadkit:clean-stale-teams`**, that prunes orphaned team registries under `~/.claude/teams/`.

## Why

When a session ends without tearing its squad down, the `~/.claude/teams/<name>/` dir lingers. A later session's `SessionStart` hook flags the remnant, but there's no encoded procedure to clean it — so ad-hoc `rm -rf` of the dir gets flagged by the auto-mode classifier as unscoped destruction. This skill makes the prune legible: classify, show the verdict, then delete.

## Behavior

- Enumerates `~/.claude/teams/`, reads each `config.json`.
- Classifies each team by: non-in-process member count, current-session match, and live-worktree refs.
- Safe to prune = only an in-process lead, zero spawned members, no live worktree references.
- Removes via `TeamDelete` when still harness-tracked, else `rm -rf` for dead-session dirs.
- Constraints rail off the risky cases: never touch teams with real members, the current session, or live-worktree refs without confirmation; no silent batch sweeps.

Complements `swarmkit:clean-worktrees` (git state) by cleaning the team registry itself.

## Changes

- New skill: `plugins/squadkit/skills/clean-stale-teams/SKILL.md`
- README Skills table entry
- squadkit `0.11.2` → `0.12.0`