### PR TITLE
fix(flowkit): add open-swarm-PR preflight gate to ship

### DIFF
--- a/plugins/flowkit/skills/ship/SKILL.md
+++ b/plugins/flowkit/skills/ship/SKILL.md
@@ -74,7 +74,7 @@ fi
 
 # No open worktree-agent-* PRs may still target main — those are unmerged swarm output;
 # shipping now would tag a snapshot that never ran the verify gate against the integrated result
-BLOCKING_PRS=$(gh pr list --state open --base main --json number,headRefName \
+BLOCKING_PRS=$(gh pr list --state open --base main --limit 200 --json number,headRefName \
   --jq '.[] | select(.headRefName | startswith("worktree-agent-")) | "\(.number)\t\(.headRefName)"')
 if [ -n "$BLOCKING_PRS" ]; then
   echo "ship: open worktree-agent-* PRs still target main. Run /swarmkit:merge-stack first." >&2

--- a/plugins/flowkit/skills/ship/SKILL.md
+++ b/plugins/flowkit/skills/ship/SKILL.md
@@ -34,9 +34,9 @@ if [ "$DEFAULT_BRANCH" = "develop" ] || { [ "$DEVELOP_EXISTS" -gt 0 ] && [ "$MAI
 fi
 ```
 
-### 1. Preflight: main, in sync, clean, progress
+### 1. Preflight: main, in sync, clean, progress, no open swarm PRs
 
-Refuse to run unless all four hold:
+Refuse to run unless all five hold:
 
 ```bash
 # Current branch must be main
@@ -70,6 +70,18 @@ if [ -n "$LAST_TAG" ]; then
     echo "ship: no commits on main since $LAST_TAG. Nothing to release." >&2
     exit 1
   fi
+fi
+
+# No open worktree-agent-* PRs may still target main — those are unmerged swarm output;
+# shipping now would tag a snapshot that never ran the verify gate against the integrated result
+BLOCKING_PRS=$(gh pr list --state open --base main --json number,headRefName \
+  --jq '.[] | select(.headRefName | startswith("worktree-agent-")) | "\(.number)\t\(.headRefName)"')
+if [ -n "$BLOCKING_PRS" ]; then
+  echo "ship: open worktree-agent-* PRs still target main. Run /swarmkit:merge-stack first." >&2
+  printf '%s\n' "$BLOCKING_PRS" | while IFS=$'\t' read -r PR_NUMBER PR_BRANCH; do
+    echo "  #${PR_NUMBER}  ${PR_BRANCH}" >&2
+  done
+  exit 1
 fi
 ```
 
@@ -216,7 +228,7 @@ Print:
 
 ## Constraints
 
-- The preflight is a hard gate — do not bypass any of the four conditions (on main, in sync, clean tree, commits since last tag) except for the first-ever-release exemption on the progress check
+- The preflight is a hard gate — do not bypass any of the five conditions (on main, in sync, clean tree, commits since last tag, no open `worktree-agent-*` PRs targeting main) except for the first-ever-release exemption on the progress check. The open-swarm-PR check has no override — it always exits 1 when blocking PRs are found
 - The tag MUST be annotated (`git tag -a`); lightweight tags lose author metadata and break `git describe` heuristics
 - Operator confirmation is non-negotiable — never push a tag without explicit operator approval
 - This skill replaces the v3 `cut → release → ship` chain. There is no RC branch, no release PR, no `gh issue close` loop — squash-merged PRs already carried `Closes #N` footers which GitHub honored at merge time

--- a/plugins/swarmkit/METHODOLOGY.md
+++ b/plugins/swarmkit/METHODOLOGY.md
@@ -147,7 +147,7 @@ The epic→main promotion is a single squash-merge:
 3. Unset `claude.flowkit.prBase`.
 4. Delete the feature branch on origin.
 
-`/flowkit:ship` then handles the release: preflight on `main`, derive next semver from conventional commits, tag, push, and create a GitHub Release. It is the release closer only — it does not invoke `merge-stack`, and aborts up front if any open `worktree-agent-*` PRs still target the resolved base.
+`/flowkit:ship` then handles the release: preflight on `main`, derive next semver from conventional commits, tag, push, and create a GitHub Release. It is the release closer only — it does not invoke `merge-stack`, and aborts up front if any open `worktree-agent-*` PRs still target `main` (the epic branch itself does not count — those PRs are expected mid-swarm and don't block).
 
 Swarm never invokes `/flowkit:ship`. The operator must explicitly trigger promotion and release.
 


### PR DESCRIPTION
## Summary
`/flowkit:ship`'s preflight previously enforced only four conditions (on main, in sync with origin, clean tree, commits since last tag) even though three docs promised a hard stop on open `worktree-agent-*` PRs targeting `main`. This adds that fifth gate inline in the existing preflight bash block: it queries `gh pr list --state open --base main` filtered to `headRefName` starting with `worktree-agent-`, prints each blocking PR (number + branch) plus a pointer to `/swarmkit:merge-stack`, and exits 1 with no override path. PRs stacked on an epic branch (base ≠ `main`) are unaffected. Docs were updated to match: the SKILL.md heading/prose and Constraints section now describe five gates instead of four, and `plugins/swarmkit/METHODOLOGY.md:150` now says the guard targets `main` specifically rather than "the resolved base."

## Test plan
- `bash -n` on the extracted new gate script confirms syntax validity.
- Re-read the full `plugins/flowkit/skills/ship/SKILL.md` to confirm the preflight section still renders as coherent markdown with correctly fenced bash blocks and the gate follows the same echo-to-stderr/exit-1 style as the other four gates.
- `python3 scripts/lint-skills.py` run locally — 0 errors, only pre-existing unrelated warnings.
- Manual read-through confirms the guard queries `base main` only (epic `feature/*` branches are not blocked), has no bypass flag, and `plugins/flowkit/README.md:63` / `CLAUDE.md:34` already described this behavior correctly and needed no changes.

Closes #1082