### PR TITLE
fix(swarmkit): fix reviewer verdict delivery and lifecycle cleanup

### DIFF
--- a/plugins/swarmkit/agents/swarm-reviewer.md
+++ b/plugins/swarmkit/agents/swarm-reviewer.md
@@ -1,7 +1,7 @@
 ---
 name: swarm-reviewer
 description: Specialized reviewer for swarm-produced PRs. Reviews a PR against the originating issue's acceptance criteria and returns findings inline — never via gh pr comment. Output always follows the required five-section structure (Verdict / Blockers / Concerns / Nits / Coverage gaps) so the swarm orchestrator can parse the result and decide whether to spawn a worker.
-tools: Bash, Read
+tools: Bash, Read, SendMessage
 ---
 
 You are a specialized code reviewer for swarm-produced pull requests. Your job is to evaluate whether the PR satisfies the originating issue's acceptance criteria and surface any problems the swarm agent may have introduced or missed.


### PR DESCRIPTION
## Summary

Two related bugs found while debugging a silent swarm review pass: `swarmkit:swarm-reviewer` couldn't deliver its verdict at all (missing tool), and even once it can, nothing ever terminates it afterward, leaking an idle teammate per reviewed PR.

## Changes

- `plugins/swarmkit/agents/swarm-reviewer.md`: add `SendMessage` to the `tools:` line (`Bash, Read` → `Bash, Read, SendMessage`). The verdict-delivery contract added in #925/#922 requires the reviewer to `SendMessage` its structured verdict to the orchestrator before terminating, but the frontmatter was never updated — the agent had no way to comply and silently idled with no verdict delivered.
- `plugins/swarmkit/skills/swarm/SKILL.md` (review/fix pass, step 6b): the orchestrator now calls `TaskStop` on the reviewer's tracked agent ID immediately after parsing its `SendMessage` verdict, before proceeding to the fix-round decision. Reviewers don't hold git/worktree state like builders do, but they're addressable teammates the harness doesn't auto-terminate — leaving them idle after verdict delivery is a resource leak.

## Test plan

- [x] Spawned `swarmkit:swarm-reviewer` against a live PR with the patched tools line and confirmed it delivered a full structured verdict via `SendMessage` on the first attempt — no idle-loop, no manual nudging required.
- [x] Confirmed `TaskStop` successfully terminates a named reviewer teammate by agent name after its verdict is parsed.
- [ ] Confirm a future `swarmkit:swarm` run's review/fix pass parses reviewer verdicts and stops each reviewer without leaving idle teammates behind.