### PR TITLE
fix(swarmkit): terminate reviewers after verdict delivery

### DIFF
--- a/plugins/swarmkit/skills/swarm/SKILL.md
+++ b/plugins/swarmkit/skills/swarm/SKILL.md
@@ -404,6 +404,8 @@ PR #1390: reviewer clean (no blockers/concerns) → no fix round
 PR #1391: reviewer flagged 1 blocker, 2 concerns → spawning fresh worker
 ```
 
+**Terminate the reviewer.** Unlike swarm builders, reviewers are never spawned with `isolation: worktree` and hold no git state — but they are addressable teammates and the harness does not auto-terminate them the way it does builders. Once a reviewer's `SendMessage` verdict has been parsed (regardless of the fix-round decision above), immediately call `TaskStop` on its tracked agent ID/name. Leaving a reviewer idle after its verdict is delivered is a resource leak, not a no-op — always stop it before moving to 6c.
+
 **6c. Spawn the fix-round worker.** For every PR whose reviewer verdict was non-clean, spawn a fresh `general-purpose` agent with `isolation: worktree`, `mode: bypassPermissions`, `run_in_background: true`. Default model `sonnet`; override via `--worker-model`.
 
 The fix-round worker prompt MUST:


### PR DESCRIPTION
## Summary

Follow-up to #1084. Reviewers spawned by `swarmkit:swarm`'s review/fix pass don't hold git/worktree state like builders do, but they are addressable teammates the harness does not auto-terminate — after delivering their `SendMessage` verdict they sit idle indefinitely, leaking one idle teammate per reviewed PR.

## Changes

- `plugins/swarmkit/skills/swarm/SKILL.md` (step 6b, review/fix pass): the orchestrator now calls `TaskStop` on the reviewer's tracked agent ID immediately after parsing its verdict, before proceeding to the fix-round decision.

## Test plan

- [x] Confirmed `TaskStop` successfully terminates a named reviewer teammate by agent name after its verdict is parsed (done manually against a live idle reviewer this session).
- [ ] Confirm a future `swarmkit:swarm` run's review/fix pass stops each reviewer immediately after parsing its verdict, with no idle teammates left behind at run completion.