### PR TITLE
chore(plugins): bump polishkit@3.1.0, speckit@1.8.1, swarmkit@6.2.0

### DIFF
--- a/plugins/polishkit/.claude-plugin/plugin.json
+++ b/plugins/polishkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polishkit",
   "description": "Codebase quality toolkit. Appraise code craft with a connoisseur's eye, sweep dead code and cruft in one pass, and polish cross-cutting code-quality issues — three focused skills for improving what you've already built.",
-  "version": "3.0.6",
+  "version": "3.1.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/speckit/.claude-plugin/plugin.json
+++ b/plugins/speckit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "speckit",
   "description": "Define and capture work as GitHub issues. Interview a feature into existence with /spec, bulk-convert findings with /catalog, or quickly file a single issue with /issue.",
-  "version": "1.8.0",
+  "version": "1.8.1",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"

--- a/plugins/swarmkit/.claude-plugin/plugin.json
+++ b/plugins/swarmkit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "swarmkit",
   "description": "Resolve GitHub issues with parallel agents. Pick what to work on, swarm it with isolated worktree agents, merge PRs in dependency order, and keep your branches clean.",
-  "version": "6.1.0",
+  "version": "6.2.0",
   "license": "MIT",
   "author": {
     "name": "Román M. Pacheco"


### PR DESCRIPTION
## Summary

Bump plugin.json versions for plugins changed since their last release.

## Changes

- polishkit@3.1.0 — feat(evals): L1 script-test gate + L2 skill-doc lint (#1072)
- speckit@1.8.1 — fix(speckit): register post-approval phase tasks at route classification (#1075)
- swarmkit@6.2.0 — feat(evals): L1 script-test gate + L2 skill-doc lint (#1072)

## Test plan

- [ ] Confirm each `plugin.json` version bump matches the per-plugin tag that will be created after merge.